### PR TITLE
Adds updated second-level domain data for Nov 3, 2015

### DIFF
--- a/dotgov-domains/2015-11-03-cities.csv
+++ b/dotgov-domains/2015-11-03-cities.csv
@@ -1,0 +1,2019 @@
+Domain Name,Domain Type,Agency,City,State
+ABERDEENWA.GOV,City,Non-Federal Agency,Aberdeen,WA
+ABINGDON-VA.GOV,City,Non-Federal Agency,Abingdon,VA
+ABINGTONMA.GOV,City,Non-Federal Agency,Abington,MA
+ABSECONNJ.GOV,City,Non-Federal Agency,Absecon,NJ
+ACCESSPRINCETONNJ.GOV,City,Non-Federal Agency,Princeton,NJ
+ACTON-MA.GOV,City,Non-Federal Agency,Acton,MA
+ACTONMA.GOV,City,Non-Federal Agency,Acton,MA
+ADAK-AK.GOV,City,Non-Federal Agency,Adak,AK
+ADAMN.GOV,City,Non-Federal Agency,Ada,MN
+ADDISONTX.GOV,City,Non-Federal Agency,Addison,TX
+ADRIANMI.GOV,City,Non-Federal Agency,Adrian,MI
+AFTONWYOMING.GOV,City,Non-Federal Agency,AFTON,WY
+AKRONOHIO.GOV,City,Non-Federal Agency,Akron,OH
+ALAMEDACA.GOV,City,Non-Federal Agency,Alameda,CA
+ALAMOHEIGHTSTX.GOV,City,Non-Federal Agency,Alamo Heights,TX
+ALBANYNY.GOV,City,Non-Federal Agency,Albany,NY
+ALBEMARLENC.GOV,City,Non-Federal Agency,Albemarle,NC
+ALEKNAGIKAK.GOV,City,Non-Federal Agency,Aleknagik,AK
+ALEXANDERCITYAL.GOV,City,Non-Federal Agency,Alexander City,AL
+ALEXANDRIAVA.GOV,City,Non-Federal Agency,Alexandria,VA
+ALGONAWA.GOV,City,Non-Federal Agency,Algona,WA
+ALGOODTN.GOV,City,Non-Federal Agency,Algood,TN
+ALIQUIPPAPA.GOV,City,Non-Federal Agency,Aliquippa,PA
+ALLENSTOWNNH.GOV,City,Non-Federal Agency,Allenstown,NH
+ALLENTOWNPA.GOV,City,Non-Federal Agency,Allentown,PA
+ALLIANCEOH.GOV,City,Non-Federal Agency,Alliance,OH
+ALMONTMICHIGAN.GOV,City,Non-Federal Agency,Almont,MI
+ALSTEADNH.GOV,City,Non-Federal Agency,Alstead,NH
+ALTAVISTAVA.GOV,City,Non-Federal Agency,Altavista,VA
+ALTON-TX.GOV,City,Non-Federal Agency,Alton,TX
+ALTUSOK.GOV,City,Non-Federal Agency,Altus,OK
+ALVIN-TX.GOV,City,Non-Federal Agency,Alvin,TX
+AMARILLO.GOV,City,Non-Federal Agency,Amarillo,TX
+AMENIANY.GOV,City,Non-Federal Agency,Amenia,NY
+AMERICUSGA.GOV,City,Non-Federal Agency,Americus,GA
+AMERYWI.GOV,City,Non-Federal Agency,Amery,WI
+AMHERSTMA.GOV,City,Non-Federal Agency,Amherst,MA
+AMHERSTNH.GOV,City,Non-Federal Agency,Amherst,NH
+AMHERSTVA.GOV,City,Non-Federal Agency,Amherst,VA
+AMITYARKANSAS.GOV,City,Non-Federal Agency,Amity,AR
+AMSTERDAMNY.GOV,City,Non-Federal Agency,Amsterdam,NY
+ANCHORAGEAK.GOV,City,Non-Federal Agency,Anchorage,AK
+ANDOVER-NH.GOV,City,Non-Federal Agency,Andover,NH
+ANDOVERMA.GOV,City,Non-Federal Agency,Andover,MA
+ANDOVERMN.GOV,City,Non-Federal Agency,Andover,MN
+ANGELFIRENM.GOV,City,Non-Federal Agency,Angel Fire,NM
+ANGELSCAMP.GOV,City,Non-Federal Agency,City of Angels Camp,CA
+ANKENYIOWA.GOV,City,Non-Federal Agency,Ankeny,IA
+ANNATEXAS.GOV,City,Non-Federal Agency,Anna,TX
+ANNETTATX.GOV,City,Non-Federal Agency,Aledo,TX
+ANNISTONAL.GOV,City,Non-Federal Agency,Anniston,AL
+APPLEVALLEYCA.GOV,City,Non-Federal Agency,Apple Valley,CA
+APPLEVALLEYUT.GOV,City,Non-Federal Agency,Apple Valley,UT
+APPOMATTOXVA.GOV,City,Non-Federal Agency,Appomattox,VA
+AQUINNAH-MA.GOV,City,Non-Federal Agency,Aquinnah,MA
+ARANSASPASSTX.GOV,City,Non-Federal Agency,Aransas Pass,TX
+ARCADIA-FL.GOV,City,Non-Federal Agency,Arcadia,FL
+ARCADIACA.GOV,City,Non-Federal Agency,Arcadia,CA
+ARCHBALDBOROUGHPA.GOV,City,Non-Federal Agency,Archbald,PA
+ARKANSASCITYKS.GOV,City,Non-Federal Agency,Arkansas City,KS
+ARLINGTON-TX.GOV,City,Non-Federal Agency,Arlington,TX
+ARLINGTONMA.GOV,City,Non-Federal Agency,Arlington,MA
+ARLINGTONTX.GOV,City,Non-Federal Agency,Arlington,TX
+ARLINGTONWA.GOV,City,Non-Federal Agency,Arlington,WA
+ARTESIANM.GOV,City,Non-Federal Agency,Artesia,NM
+ARTHUR-IL.GOV,City,Non-Federal Agency,Arthur,IL
+ASHBURNHAM-MA.GOV,City,Non-Federal Agency,Ashburnham,MA
+ASHBYMA.GOV,City,Non-Federal Agency,Ashby,MA
+ASHEBORONC.GOV,City,Non-Federal Agency,Asheboro,NC
+ASHGROVEMO.GOV,City,Non-Federal Agency,Ash Grove,MO
+ASHLANDCITYTN.GOV,City,Non-Federal Agency,Ashland City,TN
+ASHLANDKY.GOV,City,Non-Federal Agency,Ashland,KY
+ASHVILLEOHIO.GOV,City,Non-Federal Agency,Ashville,OH
+ATHOL-MA.GOV,City,Non-Federal Agency,Athol,MA
+ATKINSON-NH.GOV,City,Non-Federal Agency,Atkinson,NH
+ATLANTAGA.GOV,City,Non-Federal Agency,Atlanta,GA
+ATLANTISFL.GOV,City,Non-Federal Agency,Atlantis,FL
+ATRISCO-NM.GOV,City,Non-Federal Agency,Atrisco,NM
+ATTICA-IN.GOV,City,Non-Federal Agency,Attica,IN
+AUBREYTX.GOV,City,Non-Federal Agency,Aubrey,TX
+AUBURNMAINE.GOV,City,Non-Federal Agency,Auburn,ME
+AUGUSTAMAINE.GOV,City,Non-Federal Agency,Augusta,ME
+AUGUSTAME.GOV,City,Non-Federal Agency,Augusta,ME
+AUSTELLGA.GOV,City,Non-Federal Agency,Austell,GA
+AUSTINTEXAS.GOV,City,Non-Federal Agency,Austin,TX
+AUSTINTX.GOV,City,Non-Federal Agency,Austin,TX
+AVONCT.GOV,City,Non-Federal Agency,Avon,CT
+AVONDALEAZ.GOV,City,Non-Federal Agency,Avondale,AZ
+AZTECNM.GOV,City,Non-Federal Agency,Aztec,NM
+BADENPA.GOV,City,Non-Federal Agency,Baden,PA
+BAINBRIDGEWA.GOV,City,Non-Federal Agency,Bainbridge Island,WA
+BALHARBOURFL.GOV,City,Non-Federal Agency,Bal Harbour,FL
+BALTIMORECITY.GOV,City,Non-Federal Agency,Baltimore,MD
+BANGORMAINE.GOV,City,Non-Federal Agency,Bangor,ME
+BARLINGAR.GOV,City,Non-Federal Agency,Barling,AR
+BARRINGTON-IL.GOV,City,Non-Federal Agency,Barrington,IL
+BARRINGTONHILLS-IL.GOV,City,Non-Federal Agency,Barrington Hills,IL
+BASTROPTX.GOV,City,Non-Federal Agency,Bastrop,TX
+BATTLECREEK-MI.GOV,City,Non-Federal Agency,Battle Creek,MI
+BATTLECREEKMI.GOV,City,Non-Federal Agency,Battle Creek,MI
+BAXTERMN.GOV,City,Non-Federal Agency,Baxter,MN
+BAYSIDE-WI.GOV,City,Non-Federal Agency,Bayside,WI
+BAYSTLOUIS-MS.GOV,City,Non-Federal Agency,Bay St. Louis,MS
+BAYVILLENY.GOV,City,Non-Federal Agency,Bayville,NY
+BEACHHAVEN-NJ.GOV,City,Non-Federal Agency,Beach Haven,NJ
+BEAUMONT-CA.GOV,City,Non-Federal Agency,Beaumont,CA
+BEAUMONTTEXAS.GOV,City,Non-Federal Agency,Beaumont,TX
+BEAVERCREEKOHIO.GOV,City,Non-Federal Agency,Beavercreek,OH
+BEAVERPA.GOV,City,Non-Federal Agency,Beaver,PA
+BEAVERTONOREGON.GOV,City,Non-Federal Agency,Beaverton,OR
+BEAVERTWP-OH.GOV,City,Non-Federal Agency,North Lima,OH
+BEDFORDHEIGHTS.GOV,City,Non-Federal Agency,Bedford Heights,OH
+BEDFORDMA.GOV,City,Non-Federal Agency,Bedford,MA
+BEDFORDNY.GOV,City,Non-Federal Agency,Bedford Hills,NY
+BEDFORDOH.GOV,City,Non-Federal Agency,Bedford,OH
+BEDFORDTX.GOV,City,Non-Federal Agency,Bedford,TX
+BEDFORDVA.GOV,City,Non-Federal Agency,Bedford,VA
+BEECAVETEXAS.GOV,City,Non-Federal Agency,Bee Cave,TX
+BELAIREKS.GOV,City,Non-Federal Agency,Bel Aire,KS
+BELEN-NM.GOV,City,Non-Federal Agency,Belen,NM
+BELLAIRETX.GOV,City,Non-Federal Agency,Bellaire,TX
+BELLAVISTAAR.GOV,City,Non-Federal Agency,Bella Vista,AR
+BELLEAIRBLUFFS-FL.GOV,City,Non-Federal Agency,Belleair Bluffs,FL
+BELLEMEADE-KY.GOV,City,Non-Federal Agency,Louisville,KY
+BELLEVUEIA.GOV,City,Non-Federal Agency,Bellevue,IA
+BELLEVUEWA.GOV,City,Non-Federal Agency,Bellevue,WA
+BELMONT-MA.GOV,City,Non-Federal Agency,Belmont,MA
+BELOITWI.GOV,City,Non-Federal Agency,Beloit,WI
+BELTONPARKSMO.GOV,City,Non-Federal Agency,Belton,MO
+BELTONTEXAS.GOV,City,Non-Federal Agency,Belton,TX
+BENDOREGON.GOV,City,Non-Federal Agency,Bend,OR
+BENSALEMPA.GOV,City,Non-Federal Agency,Bensalem,PA
+BENSONAZ.GOV,City,Non-Federal Agency,Benson,AZ
+BENTONCHARTERTOWNSHIP-MI.GOV,City,Non-Federal Agency,Benton Harbor,MI
+BEREAKY.GOV,City,Non-Federal Agency,Berea,KY
+BERLINMD.GOV,City,Non-Federal Agency,Berlin,MD
+BERLINNH.GOV,City,Non-Federal Agency,Berlin,NH
+BERNCO.GOV,City,Non-Federal Agency,Albuquerque,NM
+BERWYN-IL.GOV,City,Non-Federal Agency,Berwyn,IL
+BETHANYBEACH-DE.GOV,City,Non-Federal Agency,Bethany Beach,DE
+BETHEL-CT.GOV,City,Non-Federal Agency,Bethel,CT
+BETHEL-OH.GOV,City,Non-Federal Agency,Bethel,OH
+BEVERLYHILLS-CA.GOV,City,Non-Federal Agency,Beverly Hills,CA
+BEVERLYHILLSCA.GOV,City,Non-Federal Agency,Beverly Hills,CA
+BEVERLYMA.GOV,City,Non-Federal Agency,Beverly,MA
+BIGGS-CA.GOV,City,Non-Federal Agency,Biggs,CA
+BIGSANDYTX.GOV,City,Non-Federal Agency,Big Sandy,TX
+BINGHAMTON-NY.GOV,City,Non-Federal Agency,Binghamton,NY
+BIRMINGHAMAL.GOV,City,Non-Federal Agency,Birmingham,AL
+BISBEEAZ.GOV,City,Non-Federal Agency,Bisbee,AZ
+BISCAYNEPARKFL.GOV,City,Non-Federal Agency,Biscayne Park,FL
+BISMARCKND.GOV,City,Non-Federal Agency,Bismarck,ND
+BIXBYOK.GOV,City,Non-Federal Agency,Bixby,OK
+BLAINEMN.GOV,City,Non-Federal Agency,Blaine,MN
+BLAIRSVILLE-GA.GOV,City,Non-Federal Agency,Blairsville,GA
+BLANDING-UT.GOV,City,Non-Federal Agency,Blanding,UT
+BLENDONTOWNSHIP-MI.GOV,City,Non-Federal Agency,Hudsonville,MI
+BLOOMINGDALE-GA.GOV,City,Non-Federal Agency,Bloomingdale,GA
+BLOOMINGTON-MN.GOV,City,Non-Federal Agency,Bloomington,MN
+BLUEASH-OH.GOV,City,Non-Federal Agency,Blue Ash,OH
+BOCARATON-FL.GOV,City,Non-Federal Agency,Boca Raton,FL
+BOERNE-TX.GOV,City,Non-Federal Agency,BOERNE,TX
+BOISEIDAHO.GOV,City,Non-Federal Agency,Boise,ID
+BOLTON-MA.GOV,City,Non-Federal Agency,Bolton,MA
+BONNEYTEXAS.GOV,City,Non-Federal Agency,Bonney,TX
+BORGERTX.GOV,City,Non-Federal Agency,Borger,TX
+BOSQUEFARMSNM.GOV,City,Non-Federal Agency,Bosque Farms,NM
+BOSTON.GOV,City,Non-Federal Agency,Boston,MA
+BOTHELLWA.GOV,City,Non-Federal Agency,Bothell,WA
+BOULDERCOLORADO.GOV,City,Non-Federal Agency,Boulder,CO
+BOURBON-IN.GOV,City,Non-Federal Agency,Bremen,IN
+BOWERSDE.GOV,City,Non-Federal Agency,"Frederica,",DE
+BOWLINGGREEN-MO.GOV,City,Non-Federal Agency,Bowling Green,MO
+BOWLINGGREENKY.GOV,City,Non-Federal Agency,Bowling Green,KY
+BOWMAR.GOV,City,Non-Federal Agency,Bow Mar,CO
+BOXBOROUGH-MA.GOV,City,Non-Federal Agency,Boxborough,MA
+BOYCEVA.GOV,City,Non-Federal Agency,Boyce,VA
+BOYLSTON-MA.GOV,City,Non-Federal Agency,Boylston,MA
+BOZEMAN-MT.GOV,City,Non-Federal Agency,Bozeman,MT
+BRADLEYBEACHNJ.GOV,City,Non-Federal Agency,Bradley Beach,NJ
+BRANFORD-CT.GOV,City,Non-Federal Agency,Branford,CT
+BRANSONMO.GOV,City,Non-Federal Agency,Branson,MO
+BRASWELLGA.GOV,City,Non-Federal Agency,Rockmart,GA
+BRAWLEY-CA.GOV,City,Non-Federal Agency,Brawley,CA
+BRECKENRIDGETX.GOV,City,Non-Federal Agency,Breckenridge,TX
+BREMENGA.GOV,City,Non-Federal Agency,Bremen,GA
+BREMERTONWA.GOV,City,Non-Federal Agency,Bremerton,WA
+BRENTWOOD-TN.GOV,City,Non-Federal Agency,Brentwood,TN
+BRENTWOODCA.GOV,City,Non-Federal Agency,Brentwood,CA
+BRENTWOODMD.GOV,City,Non-Federal Agency,Brentwood,MD
+BRENTWOODNH.GOV,City,Non-Federal Agency,Brentwood,NH
+BRENTWOODTN.GOV,City,Non-Federal Agency,Brentwood,TN
+BREWSTER-MA.GOV,City,Non-Federal Agency,Brewster,MA
+BREWSTERVILLAGE-NY.GOV,City,Non-Federal Agency,Brewster,NY
+BRICKTOWNSHIP-NJ.GOV,City,Non-Federal Agency,Brick,NJ
+BRIDGEPORTCT.GOV,City,Non-Federal Agency,Bridgeport,CT
+BRIDGEVIEW-IL.GOV,City,Non-Federal Agency,Bridgeview,IL
+BRIMFIELDOHIO.GOV,City,Non-Federal Agency,Kent,OH
+BRISTOLCT.GOV,City,Non-Federal Agency,Bristol,CT
+BRLA.GOV,City,Non-Federal Agency,Baton Rouge,LA
+BROADVIEW-IL.GOV,City,Non-Federal Agency,Broadview,IL
+BROKENARROWOK.GOV,City,Non-Federal Agency,Broken Arrow,OK
+BROOKFIELD-WI.GOV,City,Non-Federal Agency,Brookfield,WI
+BROOKFIELDCT.GOV,City,Non-Federal Agency,Brookfield,CT
+BROOKFIELDIL.GOV,City,Non-Federal Agency,Brookfield ,IL
+BROOKHAVENGA.GOV,City,Non-Federal Agency,Dunwoody,GA
+BROOKLINEMA.GOV,City,Non-Federal Agency,Brookline,MA
+BROOKLYNOHIO.GOV,City,Non-Federal Agency,Brooklyn,OH
+BROOKLYNWI.GOV,City,Non-Federal Agency,Brooklyn,WI
+BROWNSVILLETN.GOV,City,Non-Federal Agency,Brownsville,TN
+BROWNWOODTEXAS.GOV,City,Non-Federal Agency,Brownwood,TX
+BRYCECANYONCITYUT.GOV,City,Non-Federal Agency,Bryce Canyon City,UT
+BRYSONCITYNC.GOV,City,Non-Federal Agency,Bryson City,NC
+BUCKEYEAZ.GOV,City,Non-Federal Agency,Buckeye,AZ
+BUCKSPORTMAINE.GOV,City,Non-Federal Agency,Bucksport,ME
+BUENAVISTACO.GOV,City,Non-Federal Agency,Buena Vista,CO
+BULLHEADCITYAZ.GOV,City,Non-Federal Agency,Bullhead City,AZ
+BULVERDETX.GOV,City,Non-Federal Agency,Bulverde,TX
+BUNKERHILLTX.GOV,City,Non-Federal Agency,HOUSTON,TX
+BURBANKCA.GOV,City,Non-Federal Agency,Burbank,CA
+BURBANKIL.GOV,City,Non-Federal Agency,Burbank,IL
+BURIENWA.GOV,City,Non-Federal Agency,Burien,WA
+BURKITTSVILLE-MD.GOV,City,Non-Federal Agency,Burkittsville,MD
+BURLINGTON-WI.GOV,City,Non-Federal Agency,Burlington,WI
+BURLINGTONKANSAS.GOV,City,Non-Federal Agency,Burlington,KS
+BURLINGTONNC.GOV,City,Non-Federal Agency,Burlington,NC
+BURLINGTONVT.GOV,City,Non-Federal Agency,Burlington,VT
+BURNSHARBOR-IN.GOV,City,Non-Federal Agency,Burns Harbor,IN
+BURNSVILLEMN.GOV,City,Non-Federal Agency,Burnsville,MN
+BURR-RIDGE.GOV,City,Non-Federal Agency,Burr Ridge,IL
+BURRILLVILLE-RI.GOV,City,Non-Federal Agency,Harrisville,RI
+BURTONMI.GOV,City,Non-Federal Agency,Burton,MI
+BUTLERWI.GOV,City,Non-Federal Agency,Butler,WI
+BYESVILLEOH.GOV,City,Non-Federal Agency,Byesville,OH
+CABOTAR.GOV,City,Non-Federal Agency,Cabot,AR
+CABQ.GOV,City,Non-Federal Agency,Albuquerque,NM
+CALDWELLTX.GOV,City,Non-Federal Agency,Caldwell,TX
+CALEDONIAMN.GOV,City,Non-Federal Agency,Caledonia,MN
+CALIFORNIACITY-CA.GOV,City,Non-Federal Agency,California City,CA
+CALUMETTWP-IN.GOV,City,Non-Federal Agency,Gary,IN
+CAMBRIDGEMA.GOV,City,Non-Federal Agency,Cambridge,MA
+CAMBRIDGENY.GOV,City,Non-Federal Agency,Cambridge,NY
+CAMDENMAINE.GOV,City,Non-Federal Agency,Camden,ME
+CAMDENTN.GOV,City,Non-Federal Agency,Camden,TN
+CAMPBELLOHIO.GOV,City,Non-Federal Agency,Campbell,OH
+CANALWINCHESTEROHIO.GOV,City,Non-Federal Agency,Canal Winchester,OH
+CANNONFALLSMN.GOV,City,Non-Federal Agency,Cannon Falls,MN
+CANTONOHIO.GOV,City,Non-Federal Agency,Canton,OH
+CANTONTWP-OH.GOV,City,Non-Federal Agency,Canton,OH
+CANTONTX.GOV,City,Non-Federal Agency,Canton,TX
+CAPECORALFL.GOV,City,Non-Federal Agency,Cape Coral,FL
+CARBONDALE-PA.GOV,City,Non-Federal Agency,Carbondale,PA
+CARLISLE-IA.GOV,City,Non-Federal Agency,Carlisle,IA
+CARLISLEMA.GOV,City,Non-Federal Agency,Carlisle,MA
+CARLSBADCA.GOV,City,Non-Federal Agency,Carlsbad,CA
+CARNATIONWA.GOV,City,Non-Federal Agency,Carnation,WA
+CARNEGIEOK.GOV,City,Non-Federal Agency,Carnegie,OK
+CARNEYSPOINTNJ.GOV,City,Non-Federal Agency,Carneys Point,NJ
+CARRBORONC.GOV,City,Non-Federal Agency,Carrboro,NC
+CARROLLTON-GA.GOV,City,Non-Federal Agency,Carrollton,GA
+CARTERLAKE-IA.GOV,City,Non-Federal Agency,Carter Lake,IA
+CARTERSVILLEGA.GOV,City,Non-Federal Agency,Cartersville,GA
+CARTHAGEMO.GOV,City,Non-Federal Agency,Carthage,MO
+CARVERMA.GOV,City,Non-Federal Agency,Carver,MA
+CARYNC.GOV,City,Non-Federal Agency,Cary,NC
+CASAGRANDEAZ.GOV,City,Non-Federal Agency,Casa Grande,AZ
+CASPERWY.GOV,City,Non-Federal Agency,Casper,WY
+CASTROVILLETX.GOV,City,Non-Federal Agency,Castroville,TX
+CATHEDRALCITY.GOV,City,Non-Federal Agency,Cathedral City,CA
+CAVESPRINGSAR.GOV,City,Non-Federal Agency,Cave Springs,AR
+CECILTONMD.GOV,City,Non-Federal Agency,Cecilton ,MD
+CECILTOWNSHIP-PA.GOV,City,Non-Federal Agency,Cecil,PA
+CEDARHURST.GOV,City,Non-Federal Agency,cedarhurst,NY
+CEDARPARKTEXAS.GOV,City,Non-Federal Agency,Cedar Park,TX
+CEDARRAPIDS-IA.GOV,City,Non-Federal Agency,Cedar Rapids,IA
+CEDARTOWNGEORGIA.GOV,City,Non-Federal Agency,Cedartown,GA
+CENTENNIALCO.GOV,City,Non-Federal Agency,Centennial,CO
+CENTERCO.GOV,City,Non-Federal Agency,Center,CO
+CENTERVILLEOHIO.GOV,City,Non-Federal Agency,Centerville,OH
+CENTERVILLETX.GOV,City,Non-Federal Agency,College Station,TX
+CENTRAL-LA.GOV,City,Non-Federal Agency,Central,LA
+CENTRALPOINTOREGON.GOV,City,Non-Federal Agency,Central Point,OR
+CENTREVILLE-MD.GOV,City,Non-Federal Agency,Centreville,MD
+CGAZ.GOV,City,Non-Federal Agency,Casa Grande,AZ
+CHADDSFORDPA.GOV,City,Non-Federal Agency,Chadds Ford,PA
+CHAMBERSBURGPA.GOV,City,Non-Federal Agency,Chambersburg,PA
+CHAMBLEEGA.GOV,City,Non-Federal Agency,Chamblee,GA
+CHARLESTON-SC.GOV,City,Non-Federal Agency,Charleston,SC
+CHARLESTONWV.GOV,City,Non-Federal Agency,Charleston,WV
+CHARLESTOWN-NH.GOV,City,Non-Federal Agency,Charlestown,NH
+CHARLOTTENC.GOV,City,Non-Federal Agency,Charlotte,NC
+CHARLOTTESVILLEVA.GOV,City,Non-Federal Agency,Charlottesville,VA
+CHATHAM-MA.GOV,City,Non-Federal Agency,Chatham,MA
+CHATHAM-VA.GOV,City,Non-Federal Agency,Chatham,VA
+CHATHAMTOWNSHIP-NJ.GOV,City,Non-Federal Agency,Chatham,NJ
+CHATSWORTHGA.GOV,City,Non-Federal Agency,Chatsworth,GA
+CHATTANOOGA.GOV,City,Non-Federal Agency,Chattanooga,TN
+CHELSEAMA.GOV,City,Non-Federal Agency,Chelsea,MA
+CHESAPEAKEBEACHMD.GOV,City,Non-Federal Agency,Chesapeake Beach,MD
+CHESAPEAKECITY-MD.GOV,City,Non-Federal Agency,Chesapeake City,MD
+CHESHIRE-MA.GOV,City,Non-Federal Agency,Cheshire,MA
+CHESTER-NY.GOV,City,Non-Federal Agency,Chester,NY
+CHESTNUTHILLTWP-PA.GOV,City,Non-Federal Agency,Brodheadsville,PA
+CHEVERLY-MD.GOV,City,Non-Federal Agency,Cheverly,MD
+CHEVYCHASEVILLAGEMD.GOV,City,Non-Federal Agency,Chevy Chase,MD
+CHICAGO-IL.GOV,City,Non-Federal Agency,Chicago,IL
+CHICOCA.GOV,City,Non-Federal Agency,Chico,CA
+CHICOPEEMA.GOV,City,Non-Federal Agency,Chicopee,MA
+CHILMARKMA.GOV,City,Non-Federal Agency,Chilmark,MA
+CHINAGROVENC.GOV,City,Non-Federal Agency,China Grove,NC
+CHINCOTEAGUE-VA.GOV,City,Non-Federal Agency,Chincoteague,VA
+CHIPPEWAFALLS-WI.GOV,City,Non-Federal Agency,Chippewa Falls,WI
+CHOWANCOUNTY-NC.GOV,City,Non-Federal Agency,Edenton,NC
+CHURCHHILLTN.GOV,City,Non-Federal Agency,Church Hill,TN
+CIBOLOTX.GOV,City,Non-Federal Agency,Cibolo,TX
+CINCINNATI-OH.GOV,City,Non-Federal Agency,Cincinnati,OH
+CINCINNATIOHIO.GOV,City,Non-Federal Agency,Cincinnati,OH
+CITYKANKAKEE-IL.GOV,City,Non-Federal Agency,KANKAKEE,IL
+CITYOFADAMS-WI.GOV,City,Non-Federal Agency,Adams,WI
+CITYOFAIKENSC.GOV,City,Non-Federal Agency,Aiken,SC
+CITYOFALAMEDACA.GOV,City,Non-Federal Agency,Alameda,CA
+CITYOFALBIONMI.GOV,City,Non-Federal Agency,albion,MI
+CITYOFALCOA-TN.GOV,City,Non-Federal Agency,Alcoa,TN
+CITYOFALGOODTN.GOV,City,Non-Federal Agency,Algood,TN
+CITYOFALMAGA.GOV,City,Non-Federal Agency,Alma,GA
+CITYOFBAKERLA.GOV,City,Non-Federal Agency,Baker ,LA
+CITYOFBELOITWI.GOV,City,Non-Federal Agency,Beloit,WI
+CITYOFBENTONHARBORMI.GOV,City,Non-Federal Agency,Benton Harbor,MI
+CITYOFBLUERIDGEGA.GOV,City,Non-Federal Agency,Blue Ridge,GA
+CITYOFBOWIEMD.GOV,City,Non-Federal Agency,Bowie,MD
+CITYOFBOWMANGA.GOV,City,Non-Federal Agency,Bowman,GA
+CITYOFBRUNSWICK-GA.GOV,City,Non-Federal Agency,Brunswick,GA
+CITYOFCANALFULTON-OH.GOV,City,Non-Federal Agency,Canal Fulton,OH
+CITYOFCAYCE-SC.GOV,City,Non-Federal Agency,Cayce,SC
+CITYOFCHETEK-WI.GOV,City,Non-Federal Agency,Chetek,WI
+CITYOFCHOTEAU-MT.GOV,City,Non-Federal Agency,Choteau,MT
+CITYOFCONWAY-AR.GOV,City,Non-Federal Agency,Conway,AR
+CITYOFCOWETA-OK.GOV,City,Non-Federal Agency,Coweta,OK
+CITYOFCRISFIELD-MD.GOV,City,Non-Federal Agency,Crisfield,MD
+CITYOFCUDAHYCA.GOV,City,Non-Federal Agency,Cudahy,CA
+CITYOFDALTON-GA.GOV,City,Non-Federal Agency,Dalton,GA
+CITYOFDOUGLASGA.GOV,City,Non-Federal Agency,Douglas,GA
+CITYOFDOVERIDAHO.GOV,City,Non-Federal Agency,Dover,ID
+CITYOFDUNBARWV.GOV,City,Non-Federal Agency,Dunbar,WV
+CITYOFDUPONTWA.GOV,City,Non-Federal Agency,DuPont,WA
+CITYOFENGLEWOOD-NJ.GOV,City,Non-Federal Agency,Englewood,NJ
+CITYOFEUDORAKS.GOV,City,Non-Federal Agency,Eudora,KS
+CITYOFFAIRFAX-MN.GOV,City,Non-Federal Agency,Fairfax,MN
+CITYOFFARMERSVILLE-CA.GOV,City,Non-Federal Agency,Farmersville,CA
+CITYOFFARMINGTON-AR.GOV,City,Non-Federal Agency,Farmington,AR
+CITYOFFOLKSTON-GA.GOV,City,Non-Federal Agency,Folkston,GA
+CITYOFFORTOGLETHORPEGA.GOV,City,Non-Federal Agency,FORT OGLETHORPE,GA
+CITYOFGAFFNEY-SC.GOV,City,Non-Federal Agency,Gaffney,SC
+CITYOFGALENAPARK-TX.GOV,City,Non-Federal Agency,Galena Park,TX
+CITYOFGRAVETTE-AR.GOV,City,Non-Federal Agency,Gravette,AR
+CITYOFGROVEOK.GOV,City,Non-Federal Agency,Grove,OK
+CITYOFGUNNISON-CO.GOV,City,Non-Federal Agency,Gunnison,CO
+CITYOFHAMPTON-GA.GOV,City,Non-Federal Agency,Hampton,GA
+CITYOFHARRISON-MI.GOV,City,Non-Federal Agency,Harrison,MI
+CITYOFHAYWARDWI.GOV,City,Non-Federal Agency,Hayward,WI
+CITYOFHIRAMGA.GOV,City,Non-Federal Agency,HIRAM,GA
+CITYOFHOKAH-MN.GOV,City,Non-Federal Agency,Hokah,MN
+CITYOFHOMER-AK.GOV,City,Non-Federal Agency,Homer,AK
+CITYOFHUMBLE-TX.GOV,City,Non-Federal Agency,Humble,TX
+CITYOFHUMBLETX.GOV,City,Non-Federal Agency,Humble,TX
+CITYOFKEYWEST-FL.GOV,City,Non-Federal Agency,Key West,FL
+CITYOFKINGMAN.GOV,City,Non-Federal Agency,Kingman,AZ
+CITYOFKINGSBURG-CA.GOV,City,Non-Federal Agency,Kingsburg,CA
+CITYOFLACRESCENT-MN.GOV,City,Non-Federal Agency,La Crescent,MN
+CITYOFLAGRANGEMO.GOV,City,Non-Federal Agency,LaGrange,MO
+CITYOFLAHABRA-CA.GOV,City,Non-Federal Agency,LA HABRA,CA
+CITYOFLENEXA-KS.GOV,City,Non-Federal Agency,Lenexa,KS
+CITYOFLENEXAKS.GOV,City,Non-Federal Agency,Lenexa,KS
+CITYOFLINDALETX.GOV,City,Non-Federal Agency,LINDALE,TX
+CITYOFLISBON-IA.GOV,City,Non-Federal Agency,Lisbon,IA
+CITYOFLUBBOCKTX.GOV,City,Non-Federal Agency,Lubbock,TX
+CITYOFMACON-MO.GOV,City,Non-Federal Agency,Macon,MO
+CITYOFMARIONIL.GOV,City,Non-Federal Agency,Marion,IL
+CITYOFMARIONWI.GOV,City,Non-Federal Agency,MARION,WI
+CITYOFMCCAYSVILLEGA.GOV,City,Non-Federal Agency,McCaysville,GA
+CITYOFMIDLANDMI.GOV,City,Non-Federal Agency,Midland,MI
+CITYOFMILLBROOK-AL.GOV,City,Non-Federal Agency,Millbrook,AL
+CITYOFMILLENGA.GOV,City,Non-Federal Agency,Millen,GA
+CITYOFMONONGAHELA-PA.GOV,City,Non-Federal Agency,Monongahela,PA
+CITYOFMORROWGA.GOV,City,Non-Federal Agency,Morrow,GA
+CITYOFMTVERNON-IA.GOV,City,Non-Federal Agency,Mount Vernon,IA
+CITYOFNANTICOKE-PA.GOV,City,Non-Federal Agency,Nanticoke,PA
+CITYOFNEWBURGH-NY.GOV,City,Non-Federal Agency,Newburgh,NY
+CITYOFNEWULM-MN.GOV,City,Non-Federal Agency,New Ulm,MN
+CITYOFNORMANDY.GOV,City,Non-Federal Agency,St. Louis,MO
+CITYOFOMAHA-NE.GOV,City,Non-Federal Agency,Omaha,NE
+CITYOFPACIFICWA.GOV,City,Non-Federal Agency,Pacific,WA
+CITYOFPALMVALLEY-TX.GOV,City,Non-Federal Agency,Harlingen,TX
+CITYOFPARISTN.GOV,City,Non-Federal Agency,Paris,TN
+CITYOFPARMA-OH.GOV,City,Non-Federal Agency,Parma,OH
+CITYOFPATTERSONLA.GOV,City,Non-Federal Agency,Patterson,LA
+CITYOFPEARLANDTX.GOV,City,Non-Federal Agency,Pearland,TX
+CITYOFPHOENIX.GOV,City,Non-Federal Agency,Phoenix,AZ
+CITYOFPIGEONFORGETN.GOV,City,Non-Federal Agency,Pigeon Forge,TN
+CITYOFPLAINVILLE-KS.GOV,City,Non-Federal Agency,Plainville,KS
+CITYOFPLATTSBURGH-NY.GOV,City,Non-Federal Agency,Plattsburgh,NY
+CITYOFPLEASANTONCA.GOV,City,Non-Federal Agency,Pleasanton,CA
+CITYOFPOCOMOKEMD.GOV,City,Non-Federal Agency,Pocomoke City,MD
+CITYOFPORTLANDTN.GOV,City,Non-Federal Agency,Portland,TN
+CITYOFREDMOND.GOV,City,Non-Federal Agency,Redmond,WA
+CITYOFROCKHILLSC.GOV,City,Non-Federal Agency,Rock Hill,SC
+CITYOFROCKPORT-IN.GOV,City,Non-Federal Agency,Rockport,IN
+CITYOFSAFFORDAZ.GOV,City,Non-Federal Agency,Safford,AZ
+CITYOFSALEMNJ.GOV,City,Non-Federal Agency,Salem,NJ
+CITYOFSANTEECA.GOV,City,Non-Federal Agency,Santee,CA
+CITYOFSPARTANBURG-SC.GOV,City,Non-Federal Agency,Spartanburg,SC
+CITYOFSTOCKBRIDGE-GA.GOV,City,Non-Federal Agency,Stockbridge,GA
+CITYOFSUGAR-LANDTX.GOV,City,Non-Federal Agency,Sugar Land,TX
+CITYOFSUGARLAND-TX.GOV,City,Non-Federal Agency,Sugar Land,TX
+CITYOFSUGARLANDTX.GOV,City,Non-Federal Agency,Sugar Land,TX
+CITYOFTITUSVILLEPA.GOV,City,Non-Federal Agency,Titusville,PA
+CITYOFTORRANCECA.GOV,City,Non-Federal Agency,Torrance,CA
+CITYOFTUKWILA-WA.GOV,City,Non-Federal Agency,Tukwila,WA
+CITYOFTYLER-TX.GOV,City,Non-Federal Agency,Tyler,TX
+CITYOFTYLERTX.GOV,City,Non-Federal Agency,Tyler,TX
+CITYOFWASHINGTONGA.GOV,City,Non-Federal Agency,Washington,GA
+CITYOFWEATHERBYLAKE-MO.GOV,City,Non-Federal Agency,Weatherby Lake,MO
+CITYOFWESTONLAKES-TX.GOV,City,Non-Federal Agency,Fulshear,TX
+CITYOFWEYAUWEGA-WI.GOV,City,Non-Federal Agency,Weyauwega,WI
+CITYOFWHEATON-IL.GOV,City,Non-Federal Agency,Wheaton,IL
+CITYOFWOODBURYGA.GOV,City,Non-Federal Agency,Woodbury,GA
+CITYOFWORLANDWY.GOV,City,Non-Federal Agency,Worland,WY
+CITYOFYUKONOK.GOV,City,Non-Federal Agency,Yukon,OK
+CLAIRTON-PA.GOV,City,Non-Federal Agency,Clairton,PA
+CLARKSTONGA.GOV,City,Non-Federal Agency,Clarkston,GA
+CLARKSVILLEAR.GOV,City,Non-Federal Agency,Clarksville,AR
+CLAYTONMO.GOV,City,Non-Federal Agency,Clayton,MO
+CLEARLAKE-WI.GOV,City,Non-Federal Agency,Clear Lake,WI
+CLEARLAKESHORES-TX.GOV,City,Non-Federal Agency,Clear Lake Shores,TX
+CLERMONTFL.GOV,City,Non-Federal Agency,Clermont,FM
+CLEVELAND-OH.GOV,City,Non-Federal Agency,Cleveland,OH
+CLEVELANDOHIO.GOV,City,Non-Federal Agency,Cleveland,OH
+CLEVELANDTN.GOV,City,Non-Federal Agency,Cleveland,TN
+CLEWISTON-FL.GOV,City,Non-Federal Agency,Clewiston,FL
+CLIFFSIDEPARKNJ.GOV,City,Non-Federal Agency,Cliffside Park,NJ
+CLIFTONAZ.GOV,City,Non-Federal Agency,Clifton,AZ
+CLIFTONFORGEVA.GOV,City,Non-Federal Agency,Clifton Forge,VA
+CLINTONMA.GOV,City,Non-Federal Agency,Clinton,MA
+CLINTONNJ.GOV,City,Non-Federal Agency,New Jersey,NJ
+CLINTONOK.GOV,City,Non-Federal Agency,Clinton,OK
+CMSDCA.GOV,City,Non-Federal Agency,Costa Mesa,CA
+COALRUNKY.GOV,City,Non-Federal Agency,Pikeville,KY
+COLCHESTERCT.GOV,City,Non-Federal Agency,Colchester,CT
+COLCHESTERVT.GOV,City,Non-Federal Agency,Colchester,VT
+COLDSPRINGKY.GOV,City,Non-Federal Agency,COLD SPRING,KY
+COLDSPRINGNY.GOV,City,Non-Federal Agency,Cold Spring ,NY
+COLFAX-CA.GOV,City,Non-Federal Agency,Colfax,CA
+COLLEGEPARKMD.GOV,City,Non-Federal Agency,College Park,MD
+COLLEGEVILLE-PA.GOV,City,Non-Federal Agency,Collegeville,PA
+COLLIERVILLETN.GOV,City,Non-Federal Agency,Collierville,TN
+COLLINCOUNTYTEXAS.GOV,City,Non-Federal Agency,Mckinney,TX
+COLLINCOUNTYTX.GOV,City,Non-Federal Agency,McKinney,TX
+COLONIALHEIGHTSVA.GOV,City,Non-Federal Agency,Colonial Heights,VA
+COLONIE-NY.GOV,City,Non-Federal Agency,Newtonville,NY
+COLORADOSPRINGS.GOV,City,Non-Federal Agency,Colorado Springs,CO
+COLRAIN-MA.GOV,City,Non-Federal Agency,Colrain,MA
+COLUMBIAHEIGHTSMN.GOV,City,Non-Federal Agency,Columbia Heights,MN
+COLUMBIANAOHIO.GOV,City,Non-Federal Agency,Columbiana,OH
+COLUMBIATN.GOV,City,Non-Federal Agency,Columbia,TN
+COLUMBIATWP-OH.GOV,City,Non-Federal Agency,Columbia Station,OH
+COLUMBUS.GOV,City,Non-Federal Agency,Columbus,OH
+COLUMBUSOH.GOV,City,Non-Federal Agency,Columbus,OH
+COLUMBUSOHIO.GOV,City,Non-Federal Agency,Columbus,OH
+COMMERCIALPOINTOHIO.GOV,City,Non-Federal Agency,Commercial Point,OH
+COMO.GOV,City,Non-Federal Agency,Columbia,MO
+COMSTOCKMI.GOV,City,Non-Federal Agency,Kalamazoo,MI
+CONCORDMA.GOV,City,Non-Federal Agency,Concord,MA
+CONCORDNC.GOV,City,Non-Federal Agency,Concord,NC
+CONCORDNH.GOV,City,Non-Federal Agency,Concord,NH
+CONCRETEWA.GOV,City,Non-Federal Agency,Concrete,WA
+CONNEAUTOHIO.GOV,City,Non-Federal Agency,Conneaut,OH
+CONNERSVILLEIN.GOV,City,Non-Federal Agency,Connersville,IN
+CONOVERNC.GOV,City,Non-Federal Agency,Conover,NC
+CONYERSGA.GOV,City,Non-Federal Agency,Conyers,GA
+COOKEVILLE-TN.GOV,City,Non-Federal Agency,Cookeville,TN
+COONRAPIDSMN.GOV,City,Non-Federal Agency,Coon Rapids,MN
+COPPELLTX.GOV,City,Non-Federal Agency,Coppell,TX
+COPPERASCOVETX.GOV,City,Non-Federal Agency,Copperas Cove,TX
+COR.GOV,City,Non-Federal Agency,Richardson,TX
+CORALGABLES-FL.GOV,City,Non-Federal Agency,Coral Gables,FL
+CORALGABLESFL.GOV,City,Non-Federal Agency,Coral Gables,FL
+CORBIN-KY.GOV,City,Non-Federal Agency,Corbin,KY
+CORNINGAR.GOV,City,Non-Federal Agency,Corning,AR
+CORNWALLNY.GOV,City,Non-Federal Agency,Cornwall,NY
+CORPUSCHRISTI-TX.GOV,City,Non-Federal Agency,Corpus Christi,TX
+CORRALESNM.GOV,City,Non-Federal Agency,Corales,NM
+CORRYPA.GOV,City,Non-Federal Agency,Corry,PA
+CORVALLISOREGON.GOV,City,Non-Federal Agency,Corvallis,OR
+CORYDON-IN.GOV,City,Non-Federal Agency,Corydon,IN
+COSMOPOLISWA.GOV,City,Non-Federal Agency,Cosmopolis,WA
+COSPRINGS.GOV,City,Non-Federal Agency,Colorado Springs,CO
+COSTAMESACA.GOV,City,Non-Federal Agency,Costa Mesa,CA
+COTTAGECITYMD.GOV,City,Non-Federal Agency,Cottage City,MD
+COTTONWOODAZ.GOV,City,Non-Federal Agency,Cottonwood,AZ
+COUNTRYSIDE-IL.GOV,City,Non-Federal Agency,Countryside,IL
+COVINACA.GOV,City,Non-Federal Agency,Covina,CA
+COVINGTON-OH.GOV,City,Non-Federal Agency,COVINGTON ,OH
+COVINGTONKY.GOV,City,Non-Federal Agency,Covington,KY
+COVINGTONWA.GOV,City,Non-Federal Agency,Covington,WA
+CRANBERRYISLES-ME.GOV,City,Non-Federal Agency,Islesford,ME
+CRAWFORDSVILLE-IN.GOV,City,Non-Federal Agency,Crawfordsville,IN
+CREDITRIVER-MN.GOV,City,Non-Federal Agency,Prior Lake,MN
+CRESTONIOWA.GOV,City,Non-Federal Agency,Creston,IA
+CRETE-NE.GOV,City,Non-Federal Agency,Crete,NE
+CREVECOEURMO.GOV,City,Non-Federal Agency,Creve Coeur,MO
+CROSSROADSTX.GOV,City,Non-Federal Agency,Crossroads,TX
+CROSSVILLETN.GOV,City,Non-Federal Agency,Crossville,TN
+CROTONONHUDSON-NY.GOV,City,Non-Federal Agency,Croton-On-Hudson,NY
+CUBAASSESSORIL.GOV,City,Non-Federal Agency,Barrington,IL
+CUBATWPIL.GOV,City,Non-Federal Agency,Barrington,IL
+CUDAHY-WI.GOV,City,Non-Federal Agency,Cudahy,WI
+CULPEPERVA.GOV,City,Non-Federal Agency,Culpeper,VA
+CUMBERLANDMD.GOV,City,Non-Federal Agency,Cumberland,MD
+CUMMINGTON-MA.GOV,City,Non-Federal Agency,Cummington,MA
+CUTLERBAY-FL.GOV,City,Non-Federal Agency,Cutler Bay,FL
+DACULAGA.GOV,City,Non-Federal Agency,Dacula,GA
+DAHLONEGA-GA.GOV,City,Non-Federal Agency,Dahlonega,GA
+DALHARTTX.GOV,City,Non-Federal Agency,Dalhart,TX
+DALLAS-GA.GOV,City,Non-Federal Agency,Dallas,GA
+DALLASOR.GOV,City,Non-Federal Agency,Dallas,OR
+DALLASOREGON.GOV,City,Non-Federal Agency,Dallas,OR
+DALTON-MA.GOV,City,Non-Federal Agency,Dalton,MA
+DAMASCUSOREGON.GOV,City,Non-Federal Agency,Damascus,OR
+DANBURY-CT.GOV,City,Non-Federal Agency,Danbury,CT
+DANDRIDGETN.GOV,City,Non-Federal Agency,Dandridge,TN
+DANIABEACHFL.GOV,City,Non-Federal Agency,DANIA BEACH,FL
+DANVERSMA.GOV,City,Non-Federal Agency,Danvers,MA
+DANVILLEVA.GOV,City,Non-Federal Agency,Danville,VA
+DARIENIL.GOV,City,Non-Federal Agency,Darien,IL
+DAUGHERTYTOWNSHIP-PA.GOV,City,Non-Federal Agency,New Brighton,PA
+DAVIE-FL.GOV,City,Non-Federal Agency,Davie,FL
+DAWSONVILLE-GA.GOV,City,Non-Federal Agency,Dawsonville,GA
+DAYTON-ME.GOV,City,Non-Federal Agency,Dayton,ME
+DAYTONOHIO.GOV,City,Non-Federal Agency,Dayton,OH
+DECATURIL.GOV,City,Non-Federal Agency,Decatur,IL
+DECATURILLINOIS.GOV,City,Non-Federal Agency,Decatur,IL
+DECATURTX.GOV,City,Non-Federal Agency,Decatur,TX
+DEDHAM-MA.GOV,City,Non-Federal Agency,Dedham,MA
+DEERFIELDMICHIGAN.GOV,City,Non-Federal Agency,Deerfield,MI
+DEERPARK-OH.GOV,City,Non-Federal Agency,Deer Park,OH
+DEERPARKTX.GOV,City,Non-Federal Agency,Deer Park,TX
+DEKORRA-WI.GOV,City,Non-Federal Agency,Poynette,WI
+DELAWARETOWNSHIPPA.GOV,City,Non-Federal Agency,Dingmans Ferry,PA
+DELRAYBEACHFL.GOV,City,Non-Federal Agency,Delray Beach,FL
+DELTA-CO.GOV,City,Non-Federal Agency,Delta,CO
+DELTAMI.GOV,City,Non-Federal Agency,Lansing,MI
+DELTONAFL.GOV,City,Non-Federal Agency,Deltona,FL
+DEMOPOLISAL.GOV,City,Non-Federal Agency,Demopolis,AL
+DENVERCO.GOV,City,Non-Federal Agency,Denver,CO
+DERBYCT.GOV,City,Non-Federal Agency,Derby,CT
+DHAZ.GOV,City,Non-Federal Agency,Humboldt,AZ
+DIAMONDBARCA.GOV,City,Non-Federal Agency,Diamond Bar,CA
+DICKINSONTEXAS.GOV,City,Non-Federal Agency,Dickinson,TX
+DICKSONCITY-PA.GOV,City,Non-Federal Agency,Dickson City,PA
+DIGHTON-MA.GOV,City,Non-Federal Agency,Dighton,MA
+DISCOVERWAUKESHA-WI.GOV,City,Non-Federal Agency,Waukesha,WI
+DONALDOREGON.GOV,City,Non-Federal Agency,Donald,OR
+DONALDSONVILLE-LA.GOV,City,Non-Federal Agency,Donaldsonville,LA
+DORALPD-FL.GOV,City,Non-Federal Agency,Doral,FL
+DOUGLASAZ.GOV,City,Non-Federal Agency,Douglas,AZ
+DOUGLASVILLEGA.GOV,City,Non-Federal Agency,Douglasville,GA
+DREW-MS.GOV,City,Non-Federal Agency,Drew,MS
+DRUIDHILLSKY.GOV,City,Non-Federal Agency,Louisville,KY
+DUBLIN-CA.GOV,City,Non-Federal Agency,Dublin,CA
+DUBLINCA.GOV,City,Non-Federal Agency,Dublin,CA
+DUBLINOHIOUSA.GOV,City,Non-Federal Agency,Dublin,OH
+DUBOISPA.GOV,City,Non-Federal Agency,DuBois,PA
+DULUTHMN.GOV,City,Non-Federal Agency,Duluth,MN
+DUMFRIESVA.GOV,City,Non-Federal Agency,Dumfries,VA
+DUMONTNJ.GOV,City,Non-Federal Agency,Dumont,NJ
+DUNCANOK.GOV,City,Non-Federal Agency,Duncan,OK
+DUNCANVILLETX.GOV,City,Non-Federal Agency,Duncanville,TX
+DUNDEEVILLAGEMI.GOV,City,Non-Federal Agency,Dundee,MI
+DUNMOREPA.GOV,City,Non-Federal Agency,Dunmore,PA
+DUNSTABLE-MA.GOV,City,Non-Federal Agency,Dunstable,MA
+DUNWOODYGA.GOV,City,Non-Federal Agency,Dunwoody,GA
+DUNWOODYGEORGIA.GOV,City,Non-Federal Agency,Dunwoody,GA
+DUPONTWA.GOV,City,Non-Federal Agency,DuPont,WA
+DUSHOREPA.GOV,City,Non-Federal Agency,Dushore,PA
+DUVALLWA.GOV,City,Non-Federal Agency,Duvall,WA
+DYERSBURGTN.GOV,City,Non-Federal Agency,Dyersburg,TN
+EAGARAZ.GOV,City,Non-Federal Agency,Eagar,AZ
+EAGLE-WI.GOV,City,Non-Federal Agency,Eagle,WI
+EAGLELAKE-TX.GOV,City,Non-Federal Agency,Eagle Lake,TX
+EASTBOROUGH-KS.GOV,City,Non-Federal Agency,Eastborough,KS
+EASTCOVENTRY-PA.GOV,City,Non-Federal Agency,Pottstown,PA
+EASTHAMPTONCT.GOV,City,Non-Federal Agency,East Hampton,CT
+EASTHAMPTONNY.GOV,City,Non-Federal Agency,Amagansett,NY
+EASTHAMPTONVILLAGENY.GOV,City,Non-Federal Agency,East Hampton,NY
+EASTHARTFORDCT.GOV,City,Non-Federal Agency,East Hartford,CT
+EASTKINGSTONNH.GOV,City,Non-Federal Agency,East Kingston,NH
+EASTLONGMEADOWMA.GOV,City,Non-Federal Agency,East Longmeadow,MA
+EASTMOUNTAINTX.GOV,City,Non-Federal Agency,East Mountain,TX
+EASTONCT.GOV,City,Non-Federal Agency,Easton,CT
+EASTONMD.GOV,City,Non-Federal Agency,Easton,MD
+EASTORANGE-NJ.GOV,City,Non-Federal Agency,East ORange,NJ
+EASTPALESTINE-OH.GOV,City,Non-Federal Agency,East Palestine,OH
+EASTPORT-ME.GOV,City,Non-Federal Agency,Eastport,ME
+EASTRIDGETN.GOV,City,Non-Federal Agency,East Ridge,TN
+EASTTROYWI.GOV,City,Non-Federal Agency,East Troy,WI
+EASTVALECA.GOV,City,Non-Federal Agency,Eastvale,CA
+EATONVILLE-WA.GOV,City,Non-Federal Agency,Eatonville,WA
+ECORSEMI.GOV,City,Non-Federal Agency,ECORSE,MI
+EDDINGTONMAINE.GOV,City,Non-Federal Agency,Eddington,ME
+EDENNY.GOV,City,Non-Federal Agency,Eden,NY
+EDGARCOUNTY-IL.GOV,City,Non-Federal Agency,Paris,IL
+EDGEWATERFL.GOV,City,Non-Federal Agency,Edgewater,FL
+EDGEWOOD-FL.GOV,City,Non-Federal Agency,Edgewood,FL
+EDGEWOOD-NM.GOV,City,Non-Federal Agency,Edgewood,NM
+EDINAMN.GOV,City,Non-Federal Agency,Edina,MN
+EDMONDS-WA.GOV,City,Non-Federal Agency,Edmonds,WA
+EDMONDSWA.GOV,City,Non-Federal Agency,Edmonds,WA
+EDMONSTONMD.GOV,City,Non-Federal Agency,Edmonston,MD
+EHALERTCT.GOV,City,Non-Federal Agency,East Hartford,CT
+EHAMPTONNY.GOV,City,Non-Federal Agency,East Hampton,NY
+ELKHARTLAKEWI.GOV,City,Non-Federal Agency,Elkhart Lake,WI
+ELKOCITYNV.GOV,City,Non-Federal Agency,Elko,NV
+ELKRIVERMN.GOV,City,Non-Federal Agency,Elk River,MN
+ELKTONVA.GOV,City,Non-Federal Agency,Elkton,VA
+ELKTOWNSHIPNJ.GOV,City,Non-Federal Agency,Monroeville,NJ
+ELLAGO-TX.GOV,City,Non-Federal Agency,El Lago,TX
+ELLIJAY-GA.GOV,City,Non-Federal Agency,Ellijay,GA
+ELLINGTON-CT.GOV,City,Non-Federal Agency,Ellington,CT
+ELLSWORTHMAINE.GOV,City,Non-Federal Agency,Ellsworth,ME
+ELMIRAGE-AZ.GOV,City,Non-Federal Agency,El Mirage,AZ
+ELOYAZ.GOV,City,Non-Federal Agency,Eloy,AZ
+ELPASOTEXAS.GOV,City,Non-Federal Agency,El Paso,TX
+EMERALDBAY-TX.GOV,City,Non-Federal Agency,Bullard,TX
+EMMITSBURGMD.GOV,City,Non-Federal Agency,Emmitsburg,MD
+EMPORIA-KANSAS.GOV,City,Non-Federal Agency,Emporia,KS
+ENCINITASCA.GOV,City,Non-Federal Agency,Encinitas,CA
+ENCINITASCALIFORNIA.GOV,City,Non-Federal Agency,Encinitas,CA
+ENNISTX.GOV,City,Non-Federal Agency,Ennis,TX
+ENON-OH.GOV,City,Non-Federal Agency,Enon,OH
+ENTERPRISEAL.GOV,City,Non-Federal Agency,Enterprise,AL
+ERIECO.GOV,City,Non-Federal Agency,Erie,CO
+ESPANOLANM.GOV,City,Non-Federal Agency,Espanola,NM
+ESSEXCT.GOV,City,Non-Federal Agency,Essex,CT
+ESTERO-FL.GOV,City,Non-Federal Agency,Estero,FL
+ETON-GA.GOV,City,Non-Federal Agency,Eton,GA
+EULESSTX.GOV,City,Non-Federal Agency,Euless,TX
+EUREKA-MT.GOV,City,Non-Federal Agency,Eureka,MT
+EUREKASPRINGSAR.GOV,City,Non-Federal Agency,Eureka Springs,AR
+EVANSCOLORADO.GOV,City,Non-Federal Agency,Evans,CO
+EVERETTWA.GOV,City,Non-Federal Agency,Everett,WA
+EVESHAM-NJ.GOV,City,Non-Federal Agency,Marlton,NJ
+EXETERNH.GOV,City,Non-Federal Agency,Exeter,NH
+FABIUS-NY.GOV,City,Non-Federal Agency,Fabius,NY
+FAIRFAX-VT.GOV,City,Non-Federal Agency,Fairfax,VT
+FAIRFAXVA.GOV,City,Non-Federal Agency,Fairfax,VA
+FAIRFIELDOH.GOV,City,Non-Federal Agency,Fairfield,OH
+FAIRHOPE-AL.GOV,City,Non-Federal Agency,Fairhope,AL
+FAIRMONTWV.GOV,City,Non-Federal Agency,Fairmont,WV
+FAIRVIEWNC.GOV,City,Non-Federal Agency,Monroe,NC
+FAIRVIEWOREGON.GOV,City,Non-Federal Agency,Fairview,OR
+FALLCREEKWI.GOV,City,Non-Federal Agency,Fall Creek,WI
+FALLONNEVADA.GOV,City,Non-Federal Agency,Fallon,NV
+FALLSCHURCHCITYVA.GOV,City,Non-Federal Agency,Falls Church,VA
+FALLSCHURCHVA.GOV,City,Non-Federal Agency,Falls Church,VA
+FALLSCITYOREGON.GOV,City,Non-Federal Agency,Falls City,OR
+FARGOND.GOV,City,Non-Federal Agency,Fargo,ND
+FARMERSBRANCHTX.GOV,City,Non-Federal Agency,Farmers Branch,TX
+FARMINGTON-MO.GOV,City,Non-Federal Agency,Farmington,MO
+FARMINGTONHILLSMI.GOV,City,Non-Federal Agency,Farmington Hills,MI
+FARRAGUT-TN.GOV,City,Non-Federal Agency,Farragut,TN
+FAYETTEVILLE-AR.GOV,City,Non-Federal Agency,Fayetteville,AR
+FAYETTEVILLENC.GOV,City,Non-Federal Agency,Fayetteville,NC
+FAYETTEVILLENY.GOV,City,Non-Federal Agency,Fayetteville,NY
+FEDERALWAYWA.GOV,City,Non-Federal Agency,Federal Way ,WA
+FERNDALEMI.GOV,City,Non-Federal Agency,Ferndale,MI
+FITCHBURGMA.GOV,City,Non-Federal Agency,Fitchburg,MA
+FITCHBURGWI.GOV,City,Non-Federal Agency,Fitchburg,WI
+FITZWILLIAM-NH.GOV,City,Non-Federal Agency,Fitzwilliam,NH
+FLAGSTAFFAZ.GOV,City,Non-Federal Agency,Flagstaff,AZ
+FLATONIATX.GOV,City,Non-Federal Agency,Flatonia,TX
+FLORENCE-KY.GOV,City,Non-Federal Agency,Florence,KY
+FLORENCE-NJ.GOV,City,Non-Federal Agency,Florence,NJ
+FLORENCEAZ.GOV,City,Non-Federal Agency,Florence,AZ
+FLORIDACITYFL.GOV,City,Non-Federal Agency,Florida City,FL
+FORESTGROVE-OR.GOV,City,Non-Federal Agency,FOREST GROVE,OR
+FORESTHEIGHTSMD.GOV,City,Non-Federal Agency,Forest Heights,MD
+FORESTPARKOH.GOV,City,Non-Federal Agency,Forest Park,OH
+FORESTPARKOHIO.GOV,City,Non-Federal Agency,Forest Park,OH
+FORESTPARKOK.GOV,City,Non-Federal Agency,Forest Park,OK
+FORSYTH-IL.GOV,City,Non-Federal Agency,Forsyth,IL
+FORTCOLLINS-CO.GOV,City,Non-Federal Agency,Fort Collins,CO
+FORTLUPTON-CO.GOV,City,Non-Federal Agency,Fort Lupton,CO
+FORTLUPTONCO.GOV,City,Non-Federal Agency,Fort Lupton,CO
+FORTMADISON-IA.GOV,City,Non-Federal Agency,Fort Madison,IA
+FORTMILLSC.GOV,City,Non-Federal Agency,Fort Mill,SC
+FORTMYERSBEACHFL.GOV,City,Non-Federal Agency,Fort Myers Beach,FL
+FORTSMITHAR.GOV,City,Non-Federal Agency,Fort Smith,AR
+FORTWORTH-TEXAS.GOV,City,Non-Federal Agency,Fort Worth,TX
+FORTWORTH-TX.GOV,City,Non-Federal Agency,Fort Worth,TX
+FORTWORTHTEXAS.GOV,City,Non-Federal Agency,Fort Worth,TX
+FOSTORIAOHIO.GOV,City,Non-Federal Agency,Fostoria,OH
+FOXBOROUGHMA.GOV,City,Non-Federal Agency,Foxborough,MA
+FRAMINGHAMMA.GOV,City,Non-Federal Agency,Framingham,MA
+FRANCESTOWN-NH.GOV,City,Non-Federal Agency,Francestown,NH
+FRANKFORT-IN.GOV,City,Non-Federal Agency,Frankfort,IN
+FRANKFORT-KY.GOV,City,Non-Federal Agency,Frankfort,KY
+FRANKLIN-IN.GOV,City,Non-Federal Agency,FRANKLIN,IN
+FRANKLIN-TN.GOV,City,Non-Federal Agency,Franklin,TN
+FRANKLINPA.GOV,City,Non-Federal Agency,Franklin,PA
+FRANKLINTN.GOV,City,Non-Federal Agency,Franklin,TN
+FREDENBERGTWP-MN.GOV,City,Non-Federal Agency,Duluth,MN
+FREDERICKCO.GOV,City,Non-Federal Agency,Frederick,CO
+FREDERICKSBURGVA.GOV,City,Non-Federal Agency,Fredericksburg,VA
+FREEHOLDBOROUGHNJ.GOV,City,Non-Federal Agency,Freehold,NJ
+FREEPORTNY.GOV,City,Non-Federal Agency,Freeport,NY
+FREETOWNMA.GOV,City,Non-Federal Agency,Assonet,MA
+FREMONTNC.GOV,City,Non-Federal Agency,Fremont,NC
+FREMONTNE.GOV,City,Non-Federal Agency,Fremont,NE
+FRENCHSETTLEMENT-LA.GOV,City,Non-Federal Agency,French Settlement,LA
+FRIDLEYMN.GOV,City,Non-Federal Agency,Fridley,MN
+FRIENDSHIPHEIGHTSMD.GOV,City,Non-Federal Agency,Chevy Chase,MD
+FROMBERG-MT.GOV,City,Non-Federal Agency,Fromberg,MT
+FRONTROYAL-VA.GOV,City,Non-Federal Agency,Front Royal,VA
+FRONTROYALVA.GOV,City,Non-Federal Agency,Front Royal,VA
+FRUITPORTTOWNSHIP-MI.GOV,City,Non-Federal Agency,Fruitport,MI
+FULSHEARTEXAS.GOV,City,Non-Federal Agency,Fulshear,TX
+GAHANNA.GOV,City,Non-Federal Agency,Gahanna,OH
+GALENAOHIO.GOV,City,Non-Federal Agency,Galena,OH
+GALESBURG-IL.GOV,City,Non-Federal Agency,Galesburg,IL
+GALLATIN-TN.GOV,City,Non-Federal Agency,Gallatin,TN
+GALLAWAYTN.GOV,City,Non-Federal Agency,Gallaway,TN
+GALLOWAYTWP-NJ.GOV,City,Non-Federal Agency,Galloway,NJ
+GALLUPNM.GOV,City,Non-Federal Agency,GALLUP,NM
+GALVAIL.GOV,City,Non-Federal Agency,Galva,IL
+GARDENCITY-GA.GOV,City,Non-Federal Agency,Garden City,GA
+GARDNERKANSAS.GOV,City,Non-Federal Agency,Gardner,KS
+GARDNERVILLE-NV.GOV,City,Non-Federal Agency,Gardnerville,NV
+GARLANDTX.GOV,City,Non-Federal Agency,Garland,TX
+GARNERNC.GOV,City,Non-Federal Agency,Garner,NC
+GARRETTPARK-MD.GOV,City,Non-Federal Agency,Garrett Park,MD
+GARRETTPARKMD.GOV,City,Non-Federal Agency,Garrett Park,MD
+GATLINBURGTN.GOV,City,Non-Federal Agency,Gatlinburg,TN
+GEORGETOWN-KENTUCKY.GOV,City,Non-Federal Agency,Georgetown,KY
+GEORGETOWN-MI.GOV,City,Non-Federal Agency,Jenison,MI
+GEORGETOWNKY.GOV,City,Non-Federal Agency,Georgetown,KY
+GEORGETOWNTX.GOV,City,Non-Federal Agency,Georgetown,TX
+GERMANTOWN-TN.GOV,City,Non-Federal Agency,Germantown,TN
+GETTYSBURG-PA.GOV,City,Non-Federal Agency,Gettysburg,PA
+GILLETTEWY.GOV,City,Non-Federal Agency,Gillette,WY
+GIRARDKANSAS.GOV,City,Non-Federal Agency,Girard,KS
+GLASTONBURY-CT.GOV,City,Non-Federal Agency,Glastonbury,CT
+GLENDALE-WI.GOV,City,Non-Federal Agency,Glendale,WI
+GLENDALEAZ.GOV,City,Non-Federal Agency,Glendale,AZ
+GLENDALECA.GOV,City,Non-Federal Agency,Glendale,CA
+GLENNHEIGHTSTX.GOV,City,Non-Federal Agency,Glenn Heights,TX
+GLENVIEWKY.GOV,City,Non-Federal Agency,Glenview,KY
+GLENWILLOW-OH.GOV,City,Non-Federal Agency,Glenwillow,OH
+GLENWOODSPRINGSCO.GOV,City,Non-Federal Agency,Glenwood Springs,CO
+GLOBEAZ.GOV,City,Non-Federal Agency,GLOBE,AZ
+GLOUCESTER-MA.GOV,City,Non-Federal Agency,Gloucester,MA
+GODDARDKS.GOV,City,Non-Federal Agency,Goddard,KS
+GODLEYTX.GOV,City,Non-Federal Agency,Godley,TX
+GOFFSTOWNNH.GOV,City,Non-Federal Agency,Goffstown,NH
+GOLDBEACHOREGON.GOV,City,Non-Federal Agency,GoldBeach,OR
+GOLDENVALLEYMN.GOV,City,Non-Federal Agency,Golden Valley,MN
+GOLDSBORONC.GOV,City,Non-Federal Agency,Goldsboro,NC
+GOODHOPEAL.GOV,City,Non-Federal Agency,Cullman,AL
+GOODYEARAZ.GOV,City,Non-Federal Agency,Goodyear,AZ
+GOSHEN-OH.GOV,City,Non-Federal Agency,Goshen,OH
+GOSHEN-OHIO.GOV,City,Non-Federal Agency,Goshen,OH
+GOSHENCT.GOV,City,Non-Federal Agency,Goshen,CT
+GPSHORESMI.GOV,City,Non-Federal Agency,Grosse Pointe Shores,MI
+GRAFTON-MA.GOV,City,Non-Federal Agency,Grafton,MA
+GRANBY-MA.GOV,City,Non-Federal Agency,Granby,MA
+GRANDTERRACE-CA.GOV,City,Non-Federal Agency,Grand Terrace,CA
+GRANDVIEW-IN.GOV,City,Non-Federal Agency,Grandview,IN
+GRANGERIOWA.GOV,City,Non-Federal Agency,Granger,IA
+GRANITEFALLSWA.GOV,City,Non-Federal Agency,Granite Falls,WA
+GRANITEQUARRYNC.GOV,City,Non-Federal Agency,Granite Quarry ,NC
+GRANTFORKIL.GOV,City,Non-Federal Agency,Highland,IL
+GRANTSPASSOREGON.GOV,City,Non-Federal Agency,Grants Pass,OR
+GRANTSVILLEUT.GOV,City,Non-Federal Agency,Grantsville,UT
+GRAPEVINETEXAS.GOV,City,Non-Federal Agency,Grapevine,TX
+GRAPEVINETX.GOV,City,Non-Federal Agency,Grapevine,TX
+GREECENY.GOV,City,Non-Federal Agency,Rochester,NY
+GREENBAYWI.GOV,City,Non-Federal Agency,Green Bay,WI
+GREENBELTMD.GOV,City,Non-Federal Agency,Greenbelt,MD
+GREENCASTLEPA.GOV,City,Non-Federal Agency,Greencastle,PA
+GREENEVILLETN.GOV,City,Non-Federal Agency,Greeneville,TN
+GREENFIELD-MA.GOV,City,Non-Federal Agency,Greenfield,MA
+GREENFIELD-NH.GOV,City,Non-Federal Agency,Greenfield,NH
+GREENHOUSTONTX.GOV,City,Non-Federal Agency,Houston,TX
+GREENISLANDNY.GOV,City,Non-Federal Agency,Green Island,NY
+GREENMOUNTAINFALLSCO.GOV,City,Non-Federal Agency,Green Mountain Falls,CO
+GREENSBORO-GA.GOV,City,Non-Federal Agency,Greensboro,GA
+GREENSBOROGA.GOV,City,Non-Federal Agency,Greensboro,GA
+GREENVILLENC.GOV,City,Non-Federal Agency,Greenville,NC
+GREENVILLESC.GOV,City,Non-Federal Agency,Greenville,SC
+GRESHAMOREGON.GOV,City,Non-Federal Agency,Gresham,OR
+GREYFOREST-TX.GOV,City,Non-Federal Agency,Grey Forest,TX
+GRIMESIOWA.GOV,City,Non-Federal Agency,Grimes,IA
+GROTON-CT.GOV,City,Non-Federal Agency,Groton,CT
+GROTONMA.GOV,City,Non-Federal Agency,Groton,MA
+GROTONSD.GOV,City,Non-Federal Agency,Groton,SD
+GROVECITYOHIO.GOV,City,Non-Federal Agency,Grove City,OH
+GROVELAND-FL.GOV,City,Non-Federal Agency,Groveland,FL
+GULFBREEZEFL.GOV,City,Non-Federal Agency,Gulf Breeze,FL
+GULFPORT-MS.GOV,City,Non-Federal Agency,Gulfport,MS
+GULFSHORESAL.GOV,City,Non-Federal Agency,Gulf Shores,AL
+GUNTERSVILLEAL.GOV,City,Non-Federal Agency,Guntersville,AL
+GUSTAVUS-AK.GOV,City,Non-Federal Agency,Gustavus,AK
+GWSCO.GOV,City,Non-Federal Agency,Glenwood Springs,CO
+HADLEYMA.GOV,City,Non-Federal Agency,Hadley,MA
+HAHIRAGA.GOV,City,Non-Federal Agency,Hahira,GA
+HALLANDALEBEACHFL.GOV,City,Non-Federal Agency,hallandale beach,FL
+HAMILTON-OH.GOV,City,Non-Federal Agency,Hamilton,OH
+HAMPDENMAINE.GOV,City,Non-Federal Agency,Hampden,ME
+HAMPSTEADMD.GOV,City,Non-Federal Agency,Hampstead,MD
+HAMPTON.GOV,City,Non-Federal Agency,Hampton,VA
+HAMPTONSC.GOV,City,Non-Federal Agency,Hampton,SC
+HANKSVILLEUTAH.GOV,City,Non-Federal Agency,Hanksville,UT
+HANNIBAL-MO.GOV,City,Non-Federal Agency,Hannibal,MO
+HANOVER-MA.GOV,City,Non-Federal Agency,Hanover,MA
+HANOVERVA.GOV,City,Non-Federal Agency,Hanover,VA
+HANSON-MA.GOV,City,Non-Federal Agency,Hanson,MA
+HAPPYVALLEYOR.GOV,City,Non-Federal Agency,Happy Valley,OR
+HARMONYTWP-NJ.GOV,City,Non-Federal Agency,Phillipsburg,NJ
+HARPERCOUNTYKS.GOV,City,Non-Federal Agency,Anthony,KS
+HARRAH-OK.GOV,City,Non-Federal Agency,Harrah,OK
+HARRISBURGPA.GOV,City,Non-Federal Agency,Harrisburg,PA
+HARRISBURGSD.GOV,City,Non-Federal Agency,Harrisburg,SD
+HARRISONBURGVA.GOV,City,Non-Federal Agency,Harrisonburg,VA
+HARRISONOH.GOV,City,Non-Federal Agency,Harrison,OH
+HARRISONOHIO.GOV,City,Non-Federal Agency,Harrison,OH
+HARTFORD.GOV,City,Non-Federal Agency,Hartford,CT
+HARTSVILLESC.GOV,City,Non-Federal Agency,Hartsville,SC
+HARWICH-MA.GOV,City,Non-Federal Agency,Harwich,MA
+HASTINGSMN.GOV,City,Non-Federal Agency,Hastings,MN
+HAVERHILLMA.GOV,City,Non-Federal Agency,Haverhill,MA
+HAVREDEGRACEMD.GOV,City,Non-Federal Agency,Havre de Grace,MD
+HAWTHORNECA.GOV,City,Non-Federal Agency,Hawthorne,CA
+HAYDEN-CO.GOV,City,Non-Federal Agency,Hayden,CO
+HAYSIVIRGINIA.GOV,City,Non-Federal Agency,Haysi,VA
+HAZARDKY.GOV,City,Non-Federal Agency,Hazard,KY
+HAZLEHURSTGA.GOV,City,Non-Federal Agency,Hazlehurst,GA
+HEADOFTHEHARBORNY.GOV,City,Non-Federal Agency,Saint James,NY
+HEATHOHIO.GOV,City,Non-Federal Agency,Heath,OH
+HELENAMT.GOV,City,Non-Federal Agency,Helena,MT
+HELOTES-TX.GOV,City,Non-Federal Agency,Helotes,TX
+HENDERSONNEVADA.GOV,City,Non-Federal Agency,Henderson,NV
+HENDERSONNV.GOV,City,Non-Federal Agency,Henderson,NV
+HENDERSONTN.GOV,City,Non-Federal Agency,Henderson,TN
+HENDERSONVILLENC.GOV,City,Non-Federal Agency,Hendersonville,NC
+HEREFORD-TX.GOV,City,Non-Federal Agency,Hereford,TX
+HERNDON-VA.GOV,City,Non-Federal Agency,Herndon,VA
+HEYWORTH-IL.GOV,City,Non-Federal Agency,Heyworth,IL
+HIALEAHFL.GOV,City,Non-Federal Agency,Hialeah,FL
+HIAWASSEEGA.GOV,City,Non-Federal Agency,Hiawassee,GA
+HICKORYCREEK-TX.GOV,City,Non-Federal Agency,Hickory Creek,TX
+HICKORYNC.GOV,City,Non-Federal Agency,Hickory,NC
+HIDEOUTUTAH.GOV,City,Non-Federal Agency,Hideout,UT
+HIGHLANDHEIGHTS-KY.GOV,City,Non-Federal Agency,Highland Heights,KY
+HIGHLANDIL.GOV,City,Non-Federal Agency,Highland,IL
+HIGHLANDS-NY.GOV,City,Non-Federal Agency,Highland Falls,NY
+HILLIARDOHIO.GOV,City,Non-Federal Agency,Hilliard,OH
+HILLSBORO-OR.GOV,City,Non-Federal Agency,Hillsboro,OR
+HILLSBORO-OREGON.GOV,City,Non-Federal Agency,HILLSBORO,OR
+HILLSBOROOREGON.GOV,City,Non-Federal Agency,Hillsboro,OR
+HILLSBOROUGHNC.GOV,City,Non-Federal Agency,Hillsborough,NC
+HILTONHEADISLANDSC.GOV,City,Non-Federal Agency,Hilton Head Island,SC
+HINGHAM-MA.GOV,City,Non-Federal Agency,Hingham,MA
+HIRAM-GA.GOV,City,Non-Federal Agency,Hiram,GA
+HOBOKENNJ.GOV,City,Non-Federal Agency,Hoboken,NJ
+HOLBROOKMA.GOV,City,Non-Federal Agency,Holbrook,MA
+HOLDEN-MA.GOV,City,Non-Federal Agency,Holden,MA
+HOLDENMA.GOV,City,Non-Federal Agency,HOLDEN,MA
+HOLDERNESS-NH.GOV,City,Non-Federal Agency,Holderness,NH
+HOLLANDTOWNSHIPNJ.GOV,City,Non-Federal Agency,Milford,NJ
+HOLLYWOODPARK-TX.GOV,City,Non-Federal Agency,Hollywood Park,TX
+HOMERGLENIL.GOV,City,Non-Federal Agency,Homer Glen,IL
+HOMEWOODIL.GOV,City,Non-Federal Agency,Homewood,IL
+HOOPESTON-IL.GOV,City,Non-Federal Agency,Hoopeston,IL
+HOOVERAL.GOV,City,Non-Federal Agency,Hoover,AL
+HOOVERALABAMA.GOV,City,Non-Federal Agency,Hoover,AL
+HOPEDALE-MA.GOV,City,Non-Federal Agency,Hopedale,MA
+HOPEWELLVA.GOV,City,Non-Federal Agency,HOPEWELL,VA
+HOPKINSVILLE-KY.GOV,City,Non-Federal Agency,Hopkinsville,KY
+HOPKINTON-NH.GOV,City,Non-Federal Agency,Hopkinton,NH
+HOPKINTONMA.GOV,City,Non-Federal Agency,Hopkinton,MA
+HORICONNY.GOV,City,Non-Federal Agency,Brant Lake,NY
+HORIZONCITY-TX.GOV,City,Non-Federal Agency,Horizon City,TX
+HORSESHOE-BAY-TX.GOV,City,Non-Federal Agency,Horseshoe Bay,TX
+HOUSTON-AK.GOV,City,Non-Federal Agency,Houston,AK
+HPCA.GOV,City,Non-Federal Agency,Huntington Park,CA
+HRPDCVA.GOV,City,Non-Federal Agency,Chesapeake,VA
+HUACHUCACITYAZ.GOV,City,Non-Federal Agency,Huachuca City,AZ
+HUDSONNH.GOV,City,Non-Federal Agency,Hudson,NH
+HUETTER-ID.GOV,City,Non-Federal Agency,POST FALLS,ID
+HULMEVILLE-PA.GOV,City,Non-Federal Agency,Hulmeville,PA
+HUMBLETX.GOV,City,Non-Federal Agency,Humble,TX
+HUNTINGBURG-IN.GOV,City,Non-Federal Agency,Huntingburg,IN
+HUNTINGTONBEACHCA.GOV,City,Non-Federal Agency,Huntington Beach,CA
+HUNTINGTONNY.GOV,City,Non-Federal Agency,Huntington,NY
+HUNTSPOINT-WA.GOV,City,Non-Federal Agency,Hunts Point,WA
+HUNTSVILLEAL.GOV,City,Non-Federal Agency,Huntsville,AL
+HURLOCK-MD.GOV,City,Non-Federal Agency,Hurlock,MD
+HURST-TEXAS.GOV,City,Non-Federal Agency,Hurst,TX
+HURSTTX.GOV,City,Non-Federal Agency,Hurst,TX
+HUTTOTX.GOV,City,Non-Federal Agency,Hutto,TX
+HVLNC.GOV,City,Non-Federal Agency,Hendersonville,NC
+IDABEL-OK.GOV,City,Non-Federal Agency,Idabel,OK
+IDAHOFALLSIDAHO.GOV,City,Non-Federal Agency,Idaho Falls,ID
+ILWACO-WA.GOV,City,Non-Federal Agency,Ilwaco,WA
+IMPERIALBEACHCA.GOV,City,Non-Federal Agency,Imperial Beach,CA
+INCLINEVILLAGE-NV.GOV,City,Non-Federal Agency,INCLINE VILLAGE,NV
+INDEPENDENCEKS.GOV,City,Non-Federal Agency,INDEPENDENCE,KS
+INDEPENDENCEOHIO.GOV,City,Non-Federal Agency,Independence,OH
+INDIANAPOLIS-IN.GOV,City,Non-Federal Agency,Indianapolis,IN
+INDIANOLAIOWA.GOV,City,Non-Federal Agency,Indianola,IA
+INDIANOLAMS.GOV,City,Non-Federal Agency,Indianola,MS
+INDIANPOINT-MO.GOV,City,Non-Federal Agency,Branson,MO
+INDY.GOV,City,Non-Federal Agency,Indianapolis,IN
+INGLESIDETX.GOV,City,Non-Federal Agency,Ingleside,TX
+INTERLACHEN-FL.GOV,City,Non-Federal Agency,Interlachen,FL
+INVERNESS-FL.GOV,City,Non-Federal Agency,Inverness,FL
+INVERNESS-IL.GOV,City,Non-Federal Agency,Inverness,IL
+IPSWICH-MA.GOV,City,Non-Federal Agency,Ipswich,MA
+IPSWICHMA.GOV,City,Non-Federal Agency,Ipswich,MA
+IRONTONMO.GOV,City,Non-Federal Agency,Ironton,MO
+IRVINGTONNY.GOV,City,Non-Federal Agency,Irvington,NY
+ISLIP-NY.GOV,City,Non-Federal Agency,Islip,NY
+ISLIPNY.GOV,City,Non-Federal Agency,Islip,NY
+ISLIPTOWN-NY.GOV,City,Non-Federal Agency,Islip,NY
+ISSAQUAHWA.GOV,City,Non-Federal Agency,Issaquah,WA
+JACINTOCITY-TX.GOV,City,Non-Federal Agency,Jacinto City,TX
+JACKSON-SC.GOV,City,Non-Federal Agency,Jackson,SC
+JACKSONMS.GOV,City,Non-Federal Agency,Jackson,MS
+JACKSONTOWNSHIP-PA.GOV,City,Non-Federal Agency,Myerstown,PA
+JACKSONTOWNSHIPPA.GOV,City,Non-Federal Agency,Jackson Township,PA
+JACKSONTWP-PA.GOV,City,Non-Federal Agency,Reeders,PA
+JAMESTOWN-NC.GOV,City,Non-Federal Agency,Jamestown,NC
+JAMESTOWNRI.GOV,City,Non-Federal Agency,Jamestown,RI
+JAMESTOWNTN.GOV,City,Non-Federal Agency,Jamestown,TN
+JEFFERSONCITYMO.GOV,City,Non-Federal Agency,Jefferson City,MO
+JEFFERSONTOWNKY.GOV,City,Non-Federal Agency,Jeffersontown,KY
+JEMEZSPRINGS-NM.GOV,City,Non-Federal Agency,Jemez Springs,NM
+JERICHOVT.GOV,City,Non-Federal Agency,Jericho,VT
+JEROME-OH.GOV,City,Non-Federal Agency,Plain City,OH
+JESUPGA.GOV,City,Non-Federal Agency,Jesup,GA
+JOHNSCREEKGA.GOV,City,Non-Federal Agency,Johns Creek,GA
+JOHNSONCITYTN.GOV,City,Non-Federal Agency,Johnson City,TN
+JONESVILLENC.GOV,City,Non-Federal Agency,Jonesville,NC
+JUNCTIONCITY-KS.GOV,City,Non-Federal Agency,Junction City,KS
+JUNCTIONCITYOREGON.GOV,City,Non-Federal Agency,Junction City,OR
+JUPITERFL.GOV,City,Non-Federal Agency,Jupiter,FL
+KANNAPOLISNC.GOV,City,Non-Federal Agency,Concord,NC
+KEANSBURGNJ.GOV,City,Non-Federal Agency,Keansburg,NJ
+KELSO.GOV,City,Non-Federal Agency,Kelso,WA
+KEMAH-TX.GOV,City,Non-Federal Agency,Kemah,TX
+KENMOREWA.GOV,City,Non-Federal Agency,Kenmore,WA
+KENNEBUNKPORTME.GOV,City,Non-Federal Agency,Kennebunkport,ME
+KENNESAW-GA.GOV,City,Non-Federal Agency,Kennesaw,GA
+KENTWA.GOV,City,Non-Federal Agency,Kent,WA
+KERRVILLETX.GOV,City,Non-Federal Agency,Kerrville,TX
+KILLEENTEXAS.GOV,City,Non-Federal Agency,Killeen,TX
+KILLINGLYCT.GOV,City,Non-Federal Agency,Danielson,CT
+KINDERHOOK-NY.GOV,City,Non-Federal Agency,Niverville,NY
+KINGSLANDGA.GOV,City,Non-Federal Agency,Kingsland,GA
+KINGSPORTTN.GOV,City,Non-Federal Agency,Kingsport,TN
+KINGSTON-NY.GOV,City,Non-Federal Agency,Kingston,NY
+KINGSTONSPRINGS-TN.GOV,City,Non-Federal Agency,Kingston Springs,TN
+KINROSSTOWNSHIP-MI.GOV,City,Non-Federal Agency,Kincheloe,MI
+KINSTONNC.GOV,City,Non-Federal Agency,Kinston,NC
+KIRKLANDWA.GOV,City,Non-Federal Agency,Kirkland,WA
+KISSIMMEE-FL.GOV,City,Non-Federal Agency,Kissimmee,FL
+KISSIMMEEFL.GOV,City,Non-Federal Agency,Kissimmee,FL
+KITTERYME.GOV,City,Non-Federal Agency,Kittery,ME
+KITTYHAWKNC.GOV,City,Non-Federal Agency,Kitty Hawk,NC
+KNIGHTDALENC.GOV,City,Non-Federal Agency,Knightdale,NC
+KNOXVILLEIA.GOV,City,Non-Federal Agency,Knoxville,IA
+KNOXVILLEIOWA.GOV,City,Non-Federal Agency,Knoxville,IA
+KNOXVILLETN.GOV,City,Non-Federal Agency,Knoxville,TN
+KUNAID.GOV,City,Non-Federal Agency,Kuna,ID
+LACKAWANNANY.GOV,City,Non-Federal Agency,Lackawanna,NY
+LACKAWAXENTOWNSHIPPA.GOV,City,Non-Federal Agency,Hawley,PA
+LAFOLLETTETN.GOV,City,Non-Federal Agency,LaFollette,TN
+LAGRANGEGA.GOV,City,Non-Federal Agency,LaGrange,GA
+LAGRANGENY.GOV,City,Non-Federal Agency,Lagrangeville,NY
+LAHABRACA.GOV,City,Non-Federal Agency,LA HABRA,CA
+LAKEFORESTCA.GOV,City,Non-Federal Agency,Lake Forest,CA
+LAKEGROVENY.GOV,City,Non-Federal Agency,Lake Grove,NY
+LAKEJACKSONTX.GOV,City,Non-Federal Agency,Lake Jackson,TX
+LAKELANDGA.GOV,City,Non-Federal Agency,Lakeland,GA
+LAKELANDTN.GOV,City,Non-Federal Agency,Lakeland,TN
+LAKEPARKNC.GOV,City,Non-Federal Agency,Indian Trail,NC
+LAKEPROVIDENCELA.GOV,City,Non-Federal Agency,Lake Providence,LA
+LAKESTATION-IN.GOV,City,Non-Federal Agency,Lake Station,IN
+LAKESTEVENSWA.GOV,City,Non-Federal Agency,Lake Stevens,WA
+LAKEVILLE-MN.GOV,City,Non-Federal Agency,Lakeville,MN
+LAKEVILLEMN.GOV,City,Non-Federal Agency,Lakeville,MN
+LAKEVILLEMNFIRE.GOV,City,Non-Federal Agency,Lakeville,MN
+LAKEWAY-TX.GOV,City,Non-Federal Agency,Lakeway,TX
+LAKEWOODNJ.GOV,City,Non-Federal Agency,Lakewood,NJ
+LANCASTERCITYSC.GOV,City,Non-Federal Agency,Lancaster,SC
+LANCASTERNY.GOV,City,Non-Federal Agency,Lancaster,NY
+LANESBORO-MN.GOV,City,Non-Federal Agency,Lanesboro,MN
+LANESBOROUGH-MA.GOV,City,Non-Federal Agency,LANESBOROUGH,MA
+LANSINGMI.GOV,City,Non-Federal Agency,Lansing,MI
+LANTABUS-PA.GOV,City,Non-Federal Agency,Allentown,PA
+LAPORTETX.GOV,City,Non-Federal Agency,La Porte,TX
+LAREDOTEXAS.GOV,City,Non-Federal Agency,Laredo,TX
+LASALLE-IL.GOV,City,Non-Federal Agency,LaSalle,IL
+LASVEGASNM.GOV,City,Non-Federal Agency,Las Vegas,NM
+LAUDERDALEBYTHESEA-FL.GOV,City,Non-Federal Agency,Lauderdale By The Sea,FL
+LAUDERHILL-FL.GOV,City,Non-Federal Agency,Lauderhill,FL
+LAUDERHILLFL.GOV,City,Non-Federal Agency,Lauderhill,FL
+LAVERGNETN.GOV,City,Non-Federal Agency,La Vergne,TN
+LAVERNIA-TX.GOV,City,Non-Federal Agency,La Vernia,TX
+LAWRENCEBURGTN.GOV,City,Non-Federal Agency,Lawrenceburg,TN
+LAWTONMI.GOV,City,Non-Federal Agency,Lawton,MI
+LBTS-FL.GOV,City,Non-Federal Agency,Lauderdale-By-The-Sea,FL
+LEAGUECITY-TX.GOV,City,Non-Federal Agency,League City,TX
+LEAGUECITYTX.GOV,City,Non-Federal Agency,League City,TX
+LEANDERTX.GOV,City,Non-Federal Agency,Leander,TX
+LEBANONCT.GOV,City,Non-Federal Agency,Lebanon,CT
+LEBANONOHIO.GOV,City,Non-Federal Agency,Lebanon,OH
+LECLAIREIOWA.GOV,City,Non-Federal Agency,LECLAIRE,IA
+LEEDSALABAMA.GOV,City,Non-Federal Agency,Leeds,AL
+LEESBURGFLORIDA.GOV,City,Non-Federal Agency,Leesburg,FL
+LEESVILLELA.GOV,City,Non-Federal Agency,LEESVILLE,LA
+LEHI-UT.GOV,City,Non-Federal Agency,Lehi,UT
+LENEXA-KS.GOV,City,Non-Federal Agency,Lenexa,KS
+LENOIR-NC.GOV,City,Non-Federal Agency,Lenoir,NC
+LENOIRCITYTN.GOV,City,Non-Federal Agency,Lenoir City,TN
+LEOMINSTER-MA.GOV,City,Non-Federal Agency,Leominster,MA
+LEONIANJ.GOV,City,Non-Federal Agency,Leonia,NJ
+LEONVALLEYTEXAS.GOV,City,Non-Federal Agency,Leon Valley,TX
+LEROYTOWNSHIP-MI.GOV,City,Non-Federal Agency,Webberville,MI
+LETSMOVEBRIDGEPORTCT.GOV,City,Non-Federal Agency,Bridgeport,CT
+LEWISBURGTN.GOV,City,Non-Federal Agency,Lewisburg,TN
+LEWISTONMAINE.GOV,City,Non-Federal Agency,Lewiston,ME
+LEXINGTONKY.GOV,City,Non-Federal Agency,lexington,KY
+LEXINGTONNC.GOV,City,Non-Federal Agency,Lexington,NC
+LEXINGTONTN.GOV,City,Non-Federal Agency,Lexington,TN
+LEXINGTONVA.GOV,City,Non-Federal Agency,Lexington,VA
+LHCAZ.GOV,City,Non-Federal Agency,Lake Havasu City,AZ
+LIBERTYLAKEWA.GOV,City,Non-Federal Agency,Liberty Lake,WA
+LIBERTYMISSOURI.GOV,City,Non-Federal Agency,Liberty,MO
+LIBERTYMO.GOV,City,Non-Federal Agency,Liberty,MO
+LIMERICK-ME.GOV,City,Non-Federal Agency,Limerick,ME
+LINCOLNCA.GOV,City,Non-Federal Agency,Lincoln,CA
+LINCOLNIL.GOV,City,Non-Federal Agency,Lincoln,IL
+LINDALE-TX.GOV,City,Non-Federal Agency,Lindale,TX
+LINDALETX.GOV,City,Non-Federal Agency,Lindale,TX
+LINDENWOLDNJ.GOV,City,Non-Federal Agency,Lindenwold,NJ
+LINNDALEVILLAGE-OH.GOV,City,Non-Federal Agency,Linndale,OH
+LINTON-IN.GOV,City,Non-Federal Agency,Linton,IN
+LITCHFIELD-NH.GOV,City,Non-Federal Agency,Litchfield,NH
+LITCHFIELDNH.GOV,City,Non-Federal Agency,Litchfield,NH
+LOCKHAVENPA.GOV,City,Non-Federal Agency,Lock Haven,PA
+LOCKPORTNY.GOV,City,Non-Federal Agency,Lockport,NY
+LOCUSTGROVE-GA.GOV,City,Non-Federal Agency,Locust Grove,GA
+LOGANCO.GOV,City,Non-Federal Agency,Sterling,CO
+LOGANVILLE-GA.GOV,City,Non-Federal Agency,Loganville,GA
+LOMALINDA-CA.GOV,City,Non-Federal Agency,Loma Linda,CA
+LONEOAKTX.GOV,City,Non-Federal Agency,LONE OAK,TX
+LONGBEACH.GOV,City,Non-Federal Agency,Long Beach,CA
+LONGBEACHNY.GOV,City,Non-Federal Agency,Long Beach,NY
+LONGBEACHWA.GOV,City,Non-Federal Agency,Long Beach,WA
+LONGHILLNJ.GOV,City,Non-Federal Agency,Long Hill,NJ
+LONGLAKEMN.GOV,City,Non-Federal Agency,Long Lake,MN
+LONGMONTCOLORADO.GOV,City,Non-Federal Agency,Longmont,CO
+LONGPORTNJ.GOV,City,Non-Federal Agency,Longport,NJ
+LONGVIEWTEXAS.GOV,City,Non-Federal Agency,Longview,TX
+LONGVIEWTX.GOV,City,Non-Federal Agency,Longview,TX
+LORENATX.GOV,City,Non-Federal Agency,Lorena,TX
+LOSALTOSCA.GOV,City,Non-Federal Agency,Los Altos,CA
+LOSANGELES-CA.GOV,City,Non-Federal Agency,Los Angeles,CA
+LOSRANCHOSNM.GOV,City,Non-Federal Agency,Los Ranchos de Albuquerque,NM
+LOUISBURGKANSAS.GOV,City,Non-Federal Agency,Louisburg,KS
+LOUISVILLECO.GOV,City,Non-Federal Agency,Louisville,CO
+LOUISVILLEKY.GOV,City,Non-Federal Agency,Louisville,KY
+LOVEJOY-GA.GOV,City,Non-Federal Agency,Lovejoy,GA
+LOVETTSVILLEVA.GOV,City,Non-Federal Agency,Lovettsville,VA
+LOVINGTON-IL.GOV,City,Non-Federal Agency,Lovington,IL
+LOWELLARKANSAS.GOV,City,Non-Federal Agency,Lowell,AR
+LOWERALLOWAYSCREEK-NJ.GOV,City,Non-Federal Agency,Hancocks Bridge,NJ
+LUBBOCKTX.GOV,City,Non-Federal Agency,Lubbock,TX
+LUDINGTON-MI.GOV,City,Non-Federal Agency,Ludington,MI
+LUNENBURGMA.GOV,City,Non-Federal Agency,Lunenburg,MA
+LYMAN-ME.GOV,City,Non-Federal Agency,Lyman,ME
+LYMANSC.GOV,City,Non-Federal Agency,Lyman,SC
+LYMECT.GOV,City,Non-Federal Agency,Lyme,CT
+LYMENH.GOV,City,Non-Federal Agency,Lyme,NH
+LYNDEBOROUGHNH.GOV,City,Non-Federal Agency,Lyndeborough,NH
+LYNDONKS.GOV,City,Non-Federal Agency,Lyndon,KS
+LYNNMA.GOV,City,Non-Federal Agency,Lynn,MA
+LYNNWOODWA.GOV,City,Non-Federal Agency,Lynnwood,WA
+LYONSTOWNSHIPIL.GOV,City,Non-Federal Agency,Countryside,IL
+MACOMB-MI.GOV,City,Non-Federal Agency,Macomb,MI
+MACONGA.GOV,City,Non-Federal Agency,Macon,GA
+MADEIRABEACHFL.GOV,City,Non-Federal Agency,Madeira Beach,FL
+MADERA-CA.GOV,City,Non-Federal Agency,Madera,CA
+MADISON-AL.GOV,City,Non-Federal Agency,Madison,AL
+MADISON-IN.GOV,City,Non-Federal Agency,Madison,IN
+MADISONAL.GOV,City,Non-Federal Agency,Madison,AL
+MAHARISHIVEDICCITY-IOWA.GOV,City,Non-Federal Agency,Maharishi Vedic City,IA
+MAHOMET-IL.GOV,City,Non-Federal Agency,Mahomet,IL
+MAHWAH-NJ.GOV,City,Non-Federal Agency,Mahwah,NJ
+MAIDENNC.GOV,City,Non-Federal Agency,Maiden,NC
+MALVERNAR.GOV,City,Non-Federal Agency,Malvern,AR
+MANASQUAN-NJ.GOV,City,Non-Federal Agency,MANASQUAN,NJ
+MANASSASPARKVA.GOV,City,Non-Federal Agency,Manassas Park,VA
+MANASSASVA.GOV,City,Non-Federal Agency,Manassas,VA
+MANCHESTER-GA.GOV,City,Non-Federal Agency,Manchester,GA
+MANCHESTER-VT.GOV,City,Non-Federal Agency,Manchester Center,VT
+MANCHESTERCT.GOV,City,Non-Federal Agency,Manchester,CT
+MANCHESTERMD.GOV,City,Non-Federal Agency,MANCHESTER,MD
+MANCHESTERMO.GOV,City,Non-Federal Agency,Manchester,MO
+MANCHESTERNH.GOV,City,Non-Federal Agency,Manchester,NH
+MANISTEEMI.GOV,City,Non-Federal Agency,Traverse City,MI
+MANKATO-MN.GOV,City,Non-Federal Agency,Mankato,MN
+MANKATOMN.GOV,City,Non-Federal Agency,Mankato,MN
+MANSFIELDCT.GOV,City,Non-Federal Agency,Mansfield,CT
+MANSFIELDGA.GOV,City,Non-Federal Agency,Mans,GA
+MANSFIELDTEXAS.GOV,City,Non-Federal Agency,Mansfield,TX
+MANSFIELDTOWNSHIP-NJ.GOV,City,Non-Federal Agency,Port Murray,NJ
+MANTUATOWNSHIPOHIO.GOV,City,Non-Federal Agency,Mantua,OH
+MAPLEGROVEMN.GOV,City,Non-Federal Agency,Maple Grove,MN
+MAPLEVALLEYWA.GOV,City,Non-Federal Agency,Maple Valley,WA
+MAPLEWOODMN.GOV,City,Non-Federal Agency,Maplewood,MN
+MARANAAZ.GOV,City,Non-Federal Agency,Marana,AZ
+MARBLEFALLSTX.GOV,City,Non-Federal Agency,Marble Falls,TX
+MARICOPA-AZ.GOV,City,Non-Federal Agency,Maricopa,AZ
+MARIONKY.GOV,City,Non-Federal Agency,Marion,KY
+MARIONMA.GOV,City,Non-Federal Agency,Marion,MA
+MARIONSC.GOV,City,Non-Federal Agency,Marion,SC
+MARKESANWI.GOV,City,Non-Federal Agency,Markesan,WI
+MARLBORO-NJ.GOV,City,Non-Federal Agency,Marlboro,NJ
+MARLBOROUGH-MA.GOV,City,Non-Federal Agency,Marlborough,MA
+MARLOWNH.GOV,City,Non-Federal Agency,Marlow,NH
+MAROAILLINOIS.GOV,City,Non-Federal Agency,Maroa,IL
+MARSHFIELDMO.GOV,City,Non-Federal Agency,Marshfield,MO
+MARTINSVILLE-VA.GOV,City,Non-Federal Agency,Martinsville,VA
+MARYSVILLEWA.GOV,City,Non-Federal Agency,Marysville,WA
+MARYVILLE-TN.GOV,City,Non-Federal Agency,maryville,TN
+MASHPEEMA.GOV,City,Non-Federal Agency,Mashpee,MA
+MAYAGUEZPR.GOV,City,Non-Federal Agency,Mayaguez,PR
+MCCOMB-MS.GOV,City,Non-Federal Agency,McComb,MS
+MCDONOUGH-GA.GOV,City,Non-Federal Agency,McDonough,GA
+MCKEESPORT-PA.GOV,City,Non-Federal Agency,McKeesport,PA
+MCKENZIETN.GOV,City,Non-Federal Agency,McKenzie,TN
+MCTX.GOV,City,Non-Federal Agency,Missouri City,TX
+MEADOWSPLACETX.GOV,City,Non-Federal Agency,Meadows Place,TX
+MECHANICVILLENY.GOV,City,Non-Federal Agency,Mechanicville,NY
+MEDINA-WA.GOV,City,Non-Federal Agency,Medina,WA
+MEMPHISTN.GOV,City,Non-Federal Agency,Memphis,TN
+MENDON-MA.GOV,City,Non-Federal Agency,Mendon,MA
+MENDONMA.GOV,City,Non-Federal Agency,Mendon,MA
+MENOMONIE-WI.GOV,City,Non-Federal Agency,Menomonie,WI
+MENTONEALABAMA.GOV,City,Non-Federal Agency,Mentone,AL
+MERCHANTVILLENJ.GOV,City,Non-Federal Agency,Merchantville,NJ
+MERIDENCT.GOV,City,Non-Federal Agency,Meriden,CT
+MERRIMACKNH.GOV,City,Non-Federal Agency,Merrimack,NH
+MESAAZ.GOV,City,Non-Federal Agency,Mesa,AZ
+MESILLANM.GOV,City,Non-Federal Agency,Mesilla,NM
+MESQUITETX.GOV,City,Non-Federal Agency,Mesquite,TX
+MIAMIBEACHFL.GOV,City,Non-Federal Agency,Miami Beach,FL
+MIAMIGARDENS-FL.GOV,City,Non-Federal Agency,Miami Gardens,FL
+MIAMILAKES-FL.GOV,City,Non-Federal Agency,Miami Lakes,FL
+MIAMISPRINGS-FL.GOV,City,Non-Federal Agency,Miami Springs,FL
+MIAMITOWNSHIPOH.GOV,City,Non-Federal Agency,Milford,OH
+MIAMITWPOH.GOV,City,Non-Federal Agency,Milford,OH
+MIDDLEBURGVA.GOV,City,Non-Federal Agency,Middleburg,VA
+MIDDLETONNH.GOV,City,Non-Federal Agency,Middleton,NH
+MIDDLETOWN-CT.GOV,City,Non-Federal Agency,Middletown,CT
+MIDDLETOWNCT.GOV,City,Non-Federal Agency,Middletown,CT
+MIDDLETOWNVA.GOV,City,Non-Federal Agency,Middletown,VA
+MIDLANDTEXAS.GOV,City,Non-Federal Agency,Midland,TX
+MIDLOTHIANTX.GOV,City,Non-Federal Agency,Midlothian,TX
+MIDWAY-NC.GOV,City,Non-Federal Agency,Winston-Salem,NC
+MIFFLIN-OH.GOV,City,Non-Federal Agency,Gahanna,OH
+MILAN-NY.GOV,City,Non-Federal Agency,Milan,NY
+MILANMO.GOV,City,Non-Federal Agency,Milan,MO
+MILANOHIO.GOV,City,Non-Federal Agency,Milan,OH
+MILFORD-CT.GOV,City,Non-Federal Agency,Milford,CT
+MILFORD-DE.GOV,City,Non-Federal Agency,Milford,DE
+MILFORDNE.GOV,City,Non-Federal Agency,Milford,NE
+MILLIKENCO.GOV,City,Non-Federal Agency,Milliken,CO
+MILLIKENCOLORADO.GOV,City,Non-Federal Agency,Milliken,CO
+MILLINGTONTN.GOV,City,Non-Federal Agency,Millington,TN
+MILLSTONENJ.GOV,City,Non-Federal Agency,Millstone,NJ
+MILLSWY.GOV,City,Non-Federal Agency,Mills,WY
+MILLVILLENJ.GOV,City,Non-Federal Agency,Millville,NJ
+MILTON-WI.GOV,City,Non-Federal Agency,Milton,WI
+MILWAUKIEOREGON.GOV,City,Non-Federal Agency,Milwaukie,OR
+MINEOLA-NY.GOV,City,Non-Federal Agency,Mineola,NY
+MINERALWELLSTX.GOV,City,Non-Federal Agency,Mineral Wells,TX
+MINNEAPOLIS-MN.GOV,City,Non-Federal Agency,Minneapolis,MN
+MINNEAPOLISMN.GOV,City,Non-Federal Agency,Minneapolis,MN
+MINNETONKA-MN.GOV,City,Non-Federal Agency,Minnetonka,MN
+MIRAMARFL.GOV,City,Non-Federal Agency,Miramar,FL
+MISSIONHILLSKS.GOV,City,Non-Federal Agency,Mission Hills,KS
+MISSOULA-MT.GOV,City,Non-Federal Agency,Missoula,MT
+MISSOURICITYTEXAS.GOV,City,Non-Federal Agency,Missouri City,TX
+MISSOURICITYTX.GOV,City,Non-Federal Agency,Missouri City,TX
+MITCHELL-IN.GOV,City,Non-Federal Agency,Mitchell,IN
+MOBILE-AL.GOV,City,Non-Federal Agency,Mobile,AL
+MOCKSVILLENC.GOV,City,Non-Federal Agency,Mocksville,NC
+MONROEGA.GOV,City,Non-Federal Agency,Monroe,GA
+MONROEMI.GOV,City,Non-Federal Agency,Monroe,MI
+MONROETWP-OH.GOV,City,Non-Federal Agency,Bethel,OH
+MONROEWA.GOV,City,Non-Federal Agency,Monroe,WA
+MONTAGUE-MA.GOV,City,Non-Federal Agency,Turners Falls,MA
+MONTCLAIRCA.GOV,City,Non-Federal Agency,Montclair,CA
+MONTEREYMA.GOV,City,Non-Federal Agency,Monterey,MA
+MONTGOMERYAL.GOV,City,Non-Federal Agency,Montgomery,AL
+MONTGOMERYOHIO.GOV,City,Non-Federal Agency,Montgomery,OH
+MONTGOMERYTEXAS.GOV,City,Non-Federal Agency,Montgomery,TX
+MONTICELLOIN.GOV,City,Non-Federal Agency,Monticello,IN
+MOODYALABAMA.GOV,City,Non-Federal Agency,Moody,AL
+MOORESVILLE-NC.GOV,City,Non-Federal Agency,Mooresville,NC
+MOORPARKCA.GOV,City,Non-Federal Agency,Moorpark,CA
+MOREHEAD-KY.GOV,City,Non-Federal Agency,Morehead,KY
+MORGANTONNC.GOV,City,Non-Federal Agency,Morganton,NC
+MORGANTOWNWV.GOV,City,Non-Federal Agency,Morgantown,WV
+MOULTONBOROUGHNH.GOV,City,Non-Federal Agency,Moultonborough,NH
+MOUNTAINAIRNM.GOV,City,Non-Federal Agency,Mountainair,NM
+MOUNTAINHOUSECA.GOV,City,Non-Federal Agency,Mountain House,CA
+MOUNTAINPARK-GA.GOV,City,Non-Federal Agency,Mountain Park,GA
+MOUNTAINVIEW.GOV,City,Non-Federal Agency,Mountain View,CA
+MOUNTCARMELTN.GOV,City,Non-Federal Agency,Mount Carmel,TN
+MOUNTKISCONY.GOV,City,Non-Federal Agency,Mount Kisco,NY
+MOUNTPLEASANTTN.GOV,City,Non-Federal Agency,Mount Pleasant,TN
+MOUNTPOCONO-PA.GOV,City,Non-Federal Agency,Mount Pocono,PA
+MOUNTVERNONWA.GOV,City,Non-Federal Agency,Mount Vernon,WA
+MQUEBRADILLASPR.GOV,City,Non-Federal Agency,Quebradillas,PR
+MTCRESTEDBUTTE-CO.GOV,City,Non-Federal Agency,Mt. Crested Butte,CO
+MTPLEASANTWI.GOV,City,Non-Federal Agency,Mount Pleasant,WI
+MTSHASTACA.GOV,City,Non-Federal Agency,Mt. Shasta,CA
+MUKILTEOWA.GOV,City,Non-Federal Agency,Mukilteo,WA
+MURFREESBOROTN.GOV,City,Non-Federal Agency,Murfreesboro,TN
+MURPHYSBORO-IL.GOV,City,Non-Federal Agency,Murphysboro,IL
+MURPHYTX.GOV,City,Non-Federal Agency,Murphy,TX
+MURRAYKY.GOV,City,Non-Federal Agency,Murray,KY
+MUSCATINEIOWA.GOV,City,Non-Federal Agency,Muscatine,IA
+MUSKEGON-MI.GOV,City,Non-Federal Agency,Muskegon,MI
+MYARLINGTONTX.GOV,City,Non-Federal Agency,Arlington,TX
+MYCOLUMBUS.GOV,City,Non-Federal Agency,Columbus,OH
+MYDELRAYBEACHFL.GOV,City,Non-Federal Agency,Delray Beach,FL
+NAGSHEADNC.GOV,City,Non-Federal Agency,Nags Head,NC
+NANTICOKECITY-PA.GOV,City,Non-Federal Agency,NANTICOKE,PA
+NANTUCKET-MA.GOV,City,Non-Federal Agency,Nantucket,MA
+NAPLESCITYUT.GOV,City,Non-Federal Agency,Naples,UT
+NARBERTHPA.GOV,City,Non-Federal Agency,Narberth,PA
+NARRAGANSETTRI.GOV,City,Non-Federal Agency,Narragansett,RI
+NASHOTAH-WI.GOV,City,Non-Federal Agency,Nashotah,WI
+NASHUANH.GOV,City,Non-Federal Agency,Nashua,NH
+NASHVILLE.GOV,City,Non-Federal Agency,Nashville,TN
+NATCHITOCHESLA.GOV,City,Non-Federal Agency,Natchitoches,LA
+NATIONALCITYCA.GOV,City,Non-Federal Agency,National City,CA
+NAUGATUCK-CT.GOV,City,Non-Federal Agency,Naugatuck,CT
+NBCA.GOV,City,Non-Federal Agency,Newport Beach,CA
+NEBRASKACITYNE.GOV,City,Non-Federal Agency,Nebraska City,NE
+NEEDHAMMA.GOV,City,Non-Federal Agency,NEEDHAM,MA
+NEVADACITYCA.GOV,City,Non-Federal Agency,Nevada City,CA
+NEVILLEISLAND-PA.GOV,City,Non-Federal Agency,Pittsburgh,PA
+NEWARKDE.GOV,City,Non-Federal Agency,Newark,DE
+NEWAUBURNMN.GOV,City,Non-Federal Agency,New Auburn,MN
+NEWBEDFORD-MA.GOV,City,Non-Federal Agency,New Bedford,MA
+NEWBERGOREGON.GOV,City,Non-Federal Agency,Newberg,OR
+NEWBOSTONNH.GOV,City,Non-Federal Agency,New Boston,NH
+NEWBRIGHTONMN.GOV,City,Non-Federal Agency,New Brighton,MN
+NEWBRITAINCT.GOV,City,Non-Federal Agency,New Britain,CT
+NEWBURGH-IN.GOV,City,Non-Federal Agency,Newburgh,IN
+NEWBURGHHTSOH.GOV,City,Non-Federal Agency,Newburgh Heights,OH
+NEWCANAANCT.GOV,City,Non-Federal Agency,New Canaan,CT
+NEWCARROLLTONMD.GOV,City,Non-Federal Agency,New Carrollton,MD
+NEWCASTLEPA.GOV,City,Non-Federal Agency,New Castle,PA
+NEWCONCORD-OH.GOV,City,Non-Federal Agency,New Concord,OH
+NEWHARMONY-IN.GOV,City,Non-Federal Agency,New Harmony,IN
+NEWHAVENCT.GOV,City,Non-Federal Agency,New Haven,CT
+NEWINGTONCT.GOV,City,Non-Federal Agency,Newington,CT
+NEWMARKETNH.GOV,City,Non-Federal Agency,Newmarket,NH
+NEWMARLBOROUGHMA.GOV,City,Non-Federal Agency,Mill River,MA
+NEWNANGA.GOV,City,Non-Federal Agency,Newnan,GA
+NEWORLEANS-LA.GOV,City,Non-Federal Agency,New Orleans,LA
+NEWORLEANSLA.GOV,City,Non-Federal Agency,New Orleans,LA
+NEWPORT-RI.GOV,City,Non-Federal Agency,Newport,RI
+NEWPORTBEACH-CA.GOV,City,Non-Federal Agency,Newport Beach,CA
+NEWPORTBEACHCA.GOV,City,Non-Federal Agency,Newport Beach,CA
+NEWPORTKY.GOV,City,Non-Federal Agency,Newport,KY
+NEWPORTNEWSVA.GOV,City,Non-Federal Agency,Newport News,VA
+NEWPORTOREGON.GOV,City,Non-Federal Agency,Newport,OR
+NEWRICHMONDWI.GOV,City,Non-Federal Agency,New Richmond ,WI
+NEWRUSSIATOWNSHIP-OH.GOV,City,Non-Federal Agency,Oberlin,OH
+NEWTON-NH.GOV,City,Non-Federal Agency,Newton,NH
+NEWTONNC.GOV,City,Non-Federal Agency,Newton,NC
+NEWTOWN-CT.GOV,City,Non-Federal Agency,Newtown,CT
+NEWTOWNOHIO.GOV,City,Non-Federal Agency,Newtown,OH
+NEWTOWNPA.GOV,City,Non-Federal Agency,Newtown,PA
+NIAGARAFALLSNY.GOV,City,Non-Federal Agency,Niagara Falls,NY
+NIAGARAFALLSNYCARTS.GOV,City,Non-Federal Agency,Niagara Falls,NY
+NILES-IL.GOV,City,Non-Federal Agency,Niles,IL
+NILESTWPMI.GOV,City,Non-Federal Agency,Niles,MI
+NINNEKAHOK.GOV,City,Non-Federal Agency,NINNEKAH,OK
+NISSEQUOGUENY.GOV,City,Non-Federal Agency,St. James,NY
+NIXAMO.GOV,City,Non-Federal Agency,Nixa,MO
+NNVA.GOV,City,Non-Federal Agency,Newport News,VA
+NOGALESAZ.GOV,City,Non-Federal Agency,Nogales,AZ
+NOLA.GOV,City,Non-Federal Agency,New Orleans,LA
+NOLENSVILLETN.GOV,City,Non-Federal Agency,Nolensville,TN
+NORFOLK.GOV,City,Non-Federal Agency,Norfolk,VA
+NORFOLKNE.GOV,City,Non-Federal Agency,Norfolk,NE
+NORFOLKVA.GOV,City,Non-Federal Agency,Norfolk,VA
+NORMANDYPARKWA.GOV,City,Non-Federal Agency,Normandy Park,WA
+NORMANOK.GOV,City,Non-Federal Agency,Norman,OK
+NORMANPARKGA.GOV,City,Non-Federal Agency,Norman Park,GA
+NORRIDGE-IL.GOV,City,Non-Federal Agency,Norridge,IL
+NORTHADAMS-MA.GOV,City,Non-Federal Agency,North Adams,MA
+NORTHAMPTONMA.GOV,City,Non-Federal Agency,Northampton,MA
+NORTHANDOVERMA.GOV,City,Non-Federal Agency,North Andover,MA
+NORTHBENDWA.GOV,City,Non-Federal Agency,North Bend,WA
+NORTHBOROUGH-MA.GOV,City,Non-Federal Agency,Northborough,MA
+NORTHBROOKIL.GOV,City,Non-Federal Agency,Northbrook,IL
+NORTHBRUNSWICKNJ.GOV,City,Non-Federal Agency,North Brunswick,NJ
+NORTHCANTONOHIO.GOV,City,Non-Federal Agency,North Canton,OH
+NORTHFIELD-VT.GOV,City,Non-Federal Agency,Northfield,VT
+NORTHFIELDVILLAGE-OH.GOV,City,Non-Federal Agency,NORTHFIELD,OH
+NORTHHAVEN-CT.GOV,City,Non-Federal Agency,North Haven,CT
+NORTHHEMPSTEADNY.GOV,City,Non-Federal Agency,MANHASSET,NY
+NORTHLEBANONTWPPA.GOV,City,Non-Federal Agency,Lebanon,PA
+NORTHPORTNY.GOV,City,Non-Federal Agency,Northport,NY
+NORTHPROVIDENCERI.GOV,City,Non-Federal Agency,North Providence,RI
+NORTHREADINGMA.GOV,City,Non-Federal Agency,North Reading,MA
+NORTHSIOUXCITY-SD.GOV,City,Non-Federal Agency,N. Sioux City,SD
+NORTHSTONINGTONCT.GOV,City,Non-Federal Agency,North Stonington,CT
+NORTHVERNON-IN.GOV,City,Non-Federal Agency,North Vernon,IN
+NORTONVA.GOV,City,Non-Federal Agency,Norton,VA
+NORWALKCA.GOV,City,Non-Federal Agency,Norwalk,CA
+NORWAYMI.GOV,City,Non-Federal Agency,Norway,MI
+NORWOOD-MA.GOV,City,Non-Federal Agency,Norwood,MA
+NORWOODMA.GOV,City,Non-Federal Agency,Norwood,MA
+NOTTINGHAM-NH.GOV,City,Non-Federal Agency,Nottingham,NH
+NOWATAOK.GOV,City,Non-Federal Agency,Nowata,OK
+NSIDFL.GOV,City,Non-Federal Agency,Coral Springs,FL
+NYACK-NY.GOV,City,Non-Federal Agency,Nyack,NY
+OAK-BROOK-IL.GOV,City,Non-Federal Agency,OAK BROOK,IL
+OAKBLUFFSMA.GOV,City,Non-Federal Agency,Oak Bluffs,MA
+OAKHAM-MA.GOV,City,Non-Federal Agency,Oakham,MA
+OAKLAND-ME.GOV,City,Non-Federal Agency,Oakland,ME
+OAKLANDCA.GOV,City,Non-Federal Agency,Oakland,CA
+OAKLANDPARKFL.GOV,City,Non-Federal Agency,Oakland Park,FL
+OAKLAWN-IL.GOV,City,Non-Federal Agency,OAK LAWN,IL
+OAKRIDGETN.GOV,City,Non-Federal Agency,"Oak Ridge, TN 37830 United States",TN
+OAKWOODOHIO.GOV,City,Non-Federal Agency,Oakwood,OH
+OBERLINKANSAS.GOV,City,Non-Federal Agency,Oberlin,KS
+OCCOQUANVA.GOV,City,Non-Federal Agency,Occoquan,VA
+OCEANAWV.GOV,City,Non-Federal Agency,Oceana,WV
+OCEANCITYMD.GOV,City,Non-Federal Agency,Ocean City ,MD
+OCEANGATE-NJ.GOV,City,Non-Federal Agency,Ocean Gate,NJ
+OCEANSPRINGS-MS.GOV,City,Non-Federal Agency,Ocean Springs,MS
+OCONOMOWOC-WI.GOV,City,Non-Federal Agency,Oconomowoc,WI
+OGDEN-KS.GOV,City,Non-Federal Agency,Ogden ,KS
+OLDSAYBROOKCT.GOV,City,Non-Federal Agency,Old Saybrook,CT
+OLIVERSPRINGS-TN.GOV,City,Non-Federal Agency,Oliver Springs,TN
+OMAHA-NE.GOV,City,Non-Federal Agency,Omaha,NE
+ONTARIOCA.GOV,City,Non-Federal Agency,Ontario,CA
+OPALOCKAFL.GOV,City,Non-Federal Agency,OPALOCKA,FL
+ORMONDBEACH-FL.GOV,City,Non-Federal Agency,Ormond Beach,FL
+OROVALLEYAZ.GOV,City,Non-Federal Agency,Oro Valley,AZ
+OSAGEBEACH-MO.GOV,City,Non-Federal Agency,OSAGE BEACH,MO
+OSCODATOWNSHIPMI.GOV,City,Non-Federal Agency,Oscoda,MI
+OTHELLOWA.GOV,City,Non-Federal Agency,Othello,WA
+OTISFIELDME.GOV,City,Non-Federal Agency,OTISFIELD,ME
+OTTAWAKS.GOV,City,Non-Federal Agency,Ottawa,KS
+OYSTERBAY-NY.GOV,City,Non-Federal Agency,Oyster Bay,NY
+PADUCAHKY.GOV,City,Non-Federal Agency,Paducah,KY
+PALATKA-FL.GOV,City,Non-Federal Agency,Palatka,FL
+PALMETTOBAY-FL.GOV,City,Non-Federal Agency,Palmetto Bay,FL
+PALMSPRINGS-CA.GOV,City,Non-Federal Agency,Palm Springs,CA
+PALMSPRINGSCA.GOV,City,Non-Federal Agency,Palm Springs,CA
+PALOSHILLS-IL.GOV,City,Non-Federal Agency,Palos Hills,IL
+PANORAMAVILLAGETX.GOV,City,Non-Federal Agency,Panorama Village,TX
+PARADISEVALLEYAZ.GOV,City,Non-Federal Agency,Paradise Valley,AZ
+PARISTEXAS.GOV,City,Non-Federal Agency,Paris,TX
+PARISTN.GOV,City,Non-Federal Agency,Paris,TN
+PARKERSBURGWV.GOV,City,Non-Federal Agency,Parkersburg,WV
+PARKVILLEMO.GOV,City,Non-Federal Agency,Parkville,MO
+PARMAHEIGHTSOH.GOV,City,Non-Federal Agency,Parma Heights,OH
+PASADENACA.GOV,City,Non-Federal Agency,Pasadena,CA
+PASADENATX.GOV,City,Non-Federal Agency,Pasadena,TX
+PASCO-WA.GOV,City,Non-Federal Agency,Pasco,WA
+PATAGONIA-AZ.GOV,City,Non-Federal Agency,Patagonia,AZ
+PATERSONNJ.GOV,City,Non-Federal Agency,Paterson,NJ
+PAWLING-NY.GOV,City,Non-Federal Agency,Pawling,NY
+PAWNEEROCK-KS.GOV,City,Non-Federal Agency,Pawnee Rock,KS
+PAXTONFL.GOV,City,Non-Federal Agency,Laurel Hill,FL
+PAYSONAZ.GOV,City,Non-Federal Agency,Payson,AZ
+PEABODY-MA.GOV,City,Non-Federal Agency,Peabody,MA
+PEABODYMA.GOV,City,Non-Federal Agency,PEABODY,MA
+PEARLANDTX.GOV,City,Non-Federal Agency,Pearland,TX
+PECOSTX.GOV,City,Non-Federal Agency,Pecos,TX
+PEMBROKE-MA.GOV,City,Non-Federal Agency,Pembroke,MA
+PEORIAHEIGHTS-IL.GOV,City,Non-Federal Agency,Peoria Heights,IL
+PERRYTOWNSHIP-IN.GOV,City,Non-Federal Agency,Indianapolis,IN
+PERTHAMBOYNJ.GOV,City,Non-Federal Agency,Perth Amboy,NJ
+PETERBOROUGHNH.GOV,City,Non-Federal Agency,Peterborough,NH
+PETERSBURGAK.GOV,City,Non-Federal Agency,Petersburg,AK
+PETERSBURGVA.GOV,City,Non-Federal Agency,Petersburg,VA
+PFLUGERVILLETX.GOV,City,Non-Federal Agency,Pflugerville,TX
+PHARR-TX.GOV,City,Non-Federal Agency,Pharr,TX
+PHILA.GOV,City,Non-Federal Agency,Philadelphia,PA
+PHILLIPSTON-MA.GOV,City,Non-Federal Agency,Phillipston,MA
+PHOENIXOREGON.GOV,City,Non-Federal Agency,Phoenix,OR
+PIEDMONT-OK.GOV,City,Non-Federal Agency,PIEDMONT,OK
+PIKEVILLEKY.GOV,City,Non-Federal Agency,Pikeville,KY
+PINEBLUFFSWY.GOV,City,Non-Federal Agency,Pine Bluffs,WY
+PINEPLAINS-NY.GOV,City,Non-Federal Agency,Pine Plains,NY
+PINEVILLENC.GOV,City,Non-Federal Agency,Pineville,NC
+PITTSBORONC.GOV,City,Non-Federal Agency,Pittsboro,NC
+PITTSBURGCA.GOV,City,Non-Federal Agency,PITTSBURG,CA
+PITTSBURGHPA.GOV,City,Non-Federal Agency,Pittsburgh,PA
+PITTSFIELD-MI.GOV,City,Non-Federal Agency,Ann Arbor,MI
+PITTSFIELDNH.GOV,City,Non-Federal Agency,Pittsfield,NH
+PLAINFIELDNJ.GOV,City,Non-Federal Agency,Plainfield,NJ
+PLANDOMEHEIGHTS-NY.GOV,City,Non-Federal Agency,Manhasset,NY
+PLEASANTONCA.GOV,City,Non-Federal Agency,Pleasanton,CA
+PLEASANTONTX.GOV,City,Non-Federal Agency,Pleasanton,TX
+PLEASANTVALLEY-NY.GOV,City,Non-Federal Agency,Pleasant Valley,NY
+PLEASANTVILLE-NY.GOV,City,Non-Federal Agency,Pleasantville,NY
+PLOVERWI.GOV,City,Non-Federal Agency,Plover,WI
+PLUMSTEAD.GOV,City,Non-Federal Agency,Plumsteadville,PA
+PLYMOUTH-MA.GOV,City,Non-Federal Agency,Plymouth,MA
+PLYMOUTHMN.GOV,City,Non-Federal Agency,Plymouth,MN
+POLKCITYIA.GOV,City,Non-Federal Agency,Polk City,IA
+POMPANOBEACHFL.GOV,City,Non-Federal Agency,Pompano Beach,FL
+POMPEY-NY.GOV,City,Non-Federal Agency,MANLIUS,NY
+PONCACITYOK.GOV,City,Non-Federal Agency,Ponca City,OK
+POOLER-GA.GOV,City,Non-Federal Agency,Pooler,GA
+POOLESVILLEMD.GOV,City,Non-Federal Agency,Poolesville,MD
+POPLARBLUFF-MO.GOV,City,Non-Federal Agency,Poplar Bluff,MO
+POQUOSON-VA.GOV,City,Non-Federal Agency,Poquioson,VA
+PORTAGEWI.GOV,City,Non-Federal Agency,Portage,WI
+PORTALESNM.GOV,City,Non-Federal Agency,Portales,NM
+PORTARTHURTX.GOV,City,Non-Federal Agency,Port Arthur,TX
+PORTCLINTON-OH.GOV,City,Non-Federal Agency,Port Clinton,OH
+PORTERVILLE-CA.GOV,City,Non-Federal Agency,Porterville,CA
+PORTERVILLECA.GOV,City,Non-Federal Agency,Porterville,CA
+PORTLANDMAINE.GOV,City,Non-Federal Agency,Portland,ME
+PORTLANDOREGON.GOV,City,Non-Federal Agency,Portland,OR
+PORTLANDTX.GOV,City,Non-Federal Agency,Portland,TX
+PORTSMOUTHVIRGINIA.GOV,City,Non-Federal Agency,Portsmouth,VA
+POTTERTWP-PA.GOV,City,Non-Federal Agency,Monaca,PA
+POWHATANVA.GOV,City,Non-Federal Agency,Powhatan,VA
+PRAIRIEDUCHIEN-WI.GOV,City,Non-Federal Agency,Prairie du Chien,WI
+PRAIRIEVIEWTEXAS.GOV,City,Non-Federal Agency,Prairie View,TX
+PRATTVILLE-AL.GOV,City,Non-Federal Agency,Prattville,AL
+PRATTVILLEAL.GOV,City,Non-Federal Agency,Prattville,AL
+PRESCOTT-AZ.GOV,City,Non-Federal Agency,Prescott,AZ
+PRESCOTTVALLEY-AZ.GOV,City,Non-Federal Agency,Prescott Valley,AZ
+PRESQUEISLEMAINE.GOV,City,Non-Federal Agency,Presque Isle,ME
+PRIESTRIVER-ID.GOV,City,Non-Federal Agency,Priest River,ID
+PRINCETONNJ.GOV,City,Non-Federal Agency,Princeton,NJ
+PRINCETONTX.GOV,City,Non-Federal Agency,Princeton,TX
+PROCTORMN.GOV,City,Non-Federal Agency,Proctor,MN
+PROSPERTX.GOV,City,Non-Federal Agency,Prosper,TX
+PROVIDENCERI.GOV,City,Non-Federal Agency,Providence,RI
+PURCELLVILLEVA.GOV,City,Non-Federal Agency,Purcellville,VA
+QUAKERTOWN-PA.GOV,City,Non-Federal Agency,Quakertown,PA
+QUINCYIL.GOV,City,Non-Federal Agency,Quincy,IL
+QUINCYMA.GOV,City,Non-Federal Agency,Quincy,MA
+RADFORDVA.GOV,City,Non-Federal Agency,Radford,VA
+RALEIGHNC.GOV,City,Non-Federal Agency,Raleigh,NC
+RANCHOMIRAGECA.GOV,City,Non-Federal Agency,Rancho Mirage,CA
+RANDOLPH-MA.GOV,City,Non-Federal Agency,Randolph,MA
+RANDOLPHTOWNSHIPOHIO.GOV,City,Non-Federal Agency,Randolph,OH
+RANGELY-CO.GOV,City,Non-Federal Agency,Rangely,CO
+RANGELYCO.GOV,City,Non-Federal Agency,Rangely,CO
+RATONNM.GOV,City,Non-Federal Agency,Raton,NM
+RAYCITYGA.GOV,City,Non-Federal Agency,Ray City,GA
+RAYMONDNH.GOV,City,Non-Federal Agency,Raymond,NH
+READINGMA.GOV,City,Non-Federal Agency,READING,MA
+READINGPA.GOV,City,Non-Federal Agency,Reading,PA
+READYHOUSTONTX.GOV,City,Non-Federal Agency,Houston,TX
+READYSOUTHTEXAS.GOV,City,Non-Federal Agency,San Antonio,TX
+READYSPRINGFIELDIL.GOV,City,Non-Federal Agency,Springfield,IL
+READYWESTLINNOR.GOV,City,Non-Federal Agency,West Linn,OR
+REDBANKTN.GOV,City,Non-Federal Agency,Red Bank,TN
+REDBAY-AL.GOV,City,Non-Federal Agency,Red Bay,AL
+REDMOND.GOV,City,Non-Federal Agency,Redmond,WA
+REMINGTON-VA.GOV,City,Non-Federal Agency,Remington,VA
+RENSSELAERNY.GOV,City,Non-Federal Agency,Rensselaer,NY
+RHEACOUNTYTN.GOV,City,Non-Federal Agency,Dayton,TN
+RHINEBECK-NY.GOV,City,Non-Federal Agency,Rhinebeck,NY
+RHINEBECKNY.GOV,City,Non-Federal Agency,Rhinebeck,NY
+RICETX.GOV,City,Non-Federal Agency,Rice,TX
+RICHFIELDWI.GOV,City,Non-Federal Agency,Hubertus,WI
+RICHLANDS-VA.GOV,City,Non-Federal Agency,Richlands,VA
+RICHLANDSNC.GOV,City,Non-Federal Agency,Richlands,NC
+RICHMOND-VA.GOV,City,Non-Federal Agency,Richmond,VA
+RICHMONDHILL-GA.GOV,City,Non-Federal Agency,Richmond Hill ,GA
+RICHMONDINDIANA.GOV,City,Non-Federal Agency,Richmond,IN
+RICHMONDTX.GOV,City,Non-Federal Agency,RICHMOND,TX
+RICHMONDVA.GOV,City,Non-Federal Agency,Richmond,VA
+RICHMONDVT.GOV,City,Non-Federal Agency,Richmond,VT
+RICHWOODTX.GOV,City,Non-Federal Agency,Richwood,TX
+RICHWOODWV.GOV,City,Non-Federal Agency,Richwood,WV
+RIDGECREST-CA.GOV,City,Non-Federal Agency,Ridgecrest,CA
+RIDGEFIELDNJ.GOV,City,Non-Federal Agency,Ridgefield,NJ
+RIDGELANDSC.GOV,City,Non-Federal Agency,Ridgeland,SC
+RITZVILLE-WA.GOV,City,Non-Federal Agency,Ritzville,WA
+RIVERDALEGA.GOV,City,Non-Federal Agency,Riverdale,GA
+RIVERDALENJ.GOV,City,Non-Federal Agency,Riverdale,NJ
+RIVERDALEPARKMD.GOV,City,Non-Federal Agency,Riverdale,MD
+RIVERSIDE-GA.GOV,City,Non-Federal Agency,Moultrie,GA
+RIVERSIDECA.GOV,City,Non-Federal Agency,Riverside,CA
+ROAMINGSHORESOH.GOV,City,Non-Federal Agency,Roaming Shores,OH
+ROANOKEVA.GOV,City,Non-Federal Agency,Roanoke,VA
+ROBINSONPA.GOV,City,Non-Federal Agency,McDonald,PA
+ROCKFORD-IL.GOV,City,Non-Federal Agency,Rockford,IL
+ROCKFORDIL.GOV,City,Non-Federal Agency,Rockford,IL
+ROCKHALLMD.GOV,City,Non-Federal Agency,Rock Hall,MD
+ROCKLAND-MA.GOV,City,Non-Federal Agency,Rockland,MA
+ROCKMART-GA.GOV,City,Non-Federal Agency,Rockmart,GA
+ROCKPORTMA.GOV,City,Non-Federal Agency,Rockport,MA
+ROCKPORTMAINE.GOV,City,Non-Federal Agency,Rockport,ME
+ROCKVILLE-IN.GOV,City,Non-Federal Agency,Rockville,IN
+ROCKVILLEMD.GOV,City,Non-Federal Agency,Rockville,MD
+ROCKWELLNC.GOV,City,Non-Federal Agency,Rockwell,NC
+ROCKYHILL-NJ.GOV,City,Non-Federal Agency,Rocky Hill,NJ
+ROCKYHILLCT.GOV,City,Non-Federal Agency,Rocky Hill,CT
+ROCKYMOUNTNC.GOV,City,Non-Federal Agency,Rocky Mount,NC
+ROCKYMOUNTVA.GOV,City,Non-Federal Agency,ROCKY MOUNT,VA
+ROGERSAR.GOV,City,Non-Federal Agency,Rogers,AR
+ROLESVILLENC.GOV,City,Non-Federal Agency,Rolesville,NC
+ROLLINGHILLSESTATES-CA.GOV,City,Non-Federal Agency,Rolling Hills Estates,CA
+ROLLINGHILLSESTATESCA.GOV,City,Non-Federal Agency,Rolling Hills Estates,CA
+ROME-NY.GOV,City,Non-Federal Agency,Rome,NY
+ROMULUS-MI.GOV,City,Non-Federal Agency,Romulus,MI
+ROSEVILLE-MI.GOV,City,Non-Federal Agency,Roseville,MI
+ROSLYNNY.GOV,City,Non-Federal Agency,Roslyn,NY
+ROSWELL-NM.GOV,City,Non-Federal Agency,Roswell,NM
+ROUNDROCKTEXAS.GOV,City,Non-Federal Agency,Round Rock,TX
+ROWE-MA.GOV,City,Non-Federal Agency,Rowe,MA
+ROWLETTTX.GOV,City,Non-Federal Agency,Rowlett,TX
+ROXBURY-CT.GOV,City,Non-Federal Agency,Roxbury,CT
+ROYALSTON-MA.GOV,City,Non-Federal Agency,Royalston,MA
+RPVCA.GOV,City,Non-Federal Agency,Rancho Palos Verdes,CA
+RRNM.GOV,City,Non-Federal Agency,Rio Rancho,NM
+RUIDOSO-NM.GOV,City,Non-Federal Agency,Ruidoso,NM
+RUMSONNJ.GOV,City,Non-Federal Agency,Rumson,NJ
+RUSSELLSPOINT-OH.GOV,City,Non-Federal Agency,Russells Point,OH
+RYENY.GOV,City,Non-Federal Agency,Rye,NY
+SACKETSHARBOR-NY.GOV,City,Non-Federal Agency,Sackets Harbor,NY
+SADDLEBROOKNJ.GOV,City,Non-Federal Agency,Saddlebrook,NJ
+SADDLEROCKNY.GOV,City,Non-Federal Agency,SADDLE ROCK,NY
+SAFFORDAZ.GOV,City,Non-Federal Agency,Safford,AZ
+SAGHARBORNY.GOV,City,Non-Federal Agency,Sag Harbor,NY
+SAHUARITAAZ.GOV,City,Non-Federal Agency,Sahuarita,AZ
+SAINTPETERMN.GOV,City,Non-Federal Agency,Saint Peter,MN
+SALADOTX.GOV,City,Non-Federal Agency,Salado,TX
+SALEMCT.GOV,City,Non-Federal Agency,Salem,CT
+SALEMVA.GOV,City,Non-Federal Agency,Salem,VA
+SALISBURYMA.GOV,City,Non-Federal Agency,Salisbury,MA
+SALISBURYNC.GOV,City,Non-Federal Agency,Salisbury,NC
+SALTLAKECITY-UT.GOV,City,Non-Federal Agency,Salt Lake City,UT
+SAMMAMISHWA.GOV,City,Non-Federal Agency,Sammamish,WA
+SANANTONIO.GOV,City,Non-Federal Agency,San Antonio,TX
+SANDYSPRINGS-GA.GOV,City,Non-Federal Agency,Sandy Springs,GA
+SANDYSPRINGSGA.GOV,City,Non-Federal Agency,Sandy Springs,GA
+SANFORDFL.GOV,City,Non-Federal Agency,Sanford,FL
+SANFRANCISCO-CA.GOV,City,Non-Federal Agency,San Francisco,CA
+SANJOSECA.GOV,City,Non-Federal Agency,San Jose,CA
+SANMARCOSTEXAS.GOV,City,Non-Federal Agency,San Marcos,TX
+SANMARCOSTX.GOV,City,Non-Federal Agency,San Marcos,TX
+SANMARINOCA.GOV,City,Non-Federal Agency,San Marino,CA
+SANPABLOCA.GOV,City,Non-Federal Agency,San Pablo,CA
+SANTACLARACA.GOV,City,Non-Federal Agency,Santa Clara,CA
+SANTACLARITACA.GOV,City,Non-Federal Agency,Santa Clarita,CA
+SANTAFENM.GOV,City,Non-Federal Agency,Santa Fe,NM
+SANTAMONICACA.GOV,City,Non-Federal Agency,Santa Monica,CA
+SARANACLAKENY.GOV,City,Non-Federal Agency,Saranac Lake,NY
+SARDISCITYAL.GOV,City,Non-Federal Agency,SARDIS CITY,AL
+SAUGUS-MA.GOV,City,Non-Federal Agency,Saugus,MA
+SAULTSTEMARIE-MI.GOV,City,Non-Federal Agency,Sault Ste Marie,MI
+SAVANNA-IL.GOV,City,Non-Federal Agency,Savanna,IL
+SAVANNAHGA.GOV,City,Non-Federal Agency,Savannah,GA
+SBMTD.GOV,City,Non-Federal Agency,Santa Barbara,CA
+SCHENECTADYNY.GOV,City,Non-Federal Agency,Schenectady,NY
+SCHERTZ-TX.GOV,City,Non-Federal Agency,Schertz,TX
+SCIENCEHILL-KY.GOV,City,Non-Federal Agency,Science Hill,KY
+SCITUATEMA.GOV,City,Non-Federal Agency,Scituate,MA
+SCOTCHPLAINSNJ.GOV,City,Non-Federal Agency,SCOTCH PLAINS,NJ
+SCRANTONPA.GOV,City,Non-Federal Agency,Scranton,PA
+SEABROOKTX.GOV,City,Non-Federal Agency,Seabrook,TX
+SEACLIFF-NY.GOV,City,Non-Federal Agency,Sea Cliff,NY
+SEALBEACHCA.GOV,City,Non-Federal Agency,Seal Beach,CA
+SEARANCHLAKESFLORIDA.GOV,City,Non-Federal Agency,Sea Ranch Lakes,FL
+SEATPLEASANTMD.GOV,City,Non-Federal Agency,Seat Pleasant,MD
+SEBEWAINGMI.GOV,City,Non-Federal Agency,Sebewaing,MI
+SECAUCUSNJ.GOV,City,Non-Federal Agency,Secaucus,NJ
+SEDONAAZ.GOV,City,Non-Federal Agency,Sedona,AZ
+SEEKONK-MA.GOV,City,Non-Federal Agency,Seekonk,MA
+SEGUINTEXAS.GOV,City,Non-Federal Agency,Seguin,TX
+SELAHWA.GOV,City,Non-Federal Agency,Selah,WA
+SELLERSBURG-IN.GOV,City,Non-Federal Agency,Sellersburg,IN
+SELMA-AL.GOV,City,Non-Federal Agency,Selma,AL
+SENECASC.GOV,City,Non-Federal Agency,Seneca,SC
+SEQUIMWA.GOV,City,Non-Federal Agency,SEQUIM,WA
+SHAKOPEEMN.GOV,City,Non-Federal Agency,Shakopee,MN
+SHEBOYGANFALLS-WI.GOV,City,Non-Federal Agency,Sheboygan Falls,WI
+SHEBOYGANWI.GOV,City,Non-Federal Agency,Sheboygan,WI
+SHEFFIELDMA.GOV,City,Non-Federal Agency,Sheffield,MA
+SHELTERCOVE-CA.GOV,City,Non-Federal Agency,Whitethorn,CA
+SHERWOODOREGON.GOV,City,Non-Federal Agency,Sherwood,OR
+SHIRLEY-MA.GOV,City,Non-Federal Agency,Shirley,MA
+SHIVELYKY.GOV,City,Non-Federal Agency,Shively,KY
+SHORELINE-WA.GOV,City,Non-Federal Agency,Shoreline,WA
+SHORELINEWA.GOV,City,Non-Federal Agency,Shoreline,WA
+SHOREVIEWMN.GOV,City,Non-Federal Agency,Shoreview,MN
+SHREVEPORTLA.GOV,City,Non-Federal Agency,Shreveport,LA
+SHREWSBURYMA.GOV,City,Non-Federal Agency,Shrewsbury,MA
+SIERRAVISTAAZ.GOV,City,Non-Federal Agency,Sierra Vista,AZ
+SIGNALMOUNTAINTN.GOV,City,Non-Federal Agency,Signal Mountain,TN
+SILVERCITYNM.GOV,City,Non-Federal Agency,Silver City,NM
+SILVERSPRINGTWP-PA.GOV,City,Non-Federal Agency,Mechanicsburg,PA
+SIMONTONTEXAS.GOV,City,Non-Federal Agency,simonton,TX
+SIOUXFALLSSD.GOV,City,Non-Federal Agency,Sioux Falls,SD
+SISTERBAYWI.GOV,City,Non-Federal Agency,Sister Bay,WI
+SLEEPYHOLLOWNY.GOV,City,Non-Federal Agency,Sleepy Hollow,NY
+SLIPPERYROCKBOROUGHPA.GOV,City,Non-Federal Agency,Slippery Rock,PA
+SMITHFIELDRI.GOV,City,Non-Federal Agency,Smithfield,RI
+SMITHFIELDVA.GOV,City,Non-Federal Agency,Smithfield,VA
+SMYRNAGA.GOV,City,Non-Federal Agency,Smyrna,GA
+SNOHOMISHWA.GOV,City,Non-Federal Agency,Snohomish,WA
+SNOWFLAKE-AZ.GOV,City,Non-Federal Agency,Snowflake,AZ
+SODDY-DAISY-TN.GOV,City,Non-Federal Agency,Soddy-Daisy,TN
+SODDY-DAISYTN.GOV,City,Non-Federal Agency,Soddy-Daisy,TN
+SODDYDAISY-TN.GOV,City,Non-Federal Agency,Soddy-Daisy,TN
+SODDYDAISYTN.GOV,City,Non-Federal Agency,Soddy-daisy,TN
+SOLWAYTOWNSHIP-MN.GOV,City,Non-Federal Agency,Cloquet,MN
+SOMERSCT.GOV,City,Non-Federal Agency,Somers,CT
+SOMERSETTX.GOV,City,Non-Federal Agency,Somerset,TX
+SOMERTONAZ.GOV,City,Non-Federal Agency,Somerton,AZ
+SOMERVILLEMA.GOV,City,Non-Federal Agency,Somerville,MA
+SOMERVILLETN.GOV,City,Non-Federal Agency,Town of Somerville,TN
+SOUTHABINGTONPA.GOV,City,Non-Federal Agency,Chinchilla,PA
+SOUTHAMBOYNJ.GOV,City,Non-Federal Agency,South Amboy,NJ
+SOUTHAMPTONTOWNNY.GOV,City,Non-Federal Agency,Southampton,NY
+SOUTHBEND-WA.GOV,City,Non-Federal Agency,South Bend,WA
+SOUTHBENDIN.GOV,City,Non-Federal Agency,South Bend,IN
+SOUTHBURY-CT.GOV,City,Non-Federal Agency,Southbury,CT
+SOUTHEAST-NY.GOV,City,Non-Federal Agency,BREWSTER,NY
+SOUTHHADLEYMA.GOV,City,Non-Federal Agency,South Hadley,MA
+SOUTHJORDANUTAH.GOV,City,Non-Federal Agency,South Jordan,UT
+SOUTHMIAMIFL.GOV,City,Non-Federal Agency,South Miami,FL
+SOUTHPADRETEXAS.GOV,City,Non-Federal Agency,South Padre Island,TX
+SOUTHPASADENACA.GOV,City,Non-Federal Agency,South Pasadena,CA
+SOUTHPITTSBURG-TN.GOV,City,Non-Federal Agency,South Pittsburg,TN
+SOUTHWILLIAMSPORT-PA.GOV,City,Non-Federal Agency,South Williamsport,PA
+SPEEDWAYIN.GOV,City,Non-Federal Agency,Speedway,IN
+SPENCERMA.GOV,City,Non-Federal Agency,Spencer,MA
+SPERRYOK.GOV,City,Non-Federal Agency,Sperry,OK
+SPIRITLAKEID.GOV,City,Non-Federal Agency,Spirit Lake,ID
+SPRINGCITYPA.GOV,City,Non-Federal Agency,Spring City,PA
+SPRINGDALEAR.GOV,City,Non-Federal Agency,Springdale,AR
+SPRINGERVILLEAZ.GOV,City,Non-Federal Agency,Springerville,AZ
+SPRINGFIELD-MA.GOV,City,Non-Federal Agency,Springfield,MA
+SPRINGFIELD-OR.GOV,City,Non-Federal Agency,Springfield,OR
+SPRINGFIELDMA.GOV,City,Non-Federal Agency,Springfield,MA
+SPRINGFIELDOHIO.GOV,City,Non-Federal Agency,Springfield,OH
+SPRINGHILLKS.GOV,City,Non-Federal Agency,Spring Hill,KS
+SPRINGHILLLOUISIANA.GOV,City,Non-Federal Agency,Springhill,LA
+SPRUCEPINE-NC.GOV,City,Non-Federal Agency,Spruce Pine,NC
+STAFFORDNJ.GOV,City,Non-Federal Agency,Manawhakin,NJ
+STAFFORDTX.GOV,City,Non-Federal Agency,stafford,TX
+STAMFORDCT.GOV,City,Non-Federal Agency,Stamford,CT
+STANHOPENJ.GOV,City,Non-Federal Agency,Stanhope,NJ
+STARNC.GOV,City,Non-Federal Agency,Star,NC
+STATECOLLEGEPA.GOV,City,Non-Federal Agency,State College,PA
+STATESBOROGA.GOV,City,Non-Federal Agency,Statesboro,GA
+STAYTONOREGON.GOV,City,Non-Federal Agency,Stayton,OR
+STCHARLESCITYMO.GOV,City,Non-Federal Agency,Saint Charles,MO
+STCROIXFALLSWI.GOV,City,Non-Federal Agency,City of St. Croix Falls,WI
+STEPHENVILLETX.GOV,City,Non-Federal Agency,Stephenville,TX
+STERLING-IL.GOV,City,Non-Federal Agency,Sterling,IL
+STERLING-MA.GOV,City,Non-Federal Agency,Sterling,MA
+STERLINGHEIGHTSMI.GOV,City,Non-Federal Agency,Sterling Heights,MI
+STJOHNSAZ.GOV,City,Non-Federal Agency,St. Johns,AZ
+STLOUIS-MO.GOV,City,Non-Federal Agency,St. Louis,MO
+STLUCIECO.GOV,City,Non-Federal Agency,Ft. Pierce,FL
+STMARYSGA.GOV,City,Non-Federal Agency,ST. MARYS,GA
+STMATTHEWSKY.GOV,City,Non-Federal Agency,Louisville,KY
+STOCKTONCA.GOV,City,Non-Federal Agency,Stockton,CA
+STONEHAM-MA.GOV,City,Non-Federal Agency,Stoneham,MA
+STONINGTON-CT.GOV,City,Non-Federal Agency,Stonington,CT
+STPAUL.GOV,City,Non-Federal Agency,Saint Paul,MN
+STPETE-FL.GOV,City,Non-Federal Agency,St. Petersburg,FL
+STRATHAMNH.GOV,City,Non-Federal Agency,Stratham,NH
+STURGIS-SD.GOV,City,Non-Federal Agency,Sturgis,SD
+STURGISMI.GOV,City,Non-Federal Agency,Sturgis,MI
+SUDBURY-MA.GOV,City,Non-Federal Agency,Sudbury,MA
+SUFFOLK-VA.GOV,City,Non-Federal Agency,Suffolk,VA
+SUGAR-LANDCITYTX.GOV,City,Non-Federal Agency,Sugar Land,TX
+SUGAR-LANDTX.GOV,City,Non-Federal Agency,Sugar Land,TX
+SUGARCITYIDAHO.GOV,City,Non-Federal Agency,Sugar City,ID
+SUGARLAND-CITYTX.GOV,City,Non-Federal Agency,Sugar Land,TX
+SUGARLAND-TX.GOV,City,Non-Federal Agency,Sugar Land,TX
+SUGARLANDCITY-TX.GOV,City,Non-Federal Agency,Sugar Land,TX
+SUGARLANDCITYTX.GOV,City,Non-Federal Agency,Sugar Land,TX
+SUGARLANDTX.GOV,City,Non-Federal Agency,Sugar Land,TX
+SULLIVANOHIO.GOV,City,Non-Federal Agency,Sullivan,OH
+SUMMERVILLESC.GOV,City,Non-Federal Agency,Summerville,SC
+SUMNERWA.GOV,City,Non-Federal Agency,Sumner,WA
+SUMTERSC.GOV,City,Non-Federal Agency,Sumter,SC
+SUNLANDPARK-NM.GOV,City,Non-Federal Agency,Sunland Park,NM
+SUNNYSIDE-WA.GOV,City,Non-Federal Agency,Sunnyside,WA
+SUNRISEBEACH-MO.GOV,City,Non-Federal Agency,Sunrise Beach,MO
+SUNSETBEACHNC.GOV,City,Non-Federal Agency,Sunset Beach,NC
+SUPERIORAZ.GOV,City,Non-Federal Agency,Superior,AZ
+SUPERIORCOLORADO.GOV,City,Non-Federal Agency,Superior,CO
+SURGOINSVILLETN.GOV,City,Non-Federal Agency,Surgoinsville,TN
+SURPRISEAZ.GOV,City,Non-Federal Agency,Surprise,AZ
+SYLACAUGAAL.GOV,City,Non-Federal Agency,Sylacauga,AL
+SYRACUSEKS.GOV,City,Non-Federal Agency,Syracuse,KS
+TABERNACLENJ.GOV,City,Non-Federal Agency,Tabernacle,NJ
+TACOMAWA.GOV,City,Non-Federal Agency,Tacoma,WA
+TAFTTX.GOV,City,Non-Federal Agency,TAFT,TX
+TALLAPOOSAGA.GOV,City,Non-Federal Agency,Tallapoosa,GA
+TALLASSEE-AL.GOV,City,Non-Federal Agency,Millbrook,AL
+TALLULAH-LA.GOV,City,Non-Federal Agency,Tallulah,LA
+TAMPAFL.GOV,City,Non-Federal Agency,Tampa,FL
+TAUNTON-MA.GOV,City,Non-Federal Agency,Taunton,MA
+TAYLORMILLKY.GOV,City,Non-Federal Agency,Taylor Mill,KY
+TAYLORSVILLEUT.GOV,City,Non-Federal Agency,Taylorsville ,UT
+TAYLORTX.GOV,City,Non-Federal Agency,Taylor,TX
+TEANECKNJ.GOV,City,Non-Federal Agency,Teaneck,NJ
+TEGACAYSC.GOV,City,Non-Federal Agency,Tega Cay,SC
+TELLURIDE-CO.GOV,City,Non-Federal Agency,Telluride,CO
+TEMECULACA.GOV,City,Non-Federal Agency,Temecula,CA
+TEMPE.GOV,City,Non-Federal Agency,Tempe,AZ
+TEMPLETX.GOV,City,Non-Federal Agency,Temple,TX
+TENNILLE-GA.GOV,City,Non-Federal Agency,Tennille,GA
+THECOLONYTX.GOV,City,Non-Federal Agency,The Colony,TX
+THEWOODLANDS-TX.GOV,City,Non-Federal Agency,The Woodlands,TX
+THEWOODLANDSTOWNSHIP-TX.GOV,City,Non-Federal Agency,The Woodlands,TX
+THOMASVILLE-NC.GOV,City,Non-Federal Agency,Thomasville,NC
+THORNBURG-PA.GOV,City,Non-Federal Agency,Pittsburgh,PA
+THORNEBAY-AK.GOV,City,Non-Federal Agency,Thorne Bay,AK
+TIFFINOHIO.GOV,City,Non-Federal Agency,Tiffin,OH
+TIGARD-OR.GOV,City,Non-Federal Agency,Tigard,OR
+TILLAMOOKOR.GOV,City,Non-Federal Agency,Tillamook,OR
+TIMNATH-CO.GOV,City,Non-Federal Agency,Timnath,CO
+TINLEYPARK-IL.GOV,City,Non-Federal Agency,Tinley Park,IL
+TINLEYPARKIL.GOV,City,Non-Federal Agency,Tinley Park,IL
+TIOGATX.GOV,City,Non-Federal Agency,Tioga,TX
+TIPPCITYOHIO.GOV,City,Non-Federal Agency,Tipp City,OH
+TISBURYMA.GOV,City,Non-Federal Agency,Tisbury,MA
+TOBYHANNATWPPA.GOV,City,Non-Federal Agency,Pocono Pines,PA
+TOLLAND-MA.GOV,City,Non-Federal Agency,Tolland,MA
+TOMBALLTX.GOV,City,Non-Federal Agency,Tomball,TX
+TOMPKINSVILLEKY.GOV,City,Non-Federal Agency,Tompkinsville,KY
+TOPSFIELD-MA.GOV,City,Non-Federal Agency,Topsfield,MA
+TORRANCECA.GOV,City,Non-Federal Agency,Torrance,CA
+TORREYUTAH.GOV,City,Non-Federal Agency,Torrey,UT
+TORRINGTON-CT.GOV,City,Non-Federal Agency,Torrington,CT
+TORRINGTONWY.GOV,City,Non-Federal Agency,Torrington,WY
+TOWNOFBETHLEHEM-NY.GOV,City,Non-Federal Agency,Delmar,NY
+TOWNOFBLOWINGROCKNC.GOV,City,Non-Federal Agency,Blowing Rock,NC
+TOWNOFBLYTHEWOODSC.GOV,City,Non-Federal Agency,Blythewood,SC
+TOWNOFCALLAHAN-FL.GOV,City,Non-Federal Agency,Callahan,FL
+TOWNOFCARRBORONC.GOV,City,Non-Federal Agency,Carrboro,NC
+TOWNOFCARYNC.GOV,City,Non-Federal Agency,Cary,NC
+TOWNOFCATSKILLNY.GOV,City,Non-Federal Agency,Catskill,NY
+TOWNOFCHADBOURNNC.GOV,City,Non-Federal Agency,Chadbourn,NC
+TOWNOFCLAYTONNC.GOV,City,Non-Federal Agency,Clayton,NC
+TOWNOFEASTHAVEN-CT.GOV,City,Non-Federal Agency,East Haven,CT
+TOWNOFHALFMOON-NY.GOV,City,Non-Federal Agency,Halfmoon,NY
+TOWNOFHAVERHILL-FL.GOV,City,Non-Federal Agency,Haverhill,FL
+TOWNOFHAYDENAZ.GOV,City,Non-Federal Agency,Hayden,AZ
+TOWNOFHOMECROFTIN.GOV,City,Non-Federal Agency,Indianapolis,IN
+TOWNOFHOUNSFIELD-NY.GOV,City,Non-Federal Agency,Watertown,NY
+TOWNOFISLIP-NY.GOV,City,Non-Federal Agency,Islip,NY
+TOWNOFKENTNY.GOV,City,Non-Federal Agency,Kent Lakes,NY
+TOWNOFLAPOINTEWI.GOV,City,Non-Federal Agency,La Pointe,WI
+TOWNOFLAVETA-CO.GOV,City,Non-Federal Agency,La Veta,CO
+TOWNOFMAYNARD-MA.GOV,City,Non-Federal Agency,Maynard,MA
+TOWNOFMONTEAGLE-TN.GOV,City,Non-Federal Agency,Monteagle,TN
+TOWNOFNASHVILLENC.GOV,City,Non-Federal Agency,Nashville,NC
+TOWNOFNORTH-SC.GOV,City,Non-Federal Agency,North,SC
+TOWNOFNORTHEASTNY.GOV,City,Non-Federal Agency,Millerton,NY
+TOWNOFORANGEVA.GOV,City,Non-Federal Agency,Orange,VA
+TOWNOFOYSTERBAY-NY.GOV,City,Non-Federal Agency,Oyster Bay,NY
+TOWNOFPENNINGTONVA.GOV,City,Non-Federal Agency,Pennington Gap,VA
+TOWNOFPOUGHKEEPSIE-NY.GOV,City,Non-Federal Agency,POUGHKEEPSIE,NY
+TOWNOFROBERSONVILLE-NC.GOV,City,Non-Federal Agency,Robersonville,NC
+TOWNOFSHIELDS-WI.GOV,City,Non-Federal Agency,Montello,WI
+TOWNOFSHIRLEY-MA.GOV,City,Non-Federal Agency,Shirley,MA
+TOWNOFSTLEO-FL.GOV,City,Non-Federal Agency,Saint Leo,FL
+TOWNOFSURFSIDEFL.GOV,City,Non-Federal Agency,Surfside,FL
+TOWNOFTROPICUT.GOV,City,Non-Federal Agency,Tropic,UT
+TOWNOFVASSNC.GOV,City,Non-Federal Agency,Vass,NC
+TOWNOFWALWORTHNY.GOV,City,Non-Federal Agency,Walworth,NY
+TOWNOFWARREN-RI.GOV,City,Non-Federal Agency,Warren,RI
+TOWNOFWASHINGTONVA.GOV,City,Non-Federal Agency,Washington,VA
+TOWNOFWOODSTOCKVA.GOV,City,Non-Federal Agency,Woodstock,VA
+TOWNSHIPOFTABERNACLE-NJ.GOV,City,Non-Federal Agency,Tabernacle,NJ
+TRAVERSECITYMI.GOV,City,Non-Federal Agency,Traverse City,MI
+TREASUREISLAND-FL.GOV,City,Non-Federal Agency,Treasure Island,FL
+TRENTONGA.GOV,City,Non-Federal Agency,trenton,GA
+TRICOUNTYCONSERVANCY-IN.GOV,City,Non-Federal Agency,Plainfield,IN
+TRINITY-NC.GOV,City,Non-Federal Agency,Trinity,NC
+TRINITYAL.GOV,City,Non-Federal Agency,Trinity,AL
+TROPHYCLUBTX.GOV,City,Non-Federal Agency,Trophy Club,TX
+TROUTDALEOREGON.GOV,City,Non-Federal Agency,Troutdale,OR
+TROUTMANNC.GOV,City,Non-Federal Agency,Troutman,NC
+TROYAL.GOV,City,Non-Federal Agency,Troy,AL
+TROYMI.GOV,City,Non-Federal Agency,Troy,MI
+TROYNY.GOV,City,Non-Federal Agency,Troy,NY
+TROYOHIO.GOV,City,Non-Federal Agency,Troy,OH
+TRUMANSBURG-NY.GOV,City,Non-Federal Agency,Trumansburg,NY
+TRUMBULL-CT.GOV,City,Non-Federal Agency,Trumbull,CT
+TRURO-MA.GOV,City,Non-Federal Agency,Truro,MA
+TUALATINOREGON.GOV,City,Non-Federal Agency,TUALATIN,OR
+TUKWILA-WA.GOV,City,Non-Federal Agency,Tukwila,WA
+TUKWILAWA.GOV,City,Non-Federal Agency,Tukwila,WA
+TULIA-TX.GOV,City,Non-Federal Agency,Tulia,TX
+TULLAHOMATN.GOV,City,Non-Federal Agency,Tullahoma,TN
+TUMWATERWA.GOV,City,Non-Federal Agency,Tumwater,WA
+TUPELOMS.GOV,City,Non-Federal Agency,Tupelo,MS
+TUSAYAN-AZ.GOV,City,Non-Federal Agency,Tusayan,AZ
+TUSAYANAZ.GOV,City,Non-Federal Agency,Grand Canyon,AZ
+TUSKEGEEALABAMA.GOV,City,Non-Federal Agency,Tuskegee,AL
+TUXEDOPARK-NY.GOV,City,Non-Federal Agency,Sloatsburg,NY
+TWPOCEANNJ.GOV,City,Non-Federal Agency,Waretown,NJ
+TYNGSBOROUGHMA.GOV,City,Non-Federal Agency,Tyngsborough,MA
+TYRINGHAM-MA.GOV,City,Non-Federal Agency,Tyringham,MA
+UCTX.GOV,City,Non-Federal Agency,Universal City,TX
+UNDERHILLVT.GOV,City,Non-Federal Agency,"Underhill, Ctr",VT
+UNIONCITY-IN.GOV,City,Non-Federal Agency,Union City,IN
+UNIONCITYNJ.GOV,City,Non-Federal Agency,Union City,NJ
+UNIONCITYTN.GOV,City,Non-Federal Agency,UNION CITY,TN
+UNIONGAPWA.GOV,City,Non-Federal Agency,Union Gap,WA
+UNIONSPRINGSAL.GOV,City,Non-Federal Agency,Union Springs,AL
+UNIONTWP-HCNJ.GOV,City,Non-Federal Agency,HAMPTON,NJ
+UNIVERSALCITYTEXAS.GOV,City,Non-Federal Agency,Universal City,TX
+UPLANDCA.GOV,City,Non-Federal Agency,UPLAND,CA
+UPPERMARLBOROMD.GOV,City,Non-Federal Agency,Upper Marlboro,MD
+UPPERUWCHLAN-PA.GOV,City,Non-Federal Agency,Chester Springs,PA
+UPTONMA.GOV,City,Non-Federal Agency,Upton,MA
+URBANAILLINOIS.GOV,City,Non-Federal Agency,Urbana,IL
+URBANNAVA.GOV,City,Non-Federal Agency,Urbanna,VA
+UTICA-IL.GOV,City,Non-Federal Agency,Utica,IL
+UVALDETX.GOV,City,Non-Federal Agency,Uvalde,TX
+UXBRIDGE-MA.GOV,City,Non-Federal Agency,Uxbridge,MA
+VANMETERIA.GOV,City,Non-Federal Agency,Van Meter,IA
+VENETAOREGON.GOV,City,Non-Federal Agency,Veneta,OR
+VERMONTVILLE-MI.GOV,City,Non-Federal Agency,Vermontville,MI
+VERNON-CT.GOV,City,Non-Federal Agency,Vernon,CT
+VERNONIA-OR.GOV,City,Non-Federal Agency,Vernonia,OR
+VERNONTX.GOV,City,Non-Federal Agency,Vernon,TX
+VERONAWI.GOV,City,Non-Federal Agency,Verona,WI
+VICKSBURGMS.GOV,City,Non-Federal Agency,Vicksburg,MS
+VICTORVILLECA.GOV,City,Non-Federal Agency,Victorville,CA
+VICTORYGARDENSNJ.GOV,City,Non-Federal Agency,Victory Gardens,NJ
+VIDALIAGA.GOV,City,Non-Federal Agency,VIDALIA,GA
+VIENNAVA.GOV,City,Non-Federal Agency,VIENNA,VA
+VILLAGEOFBABYLONNY.GOV,City,Non-Federal Agency,Babylon,NY
+VILLAGEOFCAMILLUS-NY.GOV,City,Non-Federal Agency,CAMILLUS,NY
+VILLAGEOFCRESTWOODIL.GOV,City,Non-Federal Agency,Crestwood,IL
+VILLAGEOFGOSHEN-NY.GOV,City,Non-Federal Agency,Goshen,NY
+VILLAGEOFHEMPSTEADNY.GOV,City,Non-Federal Agency,Hemsptead,NY
+VILLAGEOFKENSINGTONNY.GOV,City,Non-Federal Agency,Great Neck,NY
+VILLAGEOFMCCOMBOH.GOV,City,Non-Federal Agency,McComb,OH
+VILLAGEOFMISENHEIMERNC.GOV,City,Non-Federal Agency,Misenheimer,NC
+VILLAGEOFNEWHAVEN-MI.GOV,City,Non-Federal Agency,New Haven,MI
+VILLAGEOFNEWHOLLAND-OH.GOV,City,Non-Federal Agency,New Holland,OH
+VILLAGEOFNEWTOWNOHIO.GOV,City,Non-Federal Agency,Newtown,OH
+VILLAGEOFPHOENIX-NY.GOV,City,Non-Federal Agency,Phoenix,NY
+VILLAGEOFPINEHURSTNC.GOV,City,Non-Federal Agency,Pinehurst,NC
+VILLAGEOFQUOGUENY.GOV,City,Non-Federal Agency,Quogue,NY
+VILLAGEOFVOLENTE-TX.GOV,City,Non-Federal Agency,Volente,TX
+VILLAGEOFWAUCONDA-IL.GOV,City,Non-Federal Agency,Wauconda,IL
+VIRGINIAGARDENS-FL.GOV,City,Non-Federal Agency,Virginia Gardens,FL
+VOLENTETEXAS.GOV,City,Non-Federal Agency,Volente,TX
+VOLUNTOWN.GOV,City,Non-Federal Agency,Voluntown,CT
+WACOTX.GOV,City,Non-Federal Agency,Waco,TX
+WAITEHILLOH.GOV,City,Non-Federal Agency,Waite Hill,OH
+WAKEFORESTNC.GOV,City,Non-Federal Agency,WAKE FOREST,NC
+WALDENTN.GOV,City,Non-Federal Agency,Signal Mountain,TN
+WALKER-LA.GOV,City,Non-Federal Agency,Walker,LA
+WALKERSVILLEMD.GOV,City,Non-Federal Agency,Walkersville,MD
+WALLINGFORDCT.GOV,City,Non-Federal Agency,Wallingford,CT
+WALTONHILLSOHIO.GOV,City,Non-Federal Agency,Walton Hills,OH
+WANATAH-IN.GOV,City,Non-Federal Agency,Wanatah,IN
+WAPPINGERSFALLSNY.GOV,City,Non-Federal Agency,Wappingers Falls,NY
+WARNERROBINSGA.GOV,City,Non-Federal Agency,Warner Robins,GA
+WARREN-MA.GOV,City,Non-Federal Agency,Warren,MA
+WARRENTONVA.GOV,City,Non-Federal Agency,Warrenton,VA
+WARWICKRI.GOV,City,Non-Federal Agency,Warwick,RI
+WASHINGTON-WARRENAIRPORT-NC.GOV,City,Non-Federal Agency,WASHINGTON,NC
+WASHINGTONBORO-NJ.GOV,City,Non-Federal Agency,Washington,NJ
+WASHINGTONISLAND-WI.GOV,City,Non-Federal Agency,Washington Island,WI
+WASHINGTONVA.GOV,City,Non-Federal Agency,Washington,VA
+WASHINGTONVIRGINIA.GOV,City,Non-Federal Agency,Washington,VA
+WATCHUNGNJ.GOV,City,Non-Federal Agency,Watchung,NJ
+WATERBORO-ME.GOV,City,Non-Federal Agency,East Waterboro,ME
+WATERFORDMI.GOV,City,Non-Federal Agency,Waterford,MI
+WATERTOWN-MA.GOV,City,Non-Federal Agency,Watertown,MA
+WATERTOWN-NY.GOV,City,Non-Federal Agency,Watertown,NY
+WATERVILLE-ME.GOV,City,Non-Federal Agency,Waterville,ME
+WAUCONDA-IL.GOV,City,Non-Federal Agency,Wauconda,IL
+WAUKEGANIL.GOV,City,Non-Federal Agency,Waukegan,IL
+WAUKESHA-WI.GOV,City,Non-Federal Agency,Waukesha,WI
+WAVELAND-MS.GOV,City,Non-Federal Agency,Waveland,MS
+WAYNESVILLENC.GOV,City,Non-Federal Agency,Waynesville,NC
+WEATHERFORDTX.GOV,City,Non-Federal Agency,Weatherford,TX
+WEATHERLYPA.GOV,City,Non-Federal Agency,Weatherly,PA
+WEBSTER-MA.GOV,City,Non-Federal Agency,Webster,MA
+WEBSTER-NH.GOV,City,Non-Federal Agency,Webster,NH
+WEBSTERFL.GOV,City,Non-Federal Agency,Webster,FL
+WELAKA-FL.GOV,City,Non-Federal Agency,Welaka,FL
+WELLESLEYMA.GOV,City,Non-Federal Agency,Wellesley,MA
+WELLFLEET-MA.GOV,City,Non-Federal Agency,Wellfleet,MA
+WELLINGTONCOLORADO.GOV,City,Non-Federal Agency,Wellington,CO
+WELLINGTONFL.GOV,City,Non-Federal Agency,Wellington,FL
+WELLSBURGWV.GOV,City,Non-Federal Agency,WELLSBURG,WV
+WENATCHEEWA.GOV,City,Non-Federal Agency,Wenatchee,WA
+WESLACOTX.GOV,City,Non-Federal Agency,Weslaco,TX
+WESSONMS.GOV,City,Non-Federal Agency,Wesson,MS
+WESTALLISWI.GOV,City,Non-Federal Agency,West Allis,WI
+WESTAMPTONNJ.GOV,City,Non-Federal Agency,Westampton,NJ
+WESTBOYLSTON-MA.GOV,City,Non-Federal Agency,West Boylston,MA
+WESTBUECHELKY.GOV,City,Non-Federal Agency,WEST BUECHEL,KY
+WESTCOLUMBIASC.GOV,City,Non-Federal Agency,West Columbia,SC
+WESTFARGOND.GOV,City,Non-Federal Agency,Bismarck,ND
+WESTFIELDNJ.GOV,City,Non-Federal Agency,Westfield,NJ
+WESTFORD-MA.GOV,City,Non-Federal Agency,Westford,MA
+WESTFORDMA.GOV,City,Non-Federal Agency,Westford,MA
+WESTFRANKFORT-IL.GOV,City,Non-Federal Agency,West Frankfort,IL
+WESTHARTFORDCT.GOV,City,Non-Federal Agency,West Hartford,CT
+WESTHAVEN-CT.GOV,City,Non-Federal Agency,West Haven,CT
+WESTLINNOREGON.GOV,City,Non-Federal Agency,West Linn,OR
+WESTMILTONOHIO.GOV,City,Non-Federal Agency,West Milton,OH
+WESTMINSTER-MA.GOV,City,Non-Federal Agency,Westminster,MA
+WESTMINSTERMD.GOV,City,Non-Federal Agency,Westminster,MD
+WESTONCT.GOV,City,Non-Federal Agency,Weston,CT
+WESTONWI.GOV,City,Non-Federal Agency,Weston,WI
+WESTPALMBEACH-FL.GOV,City,Non-Federal Agency,West Palm Beach,FL
+WESTPORT-MA.GOV,City,Non-Federal Agency,Westport,MA
+WESTPORTCT.GOV,City,Non-Federal Agency,Westport,CT
+WESTSTOCKBRIDGE-MA.GOV,City,Non-Federal Agency,West Stockbridge,MA
+WESTTISBURY-MA.GOV,City,Non-Federal Agency,West Tisbury,MA
+WESTUTX.GOV,City,Non-Federal Agency,West University Place ,TX
+WESTWOOD-MA.GOV,City,Non-Federal Agency,Westwood,MA
+WESTWOODMA.GOV,City,Non-Federal Agency,Westwood,MA
+WESTWOODNJ.GOV,City,Non-Federal Agency,Westwood,NJ
+WETHERSFIELDCT.GOV,City,Non-Federal Agency,Wethersfield,CT
+WHEELINGIL.GOV,City,Non-Federal Agency,Wheeling,IL
+WHEELINGWV.GOV,City,Non-Federal Agency,Wheeling,WV
+WHITECOUNTY-IL.GOV,City,Non-Federal Agency,Carmi,IL
+WHITEHOUSEOH.GOV,City,Non-Federal Agency,Whitehouse,OH
+WHITEPLAINSNY.GOV,City,Non-Federal Agency,White Plains,NY
+WHITEWATER-WI.GOV,City,Non-Federal Agency,Whitewater,WI
+WHITINGWI.GOV,City,Non-Federal Agency,Stevens Point,WI
+WHITTIERALASKA.GOV,City,Non-Federal Agency,Whittier,AK
+WICHITA.GOV,City,Non-Federal Agency,Wichita,KS
+WICHITAFALLSTX.GOV,City,Non-Federal Agency,Wichita Falls,TX
+WILBRAHAM-MA.GOV,City,Non-Federal Agency,Wilbraham,MA
+WILDWOOD-FL.GOV,City,Non-Federal Agency,Wildwood,FL
+WILKINSBURGPA.GOV,City,Non-Federal Agency,Wilkinsburg,PA
+WILLAMINAOREGON.GOV,City,Non-Federal Agency,Willamina,OR
+WILLARDNM.GOV,City,Non-Federal Agency,Willard,NM
+WILLIAMSAZ.GOV,City,Non-Federal Agency,Williams,AZ
+WILLIAMSPORTMD.GOV,City,Non-Federal Agency,WILLIAMSPORT,MD
+WILLINGBORONJ.GOV,City,Non-Federal Agency,Willingboro,NJ
+WILLISTONFL.GOV,City,Non-Federal Agency,Williston,FL
+WILLMARMN.GOV,City,Non-Federal Agency,Willmar,MN
+WILLOUGHBYHILLS-OH.GOV,City,Non-Federal Agency,Willoughby Hills,OH
+WILLOWSPRINGS-IL.GOV,City,Non-Federal Agency,Willow Springs,IL
+WILMINGTONDE.GOV,City,Non-Federal Agency,Wilmington,DE
+WILMINGTONMA.GOV,City,Non-Federal Agency,wilmington,MA
+WILTONNH.GOV,City,Non-Federal Agency,Wilton,NH
+WINCHESTER-IN.GOV,City,Non-Federal Agency,Winchester,IN
+WINCHESTER-NH.GOV,City,Non-Federal Agency,Winchester,NH
+WINCHESTERVA.GOV,City,Non-Federal Agency,Winchester,VA
+WINDCREST-TX.GOV,City,Non-Federal Agency,Windcrest,TX
+WINDGAP-PA.GOV,City,Non-Federal Agency,Wind Gap,PA
+WINDHAMNH.GOV,City,Non-Federal Agency,Windham,NH
+WINDSOR-VA.GOV,City,Non-Federal Agency,Windsor,VA
+WINDSORWI.GOV,City,Non-Federal Agency,DeForest,WI
+WINNECONNEWI.GOV,City,Non-Federal Agency,Winneconne,WI
+WINSLOW-ME.GOV,City,Non-Federal Agency,Winslow,ME
+WOBURNMA.GOV,City,Non-Federal Agency,Woburn,MA
+WOODBURN-OR.GOV,City,Non-Federal Agency,Woodburn,OR
+WOODBURYMN.GOV,City,Non-Federal Agency,Woodbury,MN
+WOODFIN-NC.GOV,City,Non-Federal Agency,Woodfin,NC
+WOODHEIGHTS-MO.GOV,City,Non-Federal Agency,Wood Heights,MO
+WOODSTOCKCT.GOV,City,Non-Federal Agency,Woodstock,CT
+WOODSTOCKGA.GOV,City,Non-Federal Agency,Woodstock,GA
+WOODSTOCKIL.GOV,City,Non-Federal Agency,Woodstock,IL
+WOODVILLE-TX.GOV,City,Non-Federal Agency,Woodville,TX
+WORCESTERMA.GOV,City,Non-Federal Agency,Worcester,MA
+WRGA.GOV,City,Non-Federal Agency,Warner Robins,GA
+WSPMN.GOV,City,Non-Federal Agency,West Saint Paul,MN
+WVC-UT.GOV,City,Non-Federal Agency,West Valley,UT
+WYLIETEXAS.GOV,City,Non-Federal Agency,Wylie,TX
+WYOMINGMI.GOV,City,Non-Federal Agency,Wyoming,MI
+WYOMINGOHIO.GOV,City,Non-Federal Agency,Wyoming,OH
+XENIA-OH.GOV,City,Non-Federal Agency,Xenia,OH
+YAKIMAWA.GOV,City,Non-Federal Agency,Yakima,WA
+YONKERSNY.GOV,City,Non-Federal Agency,Yonkers,NY
+YORKTOWNTX.GOV,City,Non-Federal Agency,Yorktown,TX
+YOUNGSTOWNOHIO.GOV,City,Non-Federal Agency,Youngstown,OH
+YOUNGSVILLELA.GOV,City,Non-Federal Agency,Youngsville,LA
+YUMAAZ.GOV,City,Non-Federal Agency,Yuma,AZ
+ZILWAUKEEMICHIGAN.GOV,City,Non-Federal Agency,Zilwaukee,MI

--- a/dotgov-domains/2015-11-03-counties.csv
+++ b/dotgov-domains/2015-11-03-counties.csv
@@ -1,0 +1,472 @@
+Domain Name,Domain Type,Agency,City,State
+ICATCO.GOV,County,General Services Administration,Newton,NC
+ADAMSCOUNTYOH.GOV,County,Non-Federal Agency,West Union,OH
+AIKENCOUNTYSC.GOV,County,Non-Federal Agency,Aiken,SC
+ALEXANDERCOUNTY-NC.GOV,County,Non-Federal Agency,Taylorsville,NC
+ALLEGHANYCOUNTY-NC.GOV,County,Non-Federal Agency,Sparta,NC
+ALLEGHENYCOUNTYPA.GOV,County,Non-Federal Agency,Pittsburgh,PA
+ALPINECOUNTYCA.GOV,County,Non-Federal Agency,Markleeville,CA
+ANDROSCOGGINCOUNTYMAINE.GOV,County,Non-Federal Agency,Auburn,ME
+ANOKACOUNTYMN.GOV,County,Non-Federal Agency,Anoka,MN
+APPOMATTOXCOUNTYVA.GOV,County,Non-Federal Agency,Appomattox,VA
+ARANSASCOUNTYTX.GOV,County,Non-Federal Agency,Rockport,TX
+AUGUSTACOUNTY-VA.GOV,County,Non-Federal Agency,Verona,VA
+AUGUSTACOUNTYVA.GOV,County,Non-Federal Agency,Verona,VA
+AVERYCOUNTYNC.GOV,County,Non-Federal Agency,Newland,NC
+BACACOUNTYCO.GOV,County,Non-Federal Agency,Springfield,CO
+BALDWINCOUNTYAL.GOV,County,Non-Federal Agency,Bay Minette,AL
+BALTIMORECOUNTYMD.GOV,County,Non-Federal Agency,Towson,MD
+BAMBERGCOUNTYSC.GOV,County,Non-Federal Agency,Bamberg,SC
+BARNSTABLECOUNTY-MA.GOV,County,Non-Federal Agency,Barnstable,MA
+BARRONCOUNTYWI.GOV,County,Non-Federal Agency,Barron,WI
+BASTROPCOUNTYTEXAS.GOV,County,Non-Federal Agency,Bastrop,TX
+BAYCOUNTY911-MI.GOV,County,Non-Federal Agency,Bay City,MI
+BAYCOUNTYFL.GOV,County,Non-Federal Agency,Panama City,FL
+BEAVERCOUNTYPA.GOV,County,Non-Federal Agency,Beaver,PA
+BEDFORDCOUNTYVA.GOV,County,Non-Federal Agency,Bedford,VA
+BENTONCOUNTYAR.GOV,County,Non-Federal Agency,Bentonville,AR
+BENTONCOUNTYMS.GOV,County,Non-Federal Agency,Ashland,MS
+BENTONCOUNTYTN.GOV,County,Non-Federal Agency,Camden,TN
+BERKELEYCOUNTYSC.GOV,County,Non-Federal Agency,Moncks Corner,SC
+BERRIENCOUNTY-MI.GOV,County,Non-Federal Agency,St. Joseph,MI
+BIGHORNCOUNTYMT.GOV,County,Non-Federal Agency,Hardin,MT
+BILLINGSCOUNTYND.GOV,County,Non-Federal Agency,Medora,ND
+BLAINECOUNTY-MT.GOV,County,Non-Federal Agency,CHINOOK,MT
+BLANDCOUNTYVA.GOV,County,Non-Federal Agency,Bland,VA
+BLUEEARTHCOUNTYMN.GOV,County,Non-Federal Agency,Mankato,MN
+BONNERCOUNTYID.GOV,County,Non-Federal Agency,Sandpoint,ID
+BOONECOUNTY-AR.GOV,County,Non-Federal Agency,Harrison,AR
+BOSSIERPARISHLA.GOV,County,Non-Federal Agency,Benton ,LA
+BOTETOURTVA.GOV,County,Non-Federal Agency,Fincastle,VA
+BOULDERCOUNTYCOLORADO.GOV,County,Non-Federal Agency,Boulder,CO
+BOWMANCOUNTYND.GOV,County,Non-Federal Agency,Bismarck,ND
+BOYDCOUNTYKY.GOV,County,Non-Federal Agency,Catlettsburg,KY
+BRADFORDCOUNTYFL.GOV,County,Non-Federal Agency,Starke,FL
+BRADLEYCOUNTYTN.GOV,County,Non-Federal Agency,Cleveland,TN
+BRANCHCOUNTYMI.GOV,County,Non-Federal Agency,Coldwater,MI
+BRAZORIACOUNTY-TX.GOV,County,Non-Federal Agency,Angleton,TX
+BRAZORIACOUNTYTX.GOV,County,Non-Federal Agency,Angleton,TX
+BRAZOSCOUNTYTX.GOV,County,Non-Federal Agency,Bryan,TX
+BROOMECOUNTYNY.GOV,County,Non-Federal Agency,Binghamton,NY
+BROWNCOUNTY-IN.GOV,County,Non-Federal Agency,Nashville,IN
+BROWNCOUNTYOHIO.GOV,County,Non-Federal Agency,Georgetown,OH
+BROWNCOUNTYWI.GOV,County,Non-Federal Agency,Green Bay,WI
+BRUNSWICKCOUNTYNC.GOV,County,Non-Federal Agency,Bolivia,NC
+BUCHANANCOUNTY-VA.GOV,County,Non-Federal Agency,Grundy,VA
+BUNCOMBECOUNTYNC.GOV,County,Non-Federal Agency,Asheville,NC
+BUREAUCOUNTY-IL.GOV,County,Non-Federal Agency,Princeton,IL
+CABARRUSCOUNTYNC.GOV,County,Non-Federal Agency,Concord,NC
+CALHOUNCOUNTYAL.GOV,County,Non-Federal Agency,Anniston,AL
+CALHOUNCOUNTYMI.GOV,County,Non-Federal Agency,Marshall,MI
+CALLOWAYCOUNTY-KY.GOV,County,Non-Federal Agency,Murray,KY
+CAMBRIACOUNTYPA.GOV,County,Non-Federal Agency,Ebensburg,PA
+CAMDENCOUNTYNC.GOV,County,Non-Federal Agency,Camden,NC
+CAMPBELLCOUNTYKY.GOV,County,Non-Federal Agency,Newport,KY
+CAMPBELLCOUNTYTN.GOV,County,Non-Federal Agency,Jacksboro,TN
+CAMPBELLCOUNTYVA.GOV,County,Non-Federal Agency,Rustburg,VA
+CANDLERCO-GA.GOV,County,Non-Federal Agency,Metter,GA
+CAPECOD-MA.GOV,County,Non-Federal Agency,Barnstable,MA
+CAPEMAYCOUNTYNJ.GOV,County,Non-Federal Agency,Cape May Court House,NJ
+CAPITALALERT.GOV,County,Non-Federal Agency,Fairfax,VA
+CAPITALERT.GOV,County,Non-Federal Agency,Fairfax,VA
+CARROLLCOUNTYIN.GOV,County,Non-Federal Agency,Delphi,IN
+CARTERCOUNTYTN.GOV,County,Non-Federal Agency,Elizabethton,TN
+CARTERETCOUNTYNC.GOV,County,Non-Federal Agency,Beaufort,NC
+CASCADECOUNTYMT.GOV,County,Non-Federal Agency,Great Falls,MT
+CASSCOUNTYND.GOV,County,Non-Federal Agency,Bismarck,ND
+CATAWBACOUNTYNC.GOV,County,Non-Federal Agency,Newton,NC
+CATRONCOUNTYNM.GOV,County,Non-Federal Agency,Reserve,NM
+CEDARCOUNTYMO.GOV,County,Non-Federal Agency,Stockton,MO
+CENTRECOUNTYPA.GOV,County,Non-Federal Agency,Bellefonte,PA
+CHAMBERSCOUNTYAL.GOV,County,Non-Federal Agency,Lafayette,AL
+CHAMBERSTX.GOV,County,Non-Federal Agency,Anahuac,TX
+CHARLESCOUNTYMD.GOV,County,Non-Federal Agency,La Plata,MD
+CHARLOTTECOUNTYFL.GOV,County,Non-Federal Agency,Port Charlotte,FL
+CHEATHAMCOUNTYTN.GOV,County,Non-Federal Agency,Ashland City,TN
+CHELANCOUNTYWA.GOV,County,Non-Federal Agency,Wenatchee,WA
+CHEROKEECOUNTY-AL.GOV,County,Non-Federal Agency,Centre,AL
+CHEROKEECOUNTY-KS.GOV,County,Non-Federal Agency,Columbus,KS
+CHEROKEECOUNTYKS.GOV,County,Non-Federal Agency,Columbus,KS
+CHEROKEECOUNTYSC.GOV,County,Non-Federal Agency,Gaffney,SC
+CHEYENNECOUNTY-CO.GOV,County,Non-Federal Agency,CHEYENNE WELLS,CO
+CHRISTIANCOUNTYKY.GOV,County,Non-Federal Agency,Hopkinsville,KY
+CHRISTIANCOUNTYMO.GOV,County,Non-Federal Agency,Ozark,MO
+CLARKCOUNTYNV.GOV,County,Non-Federal Agency,Las Vegas,NV
+CLARKCOUNTYOHIO.GOV,County,Non-Federal Agency,Springfield,OH
+CLARKECOUNTYMS.GOV,County,Non-Federal Agency,Quitman,MS
+CLAYCOUNTYMN.GOV,County,Non-Federal Agency,Moorhead,MN
+CLAYCOUNTYMO.GOV,County,Non-Federal Agency,Liberty,MO
+CLAYTONCOUNTYGA.GOV,County,Non-Federal Agency,Jonesboro,GA
+CLAYTONCOUNTYIA.GOV,County,Non-Federal Agency,Elkader,IA
+CLERMONTCOUNTYOHIO.GOV,County,Non-Federal Agency,Batavia,OH
+CLINTONCOUNTY-IA.GOV,County,Non-Federal Agency,Clinton,IA
+COLUMBIACOUNTYGA.GOV,County,Non-Federal Agency,Evans,GA
+COLUMBIACOUNTYNY.GOV,County,Non-Federal Agency,Hudson,NY
+CONVERSECOUNTYWY.GOV,County,Non-Federal Agency,Douglas,WY
+COOKCOUNTYIL.GOV,County,Non-Federal Agency,Chicago,IL
+COOPERCOUNTYMO.GOV,County,Non-Federal Agency,Boonville,MO
+CORONADOCA.GOV,County,Non-Federal Agency,Coronado,CA
+COSCPINALCOUNTYAZ.GOV,County,Non-Federal Agency,Florence,AZ
+COSTILLACOUNTY-CO.GOV,County,Non-Federal Agency,San Luis,CO
+COUNTYOFPITT-NC.GOV,County,Non-Federal Agency,Greenville,NC
+COVINGTONCOUNTYMS.GOV,County,Non-Federal Agency,Collins,MS
+CRAIGCOUNTYVA.GOV,County,Non-Federal Agency,New Castle,VA
+CRAVENCOUNTYNC.GOV,County,Non-Federal Agency,New Bern,NC
+CRAWFORDCOUNTYKANSAS.GOV,County,Non-Federal Agency,Girard,KS
+CULPEPERCOUNTY.GOV,County,Non-Federal Agency,Culpeper,VA
+CUMBERLANDCOUNTYTN.GOV,County,Non-Federal Agency,Crossville,TN
+CURRITUCKCOUNTYNC.GOV,County,Non-Federal Agency,Currituck,NC
+DADECOUNTY-GA.GOV,County,Non-Federal Agency,Trenton,GA
+DAKOTACOUNTYMN.GOV,County,Non-Federal Agency,Hastings,MN
+DALLASCOUNTY-TX.GOV,County,Non-Federal Agency,Dallas,TX
+DALLASCOUNTYIOWA.GOV,County,Non-Federal Agency,Adel,IA
+DARECOUNTYNC.GOV,County,Non-Federal Agency,Manteo,NC
+DAVIDSONCOUNTYNC.GOV,County,Non-Federal Agency,Lexington,NC
+DAVIECOUNTYNC.GOV,County,Non-Federal Agency,Mocksville,NC
+DAVISCOUNTYUT4HEALTH.GOV,County,Non-Federal Agency,Farmington,UT
+DAVISUT4HEALTH.GOV,County,Non-Federal Agency,Farmington,UT
+DAWSONCOUNTYNE.GOV,County,Non-Federal Agency,Lexington,NE
+DCONC.GOV,County,Non-Federal Agency,Durham,NC
+DECATURCOUNTYGA.GOV,County,Non-Federal Agency,Bainbridge,GA
+DEKALBCOUNTYGA.GOV,County,Non-Federal Agency,Decatur,GA
+DEKALBCOUNTYIL.GOV,County,Non-Federal Agency,Sycamore,IL
+DESOTOCOUNTYMS.GOV,County,Non-Federal Agency,HERNANDO,MS
+DICKINSONCOUNTYMI.GOV,County,Non-Federal Agency,Iron Mountain,MI
+DICKSONCOUNTYTN.GOV,County,Non-Federal Agency,Charlotte,TN
+DOUGLASCOUNTY-NE.GOV,County,Non-Federal Agency,Omaha,NE
+DOUGLASCOUNTYNV.GOV,County,Non-Federal Agency,Minden,NV
+DUNNCOUNTYWI.GOV,County,Non-Federal Agency,Menomonie,WI
+DURHAMCOUNTYNC.GOV,County,Non-Federal Agency,Durham,NC
+ECTORCOUNTYTX.GOV,County,Non-Federal Agency,Odessa,TX
+ERIE.GOV,County,Non-Federal Agency,Buffalo,NY
+FAIRFAXCOUNTYVIRGINIA.GOV,County,Non-Federal Agency,Fairfax,VA
+FAUQUIERCOUNTY.GOV,County,Non-Federal Agency,Warrenton,VA
+FENTRESSCOUNTYTN.GOV,County,Non-Federal Agency,Jamestown,TN
+FORTBENDCOUNTYTX.GOV,County,Non-Federal Agency,Richmond,TX
+FRANKLINCOUNTYGA.GOV,County,Non-Federal Agency,Carnesville,GA
+FRANKLINCOUNTYIL.GOV,County,Non-Federal Agency,Benton,IL
+FRANKLINCOUNTYMAINE.GOV,County,Non-Federal Agency,Farmington,ME
+FRANKLINCOUNTYOHIO.GOV,County,Non-Federal Agency,Columbus,OH
+FRANKLINCOUNTYPA.GOV,County,Non-Federal Agency,Chambersburg,PA
+FRANKLINCOUNTYVA.GOV,County,Non-Federal Agency,Rocky Mount,VA
+FREDERICKCOUNTYMD.GOV,County,Non-Federal Agency,Frederick,MD
+FREDERICKCOUNTYVA.GOV,County,Non-Federal Agency,Winchester,VA
+FRIOCOUNTY-TX.GOV,County,Non-Federal Agency,Pearsall,TX
+FULTONCOUNTYGA.GOV,County,Non-Federal Agency,Atlanta,GA
+FULTONCOUNTYNY.GOV,County,Non-Federal Agency,Johnstown,NY
+GADSDENCOUNTYFL.GOV,County,Non-Federal Agency,Quincy,FL
+GALVESTONCOUNTYTX.GOV,County,Non-Federal Agency,Galveston,TX
+GARFIELDCOUNTY-CO.GOV,County,Non-Federal Agency,Glenwood Springs,CO
+GATESCOUNTYNC.GOV,County,Non-Federal Agency,Gatesville,NC
+GEORGECOUNTYMS.GOV,County,Non-Federal Agency,Lucedale,MS
+GGSC.GOV,County,Non-Federal Agency,Greenville,SC
+GIBSONCOUNTY-IN.GOV,County,Non-Federal Agency,Princeton,IN
+GILACOUNTYAZ.GOV,County,Non-Federal Agency,Globe,AZ
+GILMERCOUNTY-GA.GOV,County,Non-Federal Agency,Ellijay,GA
+GILMERCOUNTYWV.GOV,County,Non-Federal Agency,GLENVILLE,WV
+GLOUCESTERCOUNTYNJ.GOV,County,Non-Federal Agency,Woodbury,NJ
+GOGEBICCOUNTYMI.GOV,County,Non-Federal Agency,Bessemer,MI
+GOLIADCOUNTYTX.GOV,County,Non-Federal Agency,Goliad,TX
+GRADYCOUNTYGA.GOV,County,Non-Federal Agency,Cairo,GA
+GRANTCOUNTY-OR.GOV,County,Non-Federal Agency,Canyon City,OR
+GRANTCOUNTYWA.GOV,County,Non-Federal Agency,Ephrata,WA
+GREENECOUNTYGA.GOV,County,Non-Federal Agency,Greensboro,GA
+GREENECOUNTYMO.GOV,County,Non-Federal Agency,Springfield,MO
+GREENECOUNTYMS.GOV,County,Non-Federal Agency,Leaksville,MS
+GREENECOUNTYNC.GOV,County,Non-Federal Agency,Snow Hill,NC
+GREENHARRISCOUNTYTX.GOV,County,Non-Federal Agency,Houston,TX
+GREENMCHENRYCOUNTYIL.GOV,County,Non-Federal Agency,Woodstock,IL
+GREENMCHENRYCOUNTYILLINOIS.GOV,County,Non-Federal Agency,Woodstock,IL
+GREENVILLECOUNTYSC.GOV,County,Non-Federal Agency,Greenville,SC
+GREENWOODSC.GOV,County,Non-Federal Agency,Greenwood,SC
+GRIGGSCOUNTYND.GOV,County,Non-Federal Agency,Bismarck,ND
+GULFCOUNTY-FL.GOV,County,Non-Federal Agency,Port St. Joe,FL
+GWINNETTCOUNTYGA.GOV,County,Non-Federal Agency,Lawrenceville,GA
+HABERSHAMCOUNTY-GA.GOV,County,Non-Federal Agency,Clarkesville,GA
+HAINESALASKA.GOV,County,Non-Federal Agency,Haines,AK
+HALIFAXCOUNTYVA.GOV,County,Non-Federal Agency,Halifax,VA
+HALLCOUNTYGA.GOV,County,Non-Federal Agency,Gainesville,GA
+HALLCOUNTYNE.GOV,County,Non-Federal Agency,Grand Island,NE
+HAMBLENCOUNTYTN.GOV,County,Non-Federal Agency,Morristown,TN
+HAMILTONCOUNTYFLORIDA.GOV,County,Non-Federal Agency,Jasper,FL
+HAMILTONCOUNTYNY.GOV,County,Non-Federal Agency,Lake Pleasent,NY
+HAMILTONCOUNTYOHIO.GOV,County,Non-Federal Agency,Cincinnati,OH
+HANCOCKCOUNTY-IL.GOV,County,Non-Federal Agency,Carthage,IL
+HANCOCKCOUNTYGA.GOV,County,Non-Federal Agency,Sparta,GA
+HANCOCKCOUNTYMS.GOV,County,Non-Federal Agency,Bay St. Louis,MS
+HARALSONCOUNTYGA.GOV,County,Non-Federal Agency,Buchanan,GA
+HARDINCOUNTYIA.GOV,County,Non-Federal Agency,Eldora,IA
+HARRISCOUNTYGA.GOV,County,Non-Federal Agency,Hamilton,GA
+HARRISCOUNTYTX.GOV,County,Non-Federal Agency,Houston,TX
+HARTCOUNTYGA.GOV,County,Non-Federal Agency,Hartwell,GA
+HAWAIICOUNTY.GOV,County,Non-Federal Agency,Hilo,HI
+HAWKINSCOUNTYTN.GOV,County,Non-Federal Agency,Rogersville,TN
+HAYWOODCOUNTYNC.GOV,County,Non-Federal Agency,Waynesville,NC
+HENDERSONCOUNTYTN.GOV,County,Non-Federal Agency,Lexington,TN
+HENRYCOUNTYVA.GOV,County,Non-Federal Agency,Martinsville,VA
+HERTFORDCOUNTYNC.GOV,County,Non-Federal Agency,Winton,NC
+HINSDALECOUNTY-CO.GOV,County,Non-Federal Agency,Lake City,CO
+HOWARDCOUNTYIN.GOV,County,Non-Federal Agency,Kokomo,IN
+HOWARDCOUNTYMARYLAND.GOV,County,Non-Federal Agency,Ellicott City,MD
+HOWARDCOUNTYMD.GOV,County,Non-Federal Agency,Ellicott City,MD
+HURONCOUNTY-OH.GOV,County,Non-Federal Agency,Norwalk,OH
+HYDECOUNTYNC.GOV,County,Non-Federal Agency,Swanquarter,NC
+ISSAQUENACOUNTYMS.GOV,County,Non-Federal Agency,Mayersville,MS
+JACKSONCOGA.GOV,County,Non-Federal Agency,Jefferson,GA
+JACKSONCOUNTY-IL.GOV,County,Non-Federal Agency,Murphysboro,IL
+JAMESCITYCOUNTYVA.GOV,County,Non-Federal Agency,Williamsburg,VA
+JASPERCOUNTYIN.GOV,County,Non-Federal Agency,Rensselaer,IN
+JASPERCOUNTYSC.GOV,County,Non-Federal Agency,Ridgeland,SC
+JEFFERSONCOUNTY-MT.GOV,County,Non-Federal Agency,Boulder,MT
+JEFFERSONCOUNTYFL.GOV,County,Non-Federal Agency,Monticello,FL
+JEFFERSONCOUNTYGA.GOV,County,Non-Federal Agency,LOUISVILLE,GA
+JEFFERSONCOUNTYMS.GOV,County,Non-Federal Agency,Fayette,MS
+JEFFERSONCOUNTYTN.GOV,County,Non-Federal Agency,Dandridge,TN
+JEFFERSONCOUNTYWI.GOV,County,Non-Federal Agency,Jefferson,WI
+JENNINGSCOUNTY-IN.GOV,County,Non-Federal Agency,Vernon,IN
+JIMWELLSCOUNTY-TX.GOV,County,Non-Federal Agency,Alice,TX
+JONESCOUNTYNC.GOV,County,Non-Federal Agency,Trenton,NC
+KAUAI.GOV,County,Non-Federal Agency,Lihue,HI
+KENNEBECCOUNTY-ME.GOV,County,Non-Federal Agency,Augusta,ME
+KERNCOG-CA.GOV,County,Non-Federal Agency,Bakersfield,CA
+KINGCOUNTY.GOV,County,Non-Federal Agency,Seattle,WA
+KINGGEORGECOUNTYVA.GOV,County,Non-Federal Agency,King George,VA
+KINGSBURYNY.GOV,County,Non-Federal Agency,Hudson Falls,NY
+KNOXCOUNTYMAINE.GOV,County,Non-Federal Agency,Rockland,ME
+KNOXCOUNTYTEXAS.GOV,County,Non-Federal Agency,Benjamin,TX
+LACOUNTY.GOV,County,Non-Federal Agency,Downey,CA
+LAKECOUNTYCA.GOV,County,Non-Federal Agency,Lakeport,CA
+LAKECOUNTYIL.GOV,County,Non-Federal Agency,Waukegan,IL
+LAKECOUNTYOHIO.GOV,County,Non-Federal Agency,Painesville,OH
+LAKEMT.GOV,County,Non-Federal Agency,Polson,MT
+LAPAZCOUNTYAZ.GOV,County,Non-Federal Agency,Parker,AZ
+LAUDERDALECOUNTYAL.GOV,County,Non-Federal Agency,Florence,AL
+LAWRENCECOUNTYTN.GOV,County,Non-Federal Agency,Lawrenceburg,TN
+LCCOUNTYMT.GOV,County,Non-Federal Agency,Helena,MT
+LEE-COUNTY-FL.GOV,County,Non-Federal Agency,Fort Myers,FL
+LEECOUNTYNC.GOV,County,Non-Federal Agency,Sanford,NC
+LEONCOUNTYFL.GOV,County,Non-Federal Agency,Tallahassee,FL
+LEWISCOUNTYWA.GOV,County,Non-Federal Agency,Chehalis,WA
+LIBERTYCOUNTY-GA.GOV,County,Non-Federal Agency,Hinesville,GA
+LIMESTONECOUNTY-AL.GOV,County,Non-Federal Agency,Athens,AL
+LIMESTONECOUNTYEMA-AL.GOV,County,Non-Federal Agency,Athens,AL
+LINCOLNCOUNTYNM.GOV,County,Non-Federal Agency,Carrizozo,NM
+LIVINGSTONCOUNTYIL.GOV,County,Non-Federal Agency,Pontiac,IL
+LIVINGSTONPARISHLA.GOV,County,Non-Federal Agency,Livingston,LA
+LOGANCOUNTYCO.GOV,County,Non-Federal Agency,Sterling,CO
+LOUDONCOUNTY-TN.GOV,County,Non-Federal Agency,Loudon,TN
+LOUDOUN.GOV,County,Non-Federal Agency,Leesburg,VA
+LOWNDESCOUNTYGA.GOV,County,Non-Federal Agency,Valdosta,GA
+LUCASCOUNTYOH.GOV,County,Non-Federal Agency,Toledo,OH
+LUMPKINCOUNTY.GOV,County,Non-Federal Agency,Dahlonega,GA
+MACOMBCOUNTYMI.GOV,County,Non-Federal Agency,Mount Clemens,MI
+MACONBIBBCOUNTYGA.GOV,County,Non-Federal Agency,Macon,GA
+MACONCOUNTYGA.GOV,County,Non-Federal Agency,Oglethorpe,GA
+MACONCOUNTYTN.GOV,County,Non-Federal Agency,Lafayette,TN
+MACOUPINCOUNTYIL.GOV,County,Non-Federal Agency,Carlinville,IL
+MADISONCOUNTYAL.GOV,County,Non-Federal Agency,Huntsville,AL
+MADISONCOUNTYNC.GOV,County,Non-Federal Agency,Marshall,NC
+MADISONCOUNTYTN.GOV,County,Non-Federal Agency,Jackson,TN
+MAHONINGCOUNTYOH.GOV,County,Non-Federal Agency,Youngstown,OH
+MANISTEECOUNTYMI.GOV,County,Non-Federal Agency,Manistee,MI
+MARIONCOUNTY-MO.GOV,County,Non-Federal Agency,Hannibal,MO
+MARSHALLCOUNTYIA.GOV,County,Non-Federal Agency,Marshalltown,IA
+MARSHALLCOUNTYKY.GOV,County,Non-Federal Agency,Benton,KY
+MATHEWSCOUNTYVA.GOV,County,Non-Federal Agency,Mathews,VA
+MAUICOUNTY-HI.GOV,County,Non-Federal Agency,Wailuku,HI
+MAUICOUNTY.GOV,County,Non-Federal Agency,Wailuku,HI
+MCCRACKENCOUNTYKY.GOV,County,Non-Federal Agency,Paducah,KY
+MCDONALDCOUNTYMO.GOV,County,Non-Federal Agency,Pineville,MO
+MCHENRYCOUNTYIL.GOV,County,Non-Federal Agency,Woodstock,IL
+MCHENRYCOUNTYILLINOIS.GOV,County,Non-Federal Agency,Woodstock,IL
+MCINTOSHCOUNTY-GA.GOV,County,Non-Federal Agency,Darien,GA
+MCLEANCOUNTYIL.GOV,County,Non-Federal Agency,Bloomington,IL
+MCLEANCOUNTYND.GOV,County,Non-Federal Agency,Washburn,ND
+MCMINNCOUNTYTN.GOV,County,Non-Federal Agency,Athens,TN
+MEADEKY.GOV,County,Non-Federal Agency,Brandenburg,KY
+MECKLENBURGCOUNTYNC.GOV,County,Non-Federal Agency,Charlotte,NC
+MEETEETSECD-WY.GOV,County,Non-Federal Agency,Meeteetse,WY
+MERCEDCOUNTYCA.GOV,County,Non-Federal Agency,Merced,CA
+MERIWETHERCOUNTYGA.GOV,County,Non-Federal Agency,Greenville,GA
+MIAMI-DADE.GOV,County,Non-Federal Agency,Miami,FL
+MIAMICOUNTYIN.GOV,County,Non-Federal Agency,Peru,IN
+MIAMICOUNTYOHIO.GOV,County,Non-Federal Agency,Troy,OH
+MIAMIDADE.GOV,County,Non-Federal Agency,Miami,FL
+MIAMIDADECOUNTY-FL.GOV,County,Non-Federal Agency,Miami,FL
+MIAMIDADECOUNTYFL.GOV,County,Non-Federal Agency,Miami,FL
+MILWAUKEECOUNTY-WI.GOV,County,Non-Federal Agency,Milwaukee,WI
+MILWAUKEECOUNTYWI.GOV,County,Non-Federal Agency,Milwaukee,WI
+MOBILECOUNTYAL.GOV,County,Non-Federal Agency,Mobile,AL
+MONROECOUNTY-FL.GOV,County,Non-Federal Agency,Key West,FL
+MONROECOUNTY.GOV,County,Non-Federal Agency,Rochester,NY
+MONROECOUNTYAL.GOV,County,Non-Federal Agency,Monroeville,AL
+MONTGOMERYCOUNTYGA.GOV,County,Non-Federal Agency,mt. vernon,GA
+MONTGOMERYCOUNTYMD.GOV,County,Non-Federal Agency,Rockville,MD
+MONTGOMERYCOUNTYVA.GOV,County,Non-Federal Agency,Christiansburg,VA
+MORGANCOUNTY-OH.GOV,County,Non-Federal Agency,McConnelsville,OH
+MORGANCOUNTYTN.GOV,County,Non-Federal Agency,wartburg,TN
+MORGANCOUNTYWV.GOV,County,Non-Federal Agency,Berkeley Springs,WV
+MORRISCOUNTYNJ.GOV,County,Non-Federal Agency,Morristown,NJ
+MORROWCOUNTYOHIO.GOV,County,Non-Federal Agency,Mount Gilead,OH
+NAVAJOCOUNTYAZ.GOV,County,Non-Federal Agency,Holbrook,AZ
+NOBLECOUNTYOHIO.GOV,County,Non-Federal Agency,Caldwell,OH
+NWCLEANAIRWA.GOV,County,Non-Federal Agency,Mount Vernon,WA
+OAKLANDCOUNTYMI.GOV,County,Non-Federal Agency,Pontiac,MI
+OGEMAWCOUNTYMI.GOV,County,Non-Federal Agency,West Branch,MI
+OGLETHORPECOUNTYGA.GOV,County,Non-Federal Agency,Lexington,GA
+OHIOCOUNTYKY.GOV,County,Non-Federal Agency,Hartford,KY
+OHIOCOUNTYWV.GOV,County,Non-Federal Agency,Wheeling,WV
+OLDHAMCOUNTYKY.GOV,County,Non-Federal Agency,La Grange,KY
+ORANGECOUNTY-VA.GOV,County,Non-Federal Agency,ORANGE,VA
+ORANGECOUNTYNC.GOV,County,Non-Federal Agency,Hillsborough,NC
+ORANGECOUNTYVA.GOV,County,Non-Federal Agency,Orange,VA
+ORANGECOUNTYVT.GOV,County,Non-Federal Agency,Chelsea,VT
+ORLEANSCOUNTYNY.GOV,County,Non-Federal Agency,Albion,NY
+OSWEGOCOUNTYNY.GOV,County,Non-Federal Agency,Oswego,NY
+OTSEGOCOUNTYMI.GOV,County,Non-Federal Agency,Gaylord,MI
+OURAYCOUNTYCO.GOV,County,Non-Federal Agency,Ouray,CO
+PARKECOUNTY-IN.GOV,County,Non-Federal Agency,Rockville,IN
+PENDERCOUNTYNC.GOV,County,Non-Federal Agency,Burgaw,NC
+PERQUIMANSCOUNTYNC.GOV,County,Non-Federal Agency,Hertford,NC
+PICKENSCOUNTYGA.GOV,County,Non-Federal Agency,Jasper,GA
+PIERCECOUNTYGA.GOV,County,Non-Federal Agency,Blackshear,GA
+PIERCECOUNTYND.GOV,County,Non-Federal Agency,Rugby,ND
+PIERCECOUNTYWA.GOV,County,Non-Federal Agency,Tacoma,WA
+PIKECOUNTY-MO.GOV,County,Non-Federal Agency,Bowling Green,MO
+PIKECOUNTYKY.GOV,County,Non-Federal Agency,Pikeville,KY
+PIMA.GOV,County,Non-Federal Agency,Tucson,AZ
+PINALCOUNTYAZ.GOV,County,Non-Federal Agency,Florence,AZ
+PINELLAS.GOV,County,Non-Federal Agency,Clearwater,FL
+PITTCOUNTY-NC.GOV,County,Non-Federal Agency,Greenville,NC
+PITTCOUNTYNC.GOV,County,Non-Federal Agency,Greenville,NC
+PITTSYLVANIACOUNTYVA.GOV,County,Non-Federal Agency,Chatham,VA
+PLYMOUTHCOUNTY-MA.GOV,County,Non-Federal Agency,Plymouth,MA
+POLKCOUNTYIOWA.GOV,County,Non-Federal Agency,Des Moines,IA
+PORTAGECOUNTYWI.GOV,County,Non-Federal Agency,Stevens Point,WI
+POSEYCOUNTYIN.GOV,County,Non-Federal Agency,Mount Vernon,IN
+POTTAWATTAMIECOUNTY-IA.GOV,County,Non-Federal Agency,COUNCIL BLUFFS,IA
+POTTCOUNTY-IA.GOV,County,Non-Federal Agency,COUNCIL BLUFFS,IA
+POWELLCOUNTYMT.GOV,County,Non-Federal Agency,Deer Lodge,MT
+PRESTONCOUNTYWV.GOV,County,Non-Federal Agency,Kingwood,WV
+PRINCEGEORGESCOUNTYMD.GOV,County,Non-Federal Agency,Largo,MD
+PUEBLOCOUNTYCO.GOV,County,Non-Federal Agency,Pueblo,CO
+PULASKICOUNTYIL.GOV,County,Non-Federal Agency,Ullin,IL
+PUTNAMCOUNTYNY.GOV,County,Non-Federal Agency,Carmel,NY
+PUTNAMCOUNTYOHIO.GOV,County,Non-Federal Agency,Ottawa,OH
+QUAYCOUNTY-NM.GOV,County,Non-Federal Agency,Tucumcari,NM
+RANDOLPHCOUNTY-MO.GOV,County,Non-Federal Agency,Huntsville,MO
+RANDOLPHCOUNTYALABAMA.GOV,County,Non-Federal Agency,Wedowee,AL
+RANDOLPHCOUNTYNC.GOV,County,Non-Federal Agency,Asheboro,NC
+RAPPAHANNOCKCOUNTYVA.GOV,County,Non-Federal Agency,Washington,VA
+READYALBANYCOUNTY-NY.GOV,County,Non-Federal Agency,Albany,NY
+READYHARRISCOUNTYTX.GOV,County,Non-Federal Agency,Houston,TX
+READYMCHENRYCOUNTYIL.GOV,County,Non-Federal Agency,Woodstock,IL
+READYMCHENRYCOUNTYILLINOIS.GOV,County,Non-Federal Agency,Woodstock,IL
+REYNOLDSCOUNTY-MO.GOV,County,Non-Federal Agency,Centerville,MO
+RILEYCOUNTYKS.GOV,County,Non-Federal Agency,Manhattan,KS
+ROANECOUNTYTN.GOV,County,Non-Federal Agency,Kingston,TN
+ROCKBRIDGECOUNTYVA.GOV,County,Non-Federal Agency,Lexington,VA
+ROCKCOUNTY-WI.GOV,County,Non-Federal Agency,Janesville,WI
+ROCKDALECOUNTYGA.GOV,County,Non-Federal Agency,Conyers,GA
+ROSEBUDCOUNTYMT.GOV,County,Non-Federal Agency,Forsyth,MT
+ROSSCOUNTYOHIO.GOV,County,Non-Federal Agency,Chillicothe,OH
+RUTHERFORDCOUNTYNC.GOV,County,Non-Federal Agency,Rutherfordton,NC
+RUTHERFORDCOUNTYTN.GOV,County,Non-Federal Agency,Murfreesboro,TN
+SAGUACHECOUNTY-CO.GOV,County,Non-Federal Agency,Saguache,CO
+SALEMCOUNTYNJ.GOV,County,Non-Federal Agency,Salem,NJ
+SANDIEGOCOUNTY.GOV,County,Non-Federal Agency,San Diego,CA
+SANDOVALCOUNTYNM.GOV,County,Non-Federal Agency,Bernalillo,NM
+SANMIGUELCOUNTYCO.GOV,County,Non-Federal Agency,TELLURIDE,CO
+SANPETECOUNTY-UT.GOV,County,Non-Federal Agency,Manti,UT
+SANTACLARACOUNTYCA.GOV,County,Non-Federal Agency,San Jose,CA
+SANTACRUZCOUNTYAZ.GOV,County,Non-Federal Agency,Nogales,AZ
+SANTAFECOUNTYNM.GOV,County,Non-Federal Agency,Santa Fe,NM
+SARATOGACOUNTYNY.GOV,County,Non-Federal Agency,Ballston Spa,NY
+SBCOUNTY.GOV,County,Non-Federal Agency,San Bernardino,CA
+SCOTTCOUNTY-TN.GOV,County,Non-Federal Agency,Huntsville,TN
+SCOTTCOUNTYMN.GOV,County,Non-Federal Agency,Shakopee,MN
+SEBASTIANCOUNTYAR.GOV,County,Non-Federal Agency,Fort Smith,AR
+SEQUATCHIECOUNTY-TN.GOV,County,Non-Federal Agency,Dunlap,TN
+SEVIERCOUNTYTN.GOV,County,Non-Federal Agency,Sevierville,TN
+SHARKEYCOUNTYMS.GOV,County,Non-Federal Agency,Rolling Fork,MS
+SHELBYCOUNTYTN.GOV,County,Non-Federal Agency,Memphis,TN
+SIERRACOUNTYNM.GOV,County,Non-Federal Agency,Truth or Consequences,NM
+SONOMACOUNTYCA.GOV,County,Non-Federal Agency,Santa Rosa,CA
+SPENCERCOUNTYKY.GOV,County,Non-Federal Agency,Taylorsville,KY
+SPOTSYLVANIACOUNTY-VA.GOV,County,Non-Federal Agency,Spotsylvania,VA
+SPOTSYLVANIACOUNTYVA.GOV,County,Non-Federal Agency,Spotsylvania,VA
+STAFFORDCOUNTYVA.GOV,County,Non-Federal Agency,Stafford,VA
+STANLYCOUNTYNC.GOV,County,Non-Federal Agency,Albemarle,NC
+STARKCOUNTYND.GOV,County,Non-Federal Agency,Bismarck,ND
+STARKCOUNTYOHIO.GOV,County,Non-Federal Agency,Canton,OH
+STCHARLESPARISH-LA.GOV,County,Non-Federal Agency,Hahnville,LA
+STCLAIRCOUNTYIL.GOV,County,Non-Federal Agency,Belleville,IL
+STEARNSCOUNTYMN.GOV,County,Non-Federal Agency,Saint Cloud,MN
+STEWARTCOUNTYGA.GOV,County,Non-Federal Agency,Lumpkin,GA
+STLOUISCOUNTYMN.GOV,County,Non-Federal Agency,Duluth,MN
+STMARYPARISHLA.GOV,County,Non-Federal Agency,FRANKLIN,LA
+STOKESCOUNTYNC.GOV,County,Non-Federal Agency,Danbury,NC
+STORYCOUNTYIOWA.GOV,County,Non-Federal Agency,Nevada,IA
+SULLIVANCOUNTYTN.GOV,County,Non-Federal Agency,Blountville,TN
+SUMMERSCOUNTYWV.GOV,County,Non-Federal Agency,Hinton,WV
+SUMMITCOUNTYCO.GOV,County,Non-Federal Agency,Breckenridge,CO
+SUMTERCOUNTYFL.GOV,County,Non-Federal Agency,Bushnell,FL
+SURRYCOUNTYVA.GOV,County,Non-Federal Agency,Surry,VA
+SUSSEXCOUNTYDE.GOV,County,Non-Federal Agency,Georgetown,DE
+SUSSEXCOUNTYVA.GOV,County,Non-Federal Agency,Sussex,VA
+SWAINCOUNTYNC.GOV,County,Non-Federal Agency,Bryson City,NC
+TALBOTCOUNTYMD.GOV,County,Non-Federal Agency,Easton,MD
+TAMACOUNTYIOWA.GOV,County,Non-Federal Agency,Toledo,IA
+TARRANTCOUNTYTX.GOV,County,Non-Federal Agency,Fort Worth,TX
+TETONCOUNTYIDAHO.GOV,County,Non-Federal Agency,Driggs,ID
+TEXASCOUNTYMISSOURI.GOV,County,Non-Federal Agency,Houston,MO
+THAYERCOUNTYNE.GOV,County,Non-Federal Agency,Hebron,NE
+THOMASCOUNTYGA.GOV,County,Non-Federal Agency,Thomasville,GA
+TOMPKINSCOUNTYNY.GOV,County,Non-Federal Agency,Ithaca,NY
+TOOELECOUNTYUT.GOV,County,Non-Federal Agency,Tooele,UT
+TOOLECOUNTYMT.GOV,County,Non-Federal Agency,Shelby,MT
+TOOMBSCOUNTYGA.GOV,County,Non-Federal Agency,Lyons,GA
+TRAVISCOUNTYTX.GOV,County,Non-Federal Agency,Austin,TX
+TROUSDALECOUNTYTN.GOV,County,Non-Federal Agency,Hartsville,TN
+ULSTERCOUNTYNY.GOV,County,Non-Federal Agency,Kingston,NY
+UNICOICOUNTYTN.GOV,County,Non-Federal Agency,Erwin,TN
+UNIONCOUNTY-FL.GOV,County,Non-Federal Agency,Lake Butler,FL
+UNIONCOUNTYGA.GOV,County,Non-Federal Agency,Blairsveille,GA
+UNIONCOUNTYIL.GOV,County,Non-Federal Agency,Jonesboro,IL
+UNIONCOUNTYIN.GOV,County,Non-Federal Agency,Liberty,IN
+UNIONCOUNTYNC.GOV,County,Non-Federal Agency,Monroe,NC
+UTAHCOUNTY.GOV,County,Non-Federal Agency,Provo,UT
+VALLEYCOUNTYMT.GOV,County,Non-Federal Agency,Glasgow,MT
+VANBURENCOUNTYIA.GOV,County,Non-Federal Agency,Keosauqua,IA
+WARRENCOUNTYNC.GOV,County,Non-Federal Agency,Warrenton,NC
+WARRENCOUNTYNY.GOV,County,Non-Federal Agency,Lake George,NY
+WARRENCOUNTYTN.GOV,County,Non-Federal Agency,McMinnville,TN
+WARRICKCOUNTY.GOV,County,Non-Federal Agency,Boonville,IN
+WASHINGTONCOUNTYGA.GOV,County,Non-Federal Agency,Sandersville,GA
+WASHINGTONCOUNTYKS.GOV,County,Non-Federal Agency,Washington,KS
+WAYNECOUNTYPA.GOV,County,Non-Federal Agency,Honesdale,PA
+WEAKLEYCOUNTYTN.GOV,County,Non-Federal Agency,Dresden,TN
+WEBERCOUNTYUTAH.GOV,County,Non-Federal Agency,Ogden,UT
+WEBSTERCOUNTYMO.GOV,County,Non-Federal Agency,Marshfield,MO
+WESTFELICIANAPARISH-LA.GOV,County,Non-Federal Agency,St. Francisville,LA
+WHITECOUNTYGA.GOV,County,Non-Federal Agency,Cleveland,GA
+WHITECOUNTYTN.GOV,County,Non-Federal Agency,Sparta,TN
+WHITEPINECOUNTYNV.GOV,County,Non-Federal Agency,Ely,NV
+WILLCOUNTY-IL.GOV,County,Non-Federal Agency,Joliet,IL
+WILLIAMSONCOUNTY-TN.GOV,County,Non-Federal Agency,Franklin,TN
+WILLIAMSONCOUNTYIL.GOV,County,Non-Federal Agency,Marion,IL
+WILSONCOUNTYTN.GOV,County,Non-Federal Agency,Lebanon,TN
+WILSONCOUNTYTX.GOV,County,Non-Federal Agency,Floresville,TX
+WINDHAMCOUNTYVT.GOV,County,Non-Federal Agency,Newfane,VT
+WINNEBAGOCOUNTYIOWA.GOV,County,Non-Federal Agency,Forest City,IA
+WOODBURYCOUNTYIOWA.GOV,County,Non-Federal Agency,Sioux City,IA
+WORCESTERCOUNTYMD.GOV,County,Non-Federal Agency,Snow Hill,MD
+YANCEYCOUNTYNC.GOV,County,Non-Federal Agency,Burnsville,NC
+YAZOOCOUNTYMS.GOV,County,Non-Federal Agency,Yazoo City,MS
+YCSOAZ.GOV,County,Non-Federal Agency,Prescott,AZ
+YORKCOUNTY.GOV,County,Non-Federal Agency,Yorktown,VA
+YORKCOUNTYMAINE.GOV,County,Non-Federal Agency,Alfred,ME
+YORKCOUNTYME.GOV,County,Non-Federal Agency,Alfred,ME
+YORKCOUNTYPA.GOV,County,Non-Federal Agency,York,PA
+YUMACOUNTYARIZONA.GOV,County,Non-Federal Agency,Yuma,AZ
+YUMACOUNTYAZ.GOV,County,Non-Federal Agency,Yuma,AZ

--- a/dotgov-domains/2015-11-03-federal.csv
+++ b/dotgov-domains/2015-11-03-federal.csv
@@ -1,0 +1,1351 @@
+Domain Name,Domain Type,Agency,City,State
+ACUS.GOV,Federal Agency,Administrative Conference of the United States,WASHINGTON,DC
+ACHP.GOV,Federal Agency,Advisory Council on Historic Preservation,Washington,DC
+PRESERVEAMERICA.GOV,Federal Agency,Advisory Council on Historic Preservation,Washington,DC
+ADF.GOV,Federal Agency,African Development Foundation,Washington,DC
+USADF.GOV,Federal Agency,African Development Foundation,Washington,DC
+ABMC.GOV,Federal Agency,American Battle Monuments Commission,Arlington,VA
+AMTRAKOIG.GOV,Federal Agency,AMTRAK,Washington,DC
+ARC.GOV,Federal Agency,Appalachian Regional Commission,Washington,DC
+ASC.GOV,Federal Agency,Appraisal Subcommittee,Washington,DC
+AFRH.GOV,Federal Agency,Armed Forces Retirement Home,Washington,DC
+CIA.GOV,Federal Agency,Central Intelligence Agency,Washington,DC
+IC.GOV,Federal Agency,Central Intelligence Agency,Washington,DC
+ISTAC.GOV,Federal Agency,Central Intelligence Agency,Washington,DC
+NCTC.GOV,Federal Agency,Central Intelligence Agency,Washington,DC
+ODCI.GOV,Federal Agency,Central Intelligence Agency,Washington,DC
+OPENSOURCE.GOV,Federal Agency,Central Intelligence Agency,Washington,DC
+OSDE.GOV,Federal Agency,Central Intelligence Agency,Reston,VA
+TTIC.GOV,Federal Agency,Central Intelligence Agency,Washington,DC
+UCIA.GOV,Federal Agency,Central Intelligence Agency,Washington,DC
+CHRISTOPHERCOLUMBUSFOUNDATION.GOV,Federal Agency,Christopher Columbus Fellowship Foundation,Washington,DC
+CAP.GOV,Federal Agency,Civil Air Patrol,BIRMINGHAM,MI
+CAPNHQ.GOV,Federal Agency,Civil Air Patrol,MAXWELL AFB,AL
+ABILITYONE.FED.US,Federal Agency,Comm for People Who Are Blind/Severly Disabled,Arlington,VA
+ABILITYONE.GOV,Federal Agency,Comm for People Who Are Blind/Severly Disabled,Arlington,VA
+JWOD.GOV,Federal Agency,Comm for People Who Are Blind/Severly Disabled,Arlington,VA
+CFTC.GOV,Federal Agency,Commodity Futures Trading Commission,Washington,DC
+SMARTCHECK.GOV,Federal Agency,Commodity Futures Trading Commission,Washington,DC
+COMPLIANCE.GOV,Federal Agency,Congressional Office of Compliance,Washington,DC
+BCFP.GOV,Federal Agency,Consumer Financial Protection Bureau,Washington,DC
+CFPA.GOV,Federal Agency,Consumer Financial Protection Bureau,Washington,DC
+CFPB.GOV,Federal Agency,Consumer Financial Protection Bureau,Washington,DC
+CONSUMERBUREAU.GOV,Federal Agency,Consumer Financial Protection Bureau,Washington,DC
+CONSUMERFINANCE.GOV,Federal Agency,Consumer Financial Protection Bureau,Washington,DC
+CONSUMERFINANCIAL.GOV,Federal Agency,Consumer Financial Protection Bureau,Washington,DC
+CONSUMERFINANCIALBUREAU.GOV,Federal Agency,Consumer Financial Protection Bureau,Washington,DC
+CONSUMERFINANCIALPROTECTIONBUREAU.GOV,Federal Agency,Consumer Financial Protection Bureau,Washington,DC
+CONSUMERPROTECTION.GOV,Federal Agency,Consumer Financial Protection Bureau,Washington,DC
+CONSUMERPROTECTIONBUREAU.GOV,Federal Agency,Consumer Financial Protection Bureau,Washington,DC
+ANCHORIT.GOV,Federal Agency,Consumer Product Safety Commission,Bethesda,MD
+ATVSAFETY.GOV,Federal Agency,Consumer Product Safety Commission,Bethesda,MD
+CPSC.GOV,Federal Agency,Consumer Product Safety Commission,Bethesda,MD
+DRYWALLRESPONSE.GOV,Federal Agency,Consumer Product Safety Commission,Bethesda,MD
+POOLSAFELY.GOV,Federal Agency,Consumer Product Safety Commission,Bethesda,MD
+POOLSAFETY.GOV,Federal Agency,Consumer Product Safety Commission,Bethesda,MD
+RECALLS.GOV,Federal Agency,Consumer Product Safety Commission,Bethesda,MD
+SAFERPRODUCT.GOV,Federal Agency,Consumer Product Safety Commission,Bethesda,MD
+SAFERPRODUCTS.GOV,Federal Agency,Consumer Product Safety Commission,Bethesda,MD
+SEGURIDADCONSUMIDOR.GOV,Federal Agency,Consumer Product Safety Commission,Bethesda,MD
+AMERICORE.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC
+AMERICORP.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC
+AMERICORPS.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC
+AMERICORPSCONNECT.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC
+AMERICORPSWEEK.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC
+CNCS.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC
+CNCSOIG.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC
+CNS.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC
+FEDERALMENTORINGCOUNCIL.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC
+GETINVOLVED.GOV,Federal Agency,Corporation for National & Community Service,Washington ,DC
+LEARNANDSERVE.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC
+MLKDAY.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC
+NATIONALSERVICE.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC
+NATIONALSERVICEGEAR.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC
+NATIONALSERVICERESOURCES.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC
+PRESIDENTIALSERVICEAWARDS.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC
+SENIORCORPS.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC
+SERVE.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC
+SERVICE.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC
+SERVICELEARNING.GOV,Federal Agency,Corporation for National & Community Service,Washington ,DC
+SERVIR.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC
+VISTA.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC
+VISTACAMPUS.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC
+VOLUNTEERINGINAMERICA.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC
+CIGIE.GOV,Federal Agency,Council of Inspector General on Integrity and Efficiency,WASHINGTON,DC
+IGNET.GOV,Federal Agency,Council of Inspector General on Integrity and Efficiency,Washington,DC
+CSOSA.FED.US,Federal Agency,Court Services and Offender Supervision,Washington,DC
+CSOSA.GOV,Federal Agency,Court Services and Offender Supervision,Washington,DC
+PRETRIALSERVICES.GOV,Federal Agency,Court Services and Offender Supervision,Washington,DC
+PSA.GOV,Federal Agency,Court Services and Offender Supervision,Washington,DC
+DNFSB.GOV,Federal Agency,Defense Nuclear Facilities Safety Board,Washington,DC
+DRA.GOV,Federal Agency,Delta Regional Authority,Clarksdale,MS
+DENALI.GOV,Federal Agency,Denali Commission,Anchorage,AK
+FEA.GOV,Federal Agency,Denali Commission,Anchorage,AK
+AFF.GOV,Federal Agency,Department of Agriculture,Boise,ID
+AG.GOV,Federal Agency,Department of Agriculture,Fort Collins,CO
+ARS-GRIN.GOV,Federal Agency,Department of Agriculture,Beltsville,MD
+ARSUSDA.GOV,Federal Agency,Department of Agriculture,Beltsville,MD
+ASKKAREN.GOV,Federal Agency,Department of Agriculture,Washington,DC
+BEFOODSAFE.GOV,Federal Agency,Department of Agriculture,Washington,DC
+BIOPREFERRED.GOV,Federal Agency,Department of Agriculture,Washington,DC
+CHOOSEMYPLATE.GOV,Federal Agency,Department of Agriculture,Alexandria,VA
+COASTALAMERICA.GOV,Federal Agency,Department of Agriculture,Washington,DC
+DIETARYGUIDELINES.GOV,Federal Agency,Department of Agriculture,Alexandria,VA
+EMPOWHR.GOV,Federal Agency,Department of Agriculture,New Orleans,LA
+EXECSEC.GOV,Federal Agency,Department of Agriculture,Washington,DC
+FARMERCLAIMS.GOV,Federal Agency,Department of Agriculture,St. Louis,MO
+FEMALEFARMERCLAIMS.GOV,Federal Agency,Department of Agriculture,St. Louis,MO
+FIREINSTITUTE.GOV,Federal Agency,Department of Agriculture,Tucson,AZ
+FOODSAFETYJOBS.GOV,Federal Agency,Department of Agriculture,Washington,DC
+FOODSAFETYWORKINGGROUP.GOV,Federal Agency,Department of Agriculture,Washington,DC
+FORESTSANDRANGELANDS.GOV,Federal Agency,Department of Agriculture,Washington,DC
+FS.FED.US,Federal Agency,Department of Agriculture,Washington,DC
+GREEN.GOV,Federal Agency,Department of Agriculture,Washington,DC
+HISPANICFARMERCLAIMS.GOV,Federal Agency,Department of Agriculture,St. Louis,MO
+ICBEMP.GOV,Federal Agency,Department of Agriculture,Portland,OR
+IIOG.GOV,Federal Agency,Department of Agriculture,Meridian,ID
+INVASIVESPECIESINFO.GOV,Federal Agency,Department of Agriculture,Beltsville,MD
+IPM.GOV,Federal Agency,Department of Agriculture,Washington,DC
+ISITDONEYET.GOV,Federal Agency,Department of Agriculture,Washington,DC
+ITAP.GOV,Federal Agency,Department of Agriculture,Beltsville,MD
+JUNIORFORESTRANGER.GOV,Federal Agency,Department of Agriculture,Washington,DC
+LATINOFARMERCLAIMS.GOV,Federal Agency,Department of Agriculture,St. Louis,MO
+LCACOMMONS.GOV,Federal Agency,Department of Agriculture,Beltsville,MD
+MTBS.GOV,Federal Agency,Department of Agriculture,Salt Lake City,UT
+NAFRI.GOV,Federal Agency,Department of Agriculture,Tucson,AZ
+NEL.GOV,Federal Agency,Department of Agriculture,Alexandria,VA
+NSTL.GOV,Federal Agency,Department of Agriculture,Ames,IA
+NUTRITION.GOV,Federal Agency,Department of Agriculture,Washington,DC
+NUTRITIONEVIDENCELIBRARY.GOV,Federal Agency,Department of Agriculture,Alexandria,VA
+NWCG.GOV,Federal Agency,Department of Agriculture,Boise,ID
+PREGUNTELEAKAREN.GOV,Federal Agency,Department of Agriculture,Washington,DC
+RECREATION.GOV,Federal Agency,Department of Agriculture,Ogden,UT
+REO.GOV,Federal Agency,Department of Agriculture,Portland,OR
+SMOKEYBEAR.GOV,Federal Agency,Department of Agriculture,Washington,DC
+START2FARM.GOV,Federal Agency,Department of Agriculture,Beltsville,MD
+SYMBOLS.GOV,Federal Agency,Department of Agriculture,Washington,DC
+THEPEOPLESGARDEN.GOV,Federal Agency,Department of Agriculture,Wahington,DC
+USDA.GOV,Federal Agency,Department of Agriculture,Ft. Collins,CO
+USDAPII.GOV,Federal Agency,Department of Agriculture,Washington,DC
+VALLESCALDERA.GOV,Federal Agency,Department of Agriculture,Jemez Springs,NM
+WILDFIRE.GOV,Federal Agency,Department of Agriculture,Boise,ID
+WOMENFARMERCLAIMS.GOV,Federal Agency,Department of Agriculture,St. Louis,MO
+WOODSY.GOV,Federal Agency,Department of Agriculture,Washington,DC
+WOODSYOWL.GOV,Federal Agency,Department of Agriculture,Washington,DC
+AP.GOV,Federal Agency,Department of Commerce,Washington,DC
+AVIATIONWEATHER.GOV,Federal Agency,Department of Commerce,Silver Spring,MD
+BEA.GOV,Federal Agency,Department of Commerce,Washington,DC
+BLDRDOC.GOV,Federal Agency,Department of Commerce,Boulder,CO
+BUYUSA.GOV,Federal Agency,Department of Commerce,Washington,DC
+CBP.GOV,Federal Agency,Department of Commerce,Alexandria,VA
+CENSUS.GOV,Federal Agency,Department of Commerce,Suitland,MD
+CIVILRIGHTSUSA.GOV,Federal Agency,Department of Commerce,Alexandria,VA
+CLIMATE.GOV,Federal Agency,Department of Commerce,Silver Spring,MD
+CLIMATECHANGE.GOV,Federal Agency,Department of Commerce,Oak Ridge,TN
+COMMERCE.GOV,Federal Agency,Department of Commerce,Washington,DC
+COOP-USPTO.GOV,Federal Agency,Department of Commerce,Arlington,VA
+DIGITALLITERACY.GOV,Federal Agency,Department of Commerce,Washington,DC
+DNSOPS.GOV,Federal Agency,Department of Commerce,Gaithersburg,MD
+DOC.GOV,Federal Agency,Department of Commerce,Washington,DC
+DROUGHT.GOV,Federal Agency,Department of Commerce,Asheville,NC
+EDA.GOV,Federal Agency,Department of Commerce,Washington,DC
+ESA.GOV,Federal Agency,Department of Commerce,Washington,DC
+EXPORT.GOV,Federal Agency,Department of Commerce,Washington,DC
+FCSM.GOV,Federal Agency,Department of Commerce,Suitland,MD
+FEDSTATS.GOV,Federal Agency,Department of Commerce,Washington,DC
+FIRSTNET.GOV,Federal Agency,Department of Commerce,Washington,DC
+FISHWATCH.GOV,Federal Agency,Department of Commerce,Silver Spring,MD
+GETYOUHOME.GOV,Federal Agency,Department of Commerce,Alexandria,VA
+GLOBALENTRY.GOV,Federal Agency,Department of Commerce,Alexandria,VA
+GOES-R.GOV,Federal Agency,Department of Commerce,Greenbelt,MD
+GPS.GOV,Federal Agency,Department of Commerce,Washington,DC
+HURRICANES.GOV,Federal Agency,Department of Commerce,Miami,FL
+ITDS.GOV,Federal Agency,Department of Commerce,Springfield,VA
+MANUFACTURING.GOV,Federal Agency,Department of Commerce,Washington,DC
+MAPSTATS.GOV,Federal Agency,Department of Commerce,Washington,DC
+MARINECADASTRE.GOV,Federal Agency,Department of Commerce,Charleston,SC
+MBDA.GOV,Federal Agency,Department of Commerce,Washington,DC
+MGI.GOV,Federal Agency,Department of Commerce,Gaithersburg,MD
+NEHRP.GOV,Federal Agency,Department of Commerce,Gaithersburg,MD
+NIST.GOV,Federal Agency,Department of Commerce,Gaithersburg,MD
+NOAA.GOV,Federal Agency,Department of Commerce,Silver Spring,MD
+NTIS.GOV,Federal Agency,Department of Commerce,Alexandria,VA
+OFCM.GOV,Federal Agency,Department of Commerce,Silver Spring,MD
+PAPAHANAUMOKUAKEA.GOV,Federal Agency,Department of Commerce,Silver Spring,MD
+PSCR.GOV,Federal Agency,Department of Commerce,Boulder,CO
+SDR.GOV,Federal Agency,Department of Commerce,Washington,DC
+SELECTUSA.GOV,Federal Agency,Department of Commerce,Washington,DC
+SPACEWEATHER.GOV,Federal Agency,Department of Commerce,Boulder,CO
+SPECTRUM.GOV,Federal Agency,Department of Commerce,Washington,DC
+STANDARDS.GOV,Federal Agency,Department of Commerce,Gaithersburg,MD
+TIME.GOV,Federal Agency,Department of Commerce,Boulder,CO
+TRADE.GOV,Federal Agency,Department of Commerce,Washington,DC
+TSUNAMI.GOV,Federal Agency,Department of Commerce,Palmer,AK
+USPTO.GOV,Federal Agency,Department of Commerce,Washington,DC
+WDOL.GOV,Federal Agency,Department of Commerce,Alexandria,VA
+WEATHER.GOV,Federal Agency,Department of Commerce,Silver Spring,MD
+ADLNET.GOV,Federal Agency,Department of Defense,Washington,DC
+AFTAC.GOV,Federal Agency,Department of Defense,Patrick AFB,FL
+ALTUSANDC.GOV,Federal Agency,Department of Defense,"patrick, afb",FL
+BRAC.GOV,Federal Agency,Department of Defense,Alexandria,VA
+CMTS.GOV,Federal Agency,Department of Defense,Mobile,AL
+CNSS.GOV,Federal Agency,Department of Defense,Ft George G. Meade,MD
+CTOC.GOV,Federal Agency,Department of Defense,Starke,FL
+CTTSO.GOV,Federal Agency,Department of Defense,Arlington,VA
+DEFENSE.GOV,Federal Agency,Department of Defense,Fort Meade,MD
+DOD.GOV,Federal Agency,Department of Defense,Fort Meade,MD
+EACLEARINGHOUSE.GOV,Federal Agency,Department of Defense,Arlington,VA
+ERDC.GOV,Federal Agency,Department of Defense,Vicksburg,MS
+FVAP.GOV,Federal Agency,Department of Defense,Alexandria,VA
+IAD.GOV,Federal Agency,Department of Defense,Ft Meade,MD
+IOSS.GOV,Federal Agency,Department of Defense,Greenbelt,MD
+ITC.GOV,Federal Agency,Department of Defense,Ft. Washington,MD
+JCCS.GOV,Federal Agency,Department of Defense,Alexandria,VA
+MCRMC.GOV,Federal Agency,Department of Defense,Arlington,VA
+MOJAVEDATA.GOV,Federal Agency,Department of Defense,Barstow,CA
+MTMC.GOV,Federal Agency,Department of Defense,Alexandria,VA
+MYPAY.GOV,Federal Agency,Department of Defense,Pensacola,FL
+NCR.GOV,Federal Agency,Department of Defense,Washington,DC
+NRO.GOV,Federal Agency,Department of Defense,Chantilly,VA
+NROJR.GOV,Federal Agency,Department of Defense,Chantilly,VA
+NSA.GOV,Federal Agency,Department of Defense,Ft. Meade,MD
+NSEP.GOV,Federal Agency,Department of Defense,Arlington,VA
+OEA.GOV,Federal Agency,Department of Defense,Arlington,VA
+OSDBU.GOV,Federal Agency,Department of Defense,Washington,DC
+PENTAGON.GOV,Federal Agency,Department of Defense,Fort Meade,MD
+SAFEXCHANGE.GOV,Federal Agency,Department of Defense,Falls Church,VA
+SITEIDIQ.GOV,Federal Agency,Department of Defense,Arlington,VA
+TSWG.GOV,Federal Agency,Department of Defense,Arlington,VA
+USANDC.GOV,Federal Agency,Department of Defense,Patrick AFB,FL
+AAPI.GOV,Federal Agency,Department of Education,Washington,DC
+BFELOB.GOV,Federal Agency,Department of Education,Washington,DC
+CHILDSTATS.GOV,Federal Agency,Department of Education,Washington,DC
+COLLEGE.GOV,Federal Agency,Department of Education,Washington,DC
+COLLEGENAVIGATOR.GOV,Federal Agency,Department of Education,Washington,DC
+ED.GOV,Federal Agency,Department of Education,Washington,DC
+EDPUBS.GOV,Federal Agency,Department of Education,Washington ,DC
+EDUCATION.GOV,Federal Agency,Department of Education,Washington,DC
+FAFSA.GOV,Federal Agency,Department of Education,Washington,DC
+FSAPUBS.GOV,Federal Agency,Department of Education,Washington,DC
+G5.GOV,Federal Agency,Department of Education,Washington,DC
+NAGB.GOV,Federal Agency,Department of Education,Washington,DC
+NATIONSREPORTCARD.GOV,Federal Agency,Department of Education,Washington,DC
+OPPORTUNITY.GOV,Federal Agency,Department of Education,Washington,DC
+STUDENTAID.GOV,Federal Agency,Department of Education,Washington,DC
+STUDENTLOANS.GOV,Federal Agency,Department of Education,Washington,DC
+AMESLAB.GOV,Federal Agency,Department of Energy,Ames,IA
+ANL.GOV,Federal Agency,Department of Energy,Argonne,IL
+ARM.GOV,Federal Agency,Department of Energy,Richland,WA
+BIOMASSBOARD.GOV,Federal Agency,Department of Energy,Washington,DC
+BNL.GOV,Federal Agency,Department of Energy,Upton,NY
+BPA.GOV,Federal Agency,Department of Energy,Portland,OR
+BRC.GOV,Federal Agency,Department of Energy,Washington,DC
+BUILDINGAMERICA.GOV,Federal Agency,Department of Energy,Golden,CO
+CASL.GOV,Federal Agency,Department of Energy,Oak Ridge,TN
+CEBAF.GOV,Federal Agency,Department of Energy,Newport News,VA
+CENDI.GOV,Federal Agency,Department of Energy,Oak Ridge,TN
+CRT2014-2024REVIEW.GOV,Federal Agency,Department of Energy,Portland,OR
+DOE.GOV,Federal Agency,Department of Energy,Washington,DC
+DOEAL.GOV,Federal Agency,Department of Energy,Albuquerque,NM
+EIA.GOV,Federal Agency,Department of Energy,Washington,DC
+ENERGY.GOV,Federal Agency,Department of Energy,Washington,DC
+ENERGYCODES.GOV,Federal Agency,Department of Energy,Richland,WA
+ENERGYPLUS.GOV,Federal Agency,Department of Energy,Washington,DC
+ENERGYSAVER.GOV,Federal Agency,Department of Energy,Washington,DC
+ENERGYSAVERS.GOV,Federal Agency,Department of Energy,Washington,DC
+FNAL.GOV,Federal Agency,Department of Energy,Batavia,IL
+FUELECONOMY.GOV,Federal Agency,Department of Energy,Oak Ridge,TN
+HANFORD.GOV,Federal Agency,Department of Energy,Richland,WA
+HIGHPERFORMANCEBUILDINGS.GOV,Federal Agency,Department of Energy,Golden,CO
+HOMEENERGYSCORE.GOV,Federal Agency,Department of Energy,Washington,DC
+HYDROGEN.GOV,Federal Agency,Department of Energy,Washington,DC
+INEL.GOV,Federal Agency,Department of Energy,Idaho Falls,ID
+INL.GOV,Federal Agency,Department of Energy,Idaho Falls,ID
+ISOTOPE.GOV,Federal Agency,Department of Energy,Oak Ridge,TN
+ISOTOPES.GOV,Federal Agency,Department of Energy,Oak Ridge,TN
+KAPL.GOV,Federal Agency,Department of Energy,Schenectady,NY
+LANL.GOV,Federal Agency,Department of Energy,Los Alamos,NM
+LBL.GOV,Federal Agency,Department of Energy,Berkeley,CA
+LLNL.GOV,Federal Agency,Department of Energy,Livermore,CA
+NCCRC.GOV,Federal Agency,Department of Energy,Oak Ridge,TN
+NCCS.GOV,Federal Agency,Department of Energy,Oak Ridge,TN
+NCRC.GOV,Federal Agency,Department of Energy,Oak Ridge,TN
+NERSC.GOV,Federal Agency,Department of Energy,Berkeley,CA
+NEUP.GOV,Federal Agency,Department of Energy,Washington,DC
+NREL.GOV,Federal Agency,Department of Energy,Golden,CO
+NRELHUB.GOV,Federal Agency,Department of Energy,Golden,CO
+NTRC.GOV,Federal Agency,Department of Energy,Knoxville,TN
+NUCLEAR.GOV,Federal Agency,Department of Energy,Washington,DC
+ORAU.GOV,Federal Agency,Department of Energy,Oak Ridge,TN
+ORNL.GOV,Federal Agency,Department of Energy,Oak Ridge,TN
+OSTI.GOV,Federal Agency,Department of Energy,Oak Ridge,TN
+PNL.GOV,Federal Agency,Department of Energy,Richland,WA
+PNNL.GOV,Federal Agency,Department of Energy,Richland,WA
+RL.GOV,Federal Agency,Department of Energy,Richland,WA
+SALMONRECOVERY.GOV,Federal Agency,Department of Energy,Portland,OR
+SANDIA.GOV,Federal Agency,Department of Energy,Albuquerque,NM
+SCIDAC.GOV,Federal Agency,Department of Energy,Oak Ridge,TN
+SCIENCE.GOV,Federal Agency,Department of Energy,Oak Ridge,TN
+SCIENCEACCELERATOR.GOV,Federal Agency,Department of Energy,Oak Ridge,TN
+SCIENCEEDUCATION.GOV,Federal Agency,Department of Energy,Oak Ridge,TN
+SMARTGRID.GOV,Federal Agency,Department of Energy,Washington,DC
+SNS.GOV,Federal Agency,Department of Energy,Oak Ridge,TN
+SOLARDECATHLON.GOV,Federal Agency,Department of Energy,Golden,CO
+SRS.GOV,Federal Agency,Department of Energy,Aiken,SC
+SWPA.GOV,Federal Agency,Department of Energy,Tulsa,OK
+UNNPP.GOV,Federal Agency,Department of Energy,West Mifflin,PA
+UNRPNET.GOV,Federal Agency,Department of Energy,Washington,DC
+WAPA.GOV,Federal Agency,Department of Energy,Lakewood,CO
+WINDPOWERINGAMERICA.GOV,Federal Agency,Department of Energy,Golden,CO
+YMP.GOV,Federal Agency,Department of Energy,Las Vegas,NV
+ACF.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+ACL.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+AFTERSCHOOL.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+AGING.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+AGINGSTATS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+AHCPR.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
+AHRQ.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
+AIDS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+ALZHEIMERS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+AOA.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+BAM.GOV,Federal Agency,Department of Health And Human Services,Atlanta,GA
+BESTBONESFOREVER.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+BETOBACCOFREE.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+BIOETHICS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+BIOSECURITYBOARD.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+BRAINHEALTH.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+CANCER.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
+CANCERNET.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
+CDC.GOV,Federal Agency,Department of Health And Human Services,Atlanta,GA
+CHILDWELFARE.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+CLINICALTRIAL.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
+CLINICALTRIALS.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
+CLUBDRUGS.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
+CMS.GOV,Federal Agency,Department of Health And Human Services,Baltimore,MD
+COLLEGEDRINKINGPREVENTION.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
+CUIDADODESALUD.GOV,Federal Agency,Department of Health And Human Services,Baltimore,MD
+DHHS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+DIABETESCOMMITTEE.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+DOCLINE.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
+DONACIONDEORGANOS.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
+DRUGABUSE.GOV,Federal Agency,Department of Health And Human Services,Baltimore,MD
+DRUGFREEWORKPLACE.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
+EDISON.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
+ELDERCARE.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+ENDINGTHEDOCUMENTGAME.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+ERRP.GOV,Federal Agency,Department of Health And Human Services,Baltimore,MD
+FATHERHOOD.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+FDA.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
+FINDYOUTHINFO.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
+FITNESS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+FLU.GOV,Federal Agency,Department of Health And Human Services,Washington ,DC
+FOODSAFETY.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+FRESHEMPIRE.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+FRUITSANDVEGGIESMATTER.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+GENBANK.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
+GENOME.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
+GIRLSHEALTH.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+GLOBALHEALTH.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
+GRANTS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+GRANTSOLUTIONS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+GUIDELINE.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
+GUIDELINES.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
+HCQUALITYCOMMISSION.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
+HEALTH.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+HEALTHCARE.GOV,Federal Agency,Department of Health And Human Services,Baltimore,MD
+HEALTHDATA.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+HEALTHFINDER.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+HEALTHINDICATORS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+HEALTHIT.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+HEALTHREFORM.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+HEALTHYPEOPLE.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+HEARTTRUTH.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
+HHS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+HHSOIG.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+HHSOPS.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
+HIV.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+HRSA.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
+IDEALAB.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+IEDISON.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
+IHS.GOV,Federal Agency,Department of Health And Human Services,Albuquerque,NM
+INSUREKIDSNOW.GOV,Federal Agency,Department of Health And Human Services,Baltimore,MD
+KNOWTHEFACTSFIRST.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+LOCATORPLUS.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
+LONGTERMCARE.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+MEDICAID.GOV,Federal Agency,Department of Health And Human Services,Baltimore,MD
+MEDICALCOUNTERMEASURES.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+MEDICALRESERVECORPS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+MEDICARE.GOV,Federal Agency,Department of Health And Human Services,Baltimore,MD
+MEDLINE.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
+MEDLINEPLUS.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
+MENTALHEALTH.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
+MESH.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
+MIMEDICARE.GOV,Federal Agency,Department of Health And Human Services,Baltimore,MD
+MYMEDICARE.GOV,Federal Agency,Department of Health And Human Services,Baltimore,MD
+NATIONALCHILDRENSSTUDY.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
+NCIFCRF.GOV,Federal Agency,Department of Health And Human Services,Frederick,MD
+NGC.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
+NIH.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
+NIHSENIORHEALTH.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
+NIOSH.GOV,Federal Agency,Department of Health And Human Services,Atlanta,GA
+NLM.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
+NNLM.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
+ORGANDONOR.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
+PANDEMICFLU.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+PCIP.GOV,Federal Agency,Department of Health And Human Services,New Orleans,LA
+PHE.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+PSC.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
+PUBMED.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
+PUBMEDCENTRAL.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
+QUIC.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
+QUICK.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
+RECOVERYMONTH.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
+SAFEYOUTH.GOV,Federal Agency,Department of Health And Human Services,Atlanta,GA
+SAMHSA.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
+SELECTAGENTS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+SMOKEFREE.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
+STEROIDABUSE.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
+STOPALCOHOLABUSE.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+STOPBULLYING.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+STOPMEDICAREFRAUD.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+SURGEONGENERAL.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+THECOOLSPOT.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
+THEREALCOST.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+TISSUEENGINEERING.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
+TOBACCO.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+USABILITY.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+USBM.GOV,Federal Agency,Department of Health And Human Services,Atlanta,GA
+USPHS.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
+VACCINES.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+WHAGING.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+WHITEHOUSECONFERENCEONAGING.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+WOMENSHEALTH.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+YOUTH.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+BIOMETRICS.GOV,Federal Agency,Department of Homeland Security,Arlington,VA
+CITIZENCORPS.GOV,Federal Agency,Department of Homeland Security,Washington,DC
+CPNIREPORTING.GOV,Federal Agency,Department of Homeland Security,Washington,DC
+DHS.GOV,Federal Agency,Department of Homeland Security,Washington,DC
+DISASTERASSISTANCE.GOV,Federal Agency,Department of Homeland Security,Bluemont,VA
+FEMA.GOV,Federal Agency,Department of Homeland Security,Washington,DC
+FIRSTRESPONDER.GOV,Federal Agency,Department of Homeland Security,Washington,DC
+FIRSTRESPONDERTRAINING.GOV,Federal Agency,Department of Homeland Security,Washington,DC
+FLETA.GOV,Federal Agency,Department of Homeland Security,Glynco,GA
+FLETC.GOV,Federal Agency,Department of Homeland Security,Glynco,GA
+FLIGHTSCHOOLCANDIDATES.GOV,Federal Agency,Department of Homeland Security,Rockville,MD
+FLOODSMART.GOV,Federal Agency,Department of Homeland Security,Bluemont,VA
+HOMELANDSECURITY.GOV,Federal Agency,Department of Homeland Security,Washington,DC
+ICE.GOV,Federal Agency,Department of Homeland Security,Washington,DC
+LISTO.GOV,Federal Agency,Department of Homeland Security,Washington,DC
+LLIS.GOV,Federal Agency,Department of Homeland Security,Washington,DC
+NMSC.GOV,Federal Agency,Department of Homeland Security,St Augustine,FL
+READY.GOV,Federal Agency,Department of Homeland Security,Washington,DC
+READYBUSINESS.GOV,Federal Agency,Department of Homeland Security,Washington,DC
+SAFECOMPROGRAM.GOV,Federal Agency,Department of Homeland Security,Washington,DC
+SAFETYACT.GOV,Federal Agency,Department of Homeland Security,Washington,DC
+SECRETSERVICE.GOV,Federal Agency,Department of Homeland Security,Washington D.C.,DC
+TSA.GOV,Federal Agency,Department of Homeland Security,Arlington,VA
+US-CERT.GOV,Federal Agency,Department of Homeland Security,Washington,DC
+USCG.GOV,Federal Agency,Department of Homeland Security,Alexandria,VA
+USCIS.GOV,Federal Agency,Department of Homeland Security,Washington,DC
+USSS.GOV,Federal Agency,Department of Homeland Security,Washington,DC
+DISASTERHOUSING.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC
+FHA.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC
+GINNIEMAE.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC
+HOMESALES.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC
+HUD.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC
+HUDOIG.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC
+HUDUSER.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC
+NATIONALHOUSING.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC
+NATIONALHOUSINGLOCATOR.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC
+NHL.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC
+NLS.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC
+ADA.GOV,Federal Agency,Department of Justice,Rockville,MD
+ADR.GOV,Federal Agency,Department of Justice,Rockville,MD
+AMBERALERT.GOV,Federal Agency,Department of Justice,Potomac,MD
+ATF.GOV,Federal Agency,Department of Justice,Washington,DC
+BIOMETRICCOE.GOV,Federal Agency,Department of Justice,Clarksburg,WV
+BJA.GOV,Federal Agency,Department of Justice,Washington ,DC
+BJS.GOV,Federal Agency,Department of Justice,Washington,DC
+BOP.GOV,Federal Agency,Department of Justice,Washington,DC
+CRIMESOLUTIONS.GOV,Federal Agency,Department of Justice,Washinton ,DC
+CRIMEVICTIMS.GOV,Federal Agency,Department of Justice,Potomac,MD
+CYBERCRIME.GOV,Federal Agency,Department of Justice,Washington,DC
+DEA.GOV,Federal Agency,Department of Justice,Rockville,MD
+DEADIVERSION.GOV,Federal Agency,Department of Justice,Potomac,MD
+DEALS.GOV,Federal Agency,Department of Justice,Washington,DC
+DNA.GOV,Federal Agency,Department of Justice,Potomac,MD
+DSAC.GOV,Federal Agency,Department of Justice,Potomac,MD
+ESPANOLFORLAWENFORCEMENT.GOV,Federal Agency,Department of Justice,Potomac,MD
+FARA.GOV,Federal Agency,Department of Justice,potomac,MD
+FBI.GOV,Federal Agency,Department of Justice,Washington,DC
+FBIJOBS.GOV,Federal Agency,Department of Justice,Washington,DC
+FIRSTFREEDOM.GOV,Federal Agency,Department of Justice,Potomac,MD
+FOIA.GOV,Federal Agency,Department of Justice,Washington,DC
+FORFEITURE.GOV,Federal Agency,Department of Justice,Potomac,MD
+FPI.GOV,Federal Agency,Department of Justice,Washington,DC
+GETSMARTABOUTDRUGS.GOV,Federal Agency,Department of Justice,Potomac,MD
+HELPINGAMERICASYOUTH.GOV,Federal Agency,Department of Justice,Potomac,MD
+IC3.GOV,Federal Agency,Department of Justice,Fairmont,WV
+INTERPOL.GOV,Federal Agency,Department of Justice,Potomac,MD
+IPRCENTER.GOV,Federal Agency,Department of Justice,Washington,DC
+JUSTICE.GOV,Federal Agency,Department of Justice,Rockville,MD
+JUSTTHINKTWICE.GOV,Federal Agency,Department of Justice,Potomac,MD
+JUVENILECOUNCIL.GOV,Federal Agency,Department of Justice,Potomac,MD
+LEP.GOV,Federal Agency,Department of Justice,Rockville,MD
+LOOKSTOOGOODTOBETRUE.GOV,Federal Agency,Department of Justice,Fairmont,WV
+MALWAREINVESTIGATOR.GOV,Federal Agency,Department of Justice,Washington,DC
+MEDALOFVALOR.GOV,Federal Agency,Department of Justice,Potomac,MD
+NAMUS.GOV,Federal Agency,Department of Justice,Potomac,MD
+NATIONALGANGCENTER.GOV,Federal Agency,Department of Justice,Tallahassee,FL
+NCIRC.GOV,Federal Agency,Department of Justice,Tallahassee,FL
+NCJRS.GOV,Federal Agency,Department of Justice,Potomac,MD
+NIBIN.GOV,Federal Agency,Department of Justice,Washington,DC
+NICIC.GOV,Federal Agency,Department of Justice,Washington,DC
+NIEM.GOV,Federal Agency,Department of Justice,Tallahassee,FL
+NIJ.GOV,Federal Agency,Department of Justice,Washington,DC
+NMVTIS.GOV,Federal Agency,Department of Justice,Washington,DC
+NSOPW.GOV,Federal Agency,Department of Justice,Washington,DC
+NVTC.GOV,Federal Agency,Department of Justice,Washington,DC
+OJJDP.GOV,Federal Agency,Department of Justice,Potomac,MD
+OJP.GOV,Federal Agency,Department of Justice,Washington,DC
+OVC.GOV,Federal Agency,Department of Justice,Potomac,MD
+OVCTTAC.GOV,Federal Agency,Department of Justice,Potomac,MD
+PROJECTSAFECHILDHOOD.GOV,Federal Agency,Department of Justice,Potomac,MD
+PROJECTSAFENEIGHBORHOODS.GOV,Federal Agency,Department of Justice,Rockville,MD
+PSOB.GOV,Federal Agency,Department of Justice,Potomac,MD
+RCFL.GOV,Federal Agency,Department of Justice,McLean,VA
+REENTRY.GOV,Federal Agency,Department of Justice,Potomac,MD
+SCRA.GOV,Federal Agency,Department of Justice,Potomac,MD
+SERVICEMEMBERS.GOV,Federal Agency,Department of Justice,Potomac,MD
+SMART.GOV,Federal Agency,Department of Justice,Washington,DC
+STOPFRAUD.GOV,Federal Agency,Department of Justice,Rockville,MD
+TRIBALJUSTICEANDSAFETY.GOV,Federal Agency,Department of Justice,Potomac,MD
+UCRDATATOOL.GOV,Federal Agency,Department of Justice,Washington,DC
+UNICOR.GOV,Federal Agency,Department of Justice,Washington,DC
+USDOJ.GOV,Federal Agency,Department of Justice,Rockville,MD
+USERRA.GOV,Federal Agency,Department of Justice,Potpmac,MD
+USMARSHALS.GOV,Federal Agency,Department of Justice,Rockville,MD
+VCF.GOV,Federal Agency,Department of Justice,Washington,DC
+VEHICLEHISTORY.GOV,Federal Agency,Department of Justice,Potomac,MD
+VOTE.GOV,Federal Agency,Department of Justice,Washington,DC
+AMERICASHEROESATWORK.GOV,Federal Agency,Department of Labor,Washington,DC
+AUTOCOMMUNITIES.GOV,Federal Agency,Department of Labor,Washington,DC
+BENEFITS.GOV,Federal Agency,Department of Labor,Washington,DC
+BLS.GOV,Federal Agency,Department of Labor,Washington,DC
+DISABILITY.GOV,Federal Agency,Department of Labor,Washington,DC
+DOL-ESA.GOV,Federal Agency,Department of Labor,Washington,DC
+DOL.GOV,Federal Agency,Department of Labor,Washington,DC
+DOLETA.GOV,Federal Agency,Department of Labor,Washington,DC
+GOVBENEFITS.GOV,Federal Agency,Department of Labor,Washington,DC
+GOVLOANS.GOV,Federal Agency,Department of Labor,Washington,DC
+JOBCORPS.GOV,Federal Agency,Department of Labor,Austin,TX
+LABOR.GOV,Federal Agency,Department of Labor,Washington,DC
+MSHA.GOV,Federal Agency,Department of Labor,Arlington,VA
+MYNEXTMOVE.GOV,Federal Agency,Department of Labor,Washington,DC
+OSHA.GOV,Federal Agency,Department of Labor,Washington,DC
+UNIONREPORTS.GOV,Federal Agency,Department of Labor,Washington,DC
+VETERANS.GOV,Federal Agency,Department of Labor,Washington,DC
+WHISTLEBLOWERS.GOV,Federal Agency,Department of Labor,Washington,DC
+WRP.GOV,Federal Agency,Department of Labor,Washington,DC
+YOUTHRULES.GOV,Federal Agency,Department of Labor,Washington,DC
+AMERICA.GOV,Federal Agency,Department of State,Washington,DC
+CIVILIANRESPONSECORPS.GOV,Federal Agency,Department of State,Washington,DC
+CONTINENTALSHELF.GOV,Federal Agency,Department of State,Washington,DC
+CWC.GOV,Federal Agency,Department of State,Washington,DC
+ECOPARTNERSHIPS.GOV,Federal Agency,Department of State,Washington,DC
+FAN.GOV,Federal Agency,Department of State,Washington,DC
+FOREIGNASSISTANCE.GOV,Federal Agency,Department of State,Washington,DC
+FSGB.GOV,Federal Agency,Department of State,Washington,DC
+GHI.GOV,Federal Agency,Department of State,Washington,DC
+HUMANRIGHTS.GOV,Federal Agency,Department of State,Washington ,DC
+IAWG.GOV,Federal Agency,Department of State,Washington,DC
+IBWC.GOV,Federal Agency,Department of State,El Paso,TX
+ICASS.GOV,Federal Agency,Department of State,Washington,DC
+OSAC.GOV,Federal Agency,Department of State,Washington,DC
+PEPFAR.GOV,Federal Agency,Department of State,Washington,DC
+STATE.GOV,Federal Agency,Department of State,Washington,DC
+USCONSULATE.GOV,Federal Agency,Department of State,Washington,DC
+USEMBASSY-MEXICO.GOV,Federal Agency,Department of State,Mexico City,11
+USEMBASSY.GOV,Federal Agency,Department of State,Washington,DC
+USINT.GOV,Federal Agency,Department of State,Washington,DC
+USMISSION.GOV,Federal Agency,Department of State,Washington,DC
+USVPP.GOV,Federal Agency,Department of State,Washington,DC
+ABANDONEDMINES.GOV,Federal Agency,Department of the Interior,Washington,DC
+ACWI.GOV,Federal Agency,Department of the Interior,Reston,VA
+ALASKACENTERS.GOV,Federal Agency,Department of the Interior,Washington,DC
+AMERICANLATINOMUSEUM.GOV,Federal Agency,Department of the Interior,Washington,WV
+AMERICASGREATOUTDOORS.GOV,Federal Agency,Department of the Interior,Washington,DC
+ANSTASKFORCE.GOV,Federal Agency,Department of the Interior,Arlington,VA
+BIA.GOV,Federal Agency,Department of the Interior,Reston,VA
+BIOECO.GOV,Federal Agency,Department of the Interior,Denver,CO
+BLM.GOV,Federal Agency,Department of the Interior,Denver,CO
+BLMNTL.GOV,Federal Agency,Department of the Interior,Denver,CO
+BOEM.GOV,Federal Agency,Department of the Interior,Herndon,VA
+BOEMRE.GOV,Federal Agency,Department of the Interior,Herndon,VA
+BOR.GOV,Federal Agency,Department of the Interior,Denver,CO
+BSEE.GOV,Federal Agency,Department of the Interior,Herndon,VA
+COAST2050.GOV,Federal Agency,Department of the Interior,Lafayette,LA
+CORALREEF.GOV,Federal Agency,Department of the Interior,Denver,CO
+CUPCAO.GOV,Federal Agency,Department of the Interior,Denver,CO
+DOI.GOV,Federal Agency,Department of the Interior,Washington,DC
+DOIOIG.GOV,Federal Agency,Department of the Interior,RESTON,VA
+EARTHQUAKE.GOV,Federal Agency,Department of the Interior,Menlo Park,CA
+EVERGLADESRESTORATION.GOV,Federal Agency,Department of the Interior,Davie,FL
+EVERYKID.GOV,Federal Agency,Department of the Interior,Washington DC,DC
+FCG.GOV,Federal Agency,Department of the Interior,Denver,CO
+FGDC.GOV,Federal Agency,Department of the Interior,Reston,VA
+FIRECODE.GOV,Federal Agency,Department of the Interior,Boise,ID
+FIRELEADERSHIP.GOV,Federal Agency,Department of the Interior,Boise,ID
+FIRENET.GOV,Federal Agency,Department of the Interior,Boise,ID
+FIRESCIENCE.GOV,Federal Agency,Department of the Interior,Boise,ID
+FWS.GOV,Federal Agency,Department of the Interior,Lakewood,CO
+GCDAMP.GOV,Federal Agency,Department of the Interior,Denver,CO
+GCMRC.GOV,Federal Agency,Department of the Interior,Flagstaff,AZ
+GEOCOMMUNICATOR.GOV,Federal Agency,Department of the Interior,Denver,CO
+GEOMAC.GOV,Federal Agency,Department of the Interior,Denver,CO
+GEOPLATFORM.GOV,Federal Agency,Department of the Interior,Washington,DC
+IAT.GOV,Federal Agency,Department of the Interior,Boise,ID
+INDIANAFFAIRS.GOV,Federal Agency,Department of the Interior,Reston,VA
+INTERIOR.GOV,Federal Agency,Department of the Interior,Washington,DC
+INVASIVESPECIES.GOV,Federal Agency,Department of the Interior,Washington,DC
+JEM.GOV,Federal Agency,Department of the Interior,Lafayett,LA
+KLAMATHRESTORATION.GOV,Federal Agency,Department of the Interior,Yreka,CA
+LACOAST.GOV,Federal Agency,Department of the Interior,Lafayette,LA
+LANDFIRE.GOV,Federal Agency,Department of the Interior,Sioux Falls,SD
+LANDIMAGING.GOV,Federal Agency,Department of the Interior,Reston,VA
+LCA.GOV,Federal Agency,Department of the Interior,Lafayette,LA
+LCRMSCP.GOV,Federal Agency,Department of the Interior,Denver,CO
+LMVSCI.GOV,Federal Agency,Department of the Interior,Lafayette,LA
+LOWERMISSISSIPPIVALLEYSCIENCE.GOV,Federal Agency,Department of the Interior,Lafayette,LA
+MAPAPLANET.GOV,Federal Agency,Department of the Interior,Flagstaff,AZ
+MARINE.GOV,Federal Agency,Department of the Interior,Camarillo,CA
+MITIGATIONCOMMISSION.GOV,Federal Agency,Department of the Interior,Denver,CO
+MMS.GOV,Federal Agency,Department of the Interior,Herndon,VA
+MRGO.GOV,Federal Agency,Department of the Interior,Lafayette,LA
+MRLC.GOV,Federal Agency,Department of the Interior,Sioux Falls,SD
+NATIONALATLAS.GOV,Federal Agency,Department of the Interior,Reston,VA
+NATIONALMAP.GOV,Federal Agency,Department of the Interior,Reston,VA
+NATIVEONESTOP.GOV,Federal Agency,Department of the Interior,Reston,VA
+NBC.GOV,Federal Agency,Department of the Interior,Denver,CO
+NDEP.GOV,Federal Agency,Department of the Interior,Reston,VA
+NDOP.GOV,Federal Agency,Department of the Interior,Reston,VA
+NEMI.GOV,Federal Agency,Department of the Interior,Middleton,WI
+NFPORS.GOV,Federal Agency,Department of the Interior,Washington,DC
+NIFC.GOV,Federal Agency,Department of the Interior,Boise,ID
+NOLAENVIRONMENTAL.GOV,Federal Agency,Department of the Interior,Lafayette,LA
+NPS.GOV,Federal Agency,Department of the Interior,WASHINGTON DC,DC
+ONHIR.GOV,Federal Agency,Department of the Interior,Flagstaff,AZ
+ONRR.GOV,Federal Agency,Department of the Interior,Herndon,VA
+OSM.GOV,Federal Agency,Department of the Interior,Washington,DC
+OSMRE.GOV,Federal Agency,Department of the Interior,Washington,DC
+PIEDRASBLANCAS.GOV,Federal Agency,Department of the Interior,Sacramento,CA
+REPORTBAND.GOV,Federal Agency,Department of the Interior,Laurel,MD
+RIVERS.GOV,Federal Agency,Department of the Interior,Burbank,WA
+SAFECOM.GOV,Federal Agency,Department of the Interior,Boise,ID
+SCIENCEBASE.GOV,Federal Agency,Department of the Interior,Denver,CO
+SIERRAWILD.GOV,Federal Agency,Department of the Interior,Yosemite,CA
+SNAP.GOV,Federal Agency,Department of the Interior,Washington,DC
+USBR.GOV,Federal Agency,Department of the Interior,Denver,CO
+USGS.GOV,Federal Agency,Department of the Interior,Reston,VA
+UTAHFIREINFO.GOV,Federal Agency,Department of the Interior,Denver,CO
+VOLCANO.GOV,Federal Agency,Department of the Interior,Anchorage,AK
+VOLUNTEER.GOV,Federal Agency,Department of the Interior,Reston,VA
+WATERMONITOR.GOV,Federal Agency,Department of the Interior,Reston,VA
+WILDLIFEADAPTATIONSTRATEGY.GOV,Federal Agency,Department of the Interior,Arlington,VA
+WLCI.GOV,Federal Agency,Department of the Interior,Denver,CO
+YOUTHGO.GOV,Federal Agency,Department of the Interior,Shepherdstown,WV
+AMA.GOV,Federal Agency,Department of the Treasury,Washington,DC
+AMERICATHEBEAUTIFULQUARTERS.GOV,Federal Agency,Department of the Treasury,Washington,DC
+ASAP.GOV,Federal Agency,Department of the Treasury,Washington,DC
+AYUDACONMIBANCO.GOV,Federal Agency,Department of the Treasury,Washington,DC
+BANKANSWERS.GOV,Federal Agency,Department of the Treasury,Washington,DC
+BANKCUSTOMER.GOV,Federal Agency,Department of the Treasury,Washington,DC
+BANKCUSTOMERASSISTANCE.GOV,Federal Agency,Department of the Treasury,Washington,DC
+BANKHELP.GOV,Federal Agency,Department of the Treasury,Washington,DC
+BANKNET.GOV,Federal Agency,Department of the Treasury,Washington,DC
+BEP.GOV,Federal Agency,Department of the Treasury,Washington,DC
+BFEM.GOV,Federal Agency,Department of the Treasury,Washington,DC
+BONDPRO.GOV,Federal Agency,Department of the Treasury,Washington,DC
+CCAC.GOV,Federal Agency,Department of the Treasury,Washington,DC
+CDFIFUND.GOV,Federal Agency,Department of the Treasury,Washington,DC
+COMPLAINTREFERRALEXPRESS.GOV,Federal Agency,Department of the Treasury,Washington,DC
+COMPTROLLEROFTHECURRENCY.GOV,Federal Agency,Department of the Treasury,Washington,DC
+DIRECTOASUCUENTA.GOV,Federal Agency,Department of the Treasury,Washington,DC
+EFTPS.GOV,Federal Agency,Department of the Treasury,Washington,DC
+ETA-FIND.GOV,Federal Agency,Department of the Treasury,DALLAS,TX
+ETHICSBURG.GOV,Federal Agency,Department of the Treasury,Parkersburg,WV
+EYENOTE.GOV,Federal Agency,Department of the Treasury,Washington,DC
+FEDERALINVESTMENTS.GOV,Federal Agency,Department of the Treasury,Pakersburg,WV
+FEDERALSPENDING.GOV,Federal Agency,Department of the Treasury,Washington,DC
+FEDINVEST.GOV,Federal Agency,Department of the Treasury,Parkersburg,WV
+FEDSPENDING.GOV,Federal Agency,Department of the Treasury,Washington,DC
+FINANCIALRESEARCH.GOV,Federal Agency,Department of the Treasury,Washington,DC
+FINANCIALSTABILITY.GOV,Federal Agency,Department of the Treasury,Washington,DC
+FINCEN.GOV,Federal Agency,Department of the Treasury,Vienna,VA
+FSOC.GOV,Federal Agency,Department of the Treasury,Washington,DC
+FTTESTTWAI.GOV,Federal Agency,Department of the Treasury,Hyattsville,MD
+GODIRECT.GOV,Federal Agency,Department of the Treasury,Washington,DC
+GWA.GOV,Federal Agency,Department of the Treasury,Hyattsville,MD
+HELPWITHMYBANK.GOV,Federal Agency,Department of the Treasury,Washington,DC
+HELPWITHMYCHECKINGACCOUNT.GOV,Federal Agency,Department of the Treasury,Washington,DC
+HELPWITHMYCREDITCARD.GOV,Federal Agency,Department of the Treasury,Washington,DC
+HELPWITHMYCREDITCARDBANK.GOV,Federal Agency,Department of the Treasury,Washington,DC
+HELPWITHMYMORTGAGE.GOV,Federal Agency,Department of the Treasury,Washington,DC
+HELPWITHMYMORTGAGEBANK.GOV,Federal Agency,Department of the Treasury,Washington,DC
+IPAC.GOV,Federal Agency,Department of the Treasury,Boston,MA
+IPP.GOV,Federal Agency,Department of the Treasury,McLean,VA
+IRS.GOV,Federal Agency,Department of the Treasury,McLean,VA
+IRSAUCTIONS.GOV,Federal Agency,Department of the Treasury,McLean,VA
+IRSNET.GOV,Federal Agency,Department of the Treasury,McLean,VA
+IRSSALES.GOV,Federal Agency,Department of the Treasury,McLean,VA
+IRSVIDEOS.GOV,Federal Agency,Department of the Treasury,Washington,DC
+ITS.GOV,Federal Agency,Department of the Treasury,McLean,VA
+MAKINGHOMEAFFORDABLE.GOV,Federal Agency,Department of the Treasury,Washington,DC
+MHA.GOV,Federal Agency,Department of the Treasury,Washington,DC
+MONEYFACTORY.GOV,Federal Agency,Department of the Treasury,Washington,DC
+MONEYFACTORYSTORE.GOV,Federal Agency,Department of the Treasury,Washington,DC
+MSB.GOV,Federal Agency,Department of the Treasury,Vienna,VA
+MYMONEY.GOV,Federal Agency,Department of the Treasury,Washington,DC
+MYRA.GOV,Federal Agency,Department of the Treasury,Washington,DC
+NATIONALBANK.GOV,Federal Agency,Department of the Treasury,McLean,VA
+NATIONALBANKHELP.GOV,Federal Agency,Department of the Treasury,Washington,DC
+NATIONALBANKNET.GOV,Federal Agency,Department of the Treasury,Washington,DC
+NAVYCASH.GOV,Federal Agency,Department of the Treasury,McLean,VA
+OCC.GOV,Federal Agency,Department of the Treasury,Washington,DC
+OCCHELPS.GOV,Federal Agency,Department of the Treasury,Washington,DC
+OCCNET.GOV,Federal Agency,Department of the Treasury,Landover,MD
+OTS.GOV,Federal Agency,Department of the Treasury,McLean,VA
+PATRIOTBONDS.GOV,Federal Agency,Department of the Treasury,Parkersburg,WV
+PAY.GOV,Federal Agency,Department of the Treasury,Washington,DC
+PRACOMMENT.GOV,Federal Agency,Department of the Treasury,Washington,DC
+QATESTTWAI.GOV,Federal Agency,Department of the Treasury,Hyattsville,MD
+SAVINGSBOND.GOV,Federal Agency,Department of the Treasury,Mclean,VA
+SAVINGSBONDS.GOV,Federal Agency,Department of the Treasury,McLean,VA
+SAVINGSBONDWIZARD.GOV,Federal Agency,Department of the Treasury,Mclean,VA
+SIGTARP.GOV,Federal Agency,Department of the Treasury,Washington,DC
+SLGS.GOV,Federal Agency,Department of the Treasury,Mclean,VA
+TAAPS.GOV,Federal Agency,Department of the Treasury,Mclean,VA
+TAX.GOV,Federal Agency,Department of the Treasury,McLean,VA
+TCIS.GOV,Federal Agency,Department of the Treasury,Washington,DC
+TIGTA.GOV,Federal Agency,Department of the Treasury,Washington,DC
+TIGTANET.GOV,Federal Agency,Department of the Treasury,McLean,VA
+TRANSPARENCY.GOV,Federal Agency,Department of the Treasury,Washington,DC
+TREAS.GOV,Federal Agency,Department of the Treasury,Washington,DC
+TREASLOCKBOX.GOV,Federal Agency,Department of the Treasury,Washington,DC
+TREASURY.FED.US,Federal Agency,Department of the Treasury,Washington,DC
+TREASURY.GOV,Federal Agency,Department of the Treasury,Washington,DC
+TREASURYAUCTION.GOV,Federal Agency,Department of the Treasury,Parkersburg,WV
+TREASURYAUCTIONS.GOV,Federal Agency,Department of the Treasury,Mclean,VA
+TREASURYDIRECT.GOV,Federal Agency,Department of the Treasury,McLean,VA
+TREASURYECM.GOV,Federal Agency,Department of the Treasury,Washington,DC
+TREASURYHUNT.GOV,Federal Agency,Department of the Treasury,Parkersburg,WV
+TREASURYSCAMS.GOV,Federal Agency,Department of the Treasury,Mclean,VA
+TRS.GOV,Federal Agency,Department of the Treasury,Washington,DC
+TTB.GOV,Federal Agency,Department of the Treasury,Washington,DC
+TTBONLINE.GOV,Federal Agency,Department of the Treasury,McLean,VA
+TTLPLUS.GOV,Federal Agency,Department of the Treasury,St. Louis,MO
+TWAI.GOV,Federal Agency,Department of the Treasury,Washington,DC
+USASPENDING.GOV,Federal Agency,Department of the Treasury,Washington,DC
+USDEBITCARD.GOV,Federal Agency,Department of the Treasury,Mclean,VA
+USMINT.GOV,Federal Agency,Department of the Treasury,Washington,DC
+USTREAS.GOV,Federal Agency,Department of the Treasury,McLean,VA
+VERIFYPAYMENT.GOV,Federal Agency,Department of the Treasury,Parkersburg,WV
+WIZARD.GOV,Federal Agency,Department of the Treasury,Mclean,VA
+WORKPLACE.GOV,Federal Agency,Department of the Treasury,Washington,DC
+911.GOV,Federal Agency,Department of Transportation,Washington,DC
+BTS.GOV,Federal Agency,Department of Transportation,Washington,DC
+CFLHD.GOV,Federal Agency,Department of Transportation,Lakewood,CO
+DISTRACTEDDRIVING.GOV,Federal Agency,Department of Transportation,Washington,DC
+DISTRACTION.GOV,Federal Agency,Department of Transportation,Washington,DC
+DOT.GOV,Federal Agency,Department of Transportation,Washington,DC
+DOTIDEAHUB.GOV,Federal Agency,Department of Transportation,Washington,DC
+DOTTRAFFICRECORDS.GOV,Federal Agency,Department of Transportation,Room 2202,DC
+EMS.GOV,Federal Agency,Department of Transportation,Washington,DC
+ESC.GOV,Federal Agency,Department of Transportation,Oklahoma City,OK
+FAA.GOV,Federal Agency,Department of Transportation,Washington,DC
+FAASAFETY.GOV,Federal Agency,Department of Transportation,Washington,DC
+ITALLADDSUP.GOV,Federal Agency,Department of Transportation,Washington,DC
+JCCBI.GOV,Federal Agency,Department of Transportation,Oklahoma City,OK
+MARVIEW.GOV,Federal Agency,Department of Transportation,Washington,DC
+MDA.GOV,Federal Agency,Department of Transportation,Washington,DC
+NHTSA.GOV,Federal Agency,Department of Transportation,Washington,DC
+NTDPROGRAM.GOV,Federal Agency,Department of Transportation,Washington,DC
+PLAINLANGUAGE.GOV,Federal Agency,Department of Transportation,Washington,DC
+PROTECTYOURMOVE.GOV,Federal Agency,Department of Transportation,Washington,DC
+SAFERCAR.GOV,Federal Agency,Department of Transportation,Washington,DC
+SAFERTRUCK.GOV,Federal Agency,Department of Transportation,Washington,DC
+SHARETHEROADSAFELY.GOV,Federal Agency,Department of Transportation,Washington,DC
+STRONGPORTS.GOV,Federal Agency,Department of Transportation,Washington,DC
+SUSTAINABLECOMMUNITIES.GOV,Federal Agency,Department of Transportation,Washington,DC
+TFHRC.GOV,Federal Agency,Department of Transportation,Mclean,VA
+TRAFFICSAFETYMARKETING.GOV,Federal Agency,Department of Transportation,Washington,DC
+TRANSPORTATION.GOV,Federal Agency,Department of Transportation,Washington,DC
+UNITEDWERIDE.GOV,Federal Agency,Department of Transportation,Washington,DC
+CDCO.GOV,Federal Agency,Department of Veterans Affairs,Austin,TX
+NATIONALRESOURCEDIRECTORY.GOV,Federal Agency,Department of Veterans Affairs,Washington,DC
+NRD.GOV,Federal Agency,Department of Veterans Affairs,Washington,DC
+VA.GOV,Federal Agency,Department of Veterans Affairs,Washington,DC
+VETBIZ.GOV,Federal Agency,Department of Veterans Affairs,Washington,DC
+VETS.GOV,Federal Agency,Department of Veterans Affairs,Washington,DC
+DNI.GOV,Federal Agency,Director of National Intelligence,McLean,VA
+IARPA-IDEAS.GOV,Federal Agency,Director of National Intelligence,Washington,DC
+IARPA.GOV,Federal Agency,Director of National Intelligence,College Park,MD
+ICJOINTDUTY.GOV,Federal Agency,Director of National Intelligence,Washington,DC
+INTELINK.GOV,Federal Agency,Director of National Intelligence,Ft. George G. Meade,MD
+INTELLIGENCE.GOV,Federal Agency,Director of National Intelligence,Washington,DC
+ISE.GOV,Federal Agency,Director of National Intelligence,Washington ,DC
+NCIX.GOV,Federal Agency,Director of National Intelligence,Washington,DC
+NCSC.GOV,Federal Agency,Director of National Intelligence,Bethesda,MD
+NMIC.GOV,Federal Agency,Director of National Intelligence,Washington,DC
+ODNI.GOV,Federal Agency,Director of National Intelligence,Washington,DC
+OSIS.GOV,Federal Agency,Director of National Intelligence,Fort George G. Meade,MD
+PIX.GOV,Federal Agency,Director of National Intelligence,Washington,DC
+QART.GOV,Federal Agency,Director of National Intelligence,Washington,DC
+UGOV.GOV,Federal Agency,Director of National Intelligence,Fort George G Meade,MD
+AIRNOW.GOV,Federal Agency,Environmental Protection Agency,Durham,NC
+CBI-EPA.GOV,Federal Agency,Environmental Protection Agency,Durham,NC
+ENERGYSTAR.GOV,Federal Agency,Environmental Protection Agency,Washington,DC
+EPA.GOV,Federal Agency,Environmental Protection Agency,Research Triangle Park,NC
+FDMS.GOV,Federal Agency,Environmental Protection Agency,Washington,DC
+FEDCENTER.GOV,Federal Agency,Environmental Protection Agency,Champaign,IL
+FRTR.GOV,Federal Agency,Environmental Protection Agency,Omaha,NE
+GREENGOV.GOV,Federal Agency,Environmental Protection Agency, Washington,DC
+OFEE.GOV,Federal Agency,Environmental Protection Agency,Washington,DC
+REGULATION.GOV,Federal Agency,Environmental Protection Agency,Washington,DC
+REGULATIONS.GOV,Federal Agency,Environmental Protection Agency,Washington,DC
+RELOCATEFEDS.GOV,Federal Agency,Environmental Protection Agency,Cincinnati,OH
+SUSTAINABILITY.GOV,Federal Agency,Environmental Protection Agency,Washington,DC
+URBANWATERS.GOV,Federal Agency,Environmental Protection Agency,Washington,DC
+EEOC.GOV,Federal Agency,Equal Employment Opportunity Commission,Washington,DC
+AIDREFUGEES.GOV,Federal Agency,Executive Office of the President,Washington,DC
+ASTRONGMIDDLECLASS.GOV,Federal Agency,Executive Office of the President,Washington,DC
+BUDGET.GOV,Federal Agency,Executive Office of the President,Washington,DC
+CHANGE.GOV,Federal Agency,Executive Office of the President,Arlington,VA
+EARMARKS.GOV,Federal Agency,Executive Office of the President,Washington,DC
+EGOV.GOV,Federal Agency,Executive Office of the President,Washington,DC
+EOP.GOV,Federal Agency,Executive Office of the President,Washington,DC
+ETHICS.GOV,Federal Agency,Executive Office of the President,Washington ,DC
+EXRWH.GOV,Federal Agency,Executive Office of the President,Washington,DC
+FISCALCOMMISSION.GOV,Federal Agency,Executive Office of the President,Washington,DC
+HC.GOV,Federal Agency,Executive Office of the President,Washington,DC
+ITDASHBOARD.GOV,Federal Agency,Executive Office of the President,Washington,DC
+JOININGFORCES.GOV,Federal Agency,Executive Office of the President,Washington,DC
+LETSMOVE.GOV,Federal Agency,Executive Office of the President,Washington,DC
+MAX.GOV,Federal Agency,Executive Office of the President,NW,WA
+NEPA.GOV,Federal Agency,Executive Office of the President,Washington,DC
+NOTALONE.GOV,Federal Agency,Executive Office of the President,Washington,DC
+NSTIC.GOV,Federal Agency,Executive Office of the President,Gaithersburg,MD
+OMB.GOV,Federal Agency,Executive Office of the President,Washington,DC
+OMBLOG.GOV,Federal Agency,Executive Office of the President,Washington,DC
+ONDCP.GOV,Federal Agency,Executive Office of the President,Washington,DC
+OSTP.GOV,Federal Agency,Executive Office of the President,Washington,DC
+PAYMENTACCURACY.GOV,Federal Agency,Executive Office of the President,Washington,DC
+PCI.GOV,Federal Agency,Executive Office of the President,Washington,DC
+PRESIDIO.GOV,Federal Agency,Executive Office of the President,San Francisco,CA
+PRESIDIOTRUST.GOV,Federal Agency,Executive Office of the President,San Francisco,CA
+REACHHIGHER.GOV,Federal Agency,Executive Office of the President,Washington,DC
+SAVE.GOV,Federal Agency,Executive Office of the President,Washington,DC
+SAVEAWARD.GOV,Federal Agency,Executive Office of the President,Washington,DC
+STRONGMIDDLECLASS.GOV,Federal Agency,Executive Office of the President,Washington,DC
+USTR.GOV,Federal Agency,Executive Office of the President,Washington,DC
+WH.GOV,Federal Agency,Executive Office of the President,Washington,DC
+WHITEHOUSE.GOV,Federal Agency,Executive Office of the President,Washington,DC
+WHITEHOUSEDRUGPOLICY.GOV,Federal Agency,Executive Office of the President,Washington,DC
+EXIM.GOV,Federal Agency,Export/Import Bank of the U.S.,Washington,DC
+EXIMCOOP.GOV,Federal Agency,Export/Import Bank of the U.S.,Washington,DC
+FCA.GOV,Federal Agency,Farm Credit Administration,McLean,VA
+FCSIC.GOV,Federal Agency,Farm Credit Administration,McLean,VA
+BROADBAND.GOV,Federal Agency,Federal Communications Commission,Washington,DC
+BROADBANDMAP.GOV,Federal Agency,Federal Communications Commission,Washington,DC
+DTV.GOV,Federal Agency,Federal Communications Commission,Washington,DC
+FCC.GOV,Federal Agency,Federal Communications Commission,Washington,DC
+FCCUNIVERSITY.GOV,Federal Agency,Federal Communications Commission,Washington,DC
+LIFELINE.GOV,Federal Agency,Federal Communications Commission,Washington,DC
+NBM.GOV,Federal Agency,Federal Communications Commission,Washington,DC
+OPENINTERNET.GOV,Federal Agency,Federal Communications Commission,Washington,DC
+ECONOMICINCLUSION.GOV,Federal Agency,Federal Deposit Insurance Corporation,Arlington,VA
+FDIC.GOV,Federal Agency,Federal Deposit Insurance Corporation,Arlington,VA
+FDICBETS.GOV,Federal Agency,Federal Deposit Insurance Corporation,Arlington,VA
+FDICCONNECT.GOV,Federal Agency,Federal Deposit Insurance Corporation,Arlington,VA
+FDICIG.GOV,Federal Agency,Federal Deposit Insurance Corporation,Arlington,VA
+FDICOIG.GOV,Federal Agency,Federal Deposit Insurance Corporation,Washington,DC
+FDICSALES.GOV,Federal Agency,Federal Deposit Insurance Corporation,Arlington,VA
+FDICSEGURO.GOV,Federal Agency,Federal Deposit Insurance Corporation,Arlington,VA
+MYFDIC.GOV,Federal Agency,Federal Deposit Insurance Corporation,Arlington,VA
+MYFDICINSURANCE.GOV,Federal Agency,Federal Deposit Insurance Corporation,Arlington,VA
+FEC.GOV,Federal Agency,Federal Elections Commission,Washington,DC
+FERC.GOV,Federal Agency,Federal Energy Regulatory Commission,Washington,DC
+FERCALT.GOV,Federal Agency,Federal Energy Regulatory Commission,Washington,DC
+FHFA.GOV,Federal Agency,Federal Housing Finance Agency,Washington,DC
+FHFB.GOV,Federal Agency,Federal Housing Finance Agency,Washington,DC
+HARP.GOV,Federal Agency,Federal Housing Finance Agency,Washington,DC
+OFHEO.GOV,Federal Agency,Federal Housing Finance Agency,Washington,DC
+FHFAOIG.GOV,Federal Agency,Federal Housing Finance Agency Office of Inspector General,Washington,DC
+FLRA.GOV,Federal Agency,Federal Labor Relations Authority,Washington,DC
+FMC.GOV,Federal Agency,Federal Maritime Commission,Washington,DC
+FMCS.GOV,Federal Agency,Federal Mediation and Conciliation Service,Washington,DC
+FBIIC.GOV,Federal Agency,Federal Reserve System,Washington,DC
+FEDCENTENNIAL.GOV,Federal Agency,Federal Reserve System,Washington,DC
+FEDERALRESERVE.GOV,Federal Agency,Federal Reserve System,Washington,DC
+FEDERALRESERVE100.GOV,Federal Agency,Federal Reserve System,Washington ,DC
+FEDERALRESERVE2013.GOV,Federal Agency,Federal Reserve System,Washington,DC
+FEDERALRESERVECENTENNIAL.GOV,Federal Agency,Federal Reserve System,Washington ,DC
+FEDERALRESERVECENTENNIALCELEBRATION.GOV,Federal Agency,Federal Reserve System,Washington,DC
+FEDERALRESERVECONSUMERHELP.GOV,Federal Agency,Federal Reserve System,Washington,DC
+FEDPARTNERSHIP.GOV,Federal Agency,Federal Reserve System,Washington,DC
+FFIEC.GOV,Federal Agency,Federal Reserve System,Washington,DC
+FRB.FED.US,Federal Agency,Federal Reserve System,Washington,DC
+FRB.GOV,Federal Agency,Federal Reserve System,Washington,DC
+FRS.GOV,Federal Agency,Federal Reserve System,Washington,DC
+NEWMONEY.GOV,Federal Agency,Federal Reserve System,Washington,DC
+USCURRENCY.GOV,Federal Agency,Federal Reserve System,Washington,DC
+EXPLORETSP.GOV,Federal Agency,Federal Retirement Thrift Investment Board,Washington,DC
+FRTIB.GOV,Federal Agency,Federal Retirement Thrift Investment Board,Washington,DC
+FRTIBTEST.GOV,Federal Agency,Federal Retirement Thrift Investment Board,Washigton,DC
+TSP.GOV,Federal Agency,Federal Retirement Thrift Investment Board,Washington,DC
+TSPTEST.GOV,Federal Agency,Federal Retirement Thrift Investment Board,Washington,DC
+ADMONGO.GOV,Federal Agency,Federal Trade Commission,Washington,DC
+ALERTAENLINEA.GOV,Federal Agency,Federal Trade Commission,Washington,DC
+ANNUALCREDITREPORT.GOV,Federal Agency,Federal Trade Commission,Washington,DC
+CONSUMER.GOV,Federal Agency,Federal Trade Commission,Washington,DC
+CONSUMERSENTINEL.GOV,Federal Agency,Federal Trade Commission,Washington,DC
+CONSUMERSENTINELNETWORK.GOV,Federal Agency,Federal Trade Commission,Washington,DC
+CONSUMIDOR.GOV,Federal Agency,Federal Trade Commission,Washington,DC
+DONOTCALL.GOV,Federal Agency,Federal Trade Commission,Washington,DC
+DONTSERVETEENS.GOV,Federal Agency,Federal Trade Commission,Washington,DC
+ECONSUMER.GOV,Federal Agency,Federal Trade Commission,Washington,DC
+FREECREDITREPORT.GOV,Federal Agency,Federal Trade Commission,Washington,DC
+FTC.GOV,Federal Agency,Federal Trade Commission,Washington,DC
+FTCCOMPLAINTASSISTANT.GOV,Federal Agency,Federal Trade Commission,Washington,DC
+FTCEFILE.GOV,Federal Agency,Federal Trade Commission,Washington,DC
+HSR.GOV,Federal Agency,Federal Trade Commission,Washington,DC
+IDENTITYTHEFT.GOV,Federal Agency,Federal Trade Commission,Washington,DC
+IDTHEFT.GOV,Federal Agency,Federal Trade Commission,Washington,DC
+NCPW.GOV,Federal Agency,Federal Trade Commission,Washington,DC
+ONGUARDONLINE.GOV,Federal Agency,Federal Trade Commission,Washington,DC
+ONLINEONGUARD.GOV,Federal Agency,Federal Trade Commission,Washington,DC
+PROTECCIONDELCONSUMIDOR.GOV,Federal Agency,Federal Trade Commission,Washington,DC
+ROBODEIDENTIDAD.GOV,Federal Agency,Federal Trade Commission,Washington,DC
+SENTINEL.GOV,Federal Agency,Federal Trade Commission,Washington,DC
+UCE.GOV,Federal Agency,Federal Trade Commission,Washington,DC
+USICN.GOV,Federal Agency,Federal Trade Commission,Washington,DC
+18F.GOV,Federal Agency,General Services Administration,Washington,DC
+ACQUISITION.GOV,Federal Agency,General Services Administration,Arlington,VA
+ADVANTAGE.GOV,Federal Agency,General Services Administration,Washington,DC
+AFADVANTAGE.GOV,Federal Agency,General Services Administration,Washington,DC
+AMERICANJOBCENTER.GOV,Federal Agency,General Services Administration,Washington,DC
+BUSINESSUSA.GOV,Federal Agency,General Services Administration,Washington,DC
+BUYACCESSIBLE.GOV,Federal Agency,General Services Administration,Washington,DC
+CAO.GOV,Federal Agency,General Services Administration,Washington,DC
+CBCA.GOV,Federal Agency,General Services Administration,Washington,DC
+CCR.GOV,Federal Agency,General Services Administration,Battle Creek,MI
+CFDA.GOV,Federal Agency,General Services Administration,Washington,DC
+CFO.GOV,Federal Agency,General Services Administration,Washington,DC
+CFOC.GOV,Federal Agency,General Services Administration,Washington,DC
+CHALLENGE.GOV,Federal Agency,General Services Administration,Washington,DC
+CHALLENGES.GOV,Federal Agency,General Services Administration,Washington,DC
+CIO.GOV,Federal Agency,General Services Administration,Washington,DC
+CLOUD.GOV,Federal Agency,General Services Administration,Washington,DC
+COMPUTERS4LEARNING.GOV,Federal Agency,General Services Administration,Arlington,VA
+COMPUTERSFORLEARNING.GOV,Federal Agency,General Services Administration,Arlington,VA
+CONNECT.GOV,Federal Agency,General Services Administration,Washington,DC
+CONSUMERACTION.GOV,Federal Agency,General Services Administration,Washington,DC
+CONTRACTDIRECTORY.GOV,Federal Agency,General Services Administration,Arlington,VA
+CPARS.GOV,Federal Agency,General Services Administration,Washington,DC
+DATA.GOV,Federal Agency,General Services Administration,Washington,DC
+DIGITALGOV.GOV,Federal Agency,General Services Administration,Washington,DC
+DOTGOV.GOV,Federal Agency,General Services Administration,Fairfax,VA
+EAC.GOV,Federal Agency,General Services Administration,Washington,DC
+ECPIC.GOV,Federal Agency,General Services Administration,Washington,DC
+EISENHOWERMEMORIAL.GOV,Federal Agency,General Services Administration,Washington,DC
+EPLS.GOV,Federal Agency,General Services Administration,Arlington,VA
+ESRS.GOV,Federal Agency,General Services Administration,arlington,VA
+EVERYKIDINAPARK.GOV,Federal Agency,General Services Administration,Washington DC,DC
+FACA.GOV,Federal Agency,General Services Administration,Washington,DC
+FACADATABASE.GOV,Federal Agency,General Services Administration,Washington,DC
+FAI.GOV,Federal Agency,General Services Administration,Washington,DC
+FAPIIS.GOV,Federal Agency,General Services Administration,Washington,DC
+FAQ.GOV,Federal Agency,General Services Administration,Washington,DC
+FBO.GOV,Federal Agency,General Services Administration,Arlington,VA
+FED.US,Federal Agency,General Services Administration,Washington,DC
+FEDBIZOPPS.GOV,Federal Agency,General Services Administration,Arlington,VA
+FEDIDCARD.GOV,Federal Agency,General Services Administration,Washington,DC
+FEDINFO.GOV,Federal Agency,General Services Administration,Washington,DC
+FEDRAMP.GOV,Federal Agency,General Services Administration,Washington,DC
+FEDROOMS.GOV,Federal Agency,General Services Administration,Arlington,VA
+FIDO.GOV,Federal Agency,General Services Administration,Washington,DC
+FIRSTGOV.GOV,Federal Agency,General Services Administration,Washington,DC
+FMI.GOV,Federal Agency,General Services Administration,Washington,DC
+FORMS.GOV,Federal Agency,General Services Administration,Washington,DC
+FPDS.GOV,Federal Agency,General Services Administration,Arlington,VA
+FPKI-LAB.GOV,Federal Agency,General Services Administration,Washington,DC
+FPKI.GOV,Federal Agency,General Services Administration,Washington,DC
+FRPP-PA.GOV,Federal Agency,General Services Administration,WASHINGTON,DC
+FSD.GOV,Federal Agency,General Services Administration,Arlington,VA
+FSRS.GOV,Federal Agency,General Services Administration,Crystal City,VA
+GOBIERNO.GOV,Federal Agency,General Services Administration,Washington,DC
+GOBIERNOUSA.GOV,Federal Agency,General Services Administration,Washington,DC
+GOVSALES.GOV,Federal Agency,General Services Administration,Arlington,VA
+GSA.GOV,Federal Agency,General Services Administration,Washington,DC
+GSAADVANTAGE.GOV,Federal Agency,General Services Administration,Washington,DC
+GSAAUCTIONS.GOV,Federal Agency,General Services Administration,Washington,DC
+GSADVANTAGE.GOV,Federal Agency,General Services Administration,Washington,DC
+GSAIG.GOV,Federal Agency,General Services Administration,Washington,DC
+GSAXCESS.GOV,Federal Agency,General Services Administration,Arlington,VA
+HOWTO.GOV,Federal Agency,General Services Administration,Washington,DC
+IDMANAGEMENT.GOV,Federal Agency,General Services Administration,Washington,DC
+INFO.GOV,Federal Agency,General Services Administration,Washington,DC
+JOBCENTER.GOV,Federal Agency,General Services Administration,Washington,DC
+KIDS.GOV,Federal Agency,General Services Administration,Washington,DC
+LEARNPERFORMANCE.GOV,Federal Agency,General Services Administration,Washington,DC
+MYUSA.GOV,Federal Agency,General Services Administration,Washington,DC
+NBRC.GOV,Federal Agency,General Services Administration,Bangor,ME
+NETWORX.GOV,Federal Agency,General Services Administration,Fairfax,VA
+NIC.GOV,Federal Agency,General Services Administration,Fairfax,VA
+PARTNER4SOLUTIONS.GOV,Federal Agency,General Services Administration,Washington,DC
+PCLOB.GOV,Federal Agency,General Services Administration,Washington,DC
+PERFORMANCE.GOV,Federal Agency,General Services Administration,Washington,DC
+PIC.GOV,Federal Agency,General Services Administration,Washington,DC
+PIF.GOV,Federal Agency,General Services Administration,Washington,DC
+PPIRS.GOV,Federal Agency,General Services Administration,Washington,DC
+PRESIDENTIALINNOVATIONFELLOWS.GOV,Federal Agency,General Services Administration,Washington,DC
+PTT.GOV,Federal Agency,General Services Administration,Washington D.C.,DC
+REALESTATESALES.GOV,Federal Agency,General Services Administration,Washington,DC
+REALPROPERTYPROFILE.GOV,Federal Agency,General Services Administration,Washington,DC
+REGINFO.GOV,Federal Agency,General Services Administration,Washington,DC
+ROCIS.GOV,Federal Agency,General Services Administration,Washington,DC
+SAM.GOV,Federal Agency,General Services Administration,Arlington,VA
+SANDBOX.GOV,Federal Agency,General Services Administration,Washinton,DC
+SBST.GOV,Federal Agency,General Services Administration,Washington,DC
+SECTION508.GOV,Federal Agency,General Services Administration,Washington,DC
+SFTOOL.GOV,Federal Agency,General Services Administration,Chicago,IL
+STRATEGICSOURCING.GOV,Federal Agency,General Services Administration,Arlington,VA
+SUPPORTTHEVOTER.GOV,Federal Agency,General Services Administration,WASHINGTON,DC
+UNITEDSTATES.GOV,Federal Agency,General Services Administration,Washington,DC
+US.GOV,Federal Agency,General Services Administration,Washington,DC
+USA.GOV,Federal Agency,General Services Administration,Washington,DC
+USAGOV.GOV,Federal Agency,General Services Administration,Washington,DC
+USAPERFORMANCE.GOV,Federal Agency,General Services Administration,Washington,DC
+USCIRF.GOV,Federal Agency,General Services Administration,Washington,DC
+USGOVERNMENT.GOV,Federal Agency,General Services Administration,Washington,DC
+USIP.GOV,Federal Agency,General Services Administration,Washington,DC
+VEF.GOV,Federal Agency,General Services Administration,Arlington,VA
+VITM.GOV,Federal Agency,General Services Administration,Arlington,VA
+BROWSETOPICS.GOV,Federal Agency,Government Printing Office,Washington,DC
+CONGRESSIONALDIRECTORY.GOV,Federal Agency,Government Printing Office,Washington,DC
+CONGRESSIONALRECORD.GOV,Federal Agency,Government Printing Office,Washington,DC
+ECFR.GOV,Federal Agency,Government Printing Office,Washington,DC
+FDLP.GOV,Federal Agency,Government Printing Office,Washington,DC
+FDSYS.GOV,Federal Agency,Government Printing Office,Washington,DC
+FEDERALREGISTER.GOV,Federal Agency,Government Printing Office,Washington,DC
+FEDREG.GOV,Federal Agency,Government Printing Office,Washington,DC
+FMSHRC.GOV,Federal Agency,Government Printing Office,Washington,DC
+GOVINFO.GOV,Federal Agency,Government Printing Office,Washington,DC
+GPO.GOV,Federal Agency,Government Printing Office,Washington,DC
+GPOACCESS.GOV,Federal Agency,Government Printing Office,Washington,DC
+HOUSECALENDAR.GOV,Federal Agency,Government Printing Office,Washington,DC
+OFR.GOV,Federal Agency,Government Printing Office,Washington,DC
+OPENWORLD.GOV,Federal Agency,Government Printing Office,Washington,DC
+PRESIDENTIALDOCUMENTS.GOV,Federal Agency,Government Printing Office,Washington,DC
+SENATECALENDAR.GOV,Federal Agency,Government Printing Office,Washington,DC
+STOPFAKES.GOV,Federal Agency,Government Printing Office,Washington,DC
+USCAPITOLPOLICE.GOV,Federal Agency,Government Printing Office,Washington,DC
+USCC.GOV,Federal Agency,Government Printing Office,Washington,DC
+USCCR.GOV,Federal Agency,Government Printing Office,Washington,DC
+USCODE.GOV,Federal Agency,Government Printing Office,Washington,DC
+USGOVERNMENTMANUAL.GOV,Federal Agency,Government Printing Office,College Park,MD
+WELCOMETOUSA.GOV,Federal Agency,Government Printing Office,Washington,DC
+RESTORETHEGULF.GOV,Federal Agency,Gulf Coast Ecosystem Restoration Council (GCERC),Silver Spring,MD
+TRUMAN.GOV,Federal Agency,Harry S. Truman Scholarship Foundation,Washington,DC
+IMLS.GOV,Federal Agency,Institute of Museum and Library Services,Washington,DC
+IAF.GOV,Federal Agency,Inter-American Foundation,Washington,DC
+BBG.GOV,Federal Agency,International Broadcasting Bureau,Washington,DC
+IBB.GOV,Federal Agency,International Broadcasting Bureau,Washington,DC
+VOA.GOV,Federal Agency,International Broadcasting Bureau,Washington,DC
+JAMESMADISON.GOV,Federal Agency,James Madison Memorial Fellowship Foundation,Alexandria,VA
+LSC.GOV,Federal Agency,Legal Services Corporation,Washington,DC
+AFRICANAMERICANHISTORYMONTH.GOV,Federal Agency,Library of Congress,Washington,DC
+AMERICANMEMORY.GOV,Federal Agency,Library of Congress,Washington,DC
+AMERICASLIBRARY.GOV,Federal Agency,Library of Congress,Washington,DC
+AMERICASSTORY.GOV,Federal Agency,Library of Congress,Washington,DC
+AMERICASTORY.GOV,Federal Agency,Library of Congress,Washington,DC
+ASIANPACIFICHERITAGE.GOV,Federal Agency,Library of Congress,Washington,DC
+CAPITOLHILL.GOV,Federal Agency,Library of Congress,Washington,DC
+COMMISSION.GOV,Federal Agency,Library of Congress,Washington,DC
+CONGRESS.GOV,Federal Agency,Library of Congress,Washington,DC
+COPYRIGHT.GOV,Federal Agency,Library of Congress,Washington,DC
+CRS.GOV,Federal Agency,Library of Congress,Washington,DC
+DIGITALPRESERVATION.GOV,Federal Agency,Library of Congress,Washington,DC
+DIGITALSTEWARDSHIP.GOV,Federal Agency,Library of Congress,Washington,DC
+DIGITIZATIONGUIDELINES.GOV,Federal Agency,Library of Congress,Washington,DC
+HILL.GOV,Federal Agency,Library of Congress,Washington,DC
+HISPANICHERITAGEMONTH.GOV,Federal Agency,Library of Congress,Washington,DC
+JEWISHHERITAGE.GOV,Federal Agency,Library of Congress,Washington,DC
+JEWISHHERITAGEMONTH.GOV,Federal Agency,Library of Congress,Washington,DC
+LAW.GOV,Federal Agency,Library of Congress,Washington,DC
+LCTL.GOV,Federal Agency,Library of Congress,Washington,DC
+LEGISLATIVE.GOV,Federal Agency,Library of Congress,Washington,DC
+LEGISLATIVEBRANCH.GOV,Federal Agency,Library of Congress,Washington,DC
+LIBRARY-OF-CONGRESS.GOV,Federal Agency,Library of Congress,Washington,DC
+LIBRARYOFCONGRESS.GOV,Federal Agency,Library of Congress,Washington,DC
+LIS.GOV,Federal Agency,Library of Congress,Washington,DC
+LITERACY.GOV,Federal Agency,Library of Congress,Washington,DC
+LOC.GOV,Federal Agency,Library of Congress,Washington,DC
+LOCIMAGES.GOV,Federal Agency,Library of Congress,Washington,DC
+LOCSTORE.GOV,Federal Agency,Library of Congress,Washington,DC
+LOCTPS.GOV,Federal Agency,Library of Congress,Washington,DC
+MYLOC.GOV,Federal Agency,Library of Congress,Washington,DC
+NATIVEAMERICANHERITAGEMONTH.GOV,Federal Agency,Library of Congress,Washington,DC
+NDSA.GOV,Federal Agency,Library of Congress,Washington,DC
+PRIMARYSOURCES.GOV,Federal Agency,Library of Congress,Washington,DC
+READ.GOV,Federal Agency,Library of Congress,Washington,DC
+SECTION108.GOV,Federal Agency,Library of Congress,Washington,DC
+TEACHINGPRIMARYSOURCES.GOV,Federal Agency,Library of Congress,Washington,DC
+TEACHINGWITHPRIMARYSOURCES.GOV,Federal Agency,Library of Congress,Washington,DC
+THOMAS.GOV,Federal Agency,Library of Congress,Washington,DC
+TPS.GOV,Federal Agency,Library of Congress,Washington,DC
+UNITEDSTATESCONGRESS.GOV,Federal Agency,Library of Congress,Washington,DC
+USCONGRESS.GOV,Federal Agency,Library of Congress,Washington,DC
+WDL.GOV,Federal Agency,Library of Congress,Washington,DC
+WOMENSHISTORYMONTH.GOV,Federal Agency,Library of Congress,Washington,DC
+WORLDDIGITALLIBRARY.GOV,Federal Agency,Library of Congress,Washington,DC
+MMC.GOV,Federal Agency,Marine Mammal Commission,Bethesda,MD
+MACPAC.GOV,Federal Agency,Medicaid and CHIP Payment and Access Commission,Washington,DC
+MEDPAC.GOV,Federal Agency,Medical Payment Advisory Commission,Washington,DC
+MSPB.GOV,Federal Agency,Merit Systems Protection Board,Washington,DC
+MCC.GOV,Federal Agency,Millennium Challenge Corporation,Washington,DC
+ECR.GOV,Federal Agency,Morris K. Udall Foundation,Tucson,AZ
+UDALL.GOV,Federal Agency,Morris K. Udall Foundation,Tucson,AZ
+GLOBE.GOV,Federal Agency,National Aeronautics and Space Administration,Greenbelt,MD
+NASA.GOV,Federal Agency,National Aeronautics and Space Administration,MSFC,AL
+NSWP.GOV,Federal Agency,National Aeronautics and Space Administration,MSFC,AL
+SCIJINKS.GOV,Federal Agency,National Aeronautics and Space Administration,MSFC,AL
+USGEO.GOV,Federal Agency,National Aeronautics and Space Administration,MSFC,AL
+9-11COMMISSION.GOV,Federal Agency,National Archives and Records Administration,College Park,MD
+911COMMISSION.GOV,Federal Agency,National Archives and Records Administration,College Park,MD
+ARCHIVES.GOV,Federal Agency,National Archives and Records Administration,College Park,MD
+CLINTONLIBRARY.GOV,Federal Agency,National Archives and Records Administration,Little Rock,AR
+EMERGENCY-FEDERAL-REGISTER.GOV,Federal Agency,National Archives and Records Administration,College Park,MD
+FCIC.GOV,Federal Agency,National Archives and Records Administration,College Park,MD
+FORDLIBRARYMUSEUM.GOV,Federal Agency,National Archives and Records Administration,College Park,MD
+FRC.GOV,Federal Agency,National Archives and Records Administration,College Park,MD
+GEORGEWBUSHLIBRARY.GOV,Federal Agency,National Archives and Records Administration,College Park,MD
+HISTORY.GOV,Federal Agency,National Archives and Records Administration,College Park,MD
+JIMMYCARTERLIBRARY.GOV,Federal Agency,National Archives and Records Administration,College,MD
+NARA-AT-WORK.GOV,Federal Agency,National Archives and Records Administration,College Park,MD
+NARA.GOV,Federal Agency,National Archives and Records Administration,College Park,MD
+NIXONLIBRARY.GOV,Federal Agency,National Archives and Records Administration,College Park,MD
+OGIS.GOV,Federal Agency,National Archives and Records Administration,College Park,MD
+OURDOCUMENTS.GOV,Federal Agency,National Archives and Records Administration,College Park,MD
+REAGANLIBRARY.GOV,Federal Agency,National Archives and Records Administration,College Park,MD
+RECORDSMANAGEMENT.GOV,Federal Agency,National Archives and Records Administration,College Park,MD
+WARTIMECONTRACTING.GOV,Federal Agency,National Archives and Records Administration,College Park,MD
+WEBHARVEST.GOV,Federal Agency,National Archives and Records Administration,College Park,MD
+NCPC.GOV,Federal Agency,National Capital Planning Commission,Washington,DC
+NCD.GOV,Federal Agency,National Council on Disability,Washington,DC
+MYCREDITUNION.GOV,Federal Agency,National Credit Union Administration,Alexandria,VA
+NCUA.GOV,Federal Agency,National Credit Union Administration,Alexandria,VA
+ARTS.GOV,Federal Agency,National Endowment for the Arts,Washington,DC
+NEA.GOV,Federal Agency,National Endowment for the Arts,Washington,DC
+HUMANITIES.GOV,Federal Agency,National Endowment for the Humanities,Washington,DC
+NEH.GOV,Federal Agency,National Endowment for the Humanities,Washington,DC
+PCAH.GOV,Federal Agency,National Endowment for the Humanities,Washington,DC
+WETHEPEOPLE.GOV,Federal Agency,National Endowment for the Humanities,Washington,DC
+NGA.GOV,Federal Agency,National Gallery of Art,Washington,DC
+NIGC.GOV,Federal Agency,National Indian Gaming Commission,Washington,DC
+NLRB.GOV,Federal Agency,National Labor Relations Board,Washington,DC
+NMB.GOV,Federal Agency,National Mediation Board,Washington,DC
+NANO.GOV,Federal Agency,National Nanotechnology Coordination Office,Arlington,VA
+ARCTIC.GOV,Federal Agency,National Science Foundation,Arlington,VA
+ARCTICGAS.GOV,Federal Agency,National Science Foundation,Washington,DC
+NSF.GOV,Federal Agency,National Science Foundation,Arlington,VA
+RESEARCH.GOV,Federal Agency,National Science Foundation,Arlington,VA
+SAC.GOV,Federal Agency,National Science Foundation,Arlington,VA
+SBIR.GOV,Federal Agency,National Science Foundation,Arlington,VA
+SCIENCE360.GOV,Federal Agency,National Science Foundation,Arlington,VA
+USAP.GOV,Federal Agency,National Science Foundation,Arlington,VA
+INTELLIGENCECAREERS.GOV,Federal Agency,National Security Agency,Ft. Meade,MD
+LPS.GOV,Federal Agency,National Security Agency,College Park,MD
+NTSB.GOV,Federal Agency,National Transportation Safety Board,Washington,DC
+ITRD.GOV,Federal Agency,Networking Information Technology Research and Development (NITRD),Arlington,VA
+NITRD.GOV,Federal Agency,Networking Information Technology Research and Development (NITRD),Arlington,VA
+HERITAGEABROAD.GOV,Federal Agency,Non-Federal Agency,Washington,DC
+IAB.GOV,Federal Agency,Non-Federal Agency,Quantico,VA
+JUSFC.GOV,Federal Agency,Non-Federal Agency,Washington,DC
+NWTRB.GOV,Federal Agency,Non-Federal Agency,Arlington,VA
+PPPL.GOV,Federal Agency,Non-Federal Agency,Princeton,NJ
+SERVEINDIANA.GOV,Federal Agency,Non-Federal Agency,Indianapolis,IN
+SJI.GOV,Federal Agency,Non-Federal Agency,Reston,VA
+WMATC.GOV,Federal Agency,Non-Federal Agency,Silver Spring,MD
+NRC-GATEWAY.GOV,Federal Agency,Nuclear Regulatory Commission,Rockville,MD
+NRC.GOV,Federal Agency,Nuclear Regulatory Commission,Rockville,MD
+OSHRC.GOV,Federal Agency,Occupational Safety & Health Review Commission,Washington,DC
+INTEGRITY.GOV,Federal Agency,Office of Government Ethics,Washington,DC
+APPLICATIONMANAGER.GOV,Federal Agency,Office of Personnel Management,Macon,GA
+CHCOC.GOV,Federal Agency,Office of Personnel Management,Washington,DC
+E-QIP.GOV,Federal Agency,Office of Personnel Management,Washington,DC
+EMPLOYEEEXPRESS.GOV,Federal Agency,Office of Personnel Management,Macon,GA
+FEB.GOV,Federal Agency,Office of Personnel Management,Washington,DC
+FEDERALJOBS.GOV,Federal Agency,Office of Personnel Management,Macon,GA
+FEDJOBS.GOV,Federal Agency,Office of Personnel Management,Macon,GA
+FEDSHIREVETS.GOV,Federal Agency,Office of Personnel Management,Washington,DC
+FEGLI.GOV,Federal Agency,Office of Personnel Management,Washington,DC
+FSAFEDS.GOV,Federal Agency,Office of Personnel Management,Washington,DC
+GOLEARN.GOV,Federal Agency,Office of Personnel Management,Washington,DC
+GOVERNMENTJOBS.GOV,Federal Agency,Office of Personnel Management,Macon,GA
+HRU.GOV,Federal Agency,Office of Personnel Management,Washington,DC
+LMRCOUNCIL.GOV,Federal Agency,Office of Personnel Management,Washington,DC
+OPM.GOV,Federal Agency,Office of Personnel Management,Macon,GA
+PAC.GOV,Federal Agency,Office of Personnel Management,Washington,DC
+PMF.GOV,Federal Agency,Office of Personnel Management,Washington,DC
+TELEWORK.GOV,Federal Agency,Office of Personnel Management,Washington,DC
+UNLOCKTALENT.GOV,Federal Agency,Office of Personnel Management,Washington,DC
+USAJOBS.GOV,Federal Agency,Office of Personnel Management,Washington,DC
+USALEARNING.GOV,Federal Agency,Office of Personnel Management,Washington,DC
+USASTAFFING.GOV,Federal Agency,Office of Personnel Management,Macon,GA
+OPIC.GOV,Federal Agency,Overseas Private Investment Corporation,Washington,DC
+PBGC.GOV,Federal Agency,Pension Benefit Guaranty Corporation,Washington,DC
+PRC.GOV,Federal Agency,Postal Rate Commission,Washington,DC
+RRB.GOV,Federal Agency,Railroad Retirement Board,Chicago,IL
+EDUCATIONJOBSFUND.GOV,Federal Agency,Recovery Accountability and Transparency Board,Washington,DC
+FEDERALACCOUNTABILITY.GOV,Federal Agency,Recovery Accountability and Transparency Board,Washington,DC
+FEDERALREPORTING.GOV,Federal Agency,Recovery Accountability and Transparency Board,Washington,DC
+FEDERALTRANSPARENCY.GOV,Federal Agency,Recovery Accountability and Transparency Board,Washington ,DC
+RATB.GOV,Federal Agency,Recovery Accountability and Transparency Board,WASHINGTON,DC
+RECOVERY.GOV,Federal Agency,Recovery Accountability and Transparency Board,Washington,DC
+404.GOV,Federal Agency,Securities and Exchange Commission,Alexandria,VA
+INVESTOR.GOV,Federal Agency,Securities and Exchange Commission,Alexandria,VA
+SEC.GOV,Federal Agency,Securities and Exchange Commission,Alexandria,VA
+SSS.GOV,Federal Agency,Selective Service System,Arlington,VA
+BUSINESS.GOV,Federal Agency,Small Business Administration,Washington,DC
+HSA.GOV,Federal Agency,Small Business Administration,Washington,DC
+NWBC.GOV,Federal Agency,Small Business Administration,Washington,DC
+ONLINEWBC.GOV,Federal Agency,Small Business Administration,Washington,DC
+SBA.GOV,Federal Agency,Small Business Administration,Washington,DC
+WOMENBIZ.GOV,Federal Agency,Small Business Administration,Washington,DC
+ITIS.GOV,Federal Agency,Smithsonian Institution,Washington,DC
+SEGUROSOCIAL.GOV,Federal Agency,Social Security Administration,Baltimore,MD
+SOCIALSECURITY.GOV,Federal Agency,Social Security Administration,Baltimore,MD
+SSA.GOV,Federal Agency,Social Security Administration,Baltimore,MD
+SSAB.GOV,Federal Agency,Social Security Advisory Board,WASHINGTON,DC
+STENNIS.GOV,Federal Agency,Stennis Center for Public Service,Starkville,MS
+TVA.GOV,Federal Agency,Tennessee Valley Authority,Knoxville,TN
+TVAOIG.GOV,Federal Agency,Tennessee Valley Authority,Knoxville,TN
+TSC.GOV,Federal Agency,Terrorist Screening Center,Washington,DC
+PTF.GOV,Federal Agency,The Intelligence Community,Washington,DC
+BANKRUPTCY.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC
+CAVC.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC
+DCSC.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC
+FEDCIR.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC
+FEDERALCOURTS.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC
+FEDERALPROBATION.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC
+FEDERALRULES.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC
+FJC.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC
+JUDICIALCONFERENCE.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC
+NMCOURT.FED.US,Federal Agency,The Judicial Branch (Courts),Albuquerque,NM
+PACER.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC
+SC-US.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC
+SCINET-TEST.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC
+SCINET.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC
+SCUS.GOV,Federal Agency,The Judicial Branch (Courts),WASHINGTON,DC
+SUPREME-COURT.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC
+SUPREMECOURT.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC
+SUPREMECOURTUS.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC
+USBANKRUPTCY.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC
+USC.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC
+USCAVC.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC
+USCOURTS.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC
+USCVA.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC
+USPROBATION.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC
+USSC.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC
+USTAXCOURT.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC
+VETAPP.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC
+AOC.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+CAPITAL.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+CAPITOL.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+CAPITOLFLAGS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+CBO.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+CBONEWS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+CECC.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+CHINA-COMMISSION.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+CHINACOMMISSION.GOV,Federal Agency,The Legislative Branch (Congress),Washington,MD
+CITIZENCOSPONSORS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+CITIZENS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+COSPONSOR.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+CSCE.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+DEMOCRATICLEADER.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+DEMOCRATICWHIP.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+DEMOCRATS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+DEMS.GOV,Federal Agency,The Legislative Branch (Congress),Washington DC,DC
+ESECLAB.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+FASAB.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+GAO.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+GAONET.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+GOP.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+GOPCONFERENCE.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+GOPLEADER.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+HOUSE.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+HOUSECOMMUNICATIONS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+HOUSEDEMOCRATS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+HOUSEDEMS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+HOUSELIVE.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+HOUSENEWSLETTERS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+JCT.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+LISTENSTOYOU.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+MAJORITYLEADER.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+MAJORITYWHIP.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+PDBCECC.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+PPDCECC.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+REPUBLICANS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+SENATE.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+SENATERESTAURANTS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+SPEAKER.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+TAXREFORM.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+USBG.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+USCAPITAL.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+USCAPITOL.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+USCAPITOLVISITORCENTER.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+USCVC.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+VISITTHECAPITAL.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+VISITTHECAPITOL.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+WORLDWAR1CENTENNIAL.GOV,Federal Agency,The United States World War One Centennial Commission,Washington,DC
+ACCESS-BOARD.GOV,Federal Agency,U. S. Access Board,Washington,DC
+USHMM.GOV,Federal Agency,U. S. Holocaust Memorial Museum,Washington,DC
+USITC.GOV,Federal Agency,U. S. International Trade Commission,Washington,DC
+OSC.GOV,Federal Agency,U. S. Office of Special Counsel,Washington,DC
+OSCNET.GOV,Federal Agency,U. S. Office of Special Counsel,Washington,DC
+PEACECORE.GOV,Federal Agency,U. S. Peace Corps,Washington,DC
+PEACECORP.GOV,Federal Agency,U. S. Peace Corps,Washington,DC
+PEACECORPS.GOV,Federal Agency,U. S. Peace Corps,Washington,DC
+CHANGEOFADDRESS.GOV,Federal Agency,U. S. Postal Service,Washington,DC
+MAIL.GOV,Federal Agency,U. S. Postal Service,Raleigh,NC
+POSTOFFICE.GOV,Federal Agency,U. S. Postal Service,Raleigh,NC
+PURCHASING.GOV,Federal Agency,U. S. Postal Service,Raleigh,NC
+USPIS.GOV,Federal Agency,U. S. Postal Service,Arlington,VA
+USPS.GOV,Federal Agency,U. S. Postal Service,Raleigh,NC
+CHILDRENINADVERSITY.GOV,Federal Agency,U.S. Agency for International Development,Washington,DC
+DFAFACTS.GOV,Federal Agency,U.S. Agency for International Development,Washington,DC
+FEEDTHEFUTURE.GOV,Federal Agency,U.S. Agency for International Development,Washington,DC
+FIGHTINGMALARIA.GOV,Federal Agency,U.S. Agency for International Development,Washington,DC
+LETGIRLSLEARN.GOV,Federal Agency,U.S. Agency for International Development,Washington,DC
+NEGLECTEDDISEASES.GOV,Federal Agency,U.S. Agency for International Development,Washington,DC
+OFDA.GOV,Federal Agency,U.S. Agency for International Development,Washington,DC
+PMI.GOV,Federal Agency,U.S. Agency for International Development,Washington,DC
+USAID.GOV,Federal Agency,U.S. Agency for International Development,Washington,DC
+USAIDALLNET.GOV,Federal Agency,U.S. Agency for International Development,Arlington,VA
+USCP.GOV,Federal Agency,U.S. Capitol Police,Washington,DC
+CHEMSAFETY.GOV,Federal Agency,U.S. Chemical Safety and Hazard Investigation Board,Washington,DC
+CSB.GOV,Federal Agency,U.S. Chemical Safety and Hazard Investigation Board,Washington,DC
+SAFETYVIDEOS.GOV,Federal Agency,U.S. Chemical Safety and Hazard Investigation Board,Washington,DC
+CFA.GOV,Federal Agency,U.S. Commission of Fine Arts,Washington,DC
+PEACECORPSOIG.GOV,Federal Agency,"U.S. Postal Service, Office of Inspector General",Washington,DC
+USPSOIG.GOV,Federal Agency,"U.S. Postal Service, Office of Inspector General",Arlington,VA
+USTDA.GOV,Federal Agency,U.S. Trade and Development Agency,Arlington,VA
+CARBONCYCLESCIENCE.GOV,Federal Agency,United Stated Global Change Research Program,Washington,DC
+GLOBALCHANGE.GOV,Federal Agency,United Stated Global Change Research Program,Washington,DC
+IPCC-WG2.GOV,Federal Agency,United Stated Global Change Research Program,Stanford,CA
+USGCRP.GOV,Federal Agency,United Stated Global Change Research Program,Washington,DC
+OGE.GOV,Federal Agency,United States Office of Government Ethics,Washington,DC
+USOGE.GOV,Federal Agency,United States Office of Government Ethics,Washington,DC
+ICH.GOV,Federal Agency,US Interagency Council on Homelessness,washington,DC
+USICH.GOV,Federal Agency,US Interagency Council on Homelessness,Washington,DC

--- a/dotgov-domains/2015-11-03-full.csv
+++ b/dotgov-domains/2015-11-03-full.csv
@@ -1,0 +1,5517 @@
+Domain Name,Domain Type,Agency,City,State
+ABERDEENWA.GOV,City,Non-Federal Agency,Aberdeen,WA
+ABINGDON-VA.GOV,City,Non-Federal Agency,Abingdon,VA
+ABINGTONMA.GOV,City,Non-Federal Agency,Abington,MA
+ABSECONNJ.GOV,City,Non-Federal Agency,Absecon,NJ
+ACCESSPRINCETONNJ.GOV,City,Non-Federal Agency,Princeton,NJ
+ACTON-MA.GOV,City,Non-Federal Agency,Acton,MA
+ACTONMA.GOV,City,Non-Federal Agency,Acton,MA
+ADAK-AK.GOV,City,Non-Federal Agency,Adak,AK
+ADAMN.GOV,City,Non-Federal Agency,Ada,MN
+ADDISONTX.GOV,City,Non-Federal Agency,Addison,TX
+ADRIANMI.GOV,City,Non-Federal Agency,Adrian,MI
+AFTONWYOMING.GOV,City,Non-Federal Agency,AFTON,WY
+AKRONOHIO.GOV,City,Non-Federal Agency,Akron,OH
+ALAMEDACA.GOV,City,Non-Federal Agency,Alameda,CA
+ALAMOHEIGHTSTX.GOV,City,Non-Federal Agency,Alamo Heights,TX
+ALBANYNY.GOV,City,Non-Federal Agency,Albany,NY
+ALBEMARLENC.GOV,City,Non-Federal Agency,Albemarle,NC
+ALEKNAGIKAK.GOV,City,Non-Federal Agency,Aleknagik,AK
+ALEXANDERCITYAL.GOV,City,Non-Federal Agency,Alexander City,AL
+ALEXANDRIAVA.GOV,City,Non-Federal Agency,Alexandria,VA
+ALGONAWA.GOV,City,Non-Federal Agency,Algona,WA
+ALGOODTN.GOV,City,Non-Federal Agency,Algood,TN
+ALIQUIPPAPA.GOV,City,Non-Federal Agency,Aliquippa,PA
+ALLENSTOWNNH.GOV,City,Non-Federal Agency,Allenstown,NH
+ALLENTOWNPA.GOV,City,Non-Federal Agency,Allentown,PA
+ALLIANCEOH.GOV,City,Non-Federal Agency,Alliance,OH
+ALMONTMICHIGAN.GOV,City,Non-Federal Agency,Almont,MI
+ALSTEADNH.GOV,City,Non-Federal Agency,Alstead,NH
+ALTAVISTAVA.GOV,City,Non-Federal Agency,Altavista,VA
+ALTON-TX.GOV,City,Non-Federal Agency,Alton,TX
+ALTUSOK.GOV,City,Non-Federal Agency,Altus,OK
+ALVIN-TX.GOV,City,Non-Federal Agency,Alvin,TX
+AMARILLO.GOV,City,Non-Federal Agency,Amarillo,TX
+AMENIANY.GOV,City,Non-Federal Agency,Amenia,NY
+AMERICUSGA.GOV,City,Non-Federal Agency,Americus,GA
+AMERYWI.GOV,City,Non-Federal Agency,Amery,WI
+AMHERSTMA.GOV,City,Non-Federal Agency,Amherst,MA
+AMHERSTNH.GOV,City,Non-Federal Agency,Amherst,NH
+AMHERSTVA.GOV,City,Non-Federal Agency,Amherst,VA
+AMITYARKANSAS.GOV,City,Non-Federal Agency,Amity,AR
+AMSTERDAMNY.GOV,City,Non-Federal Agency,Amsterdam,NY
+ANCHORAGEAK.GOV,City,Non-Federal Agency,Anchorage,AK
+ANDOVER-NH.GOV,City,Non-Federal Agency,Andover,NH
+ANDOVERMA.GOV,City,Non-Federal Agency,Andover,MA
+ANDOVERMN.GOV,City,Non-Federal Agency,Andover,MN
+ANGELFIRENM.GOV,City,Non-Federal Agency,Angel Fire,NM
+ANGELSCAMP.GOV,City,Non-Federal Agency,City of Angels Camp,CA
+ANKENYIOWA.GOV,City,Non-Federal Agency,Ankeny,IA
+ANNATEXAS.GOV,City,Non-Federal Agency,Anna,TX
+ANNETTATX.GOV,City,Non-Federal Agency,Aledo,TX
+ANNISTONAL.GOV,City,Non-Federal Agency,Anniston,AL
+APPLEVALLEYCA.GOV,City,Non-Federal Agency,Apple Valley,CA
+APPLEVALLEYUT.GOV,City,Non-Federal Agency,Apple Valley,UT
+APPOMATTOXVA.GOV,City,Non-Federal Agency,Appomattox,VA
+AQUINNAH-MA.GOV,City,Non-Federal Agency,Aquinnah,MA
+ARANSASPASSTX.GOV,City,Non-Federal Agency,Aransas Pass,TX
+ARCADIA-FL.GOV,City,Non-Federal Agency,Arcadia,FL
+ARCADIACA.GOV,City,Non-Federal Agency,Arcadia,CA
+ARCHBALDBOROUGHPA.GOV,City,Non-Federal Agency,Archbald,PA
+ARKANSASCITYKS.GOV,City,Non-Federal Agency,Arkansas City,KS
+ARLINGTON-TX.GOV,City,Non-Federal Agency,Arlington,TX
+ARLINGTONMA.GOV,City,Non-Federal Agency,Arlington,MA
+ARLINGTONTX.GOV,City,Non-Federal Agency,Arlington,TX
+ARLINGTONWA.GOV,City,Non-Federal Agency,Arlington,WA
+ARTESIANM.GOV,City,Non-Federal Agency,Artesia,NM
+ARTHUR-IL.GOV,City,Non-Federal Agency,Arthur,IL
+ASHBURNHAM-MA.GOV,City,Non-Federal Agency,Ashburnham,MA
+ASHBYMA.GOV,City,Non-Federal Agency,Ashby,MA
+ASHEBORONC.GOV,City,Non-Federal Agency,Asheboro,NC
+ASHGROVEMO.GOV,City,Non-Federal Agency,Ash Grove,MO
+ASHLANDCITYTN.GOV,City,Non-Federal Agency,Ashland City,TN
+ASHLANDKY.GOV,City,Non-Federal Agency,Ashland,KY
+ASHVILLEOHIO.GOV,City,Non-Federal Agency,Ashville,OH
+ATHOL-MA.GOV,City,Non-Federal Agency,Athol,MA
+ATKINSON-NH.GOV,City,Non-Federal Agency,Atkinson,NH
+ATLANTAGA.GOV,City,Non-Federal Agency,Atlanta,GA
+ATLANTISFL.GOV,City,Non-Federal Agency,Atlantis,FL
+ATRISCO-NM.GOV,City,Non-Federal Agency,Atrisco,NM
+ATTICA-IN.GOV,City,Non-Federal Agency,Attica,IN
+AUBREYTX.GOV,City,Non-Federal Agency,Aubrey,TX
+AUBURNMAINE.GOV,City,Non-Federal Agency,Auburn,ME
+AUGUSTAMAINE.GOV,City,Non-Federal Agency,Augusta,ME
+AUGUSTAME.GOV,City,Non-Federal Agency,Augusta,ME
+AUSTELLGA.GOV,City,Non-Federal Agency,Austell,GA
+AUSTINTEXAS.GOV,City,Non-Federal Agency,Austin,TX
+AUSTINTX.GOV,City,Non-Federal Agency,Austin,TX
+AVONCT.GOV,City,Non-Federal Agency,Avon,CT
+AVONDALEAZ.GOV,City,Non-Federal Agency,Avondale,AZ
+AZTECNM.GOV,City,Non-Federal Agency,Aztec,NM
+BADENPA.GOV,City,Non-Federal Agency,Baden,PA
+BAINBRIDGEWA.GOV,City,Non-Federal Agency,Bainbridge Island,WA
+BALHARBOURFL.GOV,City,Non-Federal Agency,Bal Harbour,FL
+BALTIMORECITY.GOV,City,Non-Federal Agency,Baltimore,MD
+BANGORMAINE.GOV,City,Non-Federal Agency,Bangor,ME
+BARLINGAR.GOV,City,Non-Federal Agency,Barling,AR
+BARRINGTON-IL.GOV,City,Non-Federal Agency,Barrington,IL
+BARRINGTONHILLS-IL.GOV,City,Non-Federal Agency,Barrington Hills,IL
+BASTROPTX.GOV,City,Non-Federal Agency,Bastrop,TX
+BATTLECREEK-MI.GOV,City,Non-Federal Agency,Battle Creek,MI
+BATTLECREEKMI.GOV,City,Non-Federal Agency,Battle Creek,MI
+BAXTERMN.GOV,City,Non-Federal Agency,Baxter,MN
+BAYSIDE-WI.GOV,City,Non-Federal Agency,Bayside,WI
+BAYSTLOUIS-MS.GOV,City,Non-Federal Agency,Bay St. Louis,MS
+BAYVILLENY.GOV,City,Non-Federal Agency,Bayville,NY
+BEACHHAVEN-NJ.GOV,City,Non-Federal Agency,Beach Haven,NJ
+BEAUMONT-CA.GOV,City,Non-Federal Agency,Beaumont,CA
+BEAUMONTTEXAS.GOV,City,Non-Federal Agency,Beaumont,TX
+BEAVERCREEKOHIO.GOV,City,Non-Federal Agency,Beavercreek,OH
+BEAVERPA.GOV,City,Non-Federal Agency,Beaver,PA
+BEAVERTONOREGON.GOV,City,Non-Federal Agency,Beaverton,OR
+BEAVERTWP-OH.GOV,City,Non-Federal Agency,North Lima,OH
+BEDFORDHEIGHTS.GOV,City,Non-Federal Agency,Bedford Heights,OH
+BEDFORDMA.GOV,City,Non-Federal Agency,Bedford,MA
+BEDFORDNY.GOV,City,Non-Federal Agency,Bedford Hills,NY
+BEDFORDOH.GOV,City,Non-Federal Agency,Bedford,OH
+BEDFORDTX.GOV,City,Non-Federal Agency,Bedford,TX
+BEDFORDVA.GOV,City,Non-Federal Agency,Bedford,VA
+BEECAVETEXAS.GOV,City,Non-Federal Agency,Bee Cave,TX
+BELAIREKS.GOV,City,Non-Federal Agency,Bel Aire,KS
+BELEN-NM.GOV,City,Non-Federal Agency,Belen,NM
+BELLAIRETX.GOV,City,Non-Federal Agency,Bellaire,TX
+BELLAVISTAAR.GOV,City,Non-Federal Agency,Bella Vista,AR
+BELLEAIRBLUFFS-FL.GOV,City,Non-Federal Agency,Belleair Bluffs,FL
+BELLEMEADE-KY.GOV,City,Non-Federal Agency,Louisville,KY
+BELLEVUEIA.GOV,City,Non-Federal Agency,Bellevue,IA
+BELLEVUEWA.GOV,City,Non-Federal Agency,Bellevue,WA
+BELMONT-MA.GOV,City,Non-Federal Agency,Belmont,MA
+BELOITWI.GOV,City,Non-Federal Agency,Beloit,WI
+BELTONPARKSMO.GOV,City,Non-Federal Agency,Belton,MO
+BELTONTEXAS.GOV,City,Non-Federal Agency,Belton,TX
+BENDOREGON.GOV,City,Non-Federal Agency,Bend,OR
+BENSALEMPA.GOV,City,Non-Federal Agency,Bensalem,PA
+BENSONAZ.GOV,City,Non-Federal Agency,Benson,AZ
+BENTONCHARTERTOWNSHIP-MI.GOV,City,Non-Federal Agency,Benton Harbor,MI
+BEREAKY.GOV,City,Non-Federal Agency,Berea,KY
+BERLINMD.GOV,City,Non-Federal Agency,Berlin,MD
+BERLINNH.GOV,City,Non-Federal Agency,Berlin,NH
+BERNCO.GOV,City,Non-Federal Agency,Albuquerque,NM
+BERWYN-IL.GOV,City,Non-Federal Agency,Berwyn,IL
+BETHANYBEACH-DE.GOV,City,Non-Federal Agency,Bethany Beach,DE
+BETHEL-CT.GOV,City,Non-Federal Agency,Bethel,CT
+BETHEL-OH.GOV,City,Non-Federal Agency,Bethel,OH
+BEVERLYHILLS-CA.GOV,City,Non-Federal Agency,Beverly Hills,CA
+BEVERLYHILLSCA.GOV,City,Non-Federal Agency,Beverly Hills,CA
+BEVERLYMA.GOV,City,Non-Federal Agency,Beverly,MA
+BIGGS-CA.GOV,City,Non-Federal Agency,Biggs,CA
+BIGSANDYTX.GOV,City,Non-Federal Agency,Big Sandy,TX
+BINGHAMTON-NY.GOV,City,Non-Federal Agency,Binghamton,NY
+BIRMINGHAMAL.GOV,City,Non-Federal Agency,Birmingham,AL
+BISBEEAZ.GOV,City,Non-Federal Agency,Bisbee,AZ
+BISCAYNEPARKFL.GOV,City,Non-Federal Agency,Biscayne Park,FL
+BISMARCKND.GOV,City,Non-Federal Agency,Bismarck,ND
+BIXBYOK.GOV,City,Non-Federal Agency,Bixby,OK
+BLAINEMN.GOV,City,Non-Federal Agency,Blaine,MN
+BLAIRSVILLE-GA.GOV,City,Non-Federal Agency,Blairsville,GA
+BLANDING-UT.GOV,City,Non-Federal Agency,Blanding,UT
+BLENDONTOWNSHIP-MI.GOV,City,Non-Federal Agency,Hudsonville,MI
+BLOOMINGDALE-GA.GOV,City,Non-Federal Agency,Bloomingdale,GA
+BLOOMINGTON-MN.GOV,City,Non-Federal Agency,Bloomington,MN
+BLUEASH-OH.GOV,City,Non-Federal Agency,Blue Ash,OH
+BOCARATON-FL.GOV,City,Non-Federal Agency,Boca Raton,FL
+BOERNE-TX.GOV,City,Non-Federal Agency,BOERNE,TX
+BOISEIDAHO.GOV,City,Non-Federal Agency,Boise,ID
+BOLTON-MA.GOV,City,Non-Federal Agency,Bolton,MA
+BONNEYTEXAS.GOV,City,Non-Federal Agency,Bonney,TX
+BORGERTX.GOV,City,Non-Federal Agency,Borger,TX
+BOSQUEFARMSNM.GOV,City,Non-Federal Agency,Bosque Farms,NM
+BOSTON.GOV,City,Non-Federal Agency,Boston,MA
+BOTHELLWA.GOV,City,Non-Federal Agency,Bothell,WA
+BOULDERCOLORADO.GOV,City,Non-Federal Agency,Boulder,CO
+BOURBON-IN.GOV,City,Non-Federal Agency,Bremen,IN
+BOWERSDE.GOV,City,Non-Federal Agency,"Frederica,",DE
+BOWLINGGREEN-MO.GOV,City,Non-Federal Agency,Bowling Green,MO
+BOWLINGGREENKY.GOV,City,Non-Federal Agency,Bowling Green,KY
+BOWMAR.GOV,City,Non-Federal Agency,Bow Mar,CO
+BOXBOROUGH-MA.GOV,City,Non-Federal Agency,Boxborough,MA
+BOYCEVA.GOV,City,Non-Federal Agency,Boyce,VA
+BOYLSTON-MA.GOV,City,Non-Federal Agency,Boylston,MA
+BOZEMAN-MT.GOV,City,Non-Federal Agency,Bozeman,MT
+BRADLEYBEACHNJ.GOV,City,Non-Federal Agency,Bradley Beach,NJ
+BRANFORD-CT.GOV,City,Non-Federal Agency,Branford,CT
+BRANSONMO.GOV,City,Non-Federal Agency,Branson,MO
+BRASWELLGA.GOV,City,Non-Federal Agency,Rockmart,GA
+BRAWLEY-CA.GOV,City,Non-Federal Agency,Brawley,CA
+BRECKENRIDGETX.GOV,City,Non-Federal Agency,Breckenridge,TX
+BREMENGA.GOV,City,Non-Federal Agency,Bremen,GA
+BREMERTONWA.GOV,City,Non-Federal Agency,Bremerton,WA
+BRENTWOOD-TN.GOV,City,Non-Federal Agency,Brentwood,TN
+BRENTWOODCA.GOV,City,Non-Federal Agency,Brentwood,CA
+BRENTWOODMD.GOV,City,Non-Federal Agency,Brentwood,MD
+BRENTWOODNH.GOV,City,Non-Federal Agency,Brentwood,NH
+BRENTWOODTN.GOV,City,Non-Federal Agency,Brentwood,TN
+BREWSTER-MA.GOV,City,Non-Federal Agency,Brewster,MA
+BREWSTERVILLAGE-NY.GOV,City,Non-Federal Agency,Brewster,NY
+BRICKTOWNSHIP-NJ.GOV,City,Non-Federal Agency,Brick,NJ
+BRIDGEPORTCT.GOV,City,Non-Federal Agency,Bridgeport,CT
+BRIDGEVIEW-IL.GOV,City,Non-Federal Agency,Bridgeview,IL
+BRIMFIELDOHIO.GOV,City,Non-Federal Agency,Kent,OH
+BRISTOLCT.GOV,City,Non-Federal Agency,Bristol,CT
+BRLA.GOV,City,Non-Federal Agency,Baton Rouge,LA
+BROADVIEW-IL.GOV,City,Non-Federal Agency,Broadview,IL
+BROKENARROWOK.GOV,City,Non-Federal Agency,Broken Arrow,OK
+BROOKFIELD-WI.GOV,City,Non-Federal Agency,Brookfield,WI
+BROOKFIELDCT.GOV,City,Non-Federal Agency,Brookfield,CT
+BROOKFIELDIL.GOV,City,Non-Federal Agency,Brookfield ,IL
+BROOKHAVENGA.GOV,City,Non-Federal Agency,Dunwoody,GA
+BROOKLINEMA.GOV,City,Non-Federal Agency,Brookline,MA
+BROOKLYNOHIO.GOV,City,Non-Federal Agency,Brooklyn,OH
+BROOKLYNWI.GOV,City,Non-Federal Agency,Brooklyn,WI
+BROWNSVILLETN.GOV,City,Non-Federal Agency,Brownsville,TN
+BROWNWOODTEXAS.GOV,City,Non-Federal Agency,Brownwood,TX
+BRYCECANYONCITYUT.GOV,City,Non-Federal Agency,Bryce Canyon City,UT
+BRYSONCITYNC.GOV,City,Non-Federal Agency,Bryson City,NC
+BUCKEYEAZ.GOV,City,Non-Federal Agency,Buckeye,AZ
+BUCKSPORTMAINE.GOV,City,Non-Federal Agency,Bucksport,ME
+BUENAVISTACO.GOV,City,Non-Federal Agency,Buena Vista,CO
+BULLHEADCITYAZ.GOV,City,Non-Federal Agency,Bullhead City,AZ
+BULVERDETX.GOV,City,Non-Federal Agency,Bulverde,TX
+BUNKERHILLTX.GOV,City,Non-Federal Agency,HOUSTON,TX
+BURBANKCA.GOV,City,Non-Federal Agency,Burbank,CA
+BURBANKIL.GOV,City,Non-Federal Agency,Burbank,IL
+BURIENWA.GOV,City,Non-Federal Agency,Burien,WA
+BURKITTSVILLE-MD.GOV,City,Non-Federal Agency,Burkittsville,MD
+BURLINGTON-WI.GOV,City,Non-Federal Agency,Burlington,WI
+BURLINGTONKANSAS.GOV,City,Non-Federal Agency,Burlington,KS
+BURLINGTONNC.GOV,City,Non-Federal Agency,Burlington,NC
+BURLINGTONVT.GOV,City,Non-Federal Agency,Burlington,VT
+BURNSHARBOR-IN.GOV,City,Non-Federal Agency,Burns Harbor,IN
+BURNSVILLEMN.GOV,City,Non-Federal Agency,Burnsville,MN
+BURR-RIDGE.GOV,City,Non-Federal Agency,Burr Ridge,IL
+BURRILLVILLE-RI.GOV,City,Non-Federal Agency,Harrisville,RI
+BURTONMI.GOV,City,Non-Federal Agency,Burton,MI
+BUTLERWI.GOV,City,Non-Federal Agency,Butler,WI
+BYESVILLEOH.GOV,City,Non-Federal Agency,Byesville,OH
+CABOTAR.GOV,City,Non-Federal Agency,Cabot,AR
+CABQ.GOV,City,Non-Federal Agency,Albuquerque,NM
+CALDWELLTX.GOV,City,Non-Federal Agency,Caldwell,TX
+CALEDONIAMN.GOV,City,Non-Federal Agency,Caledonia,MN
+CALIFORNIACITY-CA.GOV,City,Non-Federal Agency,California City,CA
+CALUMETTWP-IN.GOV,City,Non-Federal Agency,Gary,IN
+CAMBRIDGEMA.GOV,City,Non-Federal Agency,Cambridge,MA
+CAMBRIDGENY.GOV,City,Non-Federal Agency,Cambridge,NY
+CAMDENMAINE.GOV,City,Non-Federal Agency,Camden,ME
+CAMDENTN.GOV,City,Non-Federal Agency,Camden,TN
+CAMPBELLOHIO.GOV,City,Non-Federal Agency,Campbell,OH
+CANALWINCHESTEROHIO.GOV,City,Non-Federal Agency,Canal Winchester,OH
+CANNONFALLSMN.GOV,City,Non-Federal Agency,Cannon Falls,MN
+CANTONOHIO.GOV,City,Non-Federal Agency,Canton,OH
+CANTONTWP-OH.GOV,City,Non-Federal Agency,Canton,OH
+CANTONTX.GOV,City,Non-Federal Agency,Canton,TX
+CAPECORALFL.GOV,City,Non-Federal Agency,Cape Coral,FL
+CARBONDALE-PA.GOV,City,Non-Federal Agency,Carbondale,PA
+CARLISLE-IA.GOV,City,Non-Federal Agency,Carlisle,IA
+CARLISLEMA.GOV,City,Non-Federal Agency,Carlisle,MA
+CARLSBADCA.GOV,City,Non-Federal Agency,Carlsbad,CA
+CARNATIONWA.GOV,City,Non-Federal Agency,Carnation,WA
+CARNEGIEOK.GOV,City,Non-Federal Agency,Carnegie,OK
+CARNEYSPOINTNJ.GOV,City,Non-Federal Agency,Carneys Point,NJ
+CARRBORONC.GOV,City,Non-Federal Agency,Carrboro,NC
+CARROLLTON-GA.GOV,City,Non-Federal Agency,Carrollton,GA
+CARTERLAKE-IA.GOV,City,Non-Federal Agency,Carter Lake,IA
+CARTERSVILLEGA.GOV,City,Non-Federal Agency,Cartersville,GA
+CARTHAGEMO.GOV,City,Non-Federal Agency,Carthage,MO
+CARVERMA.GOV,City,Non-Federal Agency,Carver,MA
+CARYNC.GOV,City,Non-Federal Agency,Cary,NC
+CASAGRANDEAZ.GOV,City,Non-Federal Agency,Casa Grande,AZ
+CASPERWY.GOV,City,Non-Federal Agency,Casper,WY
+CASTROVILLETX.GOV,City,Non-Federal Agency,Castroville,TX
+CATHEDRALCITY.GOV,City,Non-Federal Agency,Cathedral City,CA
+CAVESPRINGSAR.GOV,City,Non-Federal Agency,Cave Springs,AR
+CECILTONMD.GOV,City,Non-Federal Agency,Cecilton ,MD
+CECILTOWNSHIP-PA.GOV,City,Non-Federal Agency,Cecil,PA
+CEDARHURST.GOV,City,Non-Federal Agency,cedarhurst,NY
+CEDARPARKTEXAS.GOV,City,Non-Federal Agency,Cedar Park,TX
+CEDARRAPIDS-IA.GOV,City,Non-Federal Agency,Cedar Rapids,IA
+CEDARTOWNGEORGIA.GOV,City,Non-Federal Agency,Cedartown,GA
+CENTENNIALCO.GOV,City,Non-Federal Agency,Centennial,CO
+CENTERCO.GOV,City,Non-Federal Agency,Center,CO
+CENTERVILLEOHIO.GOV,City,Non-Federal Agency,Centerville,OH
+CENTERVILLETX.GOV,City,Non-Federal Agency,College Station,TX
+CENTRAL-LA.GOV,City,Non-Federal Agency,Central,LA
+CENTRALPOINTOREGON.GOV,City,Non-Federal Agency,Central Point,OR
+CENTREVILLE-MD.GOV,City,Non-Federal Agency,Centreville,MD
+CGAZ.GOV,City,Non-Federal Agency,Casa Grande,AZ
+CHADDSFORDPA.GOV,City,Non-Federal Agency,Chadds Ford,PA
+CHAMBERSBURGPA.GOV,City,Non-Federal Agency,Chambersburg,PA
+CHAMBLEEGA.GOV,City,Non-Federal Agency,Chamblee,GA
+CHARLESTON-SC.GOV,City,Non-Federal Agency,Charleston,SC
+CHARLESTONWV.GOV,City,Non-Federal Agency,Charleston,WV
+CHARLESTOWN-NH.GOV,City,Non-Federal Agency,Charlestown,NH
+CHARLOTTENC.GOV,City,Non-Federal Agency,Charlotte,NC
+CHARLOTTESVILLEVA.GOV,City,Non-Federal Agency,Charlottesville,VA
+CHATHAM-MA.GOV,City,Non-Federal Agency,Chatham,MA
+CHATHAM-VA.GOV,City,Non-Federal Agency,Chatham,VA
+CHATHAMTOWNSHIP-NJ.GOV,City,Non-Federal Agency,Chatham,NJ
+CHATSWORTHGA.GOV,City,Non-Federal Agency,Chatsworth,GA
+CHATTANOOGA.GOV,City,Non-Federal Agency,Chattanooga,TN
+CHELSEAMA.GOV,City,Non-Federal Agency,Chelsea,MA
+CHESAPEAKEBEACHMD.GOV,City,Non-Federal Agency,Chesapeake Beach,MD
+CHESAPEAKECITY-MD.GOV,City,Non-Federal Agency,Chesapeake City,MD
+CHESHIRE-MA.GOV,City,Non-Federal Agency,Cheshire,MA
+CHESTER-NY.GOV,City,Non-Federal Agency,Chester,NY
+CHESTNUTHILLTWP-PA.GOV,City,Non-Federal Agency,Brodheadsville,PA
+CHEVERLY-MD.GOV,City,Non-Federal Agency,Cheverly,MD
+CHEVYCHASEVILLAGEMD.GOV,City,Non-Federal Agency,Chevy Chase,MD
+CHICAGO-IL.GOV,City,Non-Federal Agency,Chicago,IL
+CHICOCA.GOV,City,Non-Federal Agency,Chico,CA
+CHICOPEEMA.GOV,City,Non-Federal Agency,Chicopee,MA
+CHILMARKMA.GOV,City,Non-Federal Agency,Chilmark,MA
+CHINAGROVENC.GOV,City,Non-Federal Agency,China Grove,NC
+CHINCOTEAGUE-VA.GOV,City,Non-Federal Agency,Chincoteague,VA
+CHIPPEWAFALLS-WI.GOV,City,Non-Federal Agency,Chippewa Falls,WI
+CHOWANCOUNTY-NC.GOV,City,Non-Federal Agency,Edenton,NC
+CHURCHHILLTN.GOV,City,Non-Federal Agency,Church Hill,TN
+CIBOLOTX.GOV,City,Non-Federal Agency,Cibolo,TX
+CINCINNATI-OH.GOV,City,Non-Federal Agency,Cincinnati,OH
+CINCINNATIOHIO.GOV,City,Non-Federal Agency,Cincinnati,OH
+CITYKANKAKEE-IL.GOV,City,Non-Federal Agency,KANKAKEE,IL
+CITYOFADAMS-WI.GOV,City,Non-Federal Agency,Adams,WI
+CITYOFAIKENSC.GOV,City,Non-Federal Agency,Aiken,SC
+CITYOFALAMEDACA.GOV,City,Non-Federal Agency,Alameda,CA
+CITYOFALBIONMI.GOV,City,Non-Federal Agency,albion,MI
+CITYOFALCOA-TN.GOV,City,Non-Federal Agency,Alcoa,TN
+CITYOFALGOODTN.GOV,City,Non-Federal Agency,Algood,TN
+CITYOFALMAGA.GOV,City,Non-Federal Agency,Alma,GA
+CITYOFBAKERLA.GOV,City,Non-Federal Agency,Baker ,LA
+CITYOFBELOITWI.GOV,City,Non-Federal Agency,Beloit,WI
+CITYOFBENTONHARBORMI.GOV,City,Non-Federal Agency,Benton Harbor,MI
+CITYOFBLUERIDGEGA.GOV,City,Non-Federal Agency,Blue Ridge,GA
+CITYOFBOWIEMD.GOV,City,Non-Federal Agency,Bowie,MD
+CITYOFBOWMANGA.GOV,City,Non-Federal Agency,Bowman,GA
+CITYOFBRUNSWICK-GA.GOV,City,Non-Federal Agency,Brunswick,GA
+CITYOFCANALFULTON-OH.GOV,City,Non-Federal Agency,Canal Fulton,OH
+CITYOFCAYCE-SC.GOV,City,Non-Federal Agency,Cayce,SC
+CITYOFCHETEK-WI.GOV,City,Non-Federal Agency,Chetek,WI
+CITYOFCHOTEAU-MT.GOV,City,Non-Federal Agency,Choteau,MT
+CITYOFCONWAY-AR.GOV,City,Non-Federal Agency,Conway,AR
+CITYOFCOWETA-OK.GOV,City,Non-Federal Agency,Coweta,OK
+CITYOFCRISFIELD-MD.GOV,City,Non-Federal Agency,Crisfield,MD
+CITYOFCUDAHYCA.GOV,City,Non-Federal Agency,Cudahy,CA
+CITYOFDALTON-GA.GOV,City,Non-Federal Agency,Dalton,GA
+CITYOFDOUGLASGA.GOV,City,Non-Federal Agency,Douglas,GA
+CITYOFDOVERIDAHO.GOV,City,Non-Federal Agency,Dover,ID
+CITYOFDUNBARWV.GOV,City,Non-Federal Agency,Dunbar,WV
+CITYOFDUPONTWA.GOV,City,Non-Federal Agency,DuPont,WA
+CITYOFENGLEWOOD-NJ.GOV,City,Non-Federal Agency,Englewood,NJ
+CITYOFEUDORAKS.GOV,City,Non-Federal Agency,Eudora,KS
+CITYOFFAIRFAX-MN.GOV,City,Non-Federal Agency,Fairfax,MN
+CITYOFFARMERSVILLE-CA.GOV,City,Non-Federal Agency,Farmersville,CA
+CITYOFFARMINGTON-AR.GOV,City,Non-Federal Agency,Farmington,AR
+CITYOFFOLKSTON-GA.GOV,City,Non-Federal Agency,Folkston,GA
+CITYOFFORTOGLETHORPEGA.GOV,City,Non-Federal Agency,FORT OGLETHORPE,GA
+CITYOFGAFFNEY-SC.GOV,City,Non-Federal Agency,Gaffney,SC
+CITYOFGALENAPARK-TX.GOV,City,Non-Federal Agency,Galena Park,TX
+CITYOFGRAVETTE-AR.GOV,City,Non-Federal Agency,Gravette,AR
+CITYOFGROVEOK.GOV,City,Non-Federal Agency,Grove,OK
+CITYOFGUNNISON-CO.GOV,City,Non-Federal Agency,Gunnison,CO
+CITYOFHAMPTON-GA.GOV,City,Non-Federal Agency,Hampton,GA
+CITYOFHARRISON-MI.GOV,City,Non-Federal Agency,Harrison,MI
+CITYOFHAYWARDWI.GOV,City,Non-Federal Agency,Hayward,WI
+CITYOFHIRAMGA.GOV,City,Non-Federal Agency,HIRAM,GA
+CITYOFHOKAH-MN.GOV,City,Non-Federal Agency,Hokah,MN
+CITYOFHOMER-AK.GOV,City,Non-Federal Agency,Homer,AK
+CITYOFHUMBLE-TX.GOV,City,Non-Federal Agency,Humble,TX
+CITYOFHUMBLETX.GOV,City,Non-Federal Agency,Humble,TX
+CITYOFKEYWEST-FL.GOV,City,Non-Federal Agency,Key West,FL
+CITYOFKINGMAN.GOV,City,Non-Federal Agency,Kingman,AZ
+CITYOFKINGSBURG-CA.GOV,City,Non-Federal Agency,Kingsburg,CA
+CITYOFLACRESCENT-MN.GOV,City,Non-Federal Agency,La Crescent,MN
+CITYOFLAGRANGEMO.GOV,City,Non-Federal Agency,LaGrange,MO
+CITYOFLAHABRA-CA.GOV,City,Non-Federal Agency,LA HABRA,CA
+CITYOFLENEXA-KS.GOV,City,Non-Federal Agency,Lenexa,KS
+CITYOFLENEXAKS.GOV,City,Non-Federal Agency,Lenexa,KS
+CITYOFLINDALETX.GOV,City,Non-Federal Agency,LINDALE,TX
+CITYOFLISBON-IA.GOV,City,Non-Federal Agency,Lisbon,IA
+CITYOFLUBBOCKTX.GOV,City,Non-Federal Agency,Lubbock,TX
+CITYOFMACON-MO.GOV,City,Non-Federal Agency,Macon,MO
+CITYOFMARIONIL.GOV,City,Non-Federal Agency,Marion,IL
+CITYOFMARIONWI.GOV,City,Non-Federal Agency,MARION,WI
+CITYOFMCCAYSVILLEGA.GOV,City,Non-Federal Agency,McCaysville,GA
+CITYOFMIDLANDMI.GOV,City,Non-Federal Agency,Midland,MI
+CITYOFMILLBROOK-AL.GOV,City,Non-Federal Agency,Millbrook,AL
+CITYOFMILLENGA.GOV,City,Non-Federal Agency,Millen,GA
+CITYOFMONONGAHELA-PA.GOV,City,Non-Federal Agency,Monongahela,PA
+CITYOFMORROWGA.GOV,City,Non-Federal Agency,Morrow,GA
+CITYOFMTVERNON-IA.GOV,City,Non-Federal Agency,Mount Vernon,IA
+CITYOFNANTICOKE-PA.GOV,City,Non-Federal Agency,Nanticoke,PA
+CITYOFNEWBURGH-NY.GOV,City,Non-Federal Agency,Newburgh,NY
+CITYOFNEWULM-MN.GOV,City,Non-Federal Agency,New Ulm,MN
+CITYOFNORMANDY.GOV,City,Non-Federal Agency,St. Louis,MO
+CITYOFOMAHA-NE.GOV,City,Non-Federal Agency,Omaha,NE
+CITYOFPACIFICWA.GOV,City,Non-Federal Agency,Pacific,WA
+CITYOFPALMVALLEY-TX.GOV,City,Non-Federal Agency,Harlingen,TX
+CITYOFPARISTN.GOV,City,Non-Federal Agency,Paris,TN
+CITYOFPARMA-OH.GOV,City,Non-Federal Agency,Parma,OH
+CITYOFPATTERSONLA.GOV,City,Non-Federal Agency,Patterson,LA
+CITYOFPEARLANDTX.GOV,City,Non-Federal Agency,Pearland,TX
+CITYOFPHOENIX.GOV,City,Non-Federal Agency,Phoenix,AZ
+CITYOFPIGEONFORGETN.GOV,City,Non-Federal Agency,Pigeon Forge,TN
+CITYOFPLAINVILLE-KS.GOV,City,Non-Federal Agency,Plainville,KS
+CITYOFPLATTSBURGH-NY.GOV,City,Non-Federal Agency,Plattsburgh,NY
+CITYOFPLEASANTONCA.GOV,City,Non-Federal Agency,Pleasanton,CA
+CITYOFPOCOMOKEMD.GOV,City,Non-Federal Agency,Pocomoke City,MD
+CITYOFPORTLANDTN.GOV,City,Non-Federal Agency,Portland,TN
+CITYOFREDMOND.GOV,City,Non-Federal Agency,Redmond,WA
+CITYOFROCKHILLSC.GOV,City,Non-Federal Agency,Rock Hill,SC
+CITYOFROCKPORT-IN.GOV,City,Non-Federal Agency,Rockport,IN
+CITYOFSAFFORDAZ.GOV,City,Non-Federal Agency,Safford,AZ
+CITYOFSALEMNJ.GOV,City,Non-Federal Agency,Salem,NJ
+CITYOFSANTEECA.GOV,City,Non-Federal Agency,Santee,CA
+CITYOFSPARTANBURG-SC.GOV,City,Non-Federal Agency,Spartanburg,SC
+CITYOFSTOCKBRIDGE-GA.GOV,City,Non-Federal Agency,Stockbridge,GA
+CITYOFSUGAR-LANDTX.GOV,City,Non-Federal Agency,Sugar Land,TX
+CITYOFSUGARLAND-TX.GOV,City,Non-Federal Agency,Sugar Land,TX
+CITYOFSUGARLANDTX.GOV,City,Non-Federal Agency,Sugar Land,TX
+CITYOFTITUSVILLEPA.GOV,City,Non-Federal Agency,Titusville,PA
+CITYOFTORRANCECA.GOV,City,Non-Federal Agency,Torrance,CA
+CITYOFTUKWILA-WA.GOV,City,Non-Federal Agency,Tukwila,WA
+CITYOFTYLER-TX.GOV,City,Non-Federal Agency,Tyler,TX
+CITYOFTYLERTX.GOV,City,Non-Federal Agency,Tyler,TX
+CITYOFWASHINGTONGA.GOV,City,Non-Federal Agency,Washington,GA
+CITYOFWEATHERBYLAKE-MO.GOV,City,Non-Federal Agency,Weatherby Lake,MO
+CITYOFWESTONLAKES-TX.GOV,City,Non-Federal Agency,Fulshear,TX
+CITYOFWEYAUWEGA-WI.GOV,City,Non-Federal Agency,Weyauwega,WI
+CITYOFWHEATON-IL.GOV,City,Non-Federal Agency,Wheaton,IL
+CITYOFWOODBURYGA.GOV,City,Non-Federal Agency,Woodbury,GA
+CITYOFWORLANDWY.GOV,City,Non-Federal Agency,Worland,WY
+CITYOFYUKONOK.GOV,City,Non-Federal Agency,Yukon,OK
+CLAIRTON-PA.GOV,City,Non-Federal Agency,Clairton,PA
+CLARKSTONGA.GOV,City,Non-Federal Agency,Clarkston,GA
+CLARKSVILLEAR.GOV,City,Non-Federal Agency,Clarksville,AR
+CLAYTONMO.GOV,City,Non-Federal Agency,Clayton,MO
+CLEARLAKE-WI.GOV,City,Non-Federal Agency,Clear Lake,WI
+CLEARLAKESHORES-TX.GOV,City,Non-Federal Agency,Clear Lake Shores,TX
+CLERMONTFL.GOV,City,Non-Federal Agency,Clermont,FM
+CLEVELAND-OH.GOV,City,Non-Federal Agency,Cleveland,OH
+CLEVELANDOHIO.GOV,City,Non-Federal Agency,Cleveland,OH
+CLEVELANDTN.GOV,City,Non-Federal Agency,Cleveland,TN
+CLEWISTON-FL.GOV,City,Non-Federal Agency,Clewiston,FL
+CLIFFSIDEPARKNJ.GOV,City,Non-Federal Agency,Cliffside Park,NJ
+CLIFTONAZ.GOV,City,Non-Federal Agency,Clifton,AZ
+CLIFTONFORGEVA.GOV,City,Non-Federal Agency,Clifton Forge,VA
+CLINTONMA.GOV,City,Non-Federal Agency,Clinton,MA
+CLINTONNJ.GOV,City,Non-Federal Agency,New Jersey,NJ
+CLINTONOK.GOV,City,Non-Federal Agency,Clinton,OK
+CMSDCA.GOV,City,Non-Federal Agency,Costa Mesa,CA
+COALRUNKY.GOV,City,Non-Federal Agency,Pikeville,KY
+COLCHESTERCT.GOV,City,Non-Federal Agency,Colchester,CT
+COLCHESTERVT.GOV,City,Non-Federal Agency,Colchester,VT
+COLDSPRINGKY.GOV,City,Non-Federal Agency,COLD SPRING,KY
+COLDSPRINGNY.GOV,City,Non-Federal Agency,Cold Spring ,NY
+COLFAX-CA.GOV,City,Non-Federal Agency,Colfax,CA
+COLLEGEPARKMD.GOV,City,Non-Federal Agency,College Park,MD
+COLLEGEVILLE-PA.GOV,City,Non-Federal Agency,Collegeville,PA
+COLLIERVILLETN.GOV,City,Non-Federal Agency,Collierville,TN
+COLLINCOUNTYTEXAS.GOV,City,Non-Federal Agency,Mckinney,TX
+COLLINCOUNTYTX.GOV,City,Non-Federal Agency,McKinney,TX
+COLONIALHEIGHTSVA.GOV,City,Non-Federal Agency,Colonial Heights,VA
+COLONIE-NY.GOV,City,Non-Federal Agency,Newtonville,NY
+COLORADOSPRINGS.GOV,City,Non-Federal Agency,Colorado Springs,CO
+COLRAIN-MA.GOV,City,Non-Federal Agency,Colrain,MA
+COLUMBIAHEIGHTSMN.GOV,City,Non-Federal Agency,Columbia Heights,MN
+COLUMBIANAOHIO.GOV,City,Non-Federal Agency,Columbiana,OH
+COLUMBIATN.GOV,City,Non-Federal Agency,Columbia,TN
+COLUMBIATWP-OH.GOV,City,Non-Federal Agency,Columbia Station,OH
+COLUMBUS.GOV,City,Non-Federal Agency,Columbus,OH
+COLUMBUSOH.GOV,City,Non-Federal Agency,Columbus,OH
+COLUMBUSOHIO.GOV,City,Non-Federal Agency,Columbus,OH
+COMMERCIALPOINTOHIO.GOV,City,Non-Federal Agency,Commercial Point,OH
+COMO.GOV,City,Non-Federal Agency,Columbia,MO
+COMSTOCKMI.GOV,City,Non-Federal Agency,Kalamazoo,MI
+CONCORDMA.GOV,City,Non-Federal Agency,Concord,MA
+CONCORDNC.GOV,City,Non-Federal Agency,Concord,NC
+CONCORDNH.GOV,City,Non-Federal Agency,Concord,NH
+CONCRETEWA.GOV,City,Non-Federal Agency,Concrete,WA
+CONNEAUTOHIO.GOV,City,Non-Federal Agency,Conneaut,OH
+CONNERSVILLEIN.GOV,City,Non-Federal Agency,Connersville,IN
+CONOVERNC.GOV,City,Non-Federal Agency,Conover,NC
+CONYERSGA.GOV,City,Non-Federal Agency,Conyers,GA
+COOKEVILLE-TN.GOV,City,Non-Federal Agency,Cookeville,TN
+COONRAPIDSMN.GOV,City,Non-Federal Agency,Coon Rapids,MN
+COPPELLTX.GOV,City,Non-Federal Agency,Coppell,TX
+COPPERASCOVETX.GOV,City,Non-Federal Agency,Copperas Cove,TX
+COR.GOV,City,Non-Federal Agency,Richardson,TX
+CORALGABLES-FL.GOV,City,Non-Federal Agency,Coral Gables,FL
+CORALGABLESFL.GOV,City,Non-Federal Agency,Coral Gables,FL
+CORBIN-KY.GOV,City,Non-Federal Agency,Corbin,KY
+CORNINGAR.GOV,City,Non-Federal Agency,Corning,AR
+CORNWALLNY.GOV,City,Non-Federal Agency,Cornwall,NY
+CORPUSCHRISTI-TX.GOV,City,Non-Federal Agency,Corpus Christi,TX
+CORRALESNM.GOV,City,Non-Federal Agency,Corales,NM
+CORRYPA.GOV,City,Non-Federal Agency,Corry,PA
+CORVALLISOREGON.GOV,City,Non-Federal Agency,Corvallis,OR
+CORYDON-IN.GOV,City,Non-Federal Agency,Corydon,IN
+COSMOPOLISWA.GOV,City,Non-Federal Agency,Cosmopolis,WA
+COSPRINGS.GOV,City,Non-Federal Agency,Colorado Springs,CO
+COSTAMESACA.GOV,City,Non-Federal Agency,Costa Mesa,CA
+COTTAGECITYMD.GOV,City,Non-Federal Agency,Cottage City,MD
+COTTONWOODAZ.GOV,City,Non-Federal Agency,Cottonwood,AZ
+COUNTRYSIDE-IL.GOV,City,Non-Federal Agency,Countryside,IL
+COVINACA.GOV,City,Non-Federal Agency,Covina,CA
+COVINGTON-OH.GOV,City,Non-Federal Agency,COVINGTON ,OH
+COVINGTONKY.GOV,City,Non-Federal Agency,Covington,KY
+COVINGTONWA.GOV,City,Non-Federal Agency,Covington,WA
+CRANBERRYISLES-ME.GOV,City,Non-Federal Agency,Islesford,ME
+CRAWFORDSVILLE-IN.GOV,City,Non-Federal Agency,Crawfordsville,IN
+CREDITRIVER-MN.GOV,City,Non-Federal Agency,Prior Lake,MN
+CRESTONIOWA.GOV,City,Non-Federal Agency,Creston,IA
+CRETE-NE.GOV,City,Non-Federal Agency,Crete,NE
+CREVECOEURMO.GOV,City,Non-Federal Agency,Creve Coeur,MO
+CROSSROADSTX.GOV,City,Non-Federal Agency,Crossroads,TX
+CROSSVILLETN.GOV,City,Non-Federal Agency,Crossville,TN
+CROTONONHUDSON-NY.GOV,City,Non-Federal Agency,Croton-On-Hudson,NY
+CUBAASSESSORIL.GOV,City,Non-Federal Agency,Barrington,IL
+CUBATWPIL.GOV,City,Non-Federal Agency,Barrington,IL
+CUDAHY-WI.GOV,City,Non-Federal Agency,Cudahy,WI
+CULPEPERVA.GOV,City,Non-Federal Agency,Culpeper,VA
+CUMBERLANDMD.GOV,City,Non-Federal Agency,Cumberland,MD
+CUMMINGTON-MA.GOV,City,Non-Federal Agency,Cummington,MA
+CUTLERBAY-FL.GOV,City,Non-Federal Agency,Cutler Bay,FL
+DACULAGA.GOV,City,Non-Federal Agency,Dacula,GA
+DAHLONEGA-GA.GOV,City,Non-Federal Agency,Dahlonega,GA
+DALHARTTX.GOV,City,Non-Federal Agency,Dalhart,TX
+DALLAS-GA.GOV,City,Non-Federal Agency,Dallas,GA
+DALLASOR.GOV,City,Non-Federal Agency,Dallas,OR
+DALLASOREGON.GOV,City,Non-Federal Agency,Dallas,OR
+DALTON-MA.GOV,City,Non-Federal Agency,Dalton,MA
+DAMASCUSOREGON.GOV,City,Non-Federal Agency,Damascus,OR
+DANBURY-CT.GOV,City,Non-Federal Agency,Danbury,CT
+DANDRIDGETN.GOV,City,Non-Federal Agency,Dandridge,TN
+DANIABEACHFL.GOV,City,Non-Federal Agency,DANIA BEACH,FL
+DANVERSMA.GOV,City,Non-Federal Agency,Danvers,MA
+DANVILLEVA.GOV,City,Non-Federal Agency,Danville,VA
+DARIENIL.GOV,City,Non-Federal Agency,Darien,IL
+DAUGHERTYTOWNSHIP-PA.GOV,City,Non-Federal Agency,New Brighton,PA
+DAVIE-FL.GOV,City,Non-Federal Agency,Davie,FL
+DAWSONVILLE-GA.GOV,City,Non-Federal Agency,Dawsonville,GA
+DAYTON-ME.GOV,City,Non-Federal Agency,Dayton,ME
+DAYTONOHIO.GOV,City,Non-Federal Agency,Dayton,OH
+DECATURIL.GOV,City,Non-Federal Agency,Decatur,IL
+DECATURILLINOIS.GOV,City,Non-Federal Agency,Decatur,IL
+DECATURTX.GOV,City,Non-Federal Agency,Decatur,TX
+DEDHAM-MA.GOV,City,Non-Federal Agency,Dedham,MA
+DEERFIELDMICHIGAN.GOV,City,Non-Federal Agency,Deerfield,MI
+DEERPARK-OH.GOV,City,Non-Federal Agency,Deer Park,OH
+DEERPARKTX.GOV,City,Non-Federal Agency,Deer Park,TX
+DEKORRA-WI.GOV,City,Non-Federal Agency,Poynette,WI
+DELAWARETOWNSHIPPA.GOV,City,Non-Federal Agency,Dingmans Ferry,PA
+DELRAYBEACHFL.GOV,City,Non-Federal Agency,Delray Beach,FL
+DELTA-CO.GOV,City,Non-Federal Agency,Delta,CO
+DELTAMI.GOV,City,Non-Federal Agency,Lansing,MI
+DELTONAFL.GOV,City,Non-Federal Agency,Deltona,FL
+DEMOPOLISAL.GOV,City,Non-Federal Agency,Demopolis,AL
+DENVERCO.GOV,City,Non-Federal Agency,Denver,CO
+DERBYCT.GOV,City,Non-Federal Agency,Derby,CT
+DHAZ.GOV,City,Non-Federal Agency,Humboldt,AZ
+DIAMONDBARCA.GOV,City,Non-Federal Agency,Diamond Bar,CA
+DICKINSONTEXAS.GOV,City,Non-Federal Agency,Dickinson,TX
+DICKSONCITY-PA.GOV,City,Non-Federal Agency,Dickson City,PA
+DIGHTON-MA.GOV,City,Non-Federal Agency,Dighton,MA
+DISCOVERWAUKESHA-WI.GOV,City,Non-Federal Agency,Waukesha,WI
+DONALDOREGON.GOV,City,Non-Federal Agency,Donald,OR
+DONALDSONVILLE-LA.GOV,City,Non-Federal Agency,Donaldsonville,LA
+DORALPD-FL.GOV,City,Non-Federal Agency,Doral,FL
+DOUGLASAZ.GOV,City,Non-Federal Agency,Douglas,AZ
+DOUGLASVILLEGA.GOV,City,Non-Federal Agency,Douglasville,GA
+DREW-MS.GOV,City,Non-Federal Agency,Drew,MS
+DRUIDHILLSKY.GOV,City,Non-Federal Agency,Louisville,KY
+DUBLIN-CA.GOV,City,Non-Federal Agency,Dublin,CA
+DUBLINCA.GOV,City,Non-Federal Agency,Dublin,CA
+DUBLINOHIOUSA.GOV,City,Non-Federal Agency,Dublin,OH
+DUBOISPA.GOV,City,Non-Federal Agency,DuBois,PA
+DULUTHMN.GOV,City,Non-Federal Agency,Duluth,MN
+DUMFRIESVA.GOV,City,Non-Federal Agency,Dumfries,VA
+DUMONTNJ.GOV,City,Non-Federal Agency,Dumont,NJ
+DUNCANOK.GOV,City,Non-Federal Agency,Duncan,OK
+DUNCANVILLETX.GOV,City,Non-Federal Agency,Duncanville,TX
+DUNDEEVILLAGEMI.GOV,City,Non-Federal Agency,Dundee,MI
+DUNMOREPA.GOV,City,Non-Federal Agency,Dunmore,PA
+DUNSTABLE-MA.GOV,City,Non-Federal Agency,Dunstable,MA
+DUNWOODYGA.GOV,City,Non-Federal Agency,Dunwoody,GA
+DUNWOODYGEORGIA.GOV,City,Non-Federal Agency,Dunwoody,GA
+DUPONTWA.GOV,City,Non-Federal Agency,DuPont,WA
+DUSHOREPA.GOV,City,Non-Federal Agency,Dushore,PA
+DUVALLWA.GOV,City,Non-Federal Agency,Duvall,WA
+DYERSBURGTN.GOV,City,Non-Federal Agency,Dyersburg,TN
+EAGARAZ.GOV,City,Non-Federal Agency,Eagar,AZ
+EAGLE-WI.GOV,City,Non-Federal Agency,Eagle,WI
+EAGLELAKE-TX.GOV,City,Non-Federal Agency,Eagle Lake,TX
+EASTBOROUGH-KS.GOV,City,Non-Federal Agency,Eastborough,KS
+EASTCOVENTRY-PA.GOV,City,Non-Federal Agency,Pottstown,PA
+EASTHAMPTONCT.GOV,City,Non-Federal Agency,East Hampton,CT
+EASTHAMPTONNY.GOV,City,Non-Federal Agency,Amagansett,NY
+EASTHAMPTONVILLAGENY.GOV,City,Non-Federal Agency,East Hampton,NY
+EASTHARTFORDCT.GOV,City,Non-Federal Agency,East Hartford,CT
+EASTKINGSTONNH.GOV,City,Non-Federal Agency,East Kingston,NH
+EASTLONGMEADOWMA.GOV,City,Non-Federal Agency,East Longmeadow,MA
+EASTMOUNTAINTX.GOV,City,Non-Federal Agency,East Mountain,TX
+EASTONCT.GOV,City,Non-Federal Agency,Easton,CT
+EASTONMD.GOV,City,Non-Federal Agency,Easton,MD
+EASTORANGE-NJ.GOV,City,Non-Federal Agency,East ORange,NJ
+EASTPALESTINE-OH.GOV,City,Non-Federal Agency,East Palestine,OH
+EASTPORT-ME.GOV,City,Non-Federal Agency,Eastport,ME
+EASTRIDGETN.GOV,City,Non-Federal Agency,East Ridge,TN
+EASTTROYWI.GOV,City,Non-Federal Agency,East Troy,WI
+EASTVALECA.GOV,City,Non-Federal Agency,Eastvale,CA
+EATONVILLE-WA.GOV,City,Non-Federal Agency,Eatonville,WA
+ECORSEMI.GOV,City,Non-Federal Agency,ECORSE,MI
+EDDINGTONMAINE.GOV,City,Non-Federal Agency,Eddington,ME
+EDENNY.GOV,City,Non-Federal Agency,Eden,NY
+EDGARCOUNTY-IL.GOV,City,Non-Federal Agency,Paris,IL
+EDGEWATERFL.GOV,City,Non-Federal Agency,Edgewater,FL
+EDGEWOOD-FL.GOV,City,Non-Federal Agency,Edgewood,FL
+EDGEWOOD-NM.GOV,City,Non-Federal Agency,Edgewood,NM
+EDINAMN.GOV,City,Non-Federal Agency,Edina,MN
+EDMONDS-WA.GOV,City,Non-Federal Agency,Edmonds,WA
+EDMONDSWA.GOV,City,Non-Federal Agency,Edmonds,WA
+EDMONSTONMD.GOV,City,Non-Federal Agency,Edmonston,MD
+EHALERTCT.GOV,City,Non-Federal Agency,East Hartford,CT
+EHAMPTONNY.GOV,City,Non-Federal Agency,East Hampton,NY
+ELKHARTLAKEWI.GOV,City,Non-Federal Agency,Elkhart Lake,WI
+ELKOCITYNV.GOV,City,Non-Federal Agency,Elko,NV
+ELKRIVERMN.GOV,City,Non-Federal Agency,Elk River,MN
+ELKTONVA.GOV,City,Non-Federal Agency,Elkton,VA
+ELKTOWNSHIPNJ.GOV,City,Non-Federal Agency,Monroeville,NJ
+ELLAGO-TX.GOV,City,Non-Federal Agency,El Lago,TX
+ELLIJAY-GA.GOV,City,Non-Federal Agency,Ellijay,GA
+ELLINGTON-CT.GOV,City,Non-Federal Agency,Ellington,CT
+ELLSWORTHMAINE.GOV,City,Non-Federal Agency,Ellsworth,ME
+ELMIRAGE-AZ.GOV,City,Non-Federal Agency,El Mirage,AZ
+ELOYAZ.GOV,City,Non-Federal Agency,Eloy,AZ
+ELPASOTEXAS.GOV,City,Non-Federal Agency,El Paso,TX
+EMERALDBAY-TX.GOV,City,Non-Federal Agency,Bullard,TX
+EMMITSBURGMD.GOV,City,Non-Federal Agency,Emmitsburg,MD
+EMPORIA-KANSAS.GOV,City,Non-Federal Agency,Emporia,KS
+ENCINITASCA.GOV,City,Non-Federal Agency,Encinitas,CA
+ENCINITASCALIFORNIA.GOV,City,Non-Federal Agency,Encinitas,CA
+ENNISTX.GOV,City,Non-Federal Agency,Ennis,TX
+ENON-OH.GOV,City,Non-Federal Agency,Enon,OH
+ENTERPRISEAL.GOV,City,Non-Federal Agency,Enterprise,AL
+ERIECO.GOV,City,Non-Federal Agency,Erie,CO
+ESPANOLANM.GOV,City,Non-Federal Agency,Espanola,NM
+ESSEXCT.GOV,City,Non-Federal Agency,Essex,CT
+ESTERO-FL.GOV,City,Non-Federal Agency,Estero,FL
+ETON-GA.GOV,City,Non-Federal Agency,Eton,GA
+EULESSTX.GOV,City,Non-Federal Agency,Euless,TX
+EUREKA-MT.GOV,City,Non-Federal Agency,Eureka,MT
+EUREKASPRINGSAR.GOV,City,Non-Federal Agency,Eureka Springs,AR
+EVANSCOLORADO.GOV,City,Non-Federal Agency,Evans,CO
+EVERETTWA.GOV,City,Non-Federal Agency,Everett,WA
+EVESHAM-NJ.GOV,City,Non-Federal Agency,Marlton,NJ
+EXETERNH.GOV,City,Non-Federal Agency,Exeter,NH
+FABIUS-NY.GOV,City,Non-Federal Agency,Fabius,NY
+FAIRFAX-VT.GOV,City,Non-Federal Agency,Fairfax,VT
+FAIRFAXVA.GOV,City,Non-Federal Agency,Fairfax,VA
+FAIRFIELDOH.GOV,City,Non-Federal Agency,Fairfield,OH
+FAIRHOPE-AL.GOV,City,Non-Federal Agency,Fairhope,AL
+FAIRMONTWV.GOV,City,Non-Federal Agency,Fairmont,WV
+FAIRVIEWNC.GOV,City,Non-Federal Agency,Monroe,NC
+FAIRVIEWOREGON.GOV,City,Non-Federal Agency,Fairview,OR
+FALLCREEKWI.GOV,City,Non-Federal Agency,Fall Creek,WI
+FALLONNEVADA.GOV,City,Non-Federal Agency,Fallon,NV
+FALLSCHURCHCITYVA.GOV,City,Non-Federal Agency,Falls Church,VA
+FALLSCHURCHVA.GOV,City,Non-Federal Agency,Falls Church,VA
+FALLSCITYOREGON.GOV,City,Non-Federal Agency,Falls City,OR
+FARGOND.GOV,City,Non-Federal Agency,Fargo,ND
+FARMERSBRANCHTX.GOV,City,Non-Federal Agency,Farmers Branch,TX
+FARMINGTON-MO.GOV,City,Non-Federal Agency,Farmington,MO
+FARMINGTONHILLSMI.GOV,City,Non-Federal Agency,Farmington Hills,MI
+FARRAGUT-TN.GOV,City,Non-Federal Agency,Farragut,TN
+FAYETTEVILLE-AR.GOV,City,Non-Federal Agency,Fayetteville,AR
+FAYETTEVILLENC.GOV,City,Non-Federal Agency,Fayetteville,NC
+FAYETTEVILLENY.GOV,City,Non-Federal Agency,Fayetteville,NY
+FEDERALWAYWA.GOV,City,Non-Federal Agency,Federal Way ,WA
+FERNDALEMI.GOV,City,Non-Federal Agency,Ferndale,MI
+FITCHBURGMA.GOV,City,Non-Federal Agency,Fitchburg,MA
+FITCHBURGWI.GOV,City,Non-Federal Agency,Fitchburg,WI
+FITZWILLIAM-NH.GOV,City,Non-Federal Agency,Fitzwilliam,NH
+FLAGSTAFFAZ.GOV,City,Non-Federal Agency,Flagstaff,AZ
+FLATONIATX.GOV,City,Non-Federal Agency,Flatonia,TX
+FLORENCE-KY.GOV,City,Non-Federal Agency,Florence,KY
+FLORENCE-NJ.GOV,City,Non-Federal Agency,Florence,NJ
+FLORENCEAZ.GOV,City,Non-Federal Agency,Florence,AZ
+FLORIDACITYFL.GOV,City,Non-Federal Agency,Florida City,FL
+FORESTGROVE-OR.GOV,City,Non-Federal Agency,FOREST GROVE,OR
+FORESTHEIGHTSMD.GOV,City,Non-Federal Agency,Forest Heights,MD
+FORESTPARKOH.GOV,City,Non-Federal Agency,Forest Park,OH
+FORESTPARKOHIO.GOV,City,Non-Federal Agency,Forest Park,OH
+FORESTPARKOK.GOV,City,Non-Federal Agency,Forest Park,OK
+FORSYTH-IL.GOV,City,Non-Federal Agency,Forsyth,IL
+FORTCOLLINS-CO.GOV,City,Non-Federal Agency,Fort Collins,CO
+FORTLUPTON-CO.GOV,City,Non-Federal Agency,Fort Lupton,CO
+FORTLUPTONCO.GOV,City,Non-Federal Agency,Fort Lupton,CO
+FORTMADISON-IA.GOV,City,Non-Federal Agency,Fort Madison,IA
+FORTMILLSC.GOV,City,Non-Federal Agency,Fort Mill,SC
+FORTMYERSBEACHFL.GOV,City,Non-Federal Agency,Fort Myers Beach,FL
+FORTSMITHAR.GOV,City,Non-Federal Agency,Fort Smith,AR
+FORTWORTH-TEXAS.GOV,City,Non-Federal Agency,Fort Worth,TX
+FORTWORTH-TX.GOV,City,Non-Federal Agency,Fort Worth,TX
+FORTWORTHTEXAS.GOV,City,Non-Federal Agency,Fort Worth,TX
+FOSTORIAOHIO.GOV,City,Non-Federal Agency,Fostoria,OH
+FOXBOROUGHMA.GOV,City,Non-Federal Agency,Foxborough,MA
+FRAMINGHAMMA.GOV,City,Non-Federal Agency,Framingham,MA
+FRANCESTOWN-NH.GOV,City,Non-Federal Agency,Francestown,NH
+FRANKFORT-IN.GOV,City,Non-Federal Agency,Frankfort,IN
+FRANKFORT-KY.GOV,City,Non-Federal Agency,Frankfort,KY
+FRANKLIN-IN.GOV,City,Non-Federal Agency,FRANKLIN,IN
+FRANKLIN-TN.GOV,City,Non-Federal Agency,Franklin,TN
+FRANKLINPA.GOV,City,Non-Federal Agency,Franklin,PA
+FRANKLINTN.GOV,City,Non-Federal Agency,Franklin,TN
+FREDENBERGTWP-MN.GOV,City,Non-Federal Agency,Duluth,MN
+FREDERICKCO.GOV,City,Non-Federal Agency,Frederick,CO
+FREDERICKSBURGVA.GOV,City,Non-Federal Agency,Fredericksburg,VA
+FREEHOLDBOROUGHNJ.GOV,City,Non-Federal Agency,Freehold,NJ
+FREEPORTNY.GOV,City,Non-Federal Agency,Freeport,NY
+FREETOWNMA.GOV,City,Non-Federal Agency,Assonet,MA
+FREMONTNC.GOV,City,Non-Federal Agency,Fremont,NC
+FREMONTNE.GOV,City,Non-Federal Agency,Fremont,NE
+FRENCHSETTLEMENT-LA.GOV,City,Non-Federal Agency,French Settlement,LA
+FRIDLEYMN.GOV,City,Non-Federal Agency,Fridley,MN
+FRIENDSHIPHEIGHTSMD.GOV,City,Non-Federal Agency,Chevy Chase,MD
+FROMBERG-MT.GOV,City,Non-Federal Agency,Fromberg,MT
+FRONTROYAL-VA.GOV,City,Non-Federal Agency,Front Royal,VA
+FRONTROYALVA.GOV,City,Non-Federal Agency,Front Royal,VA
+FRUITPORTTOWNSHIP-MI.GOV,City,Non-Federal Agency,Fruitport,MI
+FULSHEARTEXAS.GOV,City,Non-Federal Agency,Fulshear,TX
+GAHANNA.GOV,City,Non-Federal Agency,Gahanna,OH
+GALENAOHIO.GOV,City,Non-Federal Agency,Galena,OH
+GALESBURG-IL.GOV,City,Non-Federal Agency,Galesburg,IL
+GALLATIN-TN.GOV,City,Non-Federal Agency,Gallatin,TN
+GALLAWAYTN.GOV,City,Non-Federal Agency,Gallaway,TN
+GALLOWAYTWP-NJ.GOV,City,Non-Federal Agency,Galloway,NJ
+GALLUPNM.GOV,City,Non-Federal Agency,GALLUP,NM
+GALVAIL.GOV,City,Non-Federal Agency,Galva,IL
+GARDENCITY-GA.GOV,City,Non-Federal Agency,Garden City,GA
+GARDNERKANSAS.GOV,City,Non-Federal Agency,Gardner,KS
+GARDNERVILLE-NV.GOV,City,Non-Federal Agency,Gardnerville,NV
+GARLANDTX.GOV,City,Non-Federal Agency,Garland,TX
+GARNERNC.GOV,City,Non-Federal Agency,Garner,NC
+GARRETTPARK-MD.GOV,City,Non-Federal Agency,Garrett Park,MD
+GARRETTPARKMD.GOV,City,Non-Federal Agency,Garrett Park,MD
+GATLINBURGTN.GOV,City,Non-Federal Agency,Gatlinburg,TN
+GEORGETOWN-KENTUCKY.GOV,City,Non-Federal Agency,Georgetown,KY
+GEORGETOWN-MI.GOV,City,Non-Federal Agency,Jenison,MI
+GEORGETOWNKY.GOV,City,Non-Federal Agency,Georgetown,KY
+GEORGETOWNTX.GOV,City,Non-Federal Agency,Georgetown,TX
+GERMANTOWN-TN.GOV,City,Non-Federal Agency,Germantown,TN
+GETTYSBURG-PA.GOV,City,Non-Federal Agency,Gettysburg,PA
+GILLETTEWY.GOV,City,Non-Federal Agency,Gillette,WY
+GIRARDKANSAS.GOV,City,Non-Federal Agency,Girard,KS
+GLASTONBURY-CT.GOV,City,Non-Federal Agency,Glastonbury,CT
+GLENDALE-WI.GOV,City,Non-Federal Agency,Glendale,WI
+GLENDALEAZ.GOV,City,Non-Federal Agency,Glendale,AZ
+GLENDALECA.GOV,City,Non-Federal Agency,Glendale,CA
+GLENNHEIGHTSTX.GOV,City,Non-Federal Agency,Glenn Heights,TX
+GLENVIEWKY.GOV,City,Non-Federal Agency,Glenview,KY
+GLENWILLOW-OH.GOV,City,Non-Federal Agency,Glenwillow,OH
+GLENWOODSPRINGSCO.GOV,City,Non-Federal Agency,Glenwood Springs,CO
+GLOBEAZ.GOV,City,Non-Federal Agency,GLOBE,AZ
+GLOUCESTER-MA.GOV,City,Non-Federal Agency,Gloucester,MA
+GODDARDKS.GOV,City,Non-Federal Agency,Goddard,KS
+GODLEYTX.GOV,City,Non-Federal Agency,Godley,TX
+GOFFSTOWNNH.GOV,City,Non-Federal Agency,Goffstown,NH
+GOLDBEACHOREGON.GOV,City,Non-Federal Agency,GoldBeach,OR
+GOLDENVALLEYMN.GOV,City,Non-Federal Agency,Golden Valley,MN
+GOLDSBORONC.GOV,City,Non-Federal Agency,Goldsboro,NC
+GOODHOPEAL.GOV,City,Non-Federal Agency,Cullman,AL
+GOODYEARAZ.GOV,City,Non-Federal Agency,Goodyear,AZ
+GOSHEN-OH.GOV,City,Non-Federal Agency,Goshen,OH
+GOSHEN-OHIO.GOV,City,Non-Federal Agency,Goshen,OH
+GOSHENCT.GOV,City,Non-Federal Agency,Goshen,CT
+GPSHORESMI.GOV,City,Non-Federal Agency,Grosse Pointe Shores,MI
+GRAFTON-MA.GOV,City,Non-Federal Agency,Grafton,MA
+GRANBY-MA.GOV,City,Non-Federal Agency,Granby,MA
+GRANDTERRACE-CA.GOV,City,Non-Federal Agency,Grand Terrace,CA
+GRANDVIEW-IN.GOV,City,Non-Federal Agency,Grandview,IN
+GRANGERIOWA.GOV,City,Non-Federal Agency,Granger,IA
+GRANITEFALLSWA.GOV,City,Non-Federal Agency,Granite Falls,WA
+GRANITEQUARRYNC.GOV,City,Non-Federal Agency,Granite Quarry ,NC
+GRANTFORKIL.GOV,City,Non-Federal Agency,Highland,IL
+GRANTSPASSOREGON.GOV,City,Non-Federal Agency,Grants Pass,OR
+GRANTSVILLEUT.GOV,City,Non-Federal Agency,Grantsville,UT
+GRAPEVINETEXAS.GOV,City,Non-Federal Agency,Grapevine,TX
+GRAPEVINETX.GOV,City,Non-Federal Agency,Grapevine,TX
+GREECENY.GOV,City,Non-Federal Agency,Rochester,NY
+GREENBAYWI.GOV,City,Non-Federal Agency,Green Bay,WI
+GREENBELTMD.GOV,City,Non-Federal Agency,Greenbelt,MD
+GREENCASTLEPA.GOV,City,Non-Federal Agency,Greencastle,PA
+GREENEVILLETN.GOV,City,Non-Federal Agency,Greeneville,TN
+GREENFIELD-MA.GOV,City,Non-Federal Agency,Greenfield,MA
+GREENFIELD-NH.GOV,City,Non-Federal Agency,Greenfield,NH
+GREENHOUSTONTX.GOV,City,Non-Federal Agency,Houston,TX
+GREENISLANDNY.GOV,City,Non-Federal Agency,Green Island,NY
+GREENMOUNTAINFALLSCO.GOV,City,Non-Federal Agency,Green Mountain Falls,CO
+GREENSBORO-GA.GOV,City,Non-Federal Agency,Greensboro,GA
+GREENSBOROGA.GOV,City,Non-Federal Agency,Greensboro,GA
+GREENVILLENC.GOV,City,Non-Federal Agency,Greenville,NC
+GREENVILLESC.GOV,City,Non-Federal Agency,Greenville,SC
+GRESHAMOREGON.GOV,City,Non-Federal Agency,Gresham,OR
+GREYFOREST-TX.GOV,City,Non-Federal Agency,Grey Forest,TX
+GRIMESIOWA.GOV,City,Non-Federal Agency,Grimes,IA
+GROTON-CT.GOV,City,Non-Federal Agency,Groton,CT
+GROTONMA.GOV,City,Non-Federal Agency,Groton,MA
+GROTONSD.GOV,City,Non-Federal Agency,Groton,SD
+GROVECITYOHIO.GOV,City,Non-Federal Agency,Grove City,OH
+GROVELAND-FL.GOV,City,Non-Federal Agency,Groveland,FL
+GULFBREEZEFL.GOV,City,Non-Federal Agency,Gulf Breeze,FL
+GULFPORT-MS.GOV,City,Non-Federal Agency,Gulfport,MS
+GULFSHORESAL.GOV,City,Non-Federal Agency,Gulf Shores,AL
+GUNTERSVILLEAL.GOV,City,Non-Federal Agency,Guntersville,AL
+GUSTAVUS-AK.GOV,City,Non-Federal Agency,Gustavus,AK
+GWSCO.GOV,City,Non-Federal Agency,Glenwood Springs,CO
+HADLEYMA.GOV,City,Non-Federal Agency,Hadley,MA
+HAHIRAGA.GOV,City,Non-Federal Agency,Hahira,GA
+HALLANDALEBEACHFL.GOV,City,Non-Federal Agency,hallandale beach,FL
+HAMILTON-OH.GOV,City,Non-Federal Agency,Hamilton,OH
+HAMPDENMAINE.GOV,City,Non-Federal Agency,Hampden,ME
+HAMPSTEADMD.GOV,City,Non-Federal Agency,Hampstead,MD
+HAMPTON.GOV,City,Non-Federal Agency,Hampton,VA
+HAMPTONSC.GOV,City,Non-Federal Agency,Hampton,SC
+HANKSVILLEUTAH.GOV,City,Non-Federal Agency,Hanksville,UT
+HANNIBAL-MO.GOV,City,Non-Federal Agency,Hannibal,MO
+HANOVER-MA.GOV,City,Non-Federal Agency,Hanover,MA
+HANOVERVA.GOV,City,Non-Federal Agency,Hanover,VA
+HANSON-MA.GOV,City,Non-Federal Agency,Hanson,MA
+HAPPYVALLEYOR.GOV,City,Non-Federal Agency,Happy Valley,OR
+HARMONYTWP-NJ.GOV,City,Non-Federal Agency,Phillipsburg,NJ
+HARPERCOUNTYKS.GOV,City,Non-Federal Agency,Anthony,KS
+HARRAH-OK.GOV,City,Non-Federal Agency,Harrah,OK
+HARRISBURGPA.GOV,City,Non-Federal Agency,Harrisburg,PA
+HARRISBURGSD.GOV,City,Non-Federal Agency,Harrisburg,SD
+HARRISONBURGVA.GOV,City,Non-Federal Agency,Harrisonburg,VA
+HARRISONOH.GOV,City,Non-Federal Agency,Harrison,OH
+HARRISONOHIO.GOV,City,Non-Federal Agency,Harrison,OH
+HARTFORD.GOV,City,Non-Federal Agency,Hartford,CT
+HARTSVILLESC.GOV,City,Non-Federal Agency,Hartsville,SC
+HARWICH-MA.GOV,City,Non-Federal Agency,Harwich,MA
+HASTINGSMN.GOV,City,Non-Federal Agency,Hastings,MN
+HAVERHILLMA.GOV,City,Non-Federal Agency,Haverhill,MA
+HAVREDEGRACEMD.GOV,City,Non-Federal Agency,Havre de Grace,MD
+HAWTHORNECA.GOV,City,Non-Federal Agency,Hawthorne,CA
+HAYDEN-CO.GOV,City,Non-Federal Agency,Hayden,CO
+HAYSIVIRGINIA.GOV,City,Non-Federal Agency,Haysi,VA
+HAZARDKY.GOV,City,Non-Federal Agency,Hazard,KY
+HAZLEHURSTGA.GOV,City,Non-Federal Agency,Hazlehurst,GA
+HEADOFTHEHARBORNY.GOV,City,Non-Federal Agency,Saint James,NY
+HEATHOHIO.GOV,City,Non-Federal Agency,Heath,OH
+HELENAMT.GOV,City,Non-Federal Agency,Helena,MT
+HELOTES-TX.GOV,City,Non-Federal Agency,Helotes,TX
+HENDERSONNEVADA.GOV,City,Non-Federal Agency,Henderson,NV
+HENDERSONNV.GOV,City,Non-Federal Agency,Henderson,NV
+HENDERSONTN.GOV,City,Non-Federal Agency,Henderson,TN
+HENDERSONVILLENC.GOV,City,Non-Federal Agency,Hendersonville,NC
+HEREFORD-TX.GOV,City,Non-Federal Agency,Hereford,TX
+HERNDON-VA.GOV,City,Non-Federal Agency,Herndon,VA
+HEYWORTH-IL.GOV,City,Non-Federal Agency,Heyworth,IL
+HIALEAHFL.GOV,City,Non-Federal Agency,Hialeah,FL
+HIAWASSEEGA.GOV,City,Non-Federal Agency,Hiawassee,GA
+HICKORYCREEK-TX.GOV,City,Non-Federal Agency,Hickory Creek,TX
+HICKORYNC.GOV,City,Non-Federal Agency,Hickory,NC
+HIDEOUTUTAH.GOV,City,Non-Federal Agency,Hideout,UT
+HIGHLANDHEIGHTS-KY.GOV,City,Non-Federal Agency,Highland Heights,KY
+HIGHLANDIL.GOV,City,Non-Federal Agency,Highland,IL
+HIGHLANDS-NY.GOV,City,Non-Federal Agency,Highland Falls,NY
+HILLIARDOHIO.GOV,City,Non-Federal Agency,Hilliard,OH
+HILLSBORO-OR.GOV,City,Non-Federal Agency,Hillsboro,OR
+HILLSBORO-OREGON.GOV,City,Non-Federal Agency,HILLSBORO,OR
+HILLSBOROOREGON.GOV,City,Non-Federal Agency,Hillsboro,OR
+HILLSBOROUGHNC.GOV,City,Non-Federal Agency,Hillsborough,NC
+HILTONHEADISLANDSC.GOV,City,Non-Federal Agency,Hilton Head Island,SC
+HINGHAM-MA.GOV,City,Non-Federal Agency,Hingham,MA
+HIRAM-GA.GOV,City,Non-Federal Agency,Hiram,GA
+HOBOKENNJ.GOV,City,Non-Federal Agency,Hoboken,NJ
+HOLBROOKMA.GOV,City,Non-Federal Agency,Holbrook,MA
+HOLDEN-MA.GOV,City,Non-Federal Agency,Holden,MA
+HOLDENMA.GOV,City,Non-Federal Agency,HOLDEN,MA
+HOLDERNESS-NH.GOV,City,Non-Federal Agency,Holderness,NH
+HOLLANDTOWNSHIPNJ.GOV,City,Non-Federal Agency,Milford,NJ
+HOLLYWOODPARK-TX.GOV,City,Non-Federal Agency,Hollywood Park,TX
+HOMERGLENIL.GOV,City,Non-Federal Agency,Homer Glen,IL
+HOMEWOODIL.GOV,City,Non-Federal Agency,Homewood,IL
+HOOPESTON-IL.GOV,City,Non-Federal Agency,Hoopeston,IL
+HOOVERAL.GOV,City,Non-Federal Agency,Hoover,AL
+HOOVERALABAMA.GOV,City,Non-Federal Agency,Hoover,AL
+HOPEDALE-MA.GOV,City,Non-Federal Agency,Hopedale,MA
+HOPEWELLVA.GOV,City,Non-Federal Agency,HOPEWELL,VA
+HOPKINSVILLE-KY.GOV,City,Non-Federal Agency,Hopkinsville,KY
+HOPKINTON-NH.GOV,City,Non-Federal Agency,Hopkinton,NH
+HOPKINTONMA.GOV,City,Non-Federal Agency,Hopkinton,MA
+HORICONNY.GOV,City,Non-Federal Agency,Brant Lake,NY
+HORIZONCITY-TX.GOV,City,Non-Federal Agency,Horizon City,TX
+HORSESHOE-BAY-TX.GOV,City,Non-Federal Agency,Horseshoe Bay,TX
+HOUSTON-AK.GOV,City,Non-Federal Agency,Houston,AK
+HPCA.GOV,City,Non-Federal Agency,Huntington Park,CA
+HRPDCVA.GOV,City,Non-Federal Agency,Chesapeake,VA
+HUACHUCACITYAZ.GOV,City,Non-Federal Agency,Huachuca City,AZ
+HUDSONNH.GOV,City,Non-Federal Agency,Hudson,NH
+HUETTER-ID.GOV,City,Non-Federal Agency,POST FALLS,ID
+HULMEVILLE-PA.GOV,City,Non-Federal Agency,Hulmeville,PA
+HUMBLETX.GOV,City,Non-Federal Agency,Humble,TX
+HUNTINGBURG-IN.GOV,City,Non-Federal Agency,Huntingburg,IN
+HUNTINGTONBEACHCA.GOV,City,Non-Federal Agency,Huntington Beach,CA
+HUNTINGTONNY.GOV,City,Non-Federal Agency,Huntington,NY
+HUNTSPOINT-WA.GOV,City,Non-Federal Agency,Hunts Point,WA
+HUNTSVILLEAL.GOV,City,Non-Federal Agency,Huntsville,AL
+HURLOCK-MD.GOV,City,Non-Federal Agency,Hurlock,MD
+HURST-TEXAS.GOV,City,Non-Federal Agency,Hurst,TX
+HURSTTX.GOV,City,Non-Federal Agency,Hurst,TX
+HUTTOTX.GOV,City,Non-Federal Agency,Hutto,TX
+HVLNC.GOV,City,Non-Federal Agency,Hendersonville,NC
+IDABEL-OK.GOV,City,Non-Federal Agency,Idabel,OK
+IDAHOFALLSIDAHO.GOV,City,Non-Federal Agency,Idaho Falls,ID
+ILWACO-WA.GOV,City,Non-Federal Agency,Ilwaco,WA
+IMPERIALBEACHCA.GOV,City,Non-Federal Agency,Imperial Beach,CA
+INCLINEVILLAGE-NV.GOV,City,Non-Federal Agency,INCLINE VILLAGE,NV
+INDEPENDENCEKS.GOV,City,Non-Federal Agency,INDEPENDENCE,KS
+INDEPENDENCEOHIO.GOV,City,Non-Federal Agency,Independence,OH
+INDIANAPOLIS-IN.GOV,City,Non-Federal Agency,Indianapolis,IN
+INDIANOLAIOWA.GOV,City,Non-Federal Agency,Indianola,IA
+INDIANOLAMS.GOV,City,Non-Federal Agency,Indianola,MS
+INDIANPOINT-MO.GOV,City,Non-Federal Agency,Branson,MO
+INDY.GOV,City,Non-Federal Agency,Indianapolis,IN
+INGLESIDETX.GOV,City,Non-Federal Agency,Ingleside,TX
+INTERLACHEN-FL.GOV,City,Non-Federal Agency,Interlachen,FL
+INVERNESS-FL.GOV,City,Non-Federal Agency,Inverness,FL
+INVERNESS-IL.GOV,City,Non-Federal Agency,Inverness,IL
+IPSWICH-MA.GOV,City,Non-Federal Agency,Ipswich,MA
+IPSWICHMA.GOV,City,Non-Federal Agency,Ipswich,MA
+IRONTONMO.GOV,City,Non-Federal Agency,Ironton,MO
+IRVINGTONNY.GOV,City,Non-Federal Agency,Irvington,NY
+ISLIP-NY.GOV,City,Non-Federal Agency,Islip,NY
+ISLIPNY.GOV,City,Non-Federal Agency,Islip,NY
+ISLIPTOWN-NY.GOV,City,Non-Federal Agency,Islip,NY
+ISSAQUAHWA.GOV,City,Non-Federal Agency,Issaquah,WA
+JACINTOCITY-TX.GOV,City,Non-Federal Agency,Jacinto City,TX
+JACKSON-SC.GOV,City,Non-Federal Agency,Jackson,SC
+JACKSONMS.GOV,City,Non-Federal Agency,Jackson,MS
+JACKSONTOWNSHIP-PA.GOV,City,Non-Federal Agency,Myerstown,PA
+JACKSONTOWNSHIPPA.GOV,City,Non-Federal Agency,Jackson Township,PA
+JACKSONTWP-PA.GOV,City,Non-Federal Agency,Reeders,PA
+JAMESTOWN-NC.GOV,City,Non-Federal Agency,Jamestown,NC
+JAMESTOWNRI.GOV,City,Non-Federal Agency,Jamestown,RI
+JAMESTOWNTN.GOV,City,Non-Federal Agency,Jamestown,TN
+JEFFERSONCITYMO.GOV,City,Non-Federal Agency,Jefferson City,MO
+JEFFERSONTOWNKY.GOV,City,Non-Federal Agency,Jeffersontown,KY
+JEMEZSPRINGS-NM.GOV,City,Non-Federal Agency,Jemez Springs,NM
+JERICHOVT.GOV,City,Non-Federal Agency,Jericho,VT
+JEROME-OH.GOV,City,Non-Federal Agency,Plain City,OH
+JESUPGA.GOV,City,Non-Federal Agency,Jesup,GA
+JOHNSCREEKGA.GOV,City,Non-Federal Agency,Johns Creek,GA
+JOHNSONCITYTN.GOV,City,Non-Federal Agency,Johnson City,TN
+JONESVILLENC.GOV,City,Non-Federal Agency,Jonesville,NC
+JUNCTIONCITY-KS.GOV,City,Non-Federal Agency,Junction City,KS
+JUNCTIONCITYOREGON.GOV,City,Non-Federal Agency,Junction City,OR
+JUPITERFL.GOV,City,Non-Federal Agency,Jupiter,FL
+KANNAPOLISNC.GOV,City,Non-Federal Agency,Concord,NC
+KEANSBURGNJ.GOV,City,Non-Federal Agency,Keansburg,NJ
+KELSO.GOV,City,Non-Federal Agency,Kelso,WA
+KEMAH-TX.GOV,City,Non-Federal Agency,Kemah,TX
+KENMOREWA.GOV,City,Non-Federal Agency,Kenmore,WA
+KENNEBUNKPORTME.GOV,City,Non-Federal Agency,Kennebunkport,ME
+KENNESAW-GA.GOV,City,Non-Federal Agency,Kennesaw,GA
+KENTWA.GOV,City,Non-Federal Agency,Kent,WA
+KERRVILLETX.GOV,City,Non-Federal Agency,Kerrville,TX
+KILLEENTEXAS.GOV,City,Non-Federal Agency,Killeen,TX
+KILLINGLYCT.GOV,City,Non-Federal Agency,Danielson,CT
+KINDERHOOK-NY.GOV,City,Non-Federal Agency,Niverville,NY
+KINGSLANDGA.GOV,City,Non-Federal Agency,Kingsland,GA
+KINGSPORTTN.GOV,City,Non-Federal Agency,Kingsport,TN
+KINGSTON-NY.GOV,City,Non-Federal Agency,Kingston,NY
+KINGSTONSPRINGS-TN.GOV,City,Non-Federal Agency,Kingston Springs,TN
+KINROSSTOWNSHIP-MI.GOV,City,Non-Federal Agency,Kincheloe,MI
+KINSTONNC.GOV,City,Non-Federal Agency,Kinston,NC
+KIRKLANDWA.GOV,City,Non-Federal Agency,Kirkland,WA
+KISSIMMEE-FL.GOV,City,Non-Federal Agency,Kissimmee,FL
+KISSIMMEEFL.GOV,City,Non-Federal Agency,Kissimmee,FL
+KITTERYME.GOV,City,Non-Federal Agency,Kittery,ME
+KITTYHAWKNC.GOV,City,Non-Federal Agency,Kitty Hawk,NC
+KNIGHTDALENC.GOV,City,Non-Federal Agency,Knightdale,NC
+KNOXVILLEIA.GOV,City,Non-Federal Agency,Knoxville,IA
+KNOXVILLEIOWA.GOV,City,Non-Federal Agency,Knoxville,IA
+KNOXVILLETN.GOV,City,Non-Federal Agency,Knoxville,TN
+KUNAID.GOV,City,Non-Federal Agency,Kuna,ID
+LACKAWANNANY.GOV,City,Non-Federal Agency,Lackawanna,NY
+LACKAWAXENTOWNSHIPPA.GOV,City,Non-Federal Agency,Hawley,PA
+LAFOLLETTETN.GOV,City,Non-Federal Agency,LaFollette,TN
+LAGRANGEGA.GOV,City,Non-Federal Agency,LaGrange,GA
+LAGRANGENY.GOV,City,Non-Federal Agency,Lagrangeville,NY
+LAHABRACA.GOV,City,Non-Federal Agency,LA HABRA,CA
+LAKEFORESTCA.GOV,City,Non-Federal Agency,Lake Forest,CA
+LAKEGROVENY.GOV,City,Non-Federal Agency,Lake Grove,NY
+LAKEJACKSONTX.GOV,City,Non-Federal Agency,Lake Jackson,TX
+LAKELANDGA.GOV,City,Non-Federal Agency,Lakeland,GA
+LAKELANDTN.GOV,City,Non-Federal Agency,Lakeland,TN
+LAKEPARKNC.GOV,City,Non-Federal Agency,Indian Trail,NC
+LAKEPROVIDENCELA.GOV,City,Non-Federal Agency,Lake Providence,LA
+LAKESTATION-IN.GOV,City,Non-Federal Agency,Lake Station,IN
+LAKESTEVENSWA.GOV,City,Non-Federal Agency,Lake Stevens,WA
+LAKEVILLE-MN.GOV,City,Non-Federal Agency,Lakeville,MN
+LAKEVILLEMN.GOV,City,Non-Federal Agency,Lakeville,MN
+LAKEVILLEMNFIRE.GOV,City,Non-Federal Agency,Lakeville,MN
+LAKEWAY-TX.GOV,City,Non-Federal Agency,Lakeway,TX
+LAKEWOODNJ.GOV,City,Non-Federal Agency,Lakewood,NJ
+LANCASTERCITYSC.GOV,City,Non-Federal Agency,Lancaster,SC
+LANCASTERNY.GOV,City,Non-Federal Agency,Lancaster,NY
+LANESBORO-MN.GOV,City,Non-Federal Agency,Lanesboro,MN
+LANESBOROUGH-MA.GOV,City,Non-Federal Agency,LANESBOROUGH,MA
+LANSINGMI.GOV,City,Non-Federal Agency,Lansing,MI
+LANTABUS-PA.GOV,City,Non-Federal Agency,Allentown,PA
+LAPORTETX.GOV,City,Non-Federal Agency,La Porte,TX
+LAREDOTEXAS.GOV,City,Non-Federal Agency,Laredo,TX
+LASALLE-IL.GOV,City,Non-Federal Agency,LaSalle,IL
+LASVEGASNM.GOV,City,Non-Federal Agency,Las Vegas,NM
+LAUDERDALEBYTHESEA-FL.GOV,City,Non-Federal Agency,Lauderdale By The Sea,FL
+LAUDERHILL-FL.GOV,City,Non-Federal Agency,Lauderhill,FL
+LAUDERHILLFL.GOV,City,Non-Federal Agency,Lauderhill,FL
+LAVERGNETN.GOV,City,Non-Federal Agency,La Vergne,TN
+LAVERNIA-TX.GOV,City,Non-Federal Agency,La Vernia,TX
+LAWRENCEBURGTN.GOV,City,Non-Federal Agency,Lawrenceburg,TN
+LAWTONMI.GOV,City,Non-Federal Agency,Lawton,MI
+LBTS-FL.GOV,City,Non-Federal Agency,Lauderdale-By-The-Sea,FL
+LEAGUECITY-TX.GOV,City,Non-Federal Agency,League City,TX
+LEAGUECITYTX.GOV,City,Non-Federal Agency,League City,TX
+LEANDERTX.GOV,City,Non-Federal Agency,Leander,TX
+LEBANONCT.GOV,City,Non-Federal Agency,Lebanon,CT
+LEBANONOHIO.GOV,City,Non-Federal Agency,Lebanon,OH
+LECLAIREIOWA.GOV,City,Non-Federal Agency,LECLAIRE,IA
+LEEDSALABAMA.GOV,City,Non-Federal Agency,Leeds,AL
+LEESBURGFLORIDA.GOV,City,Non-Federal Agency,Leesburg,FL
+LEESVILLELA.GOV,City,Non-Federal Agency,LEESVILLE,LA
+LEHI-UT.GOV,City,Non-Federal Agency,Lehi,UT
+LENEXA-KS.GOV,City,Non-Federal Agency,Lenexa,KS
+LENOIR-NC.GOV,City,Non-Federal Agency,Lenoir,NC
+LENOIRCITYTN.GOV,City,Non-Federal Agency,Lenoir City,TN
+LEOMINSTER-MA.GOV,City,Non-Federal Agency,Leominster,MA
+LEONIANJ.GOV,City,Non-Federal Agency,Leonia,NJ
+LEONVALLEYTEXAS.GOV,City,Non-Federal Agency,Leon Valley,TX
+LEROYTOWNSHIP-MI.GOV,City,Non-Federal Agency,Webberville,MI
+LETSMOVEBRIDGEPORTCT.GOV,City,Non-Federal Agency,Bridgeport,CT
+LEWISBURGTN.GOV,City,Non-Federal Agency,Lewisburg,TN
+LEWISTONMAINE.GOV,City,Non-Federal Agency,Lewiston,ME
+LEXINGTONKY.GOV,City,Non-Federal Agency,lexington,KY
+LEXINGTONNC.GOV,City,Non-Federal Agency,Lexington,NC
+LEXINGTONTN.GOV,City,Non-Federal Agency,Lexington,TN
+LEXINGTONVA.GOV,City,Non-Federal Agency,Lexington,VA
+LHCAZ.GOV,City,Non-Federal Agency,Lake Havasu City,AZ
+LIBERTYLAKEWA.GOV,City,Non-Federal Agency,Liberty Lake,WA
+LIBERTYMISSOURI.GOV,City,Non-Federal Agency,Liberty,MO
+LIBERTYMO.GOV,City,Non-Federal Agency,Liberty,MO
+LIMERICK-ME.GOV,City,Non-Federal Agency,Limerick,ME
+LINCOLNCA.GOV,City,Non-Federal Agency,Lincoln,CA
+LINCOLNIL.GOV,City,Non-Federal Agency,Lincoln,IL
+LINDALE-TX.GOV,City,Non-Federal Agency,Lindale,TX
+LINDALETX.GOV,City,Non-Federal Agency,Lindale,TX
+LINDENWOLDNJ.GOV,City,Non-Federal Agency,Lindenwold,NJ
+LINNDALEVILLAGE-OH.GOV,City,Non-Federal Agency,Linndale,OH
+LINTON-IN.GOV,City,Non-Federal Agency,Linton,IN
+LITCHFIELD-NH.GOV,City,Non-Federal Agency,Litchfield,NH
+LITCHFIELDNH.GOV,City,Non-Federal Agency,Litchfield,NH
+LOCKHAVENPA.GOV,City,Non-Federal Agency,Lock Haven,PA
+LOCKPORTNY.GOV,City,Non-Federal Agency,Lockport,NY
+LOCUSTGROVE-GA.GOV,City,Non-Federal Agency,Locust Grove,GA
+LOGANCO.GOV,City,Non-Federal Agency,Sterling,CO
+LOGANVILLE-GA.GOV,City,Non-Federal Agency,Loganville,GA
+LOMALINDA-CA.GOV,City,Non-Federal Agency,Loma Linda,CA
+LONEOAKTX.GOV,City,Non-Federal Agency,LONE OAK,TX
+LONGBEACH.GOV,City,Non-Federal Agency,Long Beach,CA
+LONGBEACHNY.GOV,City,Non-Federal Agency,Long Beach,NY
+LONGBEACHWA.GOV,City,Non-Federal Agency,Long Beach,WA
+LONGHILLNJ.GOV,City,Non-Federal Agency,Long Hill,NJ
+LONGLAKEMN.GOV,City,Non-Federal Agency,Long Lake,MN
+LONGMONTCOLORADO.GOV,City,Non-Federal Agency,Longmont,CO
+LONGPORTNJ.GOV,City,Non-Federal Agency,Longport,NJ
+LONGVIEWTEXAS.GOV,City,Non-Federal Agency,Longview,TX
+LONGVIEWTX.GOV,City,Non-Federal Agency,Longview,TX
+LORENATX.GOV,City,Non-Federal Agency,Lorena,TX
+LOSALTOSCA.GOV,City,Non-Federal Agency,Los Altos,CA
+LOSANGELES-CA.GOV,City,Non-Federal Agency,Los Angeles,CA
+LOSRANCHOSNM.GOV,City,Non-Federal Agency,Los Ranchos de Albuquerque,NM
+LOUISBURGKANSAS.GOV,City,Non-Federal Agency,Louisburg,KS
+LOUISVILLECO.GOV,City,Non-Federal Agency,Louisville,CO
+LOUISVILLEKY.GOV,City,Non-Federal Agency,Louisville,KY
+LOVEJOY-GA.GOV,City,Non-Federal Agency,Lovejoy,GA
+LOVETTSVILLEVA.GOV,City,Non-Federal Agency,Lovettsville,VA
+LOVINGTON-IL.GOV,City,Non-Federal Agency,Lovington,IL
+LOWELLARKANSAS.GOV,City,Non-Federal Agency,Lowell,AR
+LOWERALLOWAYSCREEK-NJ.GOV,City,Non-Federal Agency,Hancocks Bridge,NJ
+LUBBOCKTX.GOV,City,Non-Federal Agency,Lubbock,TX
+LUDINGTON-MI.GOV,City,Non-Federal Agency,Ludington,MI
+LUNENBURGMA.GOV,City,Non-Federal Agency,Lunenburg,MA
+LYMAN-ME.GOV,City,Non-Federal Agency,Lyman,ME
+LYMANSC.GOV,City,Non-Federal Agency,Lyman,SC
+LYMECT.GOV,City,Non-Federal Agency,Lyme,CT
+LYMENH.GOV,City,Non-Federal Agency,Lyme,NH
+LYNDEBOROUGHNH.GOV,City,Non-Federal Agency,Lyndeborough,NH
+LYNDONKS.GOV,City,Non-Federal Agency,Lyndon,KS
+LYNNMA.GOV,City,Non-Federal Agency,Lynn,MA
+LYNNWOODWA.GOV,City,Non-Federal Agency,Lynnwood,WA
+LYONSTOWNSHIPIL.GOV,City,Non-Federal Agency,Countryside,IL
+MACOMB-MI.GOV,City,Non-Federal Agency,Macomb,MI
+MACONGA.GOV,City,Non-Federal Agency,Macon,GA
+MADEIRABEACHFL.GOV,City,Non-Federal Agency,Madeira Beach,FL
+MADERA-CA.GOV,City,Non-Federal Agency,Madera,CA
+MADISON-AL.GOV,City,Non-Federal Agency,Madison,AL
+MADISON-IN.GOV,City,Non-Federal Agency,Madison,IN
+MADISONAL.GOV,City,Non-Federal Agency,Madison,AL
+MAHARISHIVEDICCITY-IOWA.GOV,City,Non-Federal Agency,Maharishi Vedic City,IA
+MAHOMET-IL.GOV,City,Non-Federal Agency,Mahomet,IL
+MAHWAH-NJ.GOV,City,Non-Federal Agency,Mahwah,NJ
+MAIDENNC.GOV,City,Non-Federal Agency,Maiden,NC
+MALVERNAR.GOV,City,Non-Federal Agency,Malvern,AR
+MANASQUAN-NJ.GOV,City,Non-Federal Agency,MANASQUAN,NJ
+MANASSASPARKVA.GOV,City,Non-Federal Agency,Manassas Park,VA
+MANASSASVA.GOV,City,Non-Federal Agency,Manassas,VA
+MANCHESTER-GA.GOV,City,Non-Federal Agency,Manchester,GA
+MANCHESTER-VT.GOV,City,Non-Federal Agency,Manchester Center,VT
+MANCHESTERCT.GOV,City,Non-Federal Agency,Manchester,CT
+MANCHESTERMD.GOV,City,Non-Federal Agency,MANCHESTER,MD
+MANCHESTERMO.GOV,City,Non-Federal Agency,Manchester,MO
+MANCHESTERNH.GOV,City,Non-Federal Agency,Manchester,NH
+MANISTEEMI.GOV,City,Non-Federal Agency,Traverse City,MI
+MANKATO-MN.GOV,City,Non-Federal Agency,Mankato,MN
+MANKATOMN.GOV,City,Non-Federal Agency,Mankato,MN
+MANSFIELDCT.GOV,City,Non-Federal Agency,Mansfield,CT
+MANSFIELDGA.GOV,City,Non-Federal Agency,Mans,GA
+MANSFIELDTEXAS.GOV,City,Non-Federal Agency,Mansfield,TX
+MANSFIELDTOWNSHIP-NJ.GOV,City,Non-Federal Agency,Port Murray,NJ
+MANTUATOWNSHIPOHIO.GOV,City,Non-Federal Agency,Mantua,OH
+MAPLEGROVEMN.GOV,City,Non-Federal Agency,Maple Grove,MN
+MAPLEVALLEYWA.GOV,City,Non-Federal Agency,Maple Valley,WA
+MAPLEWOODMN.GOV,City,Non-Federal Agency,Maplewood,MN
+MARANAAZ.GOV,City,Non-Federal Agency,Marana,AZ
+MARBLEFALLSTX.GOV,City,Non-Federal Agency,Marble Falls,TX
+MARICOPA-AZ.GOV,City,Non-Federal Agency,Maricopa,AZ
+MARIONKY.GOV,City,Non-Federal Agency,Marion,KY
+MARIONMA.GOV,City,Non-Federal Agency,Marion,MA
+MARIONSC.GOV,City,Non-Federal Agency,Marion,SC
+MARKESANWI.GOV,City,Non-Federal Agency,Markesan,WI
+MARLBORO-NJ.GOV,City,Non-Federal Agency,Marlboro,NJ
+MARLBOROUGH-MA.GOV,City,Non-Federal Agency,Marlborough,MA
+MARLOWNH.GOV,City,Non-Federal Agency,Marlow,NH
+MAROAILLINOIS.GOV,City,Non-Federal Agency,Maroa,IL
+MARSHFIELDMO.GOV,City,Non-Federal Agency,Marshfield,MO
+MARTINSVILLE-VA.GOV,City,Non-Federal Agency,Martinsville,VA
+MARYSVILLEWA.GOV,City,Non-Federal Agency,Marysville,WA
+MARYVILLE-TN.GOV,City,Non-Federal Agency,maryville,TN
+MASHPEEMA.GOV,City,Non-Federal Agency,Mashpee,MA
+MAYAGUEZPR.GOV,City,Non-Federal Agency,Mayaguez,PR
+MCCOMB-MS.GOV,City,Non-Federal Agency,McComb,MS
+MCDONOUGH-GA.GOV,City,Non-Federal Agency,McDonough,GA
+MCKEESPORT-PA.GOV,City,Non-Federal Agency,McKeesport,PA
+MCKENZIETN.GOV,City,Non-Federal Agency,McKenzie,TN
+MCTX.GOV,City,Non-Federal Agency,Missouri City,TX
+MEADOWSPLACETX.GOV,City,Non-Federal Agency,Meadows Place,TX
+MECHANICVILLENY.GOV,City,Non-Federal Agency,Mechanicville,NY
+MEDINA-WA.GOV,City,Non-Federal Agency,Medina,WA
+MEMPHISTN.GOV,City,Non-Federal Agency,Memphis,TN
+MENDON-MA.GOV,City,Non-Federal Agency,Mendon,MA
+MENDONMA.GOV,City,Non-Federal Agency,Mendon,MA
+MENOMONIE-WI.GOV,City,Non-Federal Agency,Menomonie,WI
+MENTONEALABAMA.GOV,City,Non-Federal Agency,Mentone,AL
+MERCHANTVILLENJ.GOV,City,Non-Federal Agency,Merchantville,NJ
+MERIDENCT.GOV,City,Non-Federal Agency,Meriden,CT
+MERRIMACKNH.GOV,City,Non-Federal Agency,Merrimack,NH
+MESAAZ.GOV,City,Non-Federal Agency,Mesa,AZ
+MESILLANM.GOV,City,Non-Federal Agency,Mesilla,NM
+MESQUITETX.GOV,City,Non-Federal Agency,Mesquite,TX
+MIAMIBEACHFL.GOV,City,Non-Federal Agency,Miami Beach,FL
+MIAMIGARDENS-FL.GOV,City,Non-Federal Agency,Miami Gardens,FL
+MIAMILAKES-FL.GOV,City,Non-Federal Agency,Miami Lakes,FL
+MIAMISPRINGS-FL.GOV,City,Non-Federal Agency,Miami Springs,FL
+MIAMITOWNSHIPOH.GOV,City,Non-Federal Agency,Milford,OH
+MIAMITWPOH.GOV,City,Non-Federal Agency,Milford,OH
+MIDDLEBURGVA.GOV,City,Non-Federal Agency,Middleburg,VA
+MIDDLETONNH.GOV,City,Non-Federal Agency,Middleton,NH
+MIDDLETOWN-CT.GOV,City,Non-Federal Agency,Middletown,CT
+MIDDLETOWNCT.GOV,City,Non-Federal Agency,Middletown,CT
+MIDDLETOWNVA.GOV,City,Non-Federal Agency,Middletown,VA
+MIDLANDTEXAS.GOV,City,Non-Federal Agency,Midland,TX
+MIDLOTHIANTX.GOV,City,Non-Federal Agency,Midlothian,TX
+MIDWAY-NC.GOV,City,Non-Federal Agency,Winston-Salem,NC
+MIFFLIN-OH.GOV,City,Non-Federal Agency,Gahanna,OH
+MILAN-NY.GOV,City,Non-Federal Agency,Milan,NY
+MILANMO.GOV,City,Non-Federal Agency,Milan,MO
+MILANOHIO.GOV,City,Non-Federal Agency,Milan,OH
+MILFORD-CT.GOV,City,Non-Federal Agency,Milford,CT
+MILFORD-DE.GOV,City,Non-Federal Agency,Milford,DE
+MILFORDNE.GOV,City,Non-Federal Agency,Milford,NE
+MILLIKENCO.GOV,City,Non-Federal Agency,Milliken,CO
+MILLIKENCOLORADO.GOV,City,Non-Federal Agency,Milliken,CO
+MILLINGTONTN.GOV,City,Non-Federal Agency,Millington,TN
+MILLSTONENJ.GOV,City,Non-Federal Agency,Millstone,NJ
+MILLSWY.GOV,City,Non-Federal Agency,Mills,WY
+MILLVILLENJ.GOV,City,Non-Federal Agency,Millville,NJ
+MILTON-WI.GOV,City,Non-Federal Agency,Milton,WI
+MILWAUKIEOREGON.GOV,City,Non-Federal Agency,Milwaukie,OR
+MINEOLA-NY.GOV,City,Non-Federal Agency,Mineola,NY
+MINERALWELLSTX.GOV,City,Non-Federal Agency,Mineral Wells,TX
+MINNEAPOLIS-MN.GOV,City,Non-Federal Agency,Minneapolis,MN
+MINNEAPOLISMN.GOV,City,Non-Federal Agency,Minneapolis,MN
+MINNETONKA-MN.GOV,City,Non-Federal Agency,Minnetonka,MN
+MIRAMARFL.GOV,City,Non-Federal Agency,Miramar,FL
+MISSIONHILLSKS.GOV,City,Non-Federal Agency,Mission Hills,KS
+MISSOULA-MT.GOV,City,Non-Federal Agency,Missoula,MT
+MISSOURICITYTEXAS.GOV,City,Non-Federal Agency,Missouri City,TX
+MISSOURICITYTX.GOV,City,Non-Federal Agency,Missouri City,TX
+MITCHELL-IN.GOV,City,Non-Federal Agency,Mitchell,IN
+MOBILE-AL.GOV,City,Non-Federal Agency,Mobile,AL
+MOCKSVILLENC.GOV,City,Non-Federal Agency,Mocksville,NC
+MONROEGA.GOV,City,Non-Federal Agency,Monroe,GA
+MONROEMI.GOV,City,Non-Federal Agency,Monroe,MI
+MONROETWP-OH.GOV,City,Non-Federal Agency,Bethel,OH
+MONROEWA.GOV,City,Non-Federal Agency,Monroe,WA
+MONTAGUE-MA.GOV,City,Non-Federal Agency,Turners Falls,MA
+MONTCLAIRCA.GOV,City,Non-Federal Agency,Montclair,CA
+MONTEREYMA.GOV,City,Non-Federal Agency,Monterey,MA
+MONTGOMERYAL.GOV,City,Non-Federal Agency,Montgomery,AL
+MONTGOMERYOHIO.GOV,City,Non-Federal Agency,Montgomery,OH
+MONTGOMERYTEXAS.GOV,City,Non-Federal Agency,Montgomery,TX
+MONTICELLOIN.GOV,City,Non-Federal Agency,Monticello,IN
+MOODYALABAMA.GOV,City,Non-Federal Agency,Moody,AL
+MOORESVILLE-NC.GOV,City,Non-Federal Agency,Mooresville,NC
+MOORPARKCA.GOV,City,Non-Federal Agency,Moorpark,CA
+MOREHEAD-KY.GOV,City,Non-Federal Agency,Morehead,KY
+MORGANTONNC.GOV,City,Non-Federal Agency,Morganton,NC
+MORGANTOWNWV.GOV,City,Non-Federal Agency,Morgantown,WV
+MOULTONBOROUGHNH.GOV,City,Non-Federal Agency,Moultonborough,NH
+MOUNTAINAIRNM.GOV,City,Non-Federal Agency,Mountainair,NM
+MOUNTAINHOUSECA.GOV,City,Non-Federal Agency,Mountain House,CA
+MOUNTAINPARK-GA.GOV,City,Non-Federal Agency,Mountain Park,GA
+MOUNTAINVIEW.GOV,City,Non-Federal Agency,Mountain View,CA
+MOUNTCARMELTN.GOV,City,Non-Federal Agency,Mount Carmel,TN
+MOUNTKISCONY.GOV,City,Non-Federal Agency,Mount Kisco,NY
+MOUNTPLEASANTTN.GOV,City,Non-Federal Agency,Mount Pleasant,TN
+MOUNTPOCONO-PA.GOV,City,Non-Federal Agency,Mount Pocono,PA
+MOUNTVERNONWA.GOV,City,Non-Federal Agency,Mount Vernon,WA
+MQUEBRADILLASPR.GOV,City,Non-Federal Agency,Quebradillas,PR
+MTCRESTEDBUTTE-CO.GOV,City,Non-Federal Agency,Mt. Crested Butte,CO
+MTPLEASANTWI.GOV,City,Non-Federal Agency,Mount Pleasant,WI
+MTSHASTACA.GOV,City,Non-Federal Agency,Mt. Shasta,CA
+MUKILTEOWA.GOV,City,Non-Federal Agency,Mukilteo,WA
+MURFREESBOROTN.GOV,City,Non-Federal Agency,Murfreesboro,TN
+MURPHYSBORO-IL.GOV,City,Non-Federal Agency,Murphysboro,IL
+MURPHYTX.GOV,City,Non-Federal Agency,Murphy,TX
+MURRAYKY.GOV,City,Non-Federal Agency,Murray,KY
+MUSCATINEIOWA.GOV,City,Non-Federal Agency,Muscatine,IA
+MUSKEGON-MI.GOV,City,Non-Federal Agency,Muskegon,MI
+MYARLINGTONTX.GOV,City,Non-Federal Agency,Arlington,TX
+MYCOLUMBUS.GOV,City,Non-Federal Agency,Columbus,OH
+MYDELRAYBEACHFL.GOV,City,Non-Federal Agency,Delray Beach,FL
+NAGSHEADNC.GOV,City,Non-Federal Agency,Nags Head,NC
+NANTICOKECITY-PA.GOV,City,Non-Federal Agency,NANTICOKE,PA
+NANTUCKET-MA.GOV,City,Non-Federal Agency,Nantucket,MA
+NAPLESCITYUT.GOV,City,Non-Federal Agency,Naples,UT
+NARBERTHPA.GOV,City,Non-Federal Agency,Narberth,PA
+NARRAGANSETTRI.GOV,City,Non-Federal Agency,Narragansett,RI
+NASHOTAH-WI.GOV,City,Non-Federal Agency,Nashotah,WI
+NASHUANH.GOV,City,Non-Federal Agency,Nashua,NH
+NASHVILLE.GOV,City,Non-Federal Agency,Nashville,TN
+NATCHITOCHESLA.GOV,City,Non-Federal Agency,Natchitoches,LA
+NATIONALCITYCA.GOV,City,Non-Federal Agency,National City,CA
+NAUGATUCK-CT.GOV,City,Non-Federal Agency,Naugatuck,CT
+NBCA.GOV,City,Non-Federal Agency,Newport Beach,CA
+NEBRASKACITYNE.GOV,City,Non-Federal Agency,Nebraska City,NE
+NEEDHAMMA.GOV,City,Non-Federal Agency,NEEDHAM,MA
+NEVADACITYCA.GOV,City,Non-Federal Agency,Nevada City,CA
+NEVILLEISLAND-PA.GOV,City,Non-Federal Agency,Pittsburgh,PA
+NEWARKDE.GOV,City,Non-Federal Agency,Newark,DE
+NEWAUBURNMN.GOV,City,Non-Federal Agency,New Auburn,MN
+NEWBEDFORD-MA.GOV,City,Non-Federal Agency,New Bedford,MA
+NEWBERGOREGON.GOV,City,Non-Federal Agency,Newberg,OR
+NEWBOSTONNH.GOV,City,Non-Federal Agency,New Boston,NH
+NEWBRIGHTONMN.GOV,City,Non-Federal Agency,New Brighton,MN
+NEWBRITAINCT.GOV,City,Non-Federal Agency,New Britain,CT
+NEWBURGH-IN.GOV,City,Non-Federal Agency,Newburgh,IN
+NEWBURGHHTSOH.GOV,City,Non-Federal Agency,Newburgh Heights,OH
+NEWCANAANCT.GOV,City,Non-Federal Agency,New Canaan,CT
+NEWCARROLLTONMD.GOV,City,Non-Federal Agency,New Carrollton,MD
+NEWCASTLEPA.GOV,City,Non-Federal Agency,New Castle,PA
+NEWCONCORD-OH.GOV,City,Non-Federal Agency,New Concord,OH
+NEWHARMONY-IN.GOV,City,Non-Federal Agency,New Harmony,IN
+NEWHAVENCT.GOV,City,Non-Federal Agency,New Haven,CT
+NEWINGTONCT.GOV,City,Non-Federal Agency,Newington,CT
+NEWMARKETNH.GOV,City,Non-Federal Agency,Newmarket,NH
+NEWMARLBOROUGHMA.GOV,City,Non-Federal Agency,Mill River,MA
+NEWNANGA.GOV,City,Non-Federal Agency,Newnan,GA
+NEWORLEANS-LA.GOV,City,Non-Federal Agency,New Orleans,LA
+NEWORLEANSLA.GOV,City,Non-Federal Agency,New Orleans,LA
+NEWPORT-RI.GOV,City,Non-Federal Agency,Newport,RI
+NEWPORTBEACH-CA.GOV,City,Non-Federal Agency,Newport Beach,CA
+NEWPORTBEACHCA.GOV,City,Non-Federal Agency,Newport Beach,CA
+NEWPORTKY.GOV,City,Non-Federal Agency,Newport,KY
+NEWPORTNEWSVA.GOV,City,Non-Federal Agency,Newport News,VA
+NEWPORTOREGON.GOV,City,Non-Federal Agency,Newport,OR
+NEWRICHMONDWI.GOV,City,Non-Federal Agency,New Richmond ,WI
+NEWRUSSIATOWNSHIP-OH.GOV,City,Non-Federal Agency,Oberlin,OH
+NEWTON-NH.GOV,City,Non-Federal Agency,Newton,NH
+NEWTONNC.GOV,City,Non-Federal Agency,Newton,NC
+NEWTOWN-CT.GOV,City,Non-Federal Agency,Newtown,CT
+NEWTOWNOHIO.GOV,City,Non-Federal Agency,Newtown,OH
+NEWTOWNPA.GOV,City,Non-Federal Agency,Newtown,PA
+NIAGARAFALLSNY.GOV,City,Non-Federal Agency,Niagara Falls,NY
+NIAGARAFALLSNYCARTS.GOV,City,Non-Federal Agency,Niagara Falls,NY
+NILES-IL.GOV,City,Non-Federal Agency,Niles,IL
+NILESTWPMI.GOV,City,Non-Federal Agency,Niles,MI
+NINNEKAHOK.GOV,City,Non-Federal Agency,NINNEKAH,OK
+NISSEQUOGUENY.GOV,City,Non-Federal Agency,St. James,NY
+NIXAMO.GOV,City,Non-Federal Agency,Nixa,MO
+NNVA.GOV,City,Non-Federal Agency,Newport News,VA
+NOGALESAZ.GOV,City,Non-Federal Agency,Nogales,AZ
+NOLA.GOV,City,Non-Federal Agency,New Orleans,LA
+NOLENSVILLETN.GOV,City,Non-Federal Agency,Nolensville,TN
+NORFOLK.GOV,City,Non-Federal Agency,Norfolk,VA
+NORFOLKNE.GOV,City,Non-Federal Agency,Norfolk,NE
+NORFOLKVA.GOV,City,Non-Federal Agency,Norfolk,VA
+NORMANDYPARKWA.GOV,City,Non-Federal Agency,Normandy Park,WA
+NORMANOK.GOV,City,Non-Federal Agency,Norman,OK
+NORMANPARKGA.GOV,City,Non-Federal Agency,Norman Park,GA
+NORRIDGE-IL.GOV,City,Non-Federal Agency,Norridge,IL
+NORTHADAMS-MA.GOV,City,Non-Federal Agency,North Adams,MA
+NORTHAMPTONMA.GOV,City,Non-Federal Agency,Northampton,MA
+NORTHANDOVERMA.GOV,City,Non-Federal Agency,North Andover,MA
+NORTHBENDWA.GOV,City,Non-Federal Agency,North Bend,WA
+NORTHBOROUGH-MA.GOV,City,Non-Federal Agency,Northborough,MA
+NORTHBROOKIL.GOV,City,Non-Federal Agency,Northbrook,IL
+NORTHBRUNSWICKNJ.GOV,City,Non-Federal Agency,North Brunswick,NJ
+NORTHCANTONOHIO.GOV,City,Non-Federal Agency,North Canton,OH
+NORTHFIELD-VT.GOV,City,Non-Federal Agency,Northfield,VT
+NORTHFIELDVILLAGE-OH.GOV,City,Non-Federal Agency,NORTHFIELD,OH
+NORTHHAVEN-CT.GOV,City,Non-Federal Agency,North Haven,CT
+NORTHHEMPSTEADNY.GOV,City,Non-Federal Agency,MANHASSET,NY
+NORTHLEBANONTWPPA.GOV,City,Non-Federal Agency,Lebanon,PA
+NORTHPORTNY.GOV,City,Non-Federal Agency,Northport,NY
+NORTHPROVIDENCERI.GOV,City,Non-Federal Agency,North Providence,RI
+NORTHREADINGMA.GOV,City,Non-Federal Agency,North Reading,MA
+NORTHSIOUXCITY-SD.GOV,City,Non-Federal Agency,N. Sioux City,SD
+NORTHSTONINGTONCT.GOV,City,Non-Federal Agency,North Stonington,CT
+NORTHVERNON-IN.GOV,City,Non-Federal Agency,North Vernon,IN
+NORTONVA.GOV,City,Non-Federal Agency,Norton,VA
+NORWALKCA.GOV,City,Non-Federal Agency,Norwalk,CA
+NORWAYMI.GOV,City,Non-Federal Agency,Norway,MI
+NORWOOD-MA.GOV,City,Non-Federal Agency,Norwood,MA
+NORWOODMA.GOV,City,Non-Federal Agency,Norwood,MA
+NOTTINGHAM-NH.GOV,City,Non-Federal Agency,Nottingham,NH
+NOWATAOK.GOV,City,Non-Federal Agency,Nowata,OK
+NSIDFL.GOV,City,Non-Federal Agency,Coral Springs,FL
+NYACK-NY.GOV,City,Non-Federal Agency,Nyack,NY
+OAK-BROOK-IL.GOV,City,Non-Federal Agency,OAK BROOK,IL
+OAKBLUFFSMA.GOV,City,Non-Federal Agency,Oak Bluffs,MA
+OAKHAM-MA.GOV,City,Non-Federal Agency,Oakham,MA
+OAKLAND-ME.GOV,City,Non-Federal Agency,Oakland,ME
+OAKLANDCA.GOV,City,Non-Federal Agency,Oakland,CA
+OAKLANDPARKFL.GOV,City,Non-Federal Agency,Oakland Park,FL
+OAKLAWN-IL.GOV,City,Non-Federal Agency,OAK LAWN,IL
+OAKRIDGETN.GOV,City,Non-Federal Agency,"Oak Ridge, TN 37830 United States",TN
+OAKWOODOHIO.GOV,City,Non-Federal Agency,Oakwood,OH
+OBERLINKANSAS.GOV,City,Non-Federal Agency,Oberlin,KS
+OCCOQUANVA.GOV,City,Non-Federal Agency,Occoquan,VA
+OCEANAWV.GOV,City,Non-Federal Agency,Oceana,WV
+OCEANCITYMD.GOV,City,Non-Federal Agency,Ocean City ,MD
+OCEANGATE-NJ.GOV,City,Non-Federal Agency,Ocean Gate,NJ
+OCEANSPRINGS-MS.GOV,City,Non-Federal Agency,Ocean Springs,MS
+OCONOMOWOC-WI.GOV,City,Non-Federal Agency,Oconomowoc,WI
+OGDEN-KS.GOV,City,Non-Federal Agency,Ogden ,KS
+OLDSAYBROOKCT.GOV,City,Non-Federal Agency,Old Saybrook,CT
+OLIVERSPRINGS-TN.GOV,City,Non-Federal Agency,Oliver Springs,TN
+OMAHA-NE.GOV,City,Non-Federal Agency,Omaha,NE
+ONTARIOCA.GOV,City,Non-Federal Agency,Ontario,CA
+OPALOCKAFL.GOV,City,Non-Federal Agency,OPALOCKA,FL
+ORMONDBEACH-FL.GOV,City,Non-Federal Agency,Ormond Beach,FL
+OROVALLEYAZ.GOV,City,Non-Federal Agency,Oro Valley,AZ
+OSAGEBEACH-MO.GOV,City,Non-Federal Agency,OSAGE BEACH,MO
+OSCODATOWNSHIPMI.GOV,City,Non-Federal Agency,Oscoda,MI
+OTHELLOWA.GOV,City,Non-Federal Agency,Othello,WA
+OTISFIELDME.GOV,City,Non-Federal Agency,OTISFIELD,ME
+OTTAWAKS.GOV,City,Non-Federal Agency,Ottawa,KS
+OYSTERBAY-NY.GOV,City,Non-Federal Agency,Oyster Bay,NY
+PADUCAHKY.GOV,City,Non-Federal Agency,Paducah,KY
+PALATKA-FL.GOV,City,Non-Federal Agency,Palatka,FL
+PALMETTOBAY-FL.GOV,City,Non-Federal Agency,Palmetto Bay,FL
+PALMSPRINGS-CA.GOV,City,Non-Federal Agency,Palm Springs,CA
+PALMSPRINGSCA.GOV,City,Non-Federal Agency,Palm Springs,CA
+PALOSHILLS-IL.GOV,City,Non-Federal Agency,Palos Hills,IL
+PANORAMAVILLAGETX.GOV,City,Non-Federal Agency,Panorama Village,TX
+PARADISEVALLEYAZ.GOV,City,Non-Federal Agency,Paradise Valley,AZ
+PARISTEXAS.GOV,City,Non-Federal Agency,Paris,TX
+PARISTN.GOV,City,Non-Federal Agency,Paris,TN
+PARKERSBURGWV.GOV,City,Non-Federal Agency,Parkersburg,WV
+PARKVILLEMO.GOV,City,Non-Federal Agency,Parkville,MO
+PARMAHEIGHTSOH.GOV,City,Non-Federal Agency,Parma Heights,OH
+PASADENACA.GOV,City,Non-Federal Agency,Pasadena,CA
+PASADENATX.GOV,City,Non-Federal Agency,Pasadena,TX
+PASCO-WA.GOV,City,Non-Federal Agency,Pasco,WA
+PATAGONIA-AZ.GOV,City,Non-Federal Agency,Patagonia,AZ
+PATERSONNJ.GOV,City,Non-Federal Agency,Paterson,NJ
+PAWLING-NY.GOV,City,Non-Federal Agency,Pawling,NY
+PAWNEEROCK-KS.GOV,City,Non-Federal Agency,Pawnee Rock,KS
+PAXTONFL.GOV,City,Non-Federal Agency,Laurel Hill,FL
+PAYSONAZ.GOV,City,Non-Federal Agency,Payson,AZ
+PEABODY-MA.GOV,City,Non-Federal Agency,Peabody,MA
+PEABODYMA.GOV,City,Non-Federal Agency,PEABODY,MA
+PEARLANDTX.GOV,City,Non-Federal Agency,Pearland,TX
+PECOSTX.GOV,City,Non-Federal Agency,Pecos,TX
+PEMBROKE-MA.GOV,City,Non-Federal Agency,Pembroke,MA
+PEORIAHEIGHTS-IL.GOV,City,Non-Federal Agency,Peoria Heights,IL
+PERRYTOWNSHIP-IN.GOV,City,Non-Federal Agency,Indianapolis,IN
+PERTHAMBOYNJ.GOV,City,Non-Federal Agency,Perth Amboy,NJ
+PETERBOROUGHNH.GOV,City,Non-Federal Agency,Peterborough,NH
+PETERSBURGAK.GOV,City,Non-Federal Agency,Petersburg,AK
+PETERSBURGVA.GOV,City,Non-Federal Agency,Petersburg,VA
+PFLUGERVILLETX.GOV,City,Non-Federal Agency,Pflugerville,TX
+PHARR-TX.GOV,City,Non-Federal Agency,Pharr,TX
+PHILA.GOV,City,Non-Federal Agency,Philadelphia,PA
+PHILLIPSTON-MA.GOV,City,Non-Federal Agency,Phillipston,MA
+PHOENIXOREGON.GOV,City,Non-Federal Agency,Phoenix,OR
+PIEDMONT-OK.GOV,City,Non-Federal Agency,PIEDMONT,OK
+PIKEVILLEKY.GOV,City,Non-Federal Agency,Pikeville,KY
+PINEBLUFFSWY.GOV,City,Non-Federal Agency,Pine Bluffs,WY
+PINEPLAINS-NY.GOV,City,Non-Federal Agency,Pine Plains,NY
+PINEVILLENC.GOV,City,Non-Federal Agency,Pineville,NC
+PITTSBORONC.GOV,City,Non-Federal Agency,Pittsboro,NC
+PITTSBURGCA.GOV,City,Non-Federal Agency,PITTSBURG,CA
+PITTSBURGHPA.GOV,City,Non-Federal Agency,Pittsburgh,PA
+PITTSFIELD-MI.GOV,City,Non-Federal Agency,Ann Arbor,MI
+PITTSFIELDNH.GOV,City,Non-Federal Agency,Pittsfield,NH
+PLAINFIELDNJ.GOV,City,Non-Federal Agency,Plainfield,NJ
+PLANDOMEHEIGHTS-NY.GOV,City,Non-Federal Agency,Manhasset,NY
+PLEASANTONCA.GOV,City,Non-Federal Agency,Pleasanton,CA
+PLEASANTONTX.GOV,City,Non-Federal Agency,Pleasanton,TX
+PLEASANTVALLEY-NY.GOV,City,Non-Federal Agency,Pleasant Valley,NY
+PLEASANTVILLE-NY.GOV,City,Non-Federal Agency,Pleasantville,NY
+PLOVERWI.GOV,City,Non-Federal Agency,Plover,WI
+PLUMSTEAD.GOV,City,Non-Federal Agency,Plumsteadville,PA
+PLYMOUTH-MA.GOV,City,Non-Federal Agency,Plymouth,MA
+PLYMOUTHMN.GOV,City,Non-Federal Agency,Plymouth,MN
+POLKCITYIA.GOV,City,Non-Federal Agency,Polk City,IA
+POMPANOBEACHFL.GOV,City,Non-Federal Agency,Pompano Beach,FL
+POMPEY-NY.GOV,City,Non-Federal Agency,MANLIUS,NY
+PONCACITYOK.GOV,City,Non-Federal Agency,Ponca City,OK
+POOLER-GA.GOV,City,Non-Federal Agency,Pooler,GA
+POOLESVILLEMD.GOV,City,Non-Federal Agency,Poolesville,MD
+POPLARBLUFF-MO.GOV,City,Non-Federal Agency,Poplar Bluff,MO
+POQUOSON-VA.GOV,City,Non-Federal Agency,Poquioson,VA
+PORTAGEWI.GOV,City,Non-Federal Agency,Portage,WI
+PORTALESNM.GOV,City,Non-Federal Agency,Portales,NM
+PORTARTHURTX.GOV,City,Non-Federal Agency,Port Arthur,TX
+PORTCLINTON-OH.GOV,City,Non-Federal Agency,Port Clinton,OH
+PORTERVILLE-CA.GOV,City,Non-Federal Agency,Porterville,CA
+PORTERVILLECA.GOV,City,Non-Federal Agency,Porterville,CA
+PORTLANDMAINE.GOV,City,Non-Federal Agency,Portland,ME
+PORTLANDOREGON.GOV,City,Non-Federal Agency,Portland,OR
+PORTLANDTX.GOV,City,Non-Federal Agency,Portland,TX
+PORTSMOUTHVIRGINIA.GOV,City,Non-Federal Agency,Portsmouth,VA
+POTTERTWP-PA.GOV,City,Non-Federal Agency,Monaca,PA
+POWHATANVA.GOV,City,Non-Federal Agency,Powhatan,VA
+PRAIRIEDUCHIEN-WI.GOV,City,Non-Federal Agency,Prairie du Chien,WI
+PRAIRIEVIEWTEXAS.GOV,City,Non-Federal Agency,Prairie View,TX
+PRATTVILLE-AL.GOV,City,Non-Federal Agency,Prattville,AL
+PRATTVILLEAL.GOV,City,Non-Federal Agency,Prattville,AL
+PRESCOTT-AZ.GOV,City,Non-Federal Agency,Prescott,AZ
+PRESCOTTVALLEY-AZ.GOV,City,Non-Federal Agency,Prescott Valley,AZ
+PRESQUEISLEMAINE.GOV,City,Non-Federal Agency,Presque Isle,ME
+PRIESTRIVER-ID.GOV,City,Non-Federal Agency,Priest River,ID
+PRINCETONNJ.GOV,City,Non-Federal Agency,Princeton,NJ
+PRINCETONTX.GOV,City,Non-Federal Agency,Princeton,TX
+PROCTORMN.GOV,City,Non-Federal Agency,Proctor,MN
+PROSPERTX.GOV,City,Non-Federal Agency,Prosper,TX
+PROVIDENCERI.GOV,City,Non-Federal Agency,Providence,RI
+PURCELLVILLEVA.GOV,City,Non-Federal Agency,Purcellville,VA
+QUAKERTOWN-PA.GOV,City,Non-Federal Agency,Quakertown,PA
+QUINCYIL.GOV,City,Non-Federal Agency,Quincy,IL
+QUINCYMA.GOV,City,Non-Federal Agency,Quincy,MA
+RADFORDVA.GOV,City,Non-Federal Agency,Radford,VA
+RALEIGHNC.GOV,City,Non-Federal Agency,Raleigh,NC
+RANCHOMIRAGECA.GOV,City,Non-Federal Agency,Rancho Mirage,CA
+RANDOLPH-MA.GOV,City,Non-Federal Agency,Randolph,MA
+RANDOLPHTOWNSHIPOHIO.GOV,City,Non-Federal Agency,Randolph,OH
+RANGELY-CO.GOV,City,Non-Federal Agency,Rangely,CO
+RANGELYCO.GOV,City,Non-Federal Agency,Rangely,CO
+RATONNM.GOV,City,Non-Federal Agency,Raton,NM
+RAYCITYGA.GOV,City,Non-Federal Agency,Ray City,GA
+RAYMONDNH.GOV,City,Non-Federal Agency,Raymond,NH
+READINGMA.GOV,City,Non-Federal Agency,READING,MA
+READINGPA.GOV,City,Non-Federal Agency,Reading,PA
+READYHOUSTONTX.GOV,City,Non-Federal Agency,Houston,TX
+READYSOUTHTEXAS.GOV,City,Non-Federal Agency,San Antonio,TX
+READYSPRINGFIELDIL.GOV,City,Non-Federal Agency,Springfield,IL
+READYWESTLINNOR.GOV,City,Non-Federal Agency,West Linn,OR
+REDBANKTN.GOV,City,Non-Federal Agency,Red Bank,TN
+REDBAY-AL.GOV,City,Non-Federal Agency,Red Bay,AL
+REDMOND.GOV,City,Non-Federal Agency,Redmond,WA
+REMINGTON-VA.GOV,City,Non-Federal Agency,Remington,VA
+RENSSELAERNY.GOV,City,Non-Federal Agency,Rensselaer,NY
+RHEACOUNTYTN.GOV,City,Non-Federal Agency,Dayton,TN
+RHINEBECK-NY.GOV,City,Non-Federal Agency,Rhinebeck,NY
+RHINEBECKNY.GOV,City,Non-Federal Agency,Rhinebeck,NY
+RICETX.GOV,City,Non-Federal Agency,Rice,TX
+RICHFIELDWI.GOV,City,Non-Federal Agency,Hubertus,WI
+RICHLANDS-VA.GOV,City,Non-Federal Agency,Richlands,VA
+RICHLANDSNC.GOV,City,Non-Federal Agency,Richlands,NC
+RICHMOND-VA.GOV,City,Non-Federal Agency,Richmond,VA
+RICHMONDHILL-GA.GOV,City,Non-Federal Agency,Richmond Hill ,GA
+RICHMONDINDIANA.GOV,City,Non-Federal Agency,Richmond,IN
+RICHMONDTX.GOV,City,Non-Federal Agency,RICHMOND,TX
+RICHMONDVA.GOV,City,Non-Federal Agency,Richmond,VA
+RICHMONDVT.GOV,City,Non-Federal Agency,Richmond,VT
+RICHWOODTX.GOV,City,Non-Federal Agency,Richwood,TX
+RICHWOODWV.GOV,City,Non-Federal Agency,Richwood,WV
+RIDGECREST-CA.GOV,City,Non-Federal Agency,Ridgecrest,CA
+RIDGEFIELDNJ.GOV,City,Non-Federal Agency,Ridgefield,NJ
+RIDGELANDSC.GOV,City,Non-Federal Agency,Ridgeland,SC
+RITZVILLE-WA.GOV,City,Non-Federal Agency,Ritzville,WA
+RIVERDALEGA.GOV,City,Non-Federal Agency,Riverdale,GA
+RIVERDALENJ.GOV,City,Non-Federal Agency,Riverdale,NJ
+RIVERDALEPARKMD.GOV,City,Non-Federal Agency,Riverdale,MD
+RIVERSIDE-GA.GOV,City,Non-Federal Agency,Moultrie,GA
+RIVERSIDECA.GOV,City,Non-Federal Agency,Riverside,CA
+ROAMINGSHORESOH.GOV,City,Non-Federal Agency,Roaming Shores,OH
+ROANOKEVA.GOV,City,Non-Federal Agency,Roanoke,VA
+ROBINSONPA.GOV,City,Non-Federal Agency,McDonald,PA
+ROCKFORD-IL.GOV,City,Non-Federal Agency,Rockford,IL
+ROCKFORDIL.GOV,City,Non-Federal Agency,Rockford,IL
+ROCKHALLMD.GOV,City,Non-Federal Agency,Rock Hall,MD
+ROCKLAND-MA.GOV,City,Non-Federal Agency,Rockland,MA
+ROCKMART-GA.GOV,City,Non-Federal Agency,Rockmart,GA
+ROCKPORTMA.GOV,City,Non-Federal Agency,Rockport,MA
+ROCKPORTMAINE.GOV,City,Non-Federal Agency,Rockport,ME
+ROCKVILLE-IN.GOV,City,Non-Federal Agency,Rockville,IN
+ROCKVILLEMD.GOV,City,Non-Federal Agency,Rockville,MD
+ROCKWELLNC.GOV,City,Non-Federal Agency,Rockwell,NC
+ROCKYHILL-NJ.GOV,City,Non-Federal Agency,Rocky Hill,NJ
+ROCKYHILLCT.GOV,City,Non-Federal Agency,Rocky Hill,CT
+ROCKYMOUNTNC.GOV,City,Non-Federal Agency,Rocky Mount,NC
+ROCKYMOUNTVA.GOV,City,Non-Federal Agency,ROCKY MOUNT,VA
+ROGERSAR.GOV,City,Non-Federal Agency,Rogers,AR
+ROLESVILLENC.GOV,City,Non-Federal Agency,Rolesville,NC
+ROLLINGHILLSESTATES-CA.GOV,City,Non-Federal Agency,Rolling Hills Estates,CA
+ROLLINGHILLSESTATESCA.GOV,City,Non-Federal Agency,Rolling Hills Estates,CA
+ROME-NY.GOV,City,Non-Federal Agency,Rome,NY
+ROMULUS-MI.GOV,City,Non-Federal Agency,Romulus,MI
+ROSEVILLE-MI.GOV,City,Non-Federal Agency,Roseville,MI
+ROSLYNNY.GOV,City,Non-Federal Agency,Roslyn,NY
+ROSWELL-NM.GOV,City,Non-Federal Agency,Roswell,NM
+ROUNDROCKTEXAS.GOV,City,Non-Federal Agency,Round Rock,TX
+ROWE-MA.GOV,City,Non-Federal Agency,Rowe,MA
+ROWLETTTX.GOV,City,Non-Federal Agency,Rowlett,TX
+ROXBURY-CT.GOV,City,Non-Federal Agency,Roxbury,CT
+ROYALSTON-MA.GOV,City,Non-Federal Agency,Royalston,MA
+RPVCA.GOV,City,Non-Federal Agency,Rancho Palos Verdes,CA
+RRNM.GOV,City,Non-Federal Agency,Rio Rancho,NM
+RUIDOSO-NM.GOV,City,Non-Federal Agency,Ruidoso,NM
+RUMSONNJ.GOV,City,Non-Federal Agency,Rumson,NJ
+RUSSELLSPOINT-OH.GOV,City,Non-Federal Agency,Russells Point,OH
+RYENY.GOV,City,Non-Federal Agency,Rye,NY
+SACKETSHARBOR-NY.GOV,City,Non-Federal Agency,Sackets Harbor,NY
+SADDLEBROOKNJ.GOV,City,Non-Federal Agency,Saddlebrook,NJ
+SADDLEROCKNY.GOV,City,Non-Federal Agency,SADDLE ROCK,NY
+SAFFORDAZ.GOV,City,Non-Federal Agency,Safford,AZ
+SAGHARBORNY.GOV,City,Non-Federal Agency,Sag Harbor,NY
+SAHUARITAAZ.GOV,City,Non-Federal Agency,Sahuarita,AZ
+SAINTPETERMN.GOV,City,Non-Federal Agency,Saint Peter,MN
+SALADOTX.GOV,City,Non-Federal Agency,Salado,TX
+SALEMCT.GOV,City,Non-Federal Agency,Salem,CT
+SALEMVA.GOV,City,Non-Federal Agency,Salem,VA
+SALISBURYMA.GOV,City,Non-Federal Agency,Salisbury,MA
+SALISBURYNC.GOV,City,Non-Federal Agency,Salisbury,NC
+SALTLAKECITY-UT.GOV,City,Non-Federal Agency,Salt Lake City,UT
+SAMMAMISHWA.GOV,City,Non-Federal Agency,Sammamish,WA
+SANANTONIO.GOV,City,Non-Federal Agency,San Antonio,TX
+SANDYSPRINGS-GA.GOV,City,Non-Federal Agency,Sandy Springs,GA
+SANDYSPRINGSGA.GOV,City,Non-Federal Agency,Sandy Springs,GA
+SANFORDFL.GOV,City,Non-Federal Agency,Sanford,FL
+SANFRANCISCO-CA.GOV,City,Non-Federal Agency,San Francisco,CA
+SANJOSECA.GOV,City,Non-Federal Agency,San Jose,CA
+SANMARCOSTEXAS.GOV,City,Non-Federal Agency,San Marcos,TX
+SANMARCOSTX.GOV,City,Non-Federal Agency,San Marcos,TX
+SANMARINOCA.GOV,City,Non-Federal Agency,San Marino,CA
+SANPABLOCA.GOV,City,Non-Federal Agency,San Pablo,CA
+SANTACLARACA.GOV,City,Non-Federal Agency,Santa Clara,CA
+SANTACLARITACA.GOV,City,Non-Federal Agency,Santa Clarita,CA
+SANTAFENM.GOV,City,Non-Federal Agency,Santa Fe,NM
+SANTAMONICACA.GOV,City,Non-Federal Agency,Santa Monica,CA
+SARANACLAKENY.GOV,City,Non-Federal Agency,Saranac Lake,NY
+SARDISCITYAL.GOV,City,Non-Federal Agency,SARDIS CITY,AL
+SAUGUS-MA.GOV,City,Non-Federal Agency,Saugus,MA
+SAULTSTEMARIE-MI.GOV,City,Non-Federal Agency,Sault Ste Marie,MI
+SAVANNA-IL.GOV,City,Non-Federal Agency,Savanna,IL
+SAVANNAHGA.GOV,City,Non-Federal Agency,Savannah,GA
+SBMTD.GOV,City,Non-Federal Agency,Santa Barbara,CA
+SCHENECTADYNY.GOV,City,Non-Federal Agency,Schenectady,NY
+SCHERTZ-TX.GOV,City,Non-Federal Agency,Schertz,TX
+SCIENCEHILL-KY.GOV,City,Non-Federal Agency,Science Hill,KY
+SCITUATEMA.GOV,City,Non-Federal Agency,Scituate,MA
+SCOTCHPLAINSNJ.GOV,City,Non-Federal Agency,SCOTCH PLAINS,NJ
+SCRANTONPA.GOV,City,Non-Federal Agency,Scranton,PA
+SEABROOKTX.GOV,City,Non-Federal Agency,Seabrook,TX
+SEACLIFF-NY.GOV,City,Non-Federal Agency,Sea Cliff,NY
+SEALBEACHCA.GOV,City,Non-Federal Agency,Seal Beach,CA
+SEARANCHLAKESFLORIDA.GOV,City,Non-Federal Agency,Sea Ranch Lakes,FL
+SEATPLEASANTMD.GOV,City,Non-Federal Agency,Seat Pleasant,MD
+SEBEWAINGMI.GOV,City,Non-Federal Agency,Sebewaing,MI
+SECAUCUSNJ.GOV,City,Non-Federal Agency,Secaucus,NJ
+SEDONAAZ.GOV,City,Non-Federal Agency,Sedona,AZ
+SEEKONK-MA.GOV,City,Non-Federal Agency,Seekonk,MA
+SEGUINTEXAS.GOV,City,Non-Federal Agency,Seguin,TX
+SELAHWA.GOV,City,Non-Federal Agency,Selah,WA
+SELLERSBURG-IN.GOV,City,Non-Federal Agency,Sellersburg,IN
+SELMA-AL.GOV,City,Non-Federal Agency,Selma,AL
+SENECASC.GOV,City,Non-Federal Agency,Seneca,SC
+SEQUIMWA.GOV,City,Non-Federal Agency,SEQUIM,WA
+SHAKOPEEMN.GOV,City,Non-Federal Agency,Shakopee,MN
+SHEBOYGANFALLS-WI.GOV,City,Non-Federal Agency,Sheboygan Falls,WI
+SHEBOYGANWI.GOV,City,Non-Federal Agency,Sheboygan,WI
+SHEFFIELDMA.GOV,City,Non-Federal Agency,Sheffield,MA
+SHELTERCOVE-CA.GOV,City,Non-Federal Agency,Whitethorn,CA
+SHERWOODOREGON.GOV,City,Non-Federal Agency,Sherwood,OR
+SHIRLEY-MA.GOV,City,Non-Federal Agency,Shirley,MA
+SHIVELYKY.GOV,City,Non-Federal Agency,Shively,KY
+SHORELINE-WA.GOV,City,Non-Federal Agency,Shoreline,WA
+SHORELINEWA.GOV,City,Non-Federal Agency,Shoreline,WA
+SHOREVIEWMN.GOV,City,Non-Federal Agency,Shoreview,MN
+SHREVEPORTLA.GOV,City,Non-Federal Agency,Shreveport,LA
+SHREWSBURYMA.GOV,City,Non-Federal Agency,Shrewsbury,MA
+SIERRAVISTAAZ.GOV,City,Non-Federal Agency,Sierra Vista,AZ
+SIGNALMOUNTAINTN.GOV,City,Non-Federal Agency,Signal Mountain,TN
+SILVERCITYNM.GOV,City,Non-Federal Agency,Silver City,NM
+SILVERSPRINGTWP-PA.GOV,City,Non-Federal Agency,Mechanicsburg,PA
+SIMONTONTEXAS.GOV,City,Non-Federal Agency,simonton,TX
+SIOUXFALLSSD.GOV,City,Non-Federal Agency,Sioux Falls,SD
+SISTERBAYWI.GOV,City,Non-Federal Agency,Sister Bay,WI
+SLEEPYHOLLOWNY.GOV,City,Non-Federal Agency,Sleepy Hollow,NY
+SLIPPERYROCKBOROUGHPA.GOV,City,Non-Federal Agency,Slippery Rock,PA
+SMITHFIELDRI.GOV,City,Non-Federal Agency,Smithfield,RI
+SMITHFIELDVA.GOV,City,Non-Federal Agency,Smithfield,VA
+SMYRNAGA.GOV,City,Non-Federal Agency,Smyrna,GA
+SNOHOMISHWA.GOV,City,Non-Federal Agency,Snohomish,WA
+SNOWFLAKE-AZ.GOV,City,Non-Federal Agency,Snowflake,AZ
+SODDY-DAISY-TN.GOV,City,Non-Federal Agency,Soddy-Daisy,TN
+SODDY-DAISYTN.GOV,City,Non-Federal Agency,Soddy-Daisy,TN
+SODDYDAISY-TN.GOV,City,Non-Federal Agency,Soddy-Daisy,TN
+SODDYDAISYTN.GOV,City,Non-Federal Agency,Soddy-daisy,TN
+SOLWAYTOWNSHIP-MN.GOV,City,Non-Federal Agency,Cloquet,MN
+SOMERSCT.GOV,City,Non-Federal Agency,Somers,CT
+SOMERSETTX.GOV,City,Non-Federal Agency,Somerset,TX
+SOMERTONAZ.GOV,City,Non-Federal Agency,Somerton,AZ
+SOMERVILLEMA.GOV,City,Non-Federal Agency,Somerville,MA
+SOMERVILLETN.GOV,City,Non-Federal Agency,Town of Somerville,TN
+SOUTHABINGTONPA.GOV,City,Non-Federal Agency,Chinchilla,PA
+SOUTHAMBOYNJ.GOV,City,Non-Federal Agency,South Amboy,NJ
+SOUTHAMPTONTOWNNY.GOV,City,Non-Federal Agency,Southampton,NY
+SOUTHBEND-WA.GOV,City,Non-Federal Agency,South Bend,WA
+SOUTHBENDIN.GOV,City,Non-Federal Agency,South Bend,IN
+SOUTHBURY-CT.GOV,City,Non-Federal Agency,Southbury,CT
+SOUTHEAST-NY.GOV,City,Non-Federal Agency,BREWSTER,NY
+SOUTHHADLEYMA.GOV,City,Non-Federal Agency,South Hadley,MA
+SOUTHJORDANUTAH.GOV,City,Non-Federal Agency,South Jordan,UT
+SOUTHMIAMIFL.GOV,City,Non-Federal Agency,South Miami,FL
+SOUTHPADRETEXAS.GOV,City,Non-Federal Agency,South Padre Island,TX
+SOUTHPASADENACA.GOV,City,Non-Federal Agency,South Pasadena,CA
+SOUTHPITTSBURG-TN.GOV,City,Non-Federal Agency,South Pittsburg,TN
+SOUTHWILLIAMSPORT-PA.GOV,City,Non-Federal Agency,South Williamsport,PA
+SPEEDWAYIN.GOV,City,Non-Federal Agency,Speedway,IN
+SPENCERMA.GOV,City,Non-Federal Agency,Spencer,MA
+SPERRYOK.GOV,City,Non-Federal Agency,Sperry,OK
+SPIRITLAKEID.GOV,City,Non-Federal Agency,Spirit Lake,ID
+SPRINGCITYPA.GOV,City,Non-Federal Agency,Spring City,PA
+SPRINGDALEAR.GOV,City,Non-Federal Agency,Springdale,AR
+SPRINGERVILLEAZ.GOV,City,Non-Federal Agency,Springerville,AZ
+SPRINGFIELD-MA.GOV,City,Non-Federal Agency,Springfield,MA
+SPRINGFIELD-OR.GOV,City,Non-Federal Agency,Springfield,OR
+SPRINGFIELDMA.GOV,City,Non-Federal Agency,Springfield,MA
+SPRINGFIELDOHIO.GOV,City,Non-Federal Agency,Springfield,OH
+SPRINGHILLKS.GOV,City,Non-Federal Agency,Spring Hill,KS
+SPRINGHILLLOUISIANA.GOV,City,Non-Federal Agency,Springhill,LA
+SPRUCEPINE-NC.GOV,City,Non-Federal Agency,Spruce Pine,NC
+STAFFORDNJ.GOV,City,Non-Federal Agency,Manawhakin,NJ
+STAFFORDTX.GOV,City,Non-Federal Agency,stafford,TX
+STAMFORDCT.GOV,City,Non-Federal Agency,Stamford,CT
+STANHOPENJ.GOV,City,Non-Federal Agency,Stanhope,NJ
+STARNC.GOV,City,Non-Federal Agency,Star,NC
+STATECOLLEGEPA.GOV,City,Non-Federal Agency,State College,PA
+STATESBOROGA.GOV,City,Non-Federal Agency,Statesboro,GA
+STAYTONOREGON.GOV,City,Non-Federal Agency,Stayton,OR
+STCHARLESCITYMO.GOV,City,Non-Federal Agency,Saint Charles,MO
+STCROIXFALLSWI.GOV,City,Non-Federal Agency,City of St. Croix Falls,WI
+STEPHENVILLETX.GOV,City,Non-Federal Agency,Stephenville,TX
+STERLING-IL.GOV,City,Non-Federal Agency,Sterling,IL
+STERLING-MA.GOV,City,Non-Federal Agency,Sterling,MA
+STERLINGHEIGHTSMI.GOV,City,Non-Federal Agency,Sterling Heights,MI
+STJOHNSAZ.GOV,City,Non-Federal Agency,St. Johns,AZ
+STLOUIS-MO.GOV,City,Non-Federal Agency,St. Louis,MO
+STLUCIECO.GOV,City,Non-Federal Agency,Ft. Pierce,FL
+STMARYSGA.GOV,City,Non-Federal Agency,ST. MARYS,GA
+STMATTHEWSKY.GOV,City,Non-Federal Agency,Louisville,KY
+STOCKTONCA.GOV,City,Non-Federal Agency,Stockton,CA
+STONEHAM-MA.GOV,City,Non-Federal Agency,Stoneham,MA
+STONINGTON-CT.GOV,City,Non-Federal Agency,Stonington,CT
+STPAUL.GOV,City,Non-Federal Agency,Saint Paul,MN
+STPETE-FL.GOV,City,Non-Federal Agency,St. Petersburg,FL
+STRATHAMNH.GOV,City,Non-Federal Agency,Stratham,NH
+STURGIS-SD.GOV,City,Non-Federal Agency,Sturgis,SD
+STURGISMI.GOV,City,Non-Federal Agency,Sturgis,MI
+SUDBURY-MA.GOV,City,Non-Federal Agency,Sudbury,MA
+SUFFOLK-VA.GOV,City,Non-Federal Agency,Suffolk,VA
+SUGAR-LANDCITYTX.GOV,City,Non-Federal Agency,Sugar Land,TX
+SUGAR-LANDTX.GOV,City,Non-Federal Agency,Sugar Land,TX
+SUGARCITYIDAHO.GOV,City,Non-Federal Agency,Sugar City,ID
+SUGARLAND-CITYTX.GOV,City,Non-Federal Agency,Sugar Land,TX
+SUGARLAND-TX.GOV,City,Non-Federal Agency,Sugar Land,TX
+SUGARLANDCITY-TX.GOV,City,Non-Federal Agency,Sugar Land,TX
+SUGARLANDCITYTX.GOV,City,Non-Federal Agency,Sugar Land,TX
+SUGARLANDTX.GOV,City,Non-Federal Agency,Sugar Land,TX
+SULLIVANOHIO.GOV,City,Non-Federal Agency,Sullivan,OH
+SUMMERVILLESC.GOV,City,Non-Federal Agency,Summerville,SC
+SUMNERWA.GOV,City,Non-Federal Agency,Sumner,WA
+SUMTERSC.GOV,City,Non-Federal Agency,Sumter,SC
+SUNLANDPARK-NM.GOV,City,Non-Federal Agency,Sunland Park,NM
+SUNNYSIDE-WA.GOV,City,Non-Federal Agency,Sunnyside,WA
+SUNRISEBEACH-MO.GOV,City,Non-Federal Agency,Sunrise Beach,MO
+SUNSETBEACHNC.GOV,City,Non-Federal Agency,Sunset Beach,NC
+SUPERIORAZ.GOV,City,Non-Federal Agency,Superior,AZ
+SUPERIORCOLORADO.GOV,City,Non-Federal Agency,Superior,CO
+SURGOINSVILLETN.GOV,City,Non-Federal Agency,Surgoinsville,TN
+SURPRISEAZ.GOV,City,Non-Federal Agency,Surprise,AZ
+SYLACAUGAAL.GOV,City,Non-Federal Agency,Sylacauga,AL
+SYRACUSEKS.GOV,City,Non-Federal Agency,Syracuse,KS
+TABERNACLENJ.GOV,City,Non-Federal Agency,Tabernacle,NJ
+TACOMAWA.GOV,City,Non-Federal Agency,Tacoma,WA
+TAFTTX.GOV,City,Non-Federal Agency,TAFT,TX
+TALLAPOOSAGA.GOV,City,Non-Federal Agency,Tallapoosa,GA
+TALLASSEE-AL.GOV,City,Non-Federal Agency,Millbrook,AL
+TALLULAH-LA.GOV,City,Non-Federal Agency,Tallulah,LA
+TAMPAFL.GOV,City,Non-Federal Agency,Tampa,FL
+TAUNTON-MA.GOV,City,Non-Federal Agency,Taunton,MA
+TAYLORMILLKY.GOV,City,Non-Federal Agency,Taylor Mill,KY
+TAYLORSVILLEUT.GOV,City,Non-Federal Agency,Taylorsville ,UT
+TAYLORTX.GOV,City,Non-Federal Agency,Taylor,TX
+TEANECKNJ.GOV,City,Non-Federal Agency,Teaneck,NJ
+TEGACAYSC.GOV,City,Non-Federal Agency,Tega Cay,SC
+TELLURIDE-CO.GOV,City,Non-Federal Agency,Telluride,CO
+TEMECULACA.GOV,City,Non-Federal Agency,Temecula,CA
+TEMPE.GOV,City,Non-Federal Agency,Tempe,AZ
+TEMPLETX.GOV,City,Non-Federal Agency,Temple,TX
+TENNILLE-GA.GOV,City,Non-Federal Agency,Tennille,GA
+THECOLONYTX.GOV,City,Non-Federal Agency,The Colony,TX
+THEWOODLANDS-TX.GOV,City,Non-Federal Agency,The Woodlands,TX
+THEWOODLANDSTOWNSHIP-TX.GOV,City,Non-Federal Agency,The Woodlands,TX
+THOMASVILLE-NC.GOV,City,Non-Federal Agency,Thomasville,NC
+THORNBURG-PA.GOV,City,Non-Federal Agency,Pittsburgh,PA
+THORNEBAY-AK.GOV,City,Non-Federal Agency,Thorne Bay,AK
+TIFFINOHIO.GOV,City,Non-Federal Agency,Tiffin,OH
+TIGARD-OR.GOV,City,Non-Federal Agency,Tigard,OR
+TILLAMOOKOR.GOV,City,Non-Federal Agency,Tillamook,OR
+TIMNATH-CO.GOV,City,Non-Federal Agency,Timnath,CO
+TINLEYPARK-IL.GOV,City,Non-Federal Agency,Tinley Park,IL
+TINLEYPARKIL.GOV,City,Non-Federal Agency,Tinley Park,IL
+TIOGATX.GOV,City,Non-Federal Agency,Tioga,TX
+TIPPCITYOHIO.GOV,City,Non-Federal Agency,Tipp City,OH
+TISBURYMA.GOV,City,Non-Federal Agency,Tisbury,MA
+TOBYHANNATWPPA.GOV,City,Non-Federal Agency,Pocono Pines,PA
+TOLLAND-MA.GOV,City,Non-Federal Agency,Tolland,MA
+TOMBALLTX.GOV,City,Non-Federal Agency,Tomball,TX
+TOMPKINSVILLEKY.GOV,City,Non-Federal Agency,Tompkinsville,KY
+TOPSFIELD-MA.GOV,City,Non-Federal Agency,Topsfield,MA
+TORRANCECA.GOV,City,Non-Federal Agency,Torrance,CA
+TORREYUTAH.GOV,City,Non-Federal Agency,Torrey,UT
+TORRINGTON-CT.GOV,City,Non-Federal Agency,Torrington,CT
+TORRINGTONWY.GOV,City,Non-Federal Agency,Torrington,WY
+TOWNOFBETHLEHEM-NY.GOV,City,Non-Federal Agency,Delmar,NY
+TOWNOFBLOWINGROCKNC.GOV,City,Non-Federal Agency,Blowing Rock,NC
+TOWNOFBLYTHEWOODSC.GOV,City,Non-Federal Agency,Blythewood,SC
+TOWNOFCALLAHAN-FL.GOV,City,Non-Federal Agency,Callahan,FL
+TOWNOFCARRBORONC.GOV,City,Non-Federal Agency,Carrboro,NC
+TOWNOFCARYNC.GOV,City,Non-Federal Agency,Cary,NC
+TOWNOFCATSKILLNY.GOV,City,Non-Federal Agency,Catskill,NY
+TOWNOFCHADBOURNNC.GOV,City,Non-Federal Agency,Chadbourn,NC
+TOWNOFCLAYTONNC.GOV,City,Non-Federal Agency,Clayton,NC
+TOWNOFEASTHAVEN-CT.GOV,City,Non-Federal Agency,East Haven,CT
+TOWNOFHALFMOON-NY.GOV,City,Non-Federal Agency,Halfmoon,NY
+TOWNOFHAVERHILL-FL.GOV,City,Non-Federal Agency,Haverhill,FL
+TOWNOFHAYDENAZ.GOV,City,Non-Federal Agency,Hayden,AZ
+TOWNOFHOMECROFTIN.GOV,City,Non-Federal Agency,Indianapolis,IN
+TOWNOFHOUNSFIELD-NY.GOV,City,Non-Federal Agency,Watertown,NY
+TOWNOFISLIP-NY.GOV,City,Non-Federal Agency,Islip,NY
+TOWNOFKENTNY.GOV,City,Non-Federal Agency,Kent Lakes,NY
+TOWNOFLAPOINTEWI.GOV,City,Non-Federal Agency,La Pointe,WI
+TOWNOFLAVETA-CO.GOV,City,Non-Federal Agency,La Veta,CO
+TOWNOFMAYNARD-MA.GOV,City,Non-Federal Agency,Maynard,MA
+TOWNOFMONTEAGLE-TN.GOV,City,Non-Federal Agency,Monteagle,TN
+TOWNOFNASHVILLENC.GOV,City,Non-Federal Agency,Nashville,NC
+TOWNOFNORTH-SC.GOV,City,Non-Federal Agency,North,SC
+TOWNOFNORTHEASTNY.GOV,City,Non-Federal Agency,Millerton,NY
+TOWNOFORANGEVA.GOV,City,Non-Federal Agency,Orange,VA
+TOWNOFOYSTERBAY-NY.GOV,City,Non-Federal Agency,Oyster Bay,NY
+TOWNOFPENNINGTONVA.GOV,City,Non-Federal Agency,Pennington Gap,VA
+TOWNOFPOUGHKEEPSIE-NY.GOV,City,Non-Federal Agency,POUGHKEEPSIE,NY
+TOWNOFROBERSONVILLE-NC.GOV,City,Non-Federal Agency,Robersonville,NC
+TOWNOFSHIELDS-WI.GOV,City,Non-Federal Agency,Montello,WI
+TOWNOFSHIRLEY-MA.GOV,City,Non-Federal Agency,Shirley,MA
+TOWNOFSTLEO-FL.GOV,City,Non-Federal Agency,Saint Leo,FL
+TOWNOFSURFSIDEFL.GOV,City,Non-Federal Agency,Surfside,FL
+TOWNOFTROPICUT.GOV,City,Non-Federal Agency,Tropic,UT
+TOWNOFVASSNC.GOV,City,Non-Federal Agency,Vass,NC
+TOWNOFWALWORTHNY.GOV,City,Non-Federal Agency,Walworth,NY
+TOWNOFWARREN-RI.GOV,City,Non-Federal Agency,Warren,RI
+TOWNOFWASHINGTONVA.GOV,City,Non-Federal Agency,Washington,VA
+TOWNOFWOODSTOCKVA.GOV,City,Non-Federal Agency,Woodstock,VA
+TOWNSHIPOFTABERNACLE-NJ.GOV,City,Non-Federal Agency,Tabernacle,NJ
+TRAVERSECITYMI.GOV,City,Non-Federal Agency,Traverse City,MI
+TREASUREISLAND-FL.GOV,City,Non-Federal Agency,Treasure Island,FL
+TRENTONGA.GOV,City,Non-Federal Agency,trenton,GA
+TRICOUNTYCONSERVANCY-IN.GOV,City,Non-Federal Agency,Plainfield,IN
+TRINITY-NC.GOV,City,Non-Federal Agency,Trinity,NC
+TRINITYAL.GOV,City,Non-Federal Agency,Trinity,AL
+TROPHYCLUBTX.GOV,City,Non-Federal Agency,Trophy Club,TX
+TROUTDALEOREGON.GOV,City,Non-Federal Agency,Troutdale,OR
+TROUTMANNC.GOV,City,Non-Federal Agency,Troutman,NC
+TROYAL.GOV,City,Non-Federal Agency,Troy,AL
+TROYMI.GOV,City,Non-Federal Agency,Troy,MI
+TROYNY.GOV,City,Non-Federal Agency,Troy,NY
+TROYOHIO.GOV,City,Non-Federal Agency,Troy,OH
+TRUMANSBURG-NY.GOV,City,Non-Federal Agency,Trumansburg,NY
+TRUMBULL-CT.GOV,City,Non-Federal Agency,Trumbull,CT
+TRURO-MA.GOV,City,Non-Federal Agency,Truro,MA
+TUALATINOREGON.GOV,City,Non-Federal Agency,TUALATIN,OR
+TUKWILA-WA.GOV,City,Non-Federal Agency,Tukwila,WA
+TUKWILAWA.GOV,City,Non-Federal Agency,Tukwila,WA
+TULIA-TX.GOV,City,Non-Federal Agency,Tulia,TX
+TULLAHOMATN.GOV,City,Non-Federal Agency,Tullahoma,TN
+TUMWATERWA.GOV,City,Non-Federal Agency,Tumwater,WA
+TUPELOMS.GOV,City,Non-Federal Agency,Tupelo,MS
+TUSAYAN-AZ.GOV,City,Non-Federal Agency,Tusayan,AZ
+TUSAYANAZ.GOV,City,Non-Federal Agency,Grand Canyon,AZ
+TUSKEGEEALABAMA.GOV,City,Non-Federal Agency,Tuskegee,AL
+TUXEDOPARK-NY.GOV,City,Non-Federal Agency,Sloatsburg,NY
+TWPOCEANNJ.GOV,City,Non-Federal Agency,Waretown,NJ
+TYNGSBOROUGHMA.GOV,City,Non-Federal Agency,Tyngsborough,MA
+TYRINGHAM-MA.GOV,City,Non-Federal Agency,Tyringham,MA
+UCTX.GOV,City,Non-Federal Agency,Universal City,TX
+UNDERHILLVT.GOV,City,Non-Federal Agency,"Underhill, Ctr",VT
+UNIONCITY-IN.GOV,City,Non-Federal Agency,Union City,IN
+UNIONCITYNJ.GOV,City,Non-Federal Agency,Union City,NJ
+UNIONCITYTN.GOV,City,Non-Federal Agency,UNION CITY,TN
+UNIONGAPWA.GOV,City,Non-Federal Agency,Union Gap,WA
+UNIONSPRINGSAL.GOV,City,Non-Federal Agency,Union Springs,AL
+UNIONTWP-HCNJ.GOV,City,Non-Federal Agency,HAMPTON,NJ
+UNIVERSALCITYTEXAS.GOV,City,Non-Federal Agency,Universal City,TX
+UPLANDCA.GOV,City,Non-Federal Agency,UPLAND,CA
+UPPERMARLBOROMD.GOV,City,Non-Federal Agency,Upper Marlboro,MD
+UPPERUWCHLAN-PA.GOV,City,Non-Federal Agency,Chester Springs,PA
+UPTONMA.GOV,City,Non-Federal Agency,Upton,MA
+URBANAILLINOIS.GOV,City,Non-Federal Agency,Urbana,IL
+URBANNAVA.GOV,City,Non-Federal Agency,Urbanna,VA
+UTICA-IL.GOV,City,Non-Federal Agency,Utica,IL
+UVALDETX.GOV,City,Non-Federal Agency,Uvalde,TX
+UXBRIDGE-MA.GOV,City,Non-Federal Agency,Uxbridge,MA
+VANMETERIA.GOV,City,Non-Federal Agency,Van Meter,IA
+VENETAOREGON.GOV,City,Non-Federal Agency,Veneta,OR
+VERMONTVILLE-MI.GOV,City,Non-Federal Agency,Vermontville,MI
+VERNON-CT.GOV,City,Non-Federal Agency,Vernon,CT
+VERNONIA-OR.GOV,City,Non-Federal Agency,Vernonia,OR
+VERNONTX.GOV,City,Non-Federal Agency,Vernon,TX
+VERONAWI.GOV,City,Non-Federal Agency,Verona,WI
+VICKSBURGMS.GOV,City,Non-Federal Agency,Vicksburg,MS
+VICTORVILLECA.GOV,City,Non-Federal Agency,Victorville,CA
+VICTORYGARDENSNJ.GOV,City,Non-Federal Agency,Victory Gardens,NJ
+VIDALIAGA.GOV,City,Non-Federal Agency,VIDALIA,GA
+VIENNAVA.GOV,City,Non-Federal Agency,VIENNA,VA
+VILLAGEOFBABYLONNY.GOV,City,Non-Federal Agency,Babylon,NY
+VILLAGEOFCAMILLUS-NY.GOV,City,Non-Federal Agency,CAMILLUS,NY
+VILLAGEOFCRESTWOODIL.GOV,City,Non-Federal Agency,Crestwood,IL
+VILLAGEOFGOSHEN-NY.GOV,City,Non-Federal Agency,Goshen,NY
+VILLAGEOFHEMPSTEADNY.GOV,City,Non-Federal Agency,Hemsptead,NY
+VILLAGEOFKENSINGTONNY.GOV,City,Non-Federal Agency,Great Neck,NY
+VILLAGEOFMCCOMBOH.GOV,City,Non-Federal Agency,McComb,OH
+VILLAGEOFMISENHEIMERNC.GOV,City,Non-Federal Agency,Misenheimer,NC
+VILLAGEOFNEWHAVEN-MI.GOV,City,Non-Federal Agency,New Haven,MI
+VILLAGEOFNEWHOLLAND-OH.GOV,City,Non-Federal Agency,New Holland,OH
+VILLAGEOFNEWTOWNOHIO.GOV,City,Non-Federal Agency,Newtown,OH
+VILLAGEOFPHOENIX-NY.GOV,City,Non-Federal Agency,Phoenix,NY
+VILLAGEOFPINEHURSTNC.GOV,City,Non-Federal Agency,Pinehurst,NC
+VILLAGEOFQUOGUENY.GOV,City,Non-Federal Agency,Quogue,NY
+VILLAGEOFVOLENTE-TX.GOV,City,Non-Federal Agency,Volente,TX
+VILLAGEOFWAUCONDA-IL.GOV,City,Non-Federal Agency,Wauconda,IL
+VIRGINIAGARDENS-FL.GOV,City,Non-Federal Agency,Virginia Gardens,FL
+VOLENTETEXAS.GOV,City,Non-Federal Agency,Volente,TX
+VOLUNTOWN.GOV,City,Non-Federal Agency,Voluntown,CT
+WACOTX.GOV,City,Non-Federal Agency,Waco,TX
+WAITEHILLOH.GOV,City,Non-Federal Agency,Waite Hill,OH
+WAKEFORESTNC.GOV,City,Non-Federal Agency,WAKE FOREST,NC
+WALDENTN.GOV,City,Non-Federal Agency,Signal Mountain,TN
+WALKER-LA.GOV,City,Non-Federal Agency,Walker,LA
+WALKERSVILLEMD.GOV,City,Non-Federal Agency,Walkersville,MD
+WALLINGFORDCT.GOV,City,Non-Federal Agency,Wallingford,CT
+WALTONHILLSOHIO.GOV,City,Non-Federal Agency,Walton Hills,OH
+WANATAH-IN.GOV,City,Non-Federal Agency,Wanatah,IN
+WAPPINGERSFALLSNY.GOV,City,Non-Federal Agency,Wappingers Falls,NY
+WARNERROBINSGA.GOV,City,Non-Federal Agency,Warner Robins,GA
+WARREN-MA.GOV,City,Non-Federal Agency,Warren,MA
+WARRENTONVA.GOV,City,Non-Federal Agency,Warrenton,VA
+WARWICKRI.GOV,City,Non-Federal Agency,Warwick,RI
+WASHINGTON-WARRENAIRPORT-NC.GOV,City,Non-Federal Agency,WASHINGTON,NC
+WASHINGTONBORO-NJ.GOV,City,Non-Federal Agency,Washington,NJ
+WASHINGTONISLAND-WI.GOV,City,Non-Federal Agency,Washington Island,WI
+WASHINGTONVA.GOV,City,Non-Federal Agency,Washington,VA
+WASHINGTONVIRGINIA.GOV,City,Non-Federal Agency,Washington,VA
+WATCHUNGNJ.GOV,City,Non-Federal Agency,Watchung,NJ
+WATERBORO-ME.GOV,City,Non-Federal Agency,East Waterboro,ME
+WATERFORDMI.GOV,City,Non-Federal Agency,Waterford,MI
+WATERTOWN-MA.GOV,City,Non-Federal Agency,Watertown,MA
+WATERTOWN-NY.GOV,City,Non-Federal Agency,Watertown,NY
+WATERVILLE-ME.GOV,City,Non-Federal Agency,Waterville,ME
+WAUCONDA-IL.GOV,City,Non-Federal Agency,Wauconda,IL
+WAUKEGANIL.GOV,City,Non-Federal Agency,Waukegan,IL
+WAUKESHA-WI.GOV,City,Non-Federal Agency,Waukesha,WI
+WAVELAND-MS.GOV,City,Non-Federal Agency,Waveland,MS
+WAYNESVILLENC.GOV,City,Non-Federal Agency,Waynesville,NC
+WEATHERFORDTX.GOV,City,Non-Federal Agency,Weatherford,TX
+WEATHERLYPA.GOV,City,Non-Federal Agency,Weatherly,PA
+WEBSTER-MA.GOV,City,Non-Federal Agency,Webster,MA
+WEBSTER-NH.GOV,City,Non-Federal Agency,Webster,NH
+WEBSTERFL.GOV,City,Non-Federal Agency,Webster,FL
+WELAKA-FL.GOV,City,Non-Federal Agency,Welaka,FL
+WELLESLEYMA.GOV,City,Non-Federal Agency,Wellesley,MA
+WELLFLEET-MA.GOV,City,Non-Federal Agency,Wellfleet,MA
+WELLINGTONCOLORADO.GOV,City,Non-Federal Agency,Wellington,CO
+WELLINGTONFL.GOV,City,Non-Federal Agency,Wellington,FL
+WELLSBURGWV.GOV,City,Non-Federal Agency,WELLSBURG,WV
+WENATCHEEWA.GOV,City,Non-Federal Agency,Wenatchee,WA
+WESLACOTX.GOV,City,Non-Federal Agency,Weslaco,TX
+WESSONMS.GOV,City,Non-Federal Agency,Wesson,MS
+WESTALLISWI.GOV,City,Non-Federal Agency,West Allis,WI
+WESTAMPTONNJ.GOV,City,Non-Federal Agency,Westampton,NJ
+WESTBOYLSTON-MA.GOV,City,Non-Federal Agency,West Boylston,MA
+WESTBUECHELKY.GOV,City,Non-Federal Agency,WEST BUECHEL,KY
+WESTCOLUMBIASC.GOV,City,Non-Federal Agency,West Columbia,SC
+WESTFARGOND.GOV,City,Non-Federal Agency,Bismarck,ND
+WESTFIELDNJ.GOV,City,Non-Federal Agency,Westfield,NJ
+WESTFORD-MA.GOV,City,Non-Federal Agency,Westford,MA
+WESTFORDMA.GOV,City,Non-Federal Agency,Westford,MA
+WESTFRANKFORT-IL.GOV,City,Non-Federal Agency,West Frankfort,IL
+WESTHARTFORDCT.GOV,City,Non-Federal Agency,West Hartford,CT
+WESTHAVEN-CT.GOV,City,Non-Federal Agency,West Haven,CT
+WESTLINNOREGON.GOV,City,Non-Federal Agency,West Linn,OR
+WESTMILTONOHIO.GOV,City,Non-Federal Agency,West Milton,OH
+WESTMINSTER-MA.GOV,City,Non-Federal Agency,Westminster,MA
+WESTMINSTERMD.GOV,City,Non-Federal Agency,Westminster,MD
+WESTONCT.GOV,City,Non-Federal Agency,Weston,CT
+WESTONWI.GOV,City,Non-Federal Agency,Weston,WI
+WESTPALMBEACH-FL.GOV,City,Non-Federal Agency,West Palm Beach,FL
+WESTPORT-MA.GOV,City,Non-Federal Agency,Westport,MA
+WESTPORTCT.GOV,City,Non-Federal Agency,Westport,CT
+WESTSTOCKBRIDGE-MA.GOV,City,Non-Federal Agency,West Stockbridge,MA
+WESTTISBURY-MA.GOV,City,Non-Federal Agency,West Tisbury,MA
+WESTUTX.GOV,City,Non-Federal Agency,West University Place ,TX
+WESTWOOD-MA.GOV,City,Non-Federal Agency,Westwood,MA
+WESTWOODMA.GOV,City,Non-Federal Agency,Westwood,MA
+WESTWOODNJ.GOV,City,Non-Federal Agency,Westwood,NJ
+WETHERSFIELDCT.GOV,City,Non-Federal Agency,Wethersfield,CT
+WHEELINGIL.GOV,City,Non-Federal Agency,Wheeling,IL
+WHEELINGWV.GOV,City,Non-Federal Agency,Wheeling,WV
+WHITECOUNTY-IL.GOV,City,Non-Federal Agency,Carmi,IL
+WHITEHOUSEOH.GOV,City,Non-Federal Agency,Whitehouse,OH
+WHITEPLAINSNY.GOV,City,Non-Federal Agency,White Plains,NY
+WHITEWATER-WI.GOV,City,Non-Federal Agency,Whitewater,WI
+WHITINGWI.GOV,City,Non-Federal Agency,Stevens Point,WI
+WHITTIERALASKA.GOV,City,Non-Federal Agency,Whittier,AK
+WICHITA.GOV,City,Non-Federal Agency,Wichita,KS
+WICHITAFALLSTX.GOV,City,Non-Federal Agency,Wichita Falls,TX
+WILBRAHAM-MA.GOV,City,Non-Federal Agency,Wilbraham,MA
+WILDWOOD-FL.GOV,City,Non-Federal Agency,Wildwood,FL
+WILKINSBURGPA.GOV,City,Non-Federal Agency,Wilkinsburg,PA
+WILLAMINAOREGON.GOV,City,Non-Federal Agency,Willamina,OR
+WILLARDNM.GOV,City,Non-Federal Agency,Willard,NM
+WILLIAMSAZ.GOV,City,Non-Federal Agency,Williams,AZ
+WILLIAMSPORTMD.GOV,City,Non-Federal Agency,WILLIAMSPORT,MD
+WILLINGBORONJ.GOV,City,Non-Federal Agency,Willingboro,NJ
+WILLISTONFL.GOV,City,Non-Federal Agency,Williston,FL
+WILLMARMN.GOV,City,Non-Federal Agency,Willmar,MN
+WILLOUGHBYHILLS-OH.GOV,City,Non-Federal Agency,Willoughby Hills,OH
+WILLOWSPRINGS-IL.GOV,City,Non-Federal Agency,Willow Springs,IL
+WILMINGTONDE.GOV,City,Non-Federal Agency,Wilmington,DE
+WILMINGTONMA.GOV,City,Non-Federal Agency,wilmington,MA
+WILTONNH.GOV,City,Non-Federal Agency,Wilton,NH
+WINCHESTER-IN.GOV,City,Non-Federal Agency,Winchester,IN
+WINCHESTER-NH.GOV,City,Non-Federal Agency,Winchester,NH
+WINCHESTERVA.GOV,City,Non-Federal Agency,Winchester,VA
+WINDCREST-TX.GOV,City,Non-Federal Agency,Windcrest,TX
+WINDGAP-PA.GOV,City,Non-Federal Agency,Wind Gap,PA
+WINDHAMNH.GOV,City,Non-Federal Agency,Windham,NH
+WINDSOR-VA.GOV,City,Non-Federal Agency,Windsor,VA
+WINDSORWI.GOV,City,Non-Federal Agency,DeForest,WI
+WINNECONNEWI.GOV,City,Non-Federal Agency,Winneconne,WI
+WINSLOW-ME.GOV,City,Non-Federal Agency,Winslow,ME
+WOBURNMA.GOV,City,Non-Federal Agency,Woburn,MA
+WOODBURN-OR.GOV,City,Non-Federal Agency,Woodburn,OR
+WOODBURYMN.GOV,City,Non-Federal Agency,Woodbury,MN
+WOODFIN-NC.GOV,City,Non-Federal Agency,Woodfin,NC
+WOODHEIGHTS-MO.GOV,City,Non-Federal Agency,Wood Heights,MO
+WOODSTOCKCT.GOV,City,Non-Federal Agency,Woodstock,CT
+WOODSTOCKGA.GOV,City,Non-Federal Agency,Woodstock,GA
+WOODSTOCKIL.GOV,City,Non-Federal Agency,Woodstock,IL
+WOODVILLE-TX.GOV,City,Non-Federal Agency,Woodville,TX
+WORCESTERMA.GOV,City,Non-Federal Agency,Worcester,MA
+WRGA.GOV,City,Non-Federal Agency,Warner Robins,GA
+WSPMN.GOV,City,Non-Federal Agency,West Saint Paul,MN
+WVC-UT.GOV,City,Non-Federal Agency,West Valley,UT
+WYLIETEXAS.GOV,City,Non-Federal Agency,Wylie,TX
+WYOMINGMI.GOV,City,Non-Federal Agency,Wyoming,MI
+WYOMINGOHIO.GOV,City,Non-Federal Agency,Wyoming,OH
+XENIA-OH.GOV,City,Non-Federal Agency,Xenia,OH
+YAKIMAWA.GOV,City,Non-Federal Agency,Yakima,WA
+YONKERSNY.GOV,City,Non-Federal Agency,Yonkers,NY
+YORKTOWNTX.GOV,City,Non-Federal Agency,Yorktown,TX
+YOUNGSTOWNOHIO.GOV,City,Non-Federal Agency,Youngstown,OH
+YOUNGSVILLELA.GOV,City,Non-Federal Agency,Youngsville,LA
+YUMAAZ.GOV,City,Non-Federal Agency,Yuma,AZ
+ZILWAUKEEMICHIGAN.GOV,City,Non-Federal Agency,Zilwaukee,MI
+ICATCO.GOV,County,General Services Administration,Newton,NC
+ADAMSCOUNTYOH.GOV,County,Non-Federal Agency,West Union,OH
+AIKENCOUNTYSC.GOV,County,Non-Federal Agency,Aiken,SC
+ALEXANDERCOUNTY-NC.GOV,County,Non-Federal Agency,Taylorsville,NC
+ALLEGHANYCOUNTY-NC.GOV,County,Non-Federal Agency,Sparta,NC
+ALLEGHENYCOUNTYPA.GOV,County,Non-Federal Agency,Pittsburgh,PA
+ALPINECOUNTYCA.GOV,County,Non-Federal Agency,Markleeville,CA
+ANDROSCOGGINCOUNTYMAINE.GOV,County,Non-Federal Agency,Auburn,ME
+ANOKACOUNTYMN.GOV,County,Non-Federal Agency,Anoka,MN
+APPOMATTOXCOUNTYVA.GOV,County,Non-Federal Agency,Appomattox,VA
+ARANSASCOUNTYTX.GOV,County,Non-Federal Agency,Rockport,TX
+AUGUSTACOUNTY-VA.GOV,County,Non-Federal Agency,Verona,VA
+AUGUSTACOUNTYVA.GOV,County,Non-Federal Agency,Verona,VA
+AVERYCOUNTYNC.GOV,County,Non-Federal Agency,Newland,NC
+BACACOUNTYCO.GOV,County,Non-Federal Agency,Springfield,CO
+BALDWINCOUNTYAL.GOV,County,Non-Federal Agency,Bay Minette,AL
+BALTIMORECOUNTYMD.GOV,County,Non-Federal Agency,Towson,MD
+BAMBERGCOUNTYSC.GOV,County,Non-Federal Agency,Bamberg,SC
+BARNSTABLECOUNTY-MA.GOV,County,Non-Federal Agency,Barnstable,MA
+BARRONCOUNTYWI.GOV,County,Non-Federal Agency,Barron,WI
+BASTROPCOUNTYTEXAS.GOV,County,Non-Federal Agency,Bastrop,TX
+BAYCOUNTY911-MI.GOV,County,Non-Federal Agency,Bay City,MI
+BAYCOUNTYFL.GOV,County,Non-Federal Agency,Panama City,FL
+BEAVERCOUNTYPA.GOV,County,Non-Federal Agency,Beaver,PA
+BEDFORDCOUNTYVA.GOV,County,Non-Federal Agency,Bedford,VA
+BENTONCOUNTYAR.GOV,County,Non-Federal Agency,Bentonville,AR
+BENTONCOUNTYMS.GOV,County,Non-Federal Agency,Ashland,MS
+BENTONCOUNTYTN.GOV,County,Non-Federal Agency,Camden,TN
+BERKELEYCOUNTYSC.GOV,County,Non-Federal Agency,Moncks Corner,SC
+BERRIENCOUNTY-MI.GOV,County,Non-Federal Agency,St. Joseph,MI
+BIGHORNCOUNTYMT.GOV,County,Non-Federal Agency,Hardin,MT
+BILLINGSCOUNTYND.GOV,County,Non-Federal Agency,Medora,ND
+BLAINECOUNTY-MT.GOV,County,Non-Federal Agency,CHINOOK,MT
+BLANDCOUNTYVA.GOV,County,Non-Federal Agency,Bland,VA
+BLUEEARTHCOUNTYMN.GOV,County,Non-Federal Agency,Mankato,MN
+BONNERCOUNTYID.GOV,County,Non-Federal Agency,Sandpoint,ID
+BOONECOUNTY-AR.GOV,County,Non-Federal Agency,Harrison,AR
+BOSSIERPARISHLA.GOV,County,Non-Federal Agency,Benton ,LA
+BOTETOURTVA.GOV,County,Non-Federal Agency,Fincastle,VA
+BOULDERCOUNTYCOLORADO.GOV,County,Non-Federal Agency,Boulder,CO
+BOWMANCOUNTYND.GOV,County,Non-Federal Agency,Bismarck,ND
+BOYDCOUNTYKY.GOV,County,Non-Federal Agency,Catlettsburg,KY
+BRADFORDCOUNTYFL.GOV,County,Non-Federal Agency,Starke,FL
+BRADLEYCOUNTYTN.GOV,County,Non-Federal Agency,Cleveland,TN
+BRANCHCOUNTYMI.GOV,County,Non-Federal Agency,Coldwater,MI
+BRAZORIACOUNTY-TX.GOV,County,Non-Federal Agency,Angleton,TX
+BRAZORIACOUNTYTX.GOV,County,Non-Federal Agency,Angleton,TX
+BRAZOSCOUNTYTX.GOV,County,Non-Federal Agency,Bryan,TX
+BROOMECOUNTYNY.GOV,County,Non-Federal Agency,Binghamton,NY
+BROWNCOUNTY-IN.GOV,County,Non-Federal Agency,Nashville,IN
+BROWNCOUNTYOHIO.GOV,County,Non-Federal Agency,Georgetown,OH
+BROWNCOUNTYWI.GOV,County,Non-Federal Agency,Green Bay,WI
+BRUNSWICKCOUNTYNC.GOV,County,Non-Federal Agency,Bolivia,NC
+BUCHANANCOUNTY-VA.GOV,County,Non-Federal Agency,Grundy,VA
+BUNCOMBECOUNTYNC.GOV,County,Non-Federal Agency,Asheville,NC
+BUREAUCOUNTY-IL.GOV,County,Non-Federal Agency,Princeton,IL
+CABARRUSCOUNTYNC.GOV,County,Non-Federal Agency,Concord,NC
+CALHOUNCOUNTYAL.GOV,County,Non-Federal Agency,Anniston,AL
+CALHOUNCOUNTYMI.GOV,County,Non-Federal Agency,Marshall,MI
+CALLOWAYCOUNTY-KY.GOV,County,Non-Federal Agency,Murray,KY
+CAMBRIACOUNTYPA.GOV,County,Non-Federal Agency,Ebensburg,PA
+CAMDENCOUNTYNC.GOV,County,Non-Federal Agency,Camden,NC
+CAMPBELLCOUNTYKY.GOV,County,Non-Federal Agency,Newport,KY
+CAMPBELLCOUNTYTN.GOV,County,Non-Federal Agency,Jacksboro,TN
+CAMPBELLCOUNTYVA.GOV,County,Non-Federal Agency,Rustburg,VA
+CANDLERCO-GA.GOV,County,Non-Federal Agency,Metter,GA
+CAPECOD-MA.GOV,County,Non-Federal Agency,Barnstable,MA
+CAPEMAYCOUNTYNJ.GOV,County,Non-Federal Agency,Cape May Court House,NJ
+CAPITALALERT.GOV,County,Non-Federal Agency,Fairfax,VA
+CAPITALERT.GOV,County,Non-Federal Agency,Fairfax,VA
+CARROLLCOUNTYIN.GOV,County,Non-Federal Agency,Delphi,IN
+CARTERCOUNTYTN.GOV,County,Non-Federal Agency,Elizabethton,TN
+CARTERETCOUNTYNC.GOV,County,Non-Federal Agency,Beaufort,NC
+CASCADECOUNTYMT.GOV,County,Non-Federal Agency,Great Falls,MT
+CASSCOUNTYND.GOV,County,Non-Federal Agency,Bismarck,ND
+CATAWBACOUNTYNC.GOV,County,Non-Federal Agency,Newton,NC
+CATRONCOUNTYNM.GOV,County,Non-Federal Agency,Reserve,NM
+CEDARCOUNTYMO.GOV,County,Non-Federal Agency,Stockton,MO
+CENTRECOUNTYPA.GOV,County,Non-Federal Agency,Bellefonte,PA
+CHAMBERSCOUNTYAL.GOV,County,Non-Federal Agency,Lafayette,AL
+CHAMBERSTX.GOV,County,Non-Federal Agency,Anahuac,TX
+CHARLESCOUNTYMD.GOV,County,Non-Federal Agency,La Plata,MD
+CHARLOTTECOUNTYFL.GOV,County,Non-Federal Agency,Port Charlotte,FL
+CHEATHAMCOUNTYTN.GOV,County,Non-Federal Agency,Ashland City,TN
+CHELANCOUNTYWA.GOV,County,Non-Federal Agency,Wenatchee,WA
+CHEROKEECOUNTY-AL.GOV,County,Non-Federal Agency,Centre,AL
+CHEROKEECOUNTY-KS.GOV,County,Non-Federal Agency,Columbus,KS
+CHEROKEECOUNTYKS.GOV,County,Non-Federal Agency,Columbus,KS
+CHEROKEECOUNTYSC.GOV,County,Non-Federal Agency,Gaffney,SC
+CHEYENNECOUNTY-CO.GOV,County,Non-Federal Agency,CHEYENNE WELLS,CO
+CHRISTIANCOUNTYKY.GOV,County,Non-Federal Agency,Hopkinsville,KY
+CHRISTIANCOUNTYMO.GOV,County,Non-Federal Agency,Ozark,MO
+CLARKCOUNTYNV.GOV,County,Non-Federal Agency,Las Vegas,NV
+CLARKCOUNTYOHIO.GOV,County,Non-Federal Agency,Springfield,OH
+CLARKECOUNTYMS.GOV,County,Non-Federal Agency,Quitman,MS
+CLAYCOUNTYMN.GOV,County,Non-Federal Agency,Moorhead,MN
+CLAYCOUNTYMO.GOV,County,Non-Federal Agency,Liberty,MO
+CLAYTONCOUNTYGA.GOV,County,Non-Federal Agency,Jonesboro,GA
+CLAYTONCOUNTYIA.GOV,County,Non-Federal Agency,Elkader,IA
+CLERMONTCOUNTYOHIO.GOV,County,Non-Federal Agency,Batavia,OH
+CLINTONCOUNTY-IA.GOV,County,Non-Federal Agency,Clinton,IA
+COLUMBIACOUNTYGA.GOV,County,Non-Federal Agency,Evans,GA
+COLUMBIACOUNTYNY.GOV,County,Non-Federal Agency,Hudson,NY
+CONVERSECOUNTYWY.GOV,County,Non-Federal Agency,Douglas,WY
+COOKCOUNTYIL.GOV,County,Non-Federal Agency,Chicago,IL
+COOPERCOUNTYMO.GOV,County,Non-Federal Agency,Boonville,MO
+CORONADOCA.GOV,County,Non-Federal Agency,Coronado,CA
+COSCPINALCOUNTYAZ.GOV,County,Non-Federal Agency,Florence,AZ
+COSTILLACOUNTY-CO.GOV,County,Non-Federal Agency,San Luis,CO
+COUNTYOFPITT-NC.GOV,County,Non-Federal Agency,Greenville,NC
+COVINGTONCOUNTYMS.GOV,County,Non-Federal Agency,Collins,MS
+CRAIGCOUNTYVA.GOV,County,Non-Federal Agency,New Castle,VA
+CRAVENCOUNTYNC.GOV,County,Non-Federal Agency,New Bern,NC
+CRAWFORDCOUNTYKANSAS.GOV,County,Non-Federal Agency,Girard,KS
+CULPEPERCOUNTY.GOV,County,Non-Federal Agency,Culpeper,VA
+CUMBERLANDCOUNTYTN.GOV,County,Non-Federal Agency,Crossville,TN
+CURRITUCKCOUNTYNC.GOV,County,Non-Federal Agency,Currituck,NC
+DADECOUNTY-GA.GOV,County,Non-Federal Agency,Trenton,GA
+DAKOTACOUNTYMN.GOV,County,Non-Federal Agency,Hastings,MN
+DALLASCOUNTY-TX.GOV,County,Non-Federal Agency,Dallas,TX
+DALLASCOUNTYIOWA.GOV,County,Non-Federal Agency,Adel,IA
+DARECOUNTYNC.GOV,County,Non-Federal Agency,Manteo,NC
+DAVIDSONCOUNTYNC.GOV,County,Non-Federal Agency,Lexington,NC
+DAVIECOUNTYNC.GOV,County,Non-Federal Agency,Mocksville,NC
+DAVISCOUNTYUT4HEALTH.GOV,County,Non-Federal Agency,Farmington,UT
+DAVISUT4HEALTH.GOV,County,Non-Federal Agency,Farmington,UT
+DAWSONCOUNTYNE.GOV,County,Non-Federal Agency,Lexington,NE
+DCONC.GOV,County,Non-Federal Agency,Durham,NC
+DECATURCOUNTYGA.GOV,County,Non-Federal Agency,Bainbridge,GA
+DEKALBCOUNTYGA.GOV,County,Non-Federal Agency,Decatur,GA
+DEKALBCOUNTYIL.GOV,County,Non-Federal Agency,Sycamore,IL
+DESOTOCOUNTYMS.GOV,County,Non-Federal Agency,HERNANDO,MS
+DICKINSONCOUNTYMI.GOV,County,Non-Federal Agency,Iron Mountain,MI
+DICKSONCOUNTYTN.GOV,County,Non-Federal Agency,Charlotte,TN
+DOUGLASCOUNTY-NE.GOV,County,Non-Federal Agency,Omaha,NE
+DOUGLASCOUNTYNV.GOV,County,Non-Federal Agency,Minden,NV
+DUNNCOUNTYWI.GOV,County,Non-Federal Agency,Menomonie,WI
+DURHAMCOUNTYNC.GOV,County,Non-Federal Agency,Durham,NC
+ECTORCOUNTYTX.GOV,County,Non-Federal Agency,Odessa,TX
+ERIE.GOV,County,Non-Federal Agency,Buffalo,NY
+FAIRFAXCOUNTYVIRGINIA.GOV,County,Non-Federal Agency,Fairfax,VA
+FAUQUIERCOUNTY.GOV,County,Non-Federal Agency,Warrenton,VA
+FENTRESSCOUNTYTN.GOV,County,Non-Federal Agency,Jamestown,TN
+FORTBENDCOUNTYTX.GOV,County,Non-Federal Agency,Richmond,TX
+FRANKLINCOUNTYGA.GOV,County,Non-Federal Agency,Carnesville,GA
+FRANKLINCOUNTYIL.GOV,County,Non-Federal Agency,Benton,IL
+FRANKLINCOUNTYMAINE.GOV,County,Non-Federal Agency,Farmington,ME
+FRANKLINCOUNTYOHIO.GOV,County,Non-Federal Agency,Columbus,OH
+FRANKLINCOUNTYPA.GOV,County,Non-Federal Agency,Chambersburg,PA
+FRANKLINCOUNTYVA.GOV,County,Non-Federal Agency,Rocky Mount,VA
+FREDERICKCOUNTYMD.GOV,County,Non-Federal Agency,Frederick,MD
+FREDERICKCOUNTYVA.GOV,County,Non-Federal Agency,Winchester,VA
+FRIOCOUNTY-TX.GOV,County,Non-Federal Agency,Pearsall,TX
+FULTONCOUNTYGA.GOV,County,Non-Federal Agency,Atlanta,GA
+FULTONCOUNTYNY.GOV,County,Non-Federal Agency,Johnstown,NY
+GADSDENCOUNTYFL.GOV,County,Non-Federal Agency,Quincy,FL
+GALVESTONCOUNTYTX.GOV,County,Non-Federal Agency,Galveston,TX
+GARFIELDCOUNTY-CO.GOV,County,Non-Federal Agency,Glenwood Springs,CO
+GATESCOUNTYNC.GOV,County,Non-Federal Agency,Gatesville,NC
+GEORGECOUNTYMS.GOV,County,Non-Federal Agency,Lucedale,MS
+GGSC.GOV,County,Non-Federal Agency,Greenville,SC
+GIBSONCOUNTY-IN.GOV,County,Non-Federal Agency,Princeton,IN
+GILACOUNTYAZ.GOV,County,Non-Federal Agency,Globe,AZ
+GILMERCOUNTY-GA.GOV,County,Non-Federal Agency,Ellijay,GA
+GILMERCOUNTYWV.GOV,County,Non-Federal Agency,GLENVILLE,WV
+GLOUCESTERCOUNTYNJ.GOV,County,Non-Federal Agency,Woodbury,NJ
+GOGEBICCOUNTYMI.GOV,County,Non-Federal Agency,Bessemer,MI
+GOLIADCOUNTYTX.GOV,County,Non-Federal Agency,Goliad,TX
+GRADYCOUNTYGA.GOV,County,Non-Federal Agency,Cairo,GA
+GRANTCOUNTY-OR.GOV,County,Non-Federal Agency,Canyon City,OR
+GRANTCOUNTYWA.GOV,County,Non-Federal Agency,Ephrata,WA
+GREENECOUNTYGA.GOV,County,Non-Federal Agency,Greensboro,GA
+GREENECOUNTYMO.GOV,County,Non-Federal Agency,Springfield,MO
+GREENECOUNTYMS.GOV,County,Non-Federal Agency,Leaksville,MS
+GREENECOUNTYNC.GOV,County,Non-Federal Agency,Snow Hill,NC
+GREENHARRISCOUNTYTX.GOV,County,Non-Federal Agency,Houston,TX
+GREENMCHENRYCOUNTYIL.GOV,County,Non-Federal Agency,Woodstock,IL
+GREENMCHENRYCOUNTYILLINOIS.GOV,County,Non-Federal Agency,Woodstock,IL
+GREENVILLECOUNTYSC.GOV,County,Non-Federal Agency,Greenville,SC
+GREENWOODSC.GOV,County,Non-Federal Agency,Greenwood,SC
+GRIGGSCOUNTYND.GOV,County,Non-Federal Agency,Bismarck,ND
+GULFCOUNTY-FL.GOV,County,Non-Federal Agency,Port St. Joe,FL
+GWINNETTCOUNTYGA.GOV,County,Non-Federal Agency,Lawrenceville,GA
+HABERSHAMCOUNTY-GA.GOV,County,Non-Federal Agency,Clarkesville,GA
+HAINESALASKA.GOV,County,Non-Federal Agency,Haines,AK
+HALIFAXCOUNTYVA.GOV,County,Non-Federal Agency,Halifax,VA
+HALLCOUNTYGA.GOV,County,Non-Federal Agency,Gainesville,GA
+HALLCOUNTYNE.GOV,County,Non-Federal Agency,Grand Island,NE
+HAMBLENCOUNTYTN.GOV,County,Non-Federal Agency,Morristown,TN
+HAMILTONCOUNTYFLORIDA.GOV,County,Non-Federal Agency,Jasper,FL
+HAMILTONCOUNTYNY.GOV,County,Non-Federal Agency,Lake Pleasent,NY
+HAMILTONCOUNTYOHIO.GOV,County,Non-Federal Agency,Cincinnati,OH
+HANCOCKCOUNTY-IL.GOV,County,Non-Federal Agency,Carthage,IL
+HANCOCKCOUNTYGA.GOV,County,Non-Federal Agency,Sparta,GA
+HANCOCKCOUNTYMS.GOV,County,Non-Federal Agency,Bay St. Louis,MS
+HARALSONCOUNTYGA.GOV,County,Non-Federal Agency,Buchanan,GA
+HARDINCOUNTYIA.GOV,County,Non-Federal Agency,Eldora,IA
+HARRISCOUNTYGA.GOV,County,Non-Federal Agency,Hamilton,GA
+HARRISCOUNTYTX.GOV,County,Non-Federal Agency,Houston,TX
+HARTCOUNTYGA.GOV,County,Non-Federal Agency,Hartwell,GA
+HAWAIICOUNTY.GOV,County,Non-Federal Agency,Hilo,HI
+HAWKINSCOUNTYTN.GOV,County,Non-Federal Agency,Rogersville,TN
+HAYWOODCOUNTYNC.GOV,County,Non-Federal Agency,Waynesville,NC
+HENDERSONCOUNTYTN.GOV,County,Non-Federal Agency,Lexington,TN
+HENRYCOUNTYVA.GOV,County,Non-Federal Agency,Martinsville,VA
+HERTFORDCOUNTYNC.GOV,County,Non-Federal Agency,Winton,NC
+HINSDALECOUNTY-CO.GOV,County,Non-Federal Agency,Lake City,CO
+HOWARDCOUNTYIN.GOV,County,Non-Federal Agency,Kokomo,IN
+HOWARDCOUNTYMARYLAND.GOV,County,Non-Federal Agency,Ellicott City,MD
+HOWARDCOUNTYMD.GOV,County,Non-Federal Agency,Ellicott City,MD
+HURONCOUNTY-OH.GOV,County,Non-Federal Agency,Norwalk,OH
+HYDECOUNTYNC.GOV,County,Non-Federal Agency,Swanquarter,NC
+ISSAQUENACOUNTYMS.GOV,County,Non-Federal Agency,Mayersville,MS
+JACKSONCOGA.GOV,County,Non-Federal Agency,Jefferson,GA
+JACKSONCOUNTY-IL.GOV,County,Non-Federal Agency,Murphysboro,IL
+JAMESCITYCOUNTYVA.GOV,County,Non-Federal Agency,Williamsburg,VA
+JASPERCOUNTYIN.GOV,County,Non-Federal Agency,Rensselaer,IN
+JASPERCOUNTYSC.GOV,County,Non-Federal Agency,Ridgeland,SC
+JEFFERSONCOUNTY-MT.GOV,County,Non-Federal Agency,Boulder,MT
+JEFFERSONCOUNTYFL.GOV,County,Non-Federal Agency,Monticello,FL
+JEFFERSONCOUNTYGA.GOV,County,Non-Federal Agency,LOUISVILLE,GA
+JEFFERSONCOUNTYMS.GOV,County,Non-Federal Agency,Fayette,MS
+JEFFERSONCOUNTYTN.GOV,County,Non-Federal Agency,Dandridge,TN
+JEFFERSONCOUNTYWI.GOV,County,Non-Federal Agency,Jefferson,WI
+JENNINGSCOUNTY-IN.GOV,County,Non-Federal Agency,Vernon,IN
+JIMWELLSCOUNTY-TX.GOV,County,Non-Federal Agency,Alice,TX
+JONESCOUNTYNC.GOV,County,Non-Federal Agency,Trenton,NC
+KAUAI.GOV,County,Non-Federal Agency,Lihue,HI
+KENNEBECCOUNTY-ME.GOV,County,Non-Federal Agency,Augusta,ME
+KERNCOG-CA.GOV,County,Non-Federal Agency,Bakersfield,CA
+KINGCOUNTY.GOV,County,Non-Federal Agency,Seattle,WA
+KINGGEORGECOUNTYVA.GOV,County,Non-Federal Agency,King George,VA
+KINGSBURYNY.GOV,County,Non-Federal Agency,Hudson Falls,NY
+KNOXCOUNTYMAINE.GOV,County,Non-Federal Agency,Rockland,ME
+KNOXCOUNTYTEXAS.GOV,County,Non-Federal Agency,Benjamin,TX
+LACOUNTY.GOV,County,Non-Federal Agency,Downey,CA
+LAKECOUNTYCA.GOV,County,Non-Federal Agency,Lakeport,CA
+LAKECOUNTYIL.GOV,County,Non-Federal Agency,Waukegan,IL
+LAKECOUNTYOHIO.GOV,County,Non-Federal Agency,Painesville,OH
+LAKEMT.GOV,County,Non-Federal Agency,Polson,MT
+LAPAZCOUNTYAZ.GOV,County,Non-Federal Agency,Parker,AZ
+LAUDERDALECOUNTYAL.GOV,County,Non-Federal Agency,Florence,AL
+LAWRENCECOUNTYTN.GOV,County,Non-Federal Agency,Lawrenceburg,TN
+LCCOUNTYMT.GOV,County,Non-Federal Agency,Helena,MT
+LEE-COUNTY-FL.GOV,County,Non-Federal Agency,Fort Myers,FL
+LEECOUNTYNC.GOV,County,Non-Federal Agency,Sanford,NC
+LEONCOUNTYFL.GOV,County,Non-Federal Agency,Tallahassee,FL
+LEWISCOUNTYWA.GOV,County,Non-Federal Agency,Chehalis,WA
+LIBERTYCOUNTY-GA.GOV,County,Non-Federal Agency,Hinesville,GA
+LIMESTONECOUNTY-AL.GOV,County,Non-Federal Agency,Athens,AL
+LIMESTONECOUNTYEMA-AL.GOV,County,Non-Federal Agency,Athens,AL
+LINCOLNCOUNTYNM.GOV,County,Non-Federal Agency,Carrizozo,NM
+LIVINGSTONCOUNTYIL.GOV,County,Non-Federal Agency,Pontiac,IL
+LIVINGSTONPARISHLA.GOV,County,Non-Federal Agency,Livingston,LA
+LOGANCOUNTYCO.GOV,County,Non-Federal Agency,Sterling,CO
+LOUDONCOUNTY-TN.GOV,County,Non-Federal Agency,Loudon,TN
+LOUDOUN.GOV,County,Non-Federal Agency,Leesburg,VA
+LOWNDESCOUNTYGA.GOV,County,Non-Federal Agency,Valdosta,GA
+LUCASCOUNTYOH.GOV,County,Non-Federal Agency,Toledo,OH
+LUMPKINCOUNTY.GOV,County,Non-Federal Agency,Dahlonega,GA
+MACOMBCOUNTYMI.GOV,County,Non-Federal Agency,Mount Clemens,MI
+MACONBIBBCOUNTYGA.GOV,County,Non-Federal Agency,Macon,GA
+MACONCOUNTYGA.GOV,County,Non-Federal Agency,Oglethorpe,GA
+MACONCOUNTYTN.GOV,County,Non-Federal Agency,Lafayette,TN
+MACOUPINCOUNTYIL.GOV,County,Non-Federal Agency,Carlinville,IL
+MADISONCOUNTYAL.GOV,County,Non-Federal Agency,Huntsville,AL
+MADISONCOUNTYNC.GOV,County,Non-Federal Agency,Marshall,NC
+MADISONCOUNTYTN.GOV,County,Non-Federal Agency,Jackson,TN
+MAHONINGCOUNTYOH.GOV,County,Non-Federal Agency,Youngstown,OH
+MANISTEECOUNTYMI.GOV,County,Non-Federal Agency,Manistee,MI
+MARIONCOUNTY-MO.GOV,County,Non-Federal Agency,Hannibal,MO
+MARSHALLCOUNTYIA.GOV,County,Non-Federal Agency,Marshalltown,IA
+MARSHALLCOUNTYKY.GOV,County,Non-Federal Agency,Benton,KY
+MATHEWSCOUNTYVA.GOV,County,Non-Federal Agency,Mathews,VA
+MAUICOUNTY-HI.GOV,County,Non-Federal Agency,Wailuku,HI
+MAUICOUNTY.GOV,County,Non-Federal Agency,Wailuku,HI
+MCCRACKENCOUNTYKY.GOV,County,Non-Federal Agency,Paducah,KY
+MCDONALDCOUNTYMO.GOV,County,Non-Federal Agency,Pineville,MO
+MCHENRYCOUNTYIL.GOV,County,Non-Federal Agency,Woodstock,IL
+MCHENRYCOUNTYILLINOIS.GOV,County,Non-Federal Agency,Woodstock,IL
+MCINTOSHCOUNTY-GA.GOV,County,Non-Federal Agency,Darien,GA
+MCLEANCOUNTYIL.GOV,County,Non-Federal Agency,Bloomington,IL
+MCLEANCOUNTYND.GOV,County,Non-Federal Agency,Washburn,ND
+MCMINNCOUNTYTN.GOV,County,Non-Federal Agency,Athens,TN
+MEADEKY.GOV,County,Non-Federal Agency,Brandenburg,KY
+MECKLENBURGCOUNTYNC.GOV,County,Non-Federal Agency,Charlotte,NC
+MEETEETSECD-WY.GOV,County,Non-Federal Agency,Meeteetse,WY
+MERCEDCOUNTYCA.GOV,County,Non-Federal Agency,Merced,CA
+MERIWETHERCOUNTYGA.GOV,County,Non-Federal Agency,Greenville,GA
+MIAMI-DADE.GOV,County,Non-Federal Agency,Miami,FL
+MIAMICOUNTYIN.GOV,County,Non-Federal Agency,Peru,IN
+MIAMICOUNTYOHIO.GOV,County,Non-Federal Agency,Troy,OH
+MIAMIDADE.GOV,County,Non-Federal Agency,Miami,FL
+MIAMIDADECOUNTY-FL.GOV,County,Non-Federal Agency,Miami,FL
+MIAMIDADECOUNTYFL.GOV,County,Non-Federal Agency,Miami,FL
+MILWAUKEECOUNTY-WI.GOV,County,Non-Federal Agency,Milwaukee,WI
+MILWAUKEECOUNTYWI.GOV,County,Non-Federal Agency,Milwaukee,WI
+MOBILECOUNTYAL.GOV,County,Non-Federal Agency,Mobile,AL
+MONROECOUNTY-FL.GOV,County,Non-Federal Agency,Key West,FL
+MONROECOUNTY.GOV,County,Non-Federal Agency,Rochester,NY
+MONROECOUNTYAL.GOV,County,Non-Federal Agency,Monroeville,AL
+MONTGOMERYCOUNTYGA.GOV,County,Non-Federal Agency,mt. vernon,GA
+MONTGOMERYCOUNTYMD.GOV,County,Non-Federal Agency,Rockville,MD
+MONTGOMERYCOUNTYVA.GOV,County,Non-Federal Agency,Christiansburg,VA
+MORGANCOUNTY-OH.GOV,County,Non-Federal Agency,McConnelsville,OH
+MORGANCOUNTYTN.GOV,County,Non-Federal Agency,wartburg,TN
+MORGANCOUNTYWV.GOV,County,Non-Federal Agency,Berkeley Springs,WV
+MORRISCOUNTYNJ.GOV,County,Non-Federal Agency,Morristown,NJ
+MORROWCOUNTYOHIO.GOV,County,Non-Federal Agency,Mount Gilead,OH
+NAVAJOCOUNTYAZ.GOV,County,Non-Federal Agency,Holbrook,AZ
+NOBLECOUNTYOHIO.GOV,County,Non-Federal Agency,Caldwell,OH
+NWCLEANAIRWA.GOV,County,Non-Federal Agency,Mount Vernon,WA
+OAKLANDCOUNTYMI.GOV,County,Non-Federal Agency,Pontiac,MI
+OGEMAWCOUNTYMI.GOV,County,Non-Federal Agency,West Branch,MI
+OGLETHORPECOUNTYGA.GOV,County,Non-Federal Agency,Lexington,GA
+OHIOCOUNTYKY.GOV,County,Non-Federal Agency,Hartford,KY
+OHIOCOUNTYWV.GOV,County,Non-Federal Agency,Wheeling,WV
+OLDHAMCOUNTYKY.GOV,County,Non-Federal Agency,La Grange,KY
+ORANGECOUNTY-VA.GOV,County,Non-Federal Agency,ORANGE,VA
+ORANGECOUNTYNC.GOV,County,Non-Federal Agency,Hillsborough,NC
+ORANGECOUNTYVA.GOV,County,Non-Federal Agency,Orange,VA
+ORANGECOUNTYVT.GOV,County,Non-Federal Agency,Chelsea,VT
+ORLEANSCOUNTYNY.GOV,County,Non-Federal Agency,Albion,NY
+OSWEGOCOUNTYNY.GOV,County,Non-Federal Agency,Oswego,NY
+OTSEGOCOUNTYMI.GOV,County,Non-Federal Agency,Gaylord,MI
+OURAYCOUNTYCO.GOV,County,Non-Federal Agency,Ouray,CO
+PARKECOUNTY-IN.GOV,County,Non-Federal Agency,Rockville,IN
+PENDERCOUNTYNC.GOV,County,Non-Federal Agency,Burgaw,NC
+PERQUIMANSCOUNTYNC.GOV,County,Non-Federal Agency,Hertford,NC
+PICKENSCOUNTYGA.GOV,County,Non-Federal Agency,Jasper,GA
+PIERCECOUNTYGA.GOV,County,Non-Federal Agency,Blackshear,GA
+PIERCECOUNTYND.GOV,County,Non-Federal Agency,Rugby,ND
+PIERCECOUNTYWA.GOV,County,Non-Federal Agency,Tacoma,WA
+PIKECOUNTY-MO.GOV,County,Non-Federal Agency,Bowling Green,MO
+PIKECOUNTYKY.GOV,County,Non-Federal Agency,Pikeville,KY
+PIMA.GOV,County,Non-Federal Agency,Tucson,AZ
+PINALCOUNTYAZ.GOV,County,Non-Federal Agency,Florence,AZ
+PINELLAS.GOV,County,Non-Federal Agency,Clearwater,FL
+PITTCOUNTY-NC.GOV,County,Non-Federal Agency,Greenville,NC
+PITTCOUNTYNC.GOV,County,Non-Federal Agency,Greenville,NC
+PITTSYLVANIACOUNTYVA.GOV,County,Non-Federal Agency,Chatham,VA
+PLYMOUTHCOUNTY-MA.GOV,County,Non-Federal Agency,Plymouth,MA
+POLKCOUNTYIOWA.GOV,County,Non-Federal Agency,Des Moines,IA
+PORTAGECOUNTYWI.GOV,County,Non-Federal Agency,Stevens Point,WI
+POSEYCOUNTYIN.GOV,County,Non-Federal Agency,Mount Vernon,IN
+POTTAWATTAMIECOUNTY-IA.GOV,County,Non-Federal Agency,COUNCIL BLUFFS,IA
+POTTCOUNTY-IA.GOV,County,Non-Federal Agency,COUNCIL BLUFFS,IA
+POWELLCOUNTYMT.GOV,County,Non-Federal Agency,Deer Lodge,MT
+PRESTONCOUNTYWV.GOV,County,Non-Federal Agency,Kingwood,WV
+PRINCEGEORGESCOUNTYMD.GOV,County,Non-Federal Agency,Largo,MD
+PUEBLOCOUNTYCO.GOV,County,Non-Federal Agency,Pueblo,CO
+PULASKICOUNTYIL.GOV,County,Non-Federal Agency,Ullin,IL
+PUTNAMCOUNTYNY.GOV,County,Non-Federal Agency,Carmel,NY
+PUTNAMCOUNTYOHIO.GOV,County,Non-Federal Agency,Ottawa,OH
+QUAYCOUNTY-NM.GOV,County,Non-Federal Agency,Tucumcari,NM
+RANDOLPHCOUNTY-MO.GOV,County,Non-Federal Agency,Huntsville,MO
+RANDOLPHCOUNTYALABAMA.GOV,County,Non-Federal Agency,Wedowee,AL
+RANDOLPHCOUNTYNC.GOV,County,Non-Federal Agency,Asheboro,NC
+RAPPAHANNOCKCOUNTYVA.GOV,County,Non-Federal Agency,Washington,VA
+READYALBANYCOUNTY-NY.GOV,County,Non-Federal Agency,Albany,NY
+READYHARRISCOUNTYTX.GOV,County,Non-Federal Agency,Houston,TX
+READYMCHENRYCOUNTYIL.GOV,County,Non-Federal Agency,Woodstock,IL
+READYMCHENRYCOUNTYILLINOIS.GOV,County,Non-Federal Agency,Woodstock,IL
+REYNOLDSCOUNTY-MO.GOV,County,Non-Federal Agency,Centerville,MO
+RILEYCOUNTYKS.GOV,County,Non-Federal Agency,Manhattan,KS
+ROANECOUNTYTN.GOV,County,Non-Federal Agency,Kingston,TN
+ROCKBRIDGECOUNTYVA.GOV,County,Non-Federal Agency,Lexington,VA
+ROCKCOUNTY-WI.GOV,County,Non-Federal Agency,Janesville,WI
+ROCKDALECOUNTYGA.GOV,County,Non-Federal Agency,Conyers,GA
+ROSEBUDCOUNTYMT.GOV,County,Non-Federal Agency,Forsyth,MT
+ROSSCOUNTYOHIO.GOV,County,Non-Federal Agency,Chillicothe,OH
+RUTHERFORDCOUNTYNC.GOV,County,Non-Federal Agency,Rutherfordton,NC
+RUTHERFORDCOUNTYTN.GOV,County,Non-Federal Agency,Murfreesboro,TN
+SAGUACHECOUNTY-CO.GOV,County,Non-Federal Agency,Saguache,CO
+SALEMCOUNTYNJ.GOV,County,Non-Federal Agency,Salem,NJ
+SANDIEGOCOUNTY.GOV,County,Non-Federal Agency,San Diego,CA
+SANDOVALCOUNTYNM.GOV,County,Non-Federal Agency,Bernalillo,NM
+SANMIGUELCOUNTYCO.GOV,County,Non-Federal Agency,TELLURIDE,CO
+SANPETECOUNTY-UT.GOV,County,Non-Federal Agency,Manti,UT
+SANTACLARACOUNTYCA.GOV,County,Non-Federal Agency,San Jose,CA
+SANTACRUZCOUNTYAZ.GOV,County,Non-Federal Agency,Nogales,AZ
+SANTAFECOUNTYNM.GOV,County,Non-Federal Agency,Santa Fe,NM
+SARATOGACOUNTYNY.GOV,County,Non-Federal Agency,Ballston Spa,NY
+SBCOUNTY.GOV,County,Non-Federal Agency,San Bernardino,CA
+SCOTTCOUNTY-TN.GOV,County,Non-Federal Agency,Huntsville,TN
+SCOTTCOUNTYMN.GOV,County,Non-Federal Agency,Shakopee,MN
+SEBASTIANCOUNTYAR.GOV,County,Non-Federal Agency,Fort Smith,AR
+SEQUATCHIECOUNTY-TN.GOV,County,Non-Federal Agency,Dunlap,TN
+SEVIERCOUNTYTN.GOV,County,Non-Federal Agency,Sevierville,TN
+SHARKEYCOUNTYMS.GOV,County,Non-Federal Agency,Rolling Fork,MS
+SHELBYCOUNTYTN.GOV,County,Non-Federal Agency,Memphis,TN
+SIERRACOUNTYNM.GOV,County,Non-Federal Agency,Truth or Consequences,NM
+SONOMACOUNTYCA.GOV,County,Non-Federal Agency,Santa Rosa,CA
+SPENCERCOUNTYKY.GOV,County,Non-Federal Agency,Taylorsville,KY
+SPOTSYLVANIACOUNTY-VA.GOV,County,Non-Federal Agency,Spotsylvania,VA
+SPOTSYLVANIACOUNTYVA.GOV,County,Non-Federal Agency,Spotsylvania,VA
+STAFFORDCOUNTYVA.GOV,County,Non-Federal Agency,Stafford,VA
+STANLYCOUNTYNC.GOV,County,Non-Federal Agency,Albemarle,NC
+STARKCOUNTYND.GOV,County,Non-Federal Agency,Bismarck,ND
+STARKCOUNTYOHIO.GOV,County,Non-Federal Agency,Canton,OH
+STCHARLESPARISH-LA.GOV,County,Non-Federal Agency,Hahnville,LA
+STCLAIRCOUNTYIL.GOV,County,Non-Federal Agency,Belleville,IL
+STEARNSCOUNTYMN.GOV,County,Non-Federal Agency,Saint Cloud,MN
+STEWARTCOUNTYGA.GOV,County,Non-Federal Agency,Lumpkin,GA
+STLOUISCOUNTYMN.GOV,County,Non-Federal Agency,Duluth,MN
+STMARYPARISHLA.GOV,County,Non-Federal Agency,FRANKLIN,LA
+STOKESCOUNTYNC.GOV,County,Non-Federal Agency,Danbury,NC
+STORYCOUNTYIOWA.GOV,County,Non-Federal Agency,Nevada,IA
+SULLIVANCOUNTYTN.GOV,County,Non-Federal Agency,Blountville,TN
+SUMMERSCOUNTYWV.GOV,County,Non-Federal Agency,Hinton,WV
+SUMMITCOUNTYCO.GOV,County,Non-Federal Agency,Breckenridge,CO
+SUMTERCOUNTYFL.GOV,County,Non-Federal Agency,Bushnell,FL
+SURRYCOUNTYVA.GOV,County,Non-Federal Agency,Surry,VA
+SUSSEXCOUNTYDE.GOV,County,Non-Federal Agency,Georgetown,DE
+SUSSEXCOUNTYVA.GOV,County,Non-Federal Agency,Sussex,VA
+SWAINCOUNTYNC.GOV,County,Non-Federal Agency,Bryson City,NC
+TALBOTCOUNTYMD.GOV,County,Non-Federal Agency,Easton,MD
+TAMACOUNTYIOWA.GOV,County,Non-Federal Agency,Toledo,IA
+TARRANTCOUNTYTX.GOV,County,Non-Federal Agency,Fort Worth,TX
+TETONCOUNTYIDAHO.GOV,County,Non-Federal Agency,Driggs,ID
+TEXASCOUNTYMISSOURI.GOV,County,Non-Federal Agency,Houston,MO
+THAYERCOUNTYNE.GOV,County,Non-Federal Agency,Hebron,NE
+THOMASCOUNTYGA.GOV,County,Non-Federal Agency,Thomasville,GA
+TOMPKINSCOUNTYNY.GOV,County,Non-Federal Agency,Ithaca,NY
+TOOELECOUNTYUT.GOV,County,Non-Federal Agency,Tooele,UT
+TOOLECOUNTYMT.GOV,County,Non-Federal Agency,Shelby,MT
+TOOMBSCOUNTYGA.GOV,County,Non-Federal Agency,Lyons,GA
+TRAVISCOUNTYTX.GOV,County,Non-Federal Agency,Austin,TX
+TROUSDALECOUNTYTN.GOV,County,Non-Federal Agency,Hartsville,TN
+ULSTERCOUNTYNY.GOV,County,Non-Federal Agency,Kingston,NY
+UNICOICOUNTYTN.GOV,County,Non-Federal Agency,Erwin,TN
+UNIONCOUNTY-FL.GOV,County,Non-Federal Agency,Lake Butler,FL
+UNIONCOUNTYGA.GOV,County,Non-Federal Agency,Blairsveille,GA
+UNIONCOUNTYIL.GOV,County,Non-Federal Agency,Jonesboro,IL
+UNIONCOUNTYIN.GOV,County,Non-Federal Agency,Liberty,IN
+UNIONCOUNTYNC.GOV,County,Non-Federal Agency,Monroe,NC
+UTAHCOUNTY.GOV,County,Non-Federal Agency,Provo,UT
+VALLEYCOUNTYMT.GOV,County,Non-Federal Agency,Glasgow,MT
+VANBURENCOUNTYIA.GOV,County,Non-Federal Agency,Keosauqua,IA
+WARRENCOUNTYNC.GOV,County,Non-Federal Agency,Warrenton,NC
+WARRENCOUNTYNY.GOV,County,Non-Federal Agency,Lake George,NY
+WARRENCOUNTYTN.GOV,County,Non-Federal Agency,McMinnville,TN
+WARRICKCOUNTY.GOV,County,Non-Federal Agency,Boonville,IN
+WASHINGTONCOUNTYGA.GOV,County,Non-Federal Agency,Sandersville,GA
+WASHINGTONCOUNTYKS.GOV,County,Non-Federal Agency,Washington,KS
+WAYNECOUNTYPA.GOV,County,Non-Federal Agency,Honesdale,PA
+WEAKLEYCOUNTYTN.GOV,County,Non-Federal Agency,Dresden,TN
+WEBERCOUNTYUTAH.GOV,County,Non-Federal Agency,Ogden,UT
+WEBSTERCOUNTYMO.GOV,County,Non-Federal Agency,Marshfield,MO
+WESTFELICIANAPARISH-LA.GOV,County,Non-Federal Agency,St. Francisville,LA
+WHITECOUNTYGA.GOV,County,Non-Federal Agency,Cleveland,GA
+WHITECOUNTYTN.GOV,County,Non-Federal Agency,Sparta,TN
+WHITEPINECOUNTYNV.GOV,County,Non-Federal Agency,Ely,NV
+WILLCOUNTY-IL.GOV,County,Non-Federal Agency,Joliet,IL
+WILLIAMSONCOUNTY-TN.GOV,County,Non-Federal Agency,Franklin,TN
+WILLIAMSONCOUNTYIL.GOV,County,Non-Federal Agency,Marion,IL
+WILSONCOUNTYTN.GOV,County,Non-Federal Agency,Lebanon,TN
+WILSONCOUNTYTX.GOV,County,Non-Federal Agency,Floresville,TX
+WINDHAMCOUNTYVT.GOV,County,Non-Federal Agency,Newfane,VT
+WINNEBAGOCOUNTYIOWA.GOV,County,Non-Federal Agency,Forest City,IA
+WOODBURYCOUNTYIOWA.GOV,County,Non-Federal Agency,Sioux City,IA
+WORCESTERCOUNTYMD.GOV,County,Non-Federal Agency,Snow Hill,MD
+YANCEYCOUNTYNC.GOV,County,Non-Federal Agency,Burnsville,NC
+YAZOOCOUNTYMS.GOV,County,Non-Federal Agency,Yazoo City,MS
+YCSOAZ.GOV,County,Non-Federal Agency,Prescott,AZ
+YORKCOUNTY.GOV,County,Non-Federal Agency,Yorktown,VA
+YORKCOUNTYMAINE.GOV,County,Non-Federal Agency,Alfred,ME
+YORKCOUNTYME.GOV,County,Non-Federal Agency,Alfred,ME
+YORKCOUNTYPA.GOV,County,Non-Federal Agency,York,PA
+YUMACOUNTYARIZONA.GOV,County,Non-Federal Agency,Yuma,AZ
+YUMACOUNTYAZ.GOV,County,Non-Federal Agency,Yuma,AZ
+ACUS.GOV,Federal Agency,Administrative Conference of the United States,WASHINGTON,DC
+ACHP.GOV,Federal Agency,Advisory Council on Historic Preservation,Washington,DC
+PRESERVEAMERICA.GOV,Federal Agency,Advisory Council on Historic Preservation,Washington,DC
+ADF.GOV,Federal Agency,African Development Foundation,Washington,DC
+USADF.GOV,Federal Agency,African Development Foundation,Washington,DC
+ABMC.GOV,Federal Agency,American Battle Monuments Commission,Arlington,VA
+AMTRAKOIG.GOV,Federal Agency,AMTRAK,Washington,DC
+ARC.GOV,Federal Agency,Appalachian Regional Commission,Washington,DC
+ASC.GOV,Federal Agency,Appraisal Subcommittee,Washington,DC
+AFRH.GOV,Federal Agency,Armed Forces Retirement Home,Washington,DC
+CIA.GOV,Federal Agency,Central Intelligence Agency,Washington,DC
+IC.GOV,Federal Agency,Central Intelligence Agency,Washington,DC
+ISTAC.GOV,Federal Agency,Central Intelligence Agency,Washington,DC
+NCTC.GOV,Federal Agency,Central Intelligence Agency,Washington,DC
+ODCI.GOV,Federal Agency,Central Intelligence Agency,Washington,DC
+OPENSOURCE.GOV,Federal Agency,Central Intelligence Agency,Washington,DC
+OSDE.GOV,Federal Agency,Central Intelligence Agency,Reston,VA
+TTIC.GOV,Federal Agency,Central Intelligence Agency,Washington,DC
+UCIA.GOV,Federal Agency,Central Intelligence Agency,Washington,DC
+CHRISTOPHERCOLUMBUSFOUNDATION.GOV,Federal Agency,Christopher Columbus Fellowship Foundation,Washington,DC
+CAP.GOV,Federal Agency,Civil Air Patrol,BIRMINGHAM,MI
+CAPNHQ.GOV,Federal Agency,Civil Air Patrol,MAXWELL AFB,AL
+ABILITYONE.FED.US,Federal Agency,Comm for People Who Are Blind/Severly Disabled,Arlington,VA
+ABILITYONE.GOV,Federal Agency,Comm for People Who Are Blind/Severly Disabled,Arlington,VA
+JWOD.GOV,Federal Agency,Comm for People Who Are Blind/Severly Disabled,Arlington,VA
+CFTC.GOV,Federal Agency,Commodity Futures Trading Commission,Washington,DC
+SMARTCHECK.GOV,Federal Agency,Commodity Futures Trading Commission,Washington,DC
+COMPLIANCE.GOV,Federal Agency,Congressional Office of Compliance,Washington,DC
+BCFP.GOV,Federal Agency,Consumer Financial Protection Bureau,Washington,DC
+CFPA.GOV,Federal Agency,Consumer Financial Protection Bureau,Washington,DC
+CFPB.GOV,Federal Agency,Consumer Financial Protection Bureau,Washington,DC
+CONSUMERBUREAU.GOV,Federal Agency,Consumer Financial Protection Bureau,Washington,DC
+CONSUMERFINANCE.GOV,Federal Agency,Consumer Financial Protection Bureau,Washington,DC
+CONSUMERFINANCIAL.GOV,Federal Agency,Consumer Financial Protection Bureau,Washington,DC
+CONSUMERFINANCIALBUREAU.GOV,Federal Agency,Consumer Financial Protection Bureau,Washington,DC
+CONSUMERFINANCIALPROTECTIONBUREAU.GOV,Federal Agency,Consumer Financial Protection Bureau,Washington,DC
+CONSUMERPROTECTION.GOV,Federal Agency,Consumer Financial Protection Bureau,Washington,DC
+CONSUMERPROTECTIONBUREAU.GOV,Federal Agency,Consumer Financial Protection Bureau,Washington,DC
+ANCHORIT.GOV,Federal Agency,Consumer Product Safety Commission,Bethesda,MD
+ATVSAFETY.GOV,Federal Agency,Consumer Product Safety Commission,Bethesda,MD
+CPSC.GOV,Federal Agency,Consumer Product Safety Commission,Bethesda,MD
+DRYWALLRESPONSE.GOV,Federal Agency,Consumer Product Safety Commission,Bethesda,MD
+POOLSAFELY.GOV,Federal Agency,Consumer Product Safety Commission,Bethesda,MD
+POOLSAFETY.GOV,Federal Agency,Consumer Product Safety Commission,Bethesda,MD
+RECALLS.GOV,Federal Agency,Consumer Product Safety Commission,Bethesda,MD
+SAFERPRODUCT.GOV,Federal Agency,Consumer Product Safety Commission,Bethesda,MD
+SAFERPRODUCTS.GOV,Federal Agency,Consumer Product Safety Commission,Bethesda,MD
+SEGURIDADCONSUMIDOR.GOV,Federal Agency,Consumer Product Safety Commission,Bethesda,MD
+AMERICORE.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC
+AMERICORP.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC
+AMERICORPS.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC
+AMERICORPSCONNECT.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC
+AMERICORPSWEEK.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC
+CNCS.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC
+CNCSOIG.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC
+CNS.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC
+FEDERALMENTORINGCOUNCIL.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC
+GETINVOLVED.GOV,Federal Agency,Corporation for National & Community Service,Washington ,DC
+LEARNANDSERVE.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC
+MLKDAY.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC
+NATIONALSERVICE.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC
+NATIONALSERVICEGEAR.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC
+NATIONALSERVICERESOURCES.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC
+PRESIDENTIALSERVICEAWARDS.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC
+SENIORCORPS.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC
+SERVE.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC
+SERVICE.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC
+SERVICELEARNING.GOV,Federal Agency,Corporation for National & Community Service,Washington ,DC
+SERVIR.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC
+VISTA.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC
+VISTACAMPUS.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC
+VOLUNTEERINGINAMERICA.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC
+CIGIE.GOV,Federal Agency,Council of Inspector General on Integrity and Efficiency,WASHINGTON,DC
+IGNET.GOV,Federal Agency,Council of Inspector General on Integrity and Efficiency,Washington,DC
+CSOSA.FED.US,Federal Agency,Court Services and Offender Supervision,Washington,DC
+CSOSA.GOV,Federal Agency,Court Services and Offender Supervision,Washington,DC
+PRETRIALSERVICES.GOV,Federal Agency,Court Services and Offender Supervision,Washington,DC
+PSA.GOV,Federal Agency,Court Services and Offender Supervision,Washington,DC
+DNFSB.GOV,Federal Agency,Defense Nuclear Facilities Safety Board,Washington,DC
+DRA.GOV,Federal Agency,Delta Regional Authority,Clarksdale,MS
+DENALI.GOV,Federal Agency,Denali Commission,Anchorage,AK
+FEA.GOV,Federal Agency,Denali Commission,Anchorage,AK
+AFF.GOV,Federal Agency,Department of Agriculture,Boise,ID
+AG.GOV,Federal Agency,Department of Agriculture,Fort Collins,CO
+ARS-GRIN.GOV,Federal Agency,Department of Agriculture,Beltsville,MD
+ARSUSDA.GOV,Federal Agency,Department of Agriculture,Beltsville,MD
+ASKKAREN.GOV,Federal Agency,Department of Agriculture,Washington,DC
+BEFOODSAFE.GOV,Federal Agency,Department of Agriculture,Washington,DC
+BIOPREFERRED.GOV,Federal Agency,Department of Agriculture,Washington,DC
+CHOOSEMYPLATE.GOV,Federal Agency,Department of Agriculture,Alexandria,VA
+COASTALAMERICA.GOV,Federal Agency,Department of Agriculture,Washington,DC
+DIETARYGUIDELINES.GOV,Federal Agency,Department of Agriculture,Alexandria,VA
+EMPOWHR.GOV,Federal Agency,Department of Agriculture,New Orleans,LA
+EXECSEC.GOV,Federal Agency,Department of Agriculture,Washington,DC
+FARMERCLAIMS.GOV,Federal Agency,Department of Agriculture,St. Louis,MO
+FEMALEFARMERCLAIMS.GOV,Federal Agency,Department of Agriculture,St. Louis,MO
+FIREINSTITUTE.GOV,Federal Agency,Department of Agriculture,Tucson,AZ
+FOODSAFETYJOBS.GOV,Federal Agency,Department of Agriculture,Washington,DC
+FOODSAFETYWORKINGGROUP.GOV,Federal Agency,Department of Agriculture,Washington,DC
+FORESTSANDRANGELANDS.GOV,Federal Agency,Department of Agriculture,Washington,DC
+FS.FED.US,Federal Agency,Department of Agriculture,Washington,DC
+GREEN.GOV,Federal Agency,Department of Agriculture,Washington,DC
+HISPANICFARMERCLAIMS.GOV,Federal Agency,Department of Agriculture,St. Louis,MO
+ICBEMP.GOV,Federal Agency,Department of Agriculture,Portland,OR
+IIOG.GOV,Federal Agency,Department of Agriculture,Meridian,ID
+INVASIVESPECIESINFO.GOV,Federal Agency,Department of Agriculture,Beltsville,MD
+IPM.GOV,Federal Agency,Department of Agriculture,Washington,DC
+ISITDONEYET.GOV,Federal Agency,Department of Agriculture,Washington,DC
+ITAP.GOV,Federal Agency,Department of Agriculture,Beltsville,MD
+JUNIORFORESTRANGER.GOV,Federal Agency,Department of Agriculture,Washington,DC
+LATINOFARMERCLAIMS.GOV,Federal Agency,Department of Agriculture,St. Louis,MO
+LCACOMMONS.GOV,Federal Agency,Department of Agriculture,Beltsville,MD
+MTBS.GOV,Federal Agency,Department of Agriculture,Salt Lake City,UT
+NAFRI.GOV,Federal Agency,Department of Agriculture,Tucson,AZ
+NEL.GOV,Federal Agency,Department of Agriculture,Alexandria,VA
+NSTL.GOV,Federal Agency,Department of Agriculture,Ames,IA
+NUTRITION.GOV,Federal Agency,Department of Agriculture,Washington,DC
+NUTRITIONEVIDENCELIBRARY.GOV,Federal Agency,Department of Agriculture,Alexandria,VA
+NWCG.GOV,Federal Agency,Department of Agriculture,Boise,ID
+PREGUNTELEAKAREN.GOV,Federal Agency,Department of Agriculture,Washington,DC
+RECREATION.GOV,Federal Agency,Department of Agriculture,Ogden,UT
+REO.GOV,Federal Agency,Department of Agriculture,Portland,OR
+SMOKEYBEAR.GOV,Federal Agency,Department of Agriculture,Washington,DC
+START2FARM.GOV,Federal Agency,Department of Agriculture,Beltsville,MD
+SYMBOLS.GOV,Federal Agency,Department of Agriculture,Washington,DC
+THEPEOPLESGARDEN.GOV,Federal Agency,Department of Agriculture,Wahington,DC
+USDA.GOV,Federal Agency,Department of Agriculture,Ft. Collins,CO
+USDAPII.GOV,Federal Agency,Department of Agriculture,Washington,DC
+VALLESCALDERA.GOV,Federal Agency,Department of Agriculture,Jemez Springs,NM
+WILDFIRE.GOV,Federal Agency,Department of Agriculture,Boise,ID
+WOMENFARMERCLAIMS.GOV,Federal Agency,Department of Agriculture,St. Louis,MO
+WOODSY.GOV,Federal Agency,Department of Agriculture,Washington,DC
+WOODSYOWL.GOV,Federal Agency,Department of Agriculture,Washington,DC
+AP.GOV,Federal Agency,Department of Commerce,Washington,DC
+AVIATIONWEATHER.GOV,Federal Agency,Department of Commerce,Silver Spring,MD
+BEA.GOV,Federal Agency,Department of Commerce,Washington,DC
+BLDRDOC.GOV,Federal Agency,Department of Commerce,Boulder,CO
+BUYUSA.GOV,Federal Agency,Department of Commerce,Washington,DC
+CBP.GOV,Federal Agency,Department of Commerce,Alexandria,VA
+CENSUS.GOV,Federal Agency,Department of Commerce,Suitland,MD
+CIVILRIGHTSUSA.GOV,Federal Agency,Department of Commerce,Alexandria,VA
+CLIMATE.GOV,Federal Agency,Department of Commerce,Silver Spring,MD
+CLIMATECHANGE.GOV,Federal Agency,Department of Commerce,Oak Ridge,TN
+COMMERCE.GOV,Federal Agency,Department of Commerce,Washington,DC
+COOP-USPTO.GOV,Federal Agency,Department of Commerce,Arlington,VA
+DIGITALLITERACY.GOV,Federal Agency,Department of Commerce,Washington,DC
+DNSOPS.GOV,Federal Agency,Department of Commerce,Gaithersburg,MD
+DOC.GOV,Federal Agency,Department of Commerce,Washington,DC
+DROUGHT.GOV,Federal Agency,Department of Commerce,Asheville,NC
+EDA.GOV,Federal Agency,Department of Commerce,Washington,DC
+ESA.GOV,Federal Agency,Department of Commerce,Washington,DC
+EXPORT.GOV,Federal Agency,Department of Commerce,Washington,DC
+FCSM.GOV,Federal Agency,Department of Commerce,Suitland,MD
+FEDSTATS.GOV,Federal Agency,Department of Commerce,Washington,DC
+FIRSTNET.GOV,Federal Agency,Department of Commerce,Washington,DC
+FISHWATCH.GOV,Federal Agency,Department of Commerce,Silver Spring,MD
+GETYOUHOME.GOV,Federal Agency,Department of Commerce,Alexandria,VA
+GLOBALENTRY.GOV,Federal Agency,Department of Commerce,Alexandria,VA
+GOES-R.GOV,Federal Agency,Department of Commerce,Greenbelt,MD
+GPS.GOV,Federal Agency,Department of Commerce,Washington,DC
+HURRICANES.GOV,Federal Agency,Department of Commerce,Miami,FL
+ITDS.GOV,Federal Agency,Department of Commerce,Springfield,VA
+MANUFACTURING.GOV,Federal Agency,Department of Commerce,Washington,DC
+MAPSTATS.GOV,Federal Agency,Department of Commerce,Washington,DC
+MARINECADASTRE.GOV,Federal Agency,Department of Commerce,Charleston,SC
+MBDA.GOV,Federal Agency,Department of Commerce,Washington,DC
+MGI.GOV,Federal Agency,Department of Commerce,Gaithersburg,MD
+NEHRP.GOV,Federal Agency,Department of Commerce,Gaithersburg,MD
+NIST.GOV,Federal Agency,Department of Commerce,Gaithersburg,MD
+NOAA.GOV,Federal Agency,Department of Commerce,Silver Spring,MD
+NTIS.GOV,Federal Agency,Department of Commerce,Alexandria,VA
+OFCM.GOV,Federal Agency,Department of Commerce,Silver Spring,MD
+PAPAHANAUMOKUAKEA.GOV,Federal Agency,Department of Commerce,Silver Spring,MD
+PSCR.GOV,Federal Agency,Department of Commerce,Boulder,CO
+SDR.GOV,Federal Agency,Department of Commerce,Washington,DC
+SELECTUSA.GOV,Federal Agency,Department of Commerce,Washington,DC
+SPACEWEATHER.GOV,Federal Agency,Department of Commerce,Boulder,CO
+SPECTRUM.GOV,Federal Agency,Department of Commerce,Washington,DC
+STANDARDS.GOV,Federal Agency,Department of Commerce,Gaithersburg,MD
+TIME.GOV,Federal Agency,Department of Commerce,Boulder,CO
+TRADE.GOV,Federal Agency,Department of Commerce,Washington,DC
+TSUNAMI.GOV,Federal Agency,Department of Commerce,Palmer,AK
+USPTO.GOV,Federal Agency,Department of Commerce,Washington,DC
+WDOL.GOV,Federal Agency,Department of Commerce,Alexandria,VA
+WEATHER.GOV,Federal Agency,Department of Commerce,Silver Spring,MD
+ADLNET.GOV,Federal Agency,Department of Defense,Washington,DC
+AFTAC.GOV,Federal Agency,Department of Defense,Patrick AFB,FL
+ALTUSANDC.GOV,Federal Agency,Department of Defense,"patrick, afb",FL
+BRAC.GOV,Federal Agency,Department of Defense,Alexandria,VA
+CMTS.GOV,Federal Agency,Department of Defense,Mobile,AL
+CNSS.GOV,Federal Agency,Department of Defense,Ft George G. Meade,MD
+CTOC.GOV,Federal Agency,Department of Defense,Starke,FL
+CTTSO.GOV,Federal Agency,Department of Defense,Arlington,VA
+DEFENSE.GOV,Federal Agency,Department of Defense,Fort Meade,MD
+DOD.GOV,Federal Agency,Department of Defense,Fort Meade,MD
+EACLEARINGHOUSE.GOV,Federal Agency,Department of Defense,Arlington,VA
+ERDC.GOV,Federal Agency,Department of Defense,Vicksburg,MS
+FVAP.GOV,Federal Agency,Department of Defense,Alexandria,VA
+IAD.GOV,Federal Agency,Department of Defense,Ft Meade,MD
+IOSS.GOV,Federal Agency,Department of Defense,Greenbelt,MD
+ITC.GOV,Federal Agency,Department of Defense,Ft. Washington,MD
+JCCS.GOV,Federal Agency,Department of Defense,Alexandria,VA
+MCRMC.GOV,Federal Agency,Department of Defense,Arlington,VA
+MOJAVEDATA.GOV,Federal Agency,Department of Defense,Barstow,CA
+MTMC.GOV,Federal Agency,Department of Defense,Alexandria,VA
+MYPAY.GOV,Federal Agency,Department of Defense,Pensacola,FL
+NCR.GOV,Federal Agency,Department of Defense,Washington,DC
+NRO.GOV,Federal Agency,Department of Defense,Chantilly,VA
+NROJR.GOV,Federal Agency,Department of Defense,Chantilly,VA
+NSA.GOV,Federal Agency,Department of Defense,Ft. Meade,MD
+NSEP.GOV,Federal Agency,Department of Defense,Arlington,VA
+OEA.GOV,Federal Agency,Department of Defense,Arlington,VA
+OSDBU.GOV,Federal Agency,Department of Defense,Washington,DC
+PENTAGON.GOV,Federal Agency,Department of Defense,Fort Meade,MD
+SAFEXCHANGE.GOV,Federal Agency,Department of Defense,Falls Church,VA
+SITEIDIQ.GOV,Federal Agency,Department of Defense,Arlington,VA
+TSWG.GOV,Federal Agency,Department of Defense,Arlington,VA
+USANDC.GOV,Federal Agency,Department of Defense,Patrick AFB,FL
+AAPI.GOV,Federal Agency,Department of Education,Washington,DC
+BFELOB.GOV,Federal Agency,Department of Education,Washington,DC
+CHILDSTATS.GOV,Federal Agency,Department of Education,Washington,DC
+COLLEGE.GOV,Federal Agency,Department of Education,Washington,DC
+COLLEGENAVIGATOR.GOV,Federal Agency,Department of Education,Washington,DC
+ED.GOV,Federal Agency,Department of Education,Washington,DC
+EDPUBS.GOV,Federal Agency,Department of Education,Washington ,DC
+EDUCATION.GOV,Federal Agency,Department of Education,Washington,DC
+FAFSA.GOV,Federal Agency,Department of Education,Washington,DC
+FSAPUBS.GOV,Federal Agency,Department of Education,Washington,DC
+G5.GOV,Federal Agency,Department of Education,Washington,DC
+NAGB.GOV,Federal Agency,Department of Education,Washington,DC
+NATIONSREPORTCARD.GOV,Federal Agency,Department of Education,Washington,DC
+OPPORTUNITY.GOV,Federal Agency,Department of Education,Washington,DC
+STUDENTAID.GOV,Federal Agency,Department of Education,Washington,DC
+STUDENTLOANS.GOV,Federal Agency,Department of Education,Washington,DC
+AMESLAB.GOV,Federal Agency,Department of Energy,Ames,IA
+ANL.GOV,Federal Agency,Department of Energy,Argonne,IL
+ARM.GOV,Federal Agency,Department of Energy,Richland,WA
+BIOMASSBOARD.GOV,Federal Agency,Department of Energy,Washington,DC
+BNL.GOV,Federal Agency,Department of Energy,Upton,NY
+BPA.GOV,Federal Agency,Department of Energy,Portland,OR
+BRC.GOV,Federal Agency,Department of Energy,Washington,DC
+BUILDINGAMERICA.GOV,Federal Agency,Department of Energy,Golden,CO
+CASL.GOV,Federal Agency,Department of Energy,Oak Ridge,TN
+CEBAF.GOV,Federal Agency,Department of Energy,Newport News,VA
+CENDI.GOV,Federal Agency,Department of Energy,Oak Ridge,TN
+CRT2014-2024REVIEW.GOV,Federal Agency,Department of Energy,Portland,OR
+DOE.GOV,Federal Agency,Department of Energy,Washington,DC
+DOEAL.GOV,Federal Agency,Department of Energy,Albuquerque,NM
+EIA.GOV,Federal Agency,Department of Energy,Washington,DC
+ENERGY.GOV,Federal Agency,Department of Energy,Washington,DC
+ENERGYCODES.GOV,Federal Agency,Department of Energy,Richland,WA
+ENERGYPLUS.GOV,Federal Agency,Department of Energy,Washington,DC
+ENERGYSAVER.GOV,Federal Agency,Department of Energy,Washington,DC
+ENERGYSAVERS.GOV,Federal Agency,Department of Energy,Washington,DC
+FNAL.GOV,Federal Agency,Department of Energy,Batavia,IL
+FUELECONOMY.GOV,Federal Agency,Department of Energy,Oak Ridge,TN
+HANFORD.GOV,Federal Agency,Department of Energy,Richland,WA
+HIGHPERFORMANCEBUILDINGS.GOV,Federal Agency,Department of Energy,Golden,CO
+HOMEENERGYSCORE.GOV,Federal Agency,Department of Energy,Washington,DC
+HYDROGEN.GOV,Federal Agency,Department of Energy,Washington,DC
+INEL.GOV,Federal Agency,Department of Energy,Idaho Falls,ID
+INL.GOV,Federal Agency,Department of Energy,Idaho Falls,ID
+ISOTOPE.GOV,Federal Agency,Department of Energy,Oak Ridge,TN
+ISOTOPES.GOV,Federal Agency,Department of Energy,Oak Ridge,TN
+KAPL.GOV,Federal Agency,Department of Energy,Schenectady,NY
+LANL.GOV,Federal Agency,Department of Energy,Los Alamos,NM
+LBL.GOV,Federal Agency,Department of Energy,Berkeley,CA
+LLNL.GOV,Federal Agency,Department of Energy,Livermore,CA
+NCCRC.GOV,Federal Agency,Department of Energy,Oak Ridge,TN
+NCCS.GOV,Federal Agency,Department of Energy,Oak Ridge,TN
+NCRC.GOV,Federal Agency,Department of Energy,Oak Ridge,TN
+NERSC.GOV,Federal Agency,Department of Energy,Berkeley,CA
+NEUP.GOV,Federal Agency,Department of Energy,Washington,DC
+NREL.GOV,Federal Agency,Department of Energy,Golden,CO
+NRELHUB.GOV,Federal Agency,Department of Energy,Golden,CO
+NTRC.GOV,Federal Agency,Department of Energy,Knoxville,TN
+NUCLEAR.GOV,Federal Agency,Department of Energy,Washington,DC
+ORAU.GOV,Federal Agency,Department of Energy,Oak Ridge,TN
+ORNL.GOV,Federal Agency,Department of Energy,Oak Ridge,TN
+OSTI.GOV,Federal Agency,Department of Energy,Oak Ridge,TN
+PNL.GOV,Federal Agency,Department of Energy,Richland,WA
+PNNL.GOV,Federal Agency,Department of Energy,Richland,WA
+RL.GOV,Federal Agency,Department of Energy,Richland,WA
+SALMONRECOVERY.GOV,Federal Agency,Department of Energy,Portland,OR
+SANDIA.GOV,Federal Agency,Department of Energy,Albuquerque,NM
+SCIDAC.GOV,Federal Agency,Department of Energy,Oak Ridge,TN
+SCIENCE.GOV,Federal Agency,Department of Energy,Oak Ridge,TN
+SCIENCEACCELERATOR.GOV,Federal Agency,Department of Energy,Oak Ridge,TN
+SCIENCEEDUCATION.GOV,Federal Agency,Department of Energy,Oak Ridge,TN
+SMARTGRID.GOV,Federal Agency,Department of Energy,Washington,DC
+SNS.GOV,Federal Agency,Department of Energy,Oak Ridge,TN
+SOLARDECATHLON.GOV,Federal Agency,Department of Energy,Golden,CO
+SRS.GOV,Federal Agency,Department of Energy,Aiken,SC
+SWPA.GOV,Federal Agency,Department of Energy,Tulsa,OK
+UNNPP.GOV,Federal Agency,Department of Energy,West Mifflin,PA
+UNRPNET.GOV,Federal Agency,Department of Energy,Washington,DC
+WAPA.GOV,Federal Agency,Department of Energy,Lakewood,CO
+WINDPOWERINGAMERICA.GOV,Federal Agency,Department of Energy,Golden,CO
+YMP.GOV,Federal Agency,Department of Energy,Las Vegas,NV
+ACF.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+ACL.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+AFTERSCHOOL.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+AGING.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+AGINGSTATS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+AHCPR.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
+AHRQ.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
+AIDS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+ALZHEIMERS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+AOA.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+BAM.GOV,Federal Agency,Department of Health And Human Services,Atlanta,GA
+BESTBONESFOREVER.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+BETOBACCOFREE.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+BIOETHICS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+BIOSECURITYBOARD.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+BRAINHEALTH.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+CANCER.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
+CANCERNET.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
+CDC.GOV,Federal Agency,Department of Health And Human Services,Atlanta,GA
+CHILDWELFARE.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+CLINICALTRIAL.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
+CLINICALTRIALS.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
+CLUBDRUGS.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
+CMS.GOV,Federal Agency,Department of Health And Human Services,Baltimore,MD
+COLLEGEDRINKINGPREVENTION.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
+CUIDADODESALUD.GOV,Federal Agency,Department of Health And Human Services,Baltimore,MD
+DHHS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+DIABETESCOMMITTEE.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+DOCLINE.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
+DONACIONDEORGANOS.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
+DRUGABUSE.GOV,Federal Agency,Department of Health And Human Services,Baltimore,MD
+DRUGFREEWORKPLACE.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
+EDISON.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
+ELDERCARE.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+ENDINGTHEDOCUMENTGAME.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+ERRP.GOV,Federal Agency,Department of Health And Human Services,Baltimore,MD
+FATHERHOOD.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+FDA.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
+FINDYOUTHINFO.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
+FITNESS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+FLU.GOV,Federal Agency,Department of Health And Human Services,Washington ,DC
+FOODSAFETY.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+FRESHEMPIRE.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+FRUITSANDVEGGIESMATTER.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+GENBANK.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
+GENOME.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
+GIRLSHEALTH.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+GLOBALHEALTH.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
+GRANTS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+GRANTSOLUTIONS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+GUIDELINE.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
+GUIDELINES.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
+HCQUALITYCOMMISSION.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
+HEALTH.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+HEALTHCARE.GOV,Federal Agency,Department of Health And Human Services,Baltimore,MD
+HEALTHDATA.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+HEALTHFINDER.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+HEALTHINDICATORS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+HEALTHIT.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+HEALTHREFORM.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+HEALTHYPEOPLE.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+HEARTTRUTH.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
+HHS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+HHSOIG.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+HHSOPS.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
+HIV.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+HRSA.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
+IDEALAB.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+IEDISON.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
+IHS.GOV,Federal Agency,Department of Health And Human Services,Albuquerque,NM
+INSUREKIDSNOW.GOV,Federal Agency,Department of Health And Human Services,Baltimore,MD
+KNOWTHEFACTSFIRST.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+LOCATORPLUS.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
+LONGTERMCARE.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+MEDICAID.GOV,Federal Agency,Department of Health And Human Services,Baltimore,MD
+MEDICALCOUNTERMEASURES.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+MEDICALRESERVECORPS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+MEDICARE.GOV,Federal Agency,Department of Health And Human Services,Baltimore,MD
+MEDLINE.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
+MEDLINEPLUS.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
+MENTALHEALTH.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
+MESH.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
+MIMEDICARE.GOV,Federal Agency,Department of Health And Human Services,Baltimore,MD
+MYMEDICARE.GOV,Federal Agency,Department of Health And Human Services,Baltimore,MD
+NATIONALCHILDRENSSTUDY.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
+NCIFCRF.GOV,Federal Agency,Department of Health And Human Services,Frederick,MD
+NGC.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
+NIH.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
+NIHSENIORHEALTH.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
+NIOSH.GOV,Federal Agency,Department of Health And Human Services,Atlanta,GA
+NLM.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
+NNLM.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
+ORGANDONOR.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
+PANDEMICFLU.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+PCIP.GOV,Federal Agency,Department of Health And Human Services,New Orleans,LA
+PHE.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+PSC.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
+PUBMED.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
+PUBMEDCENTRAL.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
+QUIC.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
+QUICK.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
+RECOVERYMONTH.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
+SAFEYOUTH.GOV,Federal Agency,Department of Health And Human Services,Atlanta,GA
+SAMHSA.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
+SELECTAGENTS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+SMOKEFREE.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
+STEROIDABUSE.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
+STOPALCOHOLABUSE.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+STOPBULLYING.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+STOPMEDICAREFRAUD.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+SURGEONGENERAL.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+THECOOLSPOT.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
+THEREALCOST.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+TISSUEENGINEERING.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
+TOBACCO.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+USABILITY.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+USBM.GOV,Federal Agency,Department of Health And Human Services,Atlanta,GA
+USPHS.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
+VACCINES.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+WHAGING.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+WHITEHOUSECONFERENCEONAGING.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+WOMENSHEALTH.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+YOUTH.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+BIOMETRICS.GOV,Federal Agency,Department of Homeland Security,Arlington,VA
+CITIZENCORPS.GOV,Federal Agency,Department of Homeland Security,Washington,DC
+CPNIREPORTING.GOV,Federal Agency,Department of Homeland Security,Washington,DC
+DHS.GOV,Federal Agency,Department of Homeland Security,Washington,DC
+DISASTERASSISTANCE.GOV,Federal Agency,Department of Homeland Security,Bluemont,VA
+FEMA.GOV,Federal Agency,Department of Homeland Security,Washington,DC
+FIRSTRESPONDER.GOV,Federal Agency,Department of Homeland Security,Washington,DC
+FIRSTRESPONDERTRAINING.GOV,Federal Agency,Department of Homeland Security,Washington,DC
+FLETA.GOV,Federal Agency,Department of Homeland Security,Glynco,GA
+FLETC.GOV,Federal Agency,Department of Homeland Security,Glynco,GA
+FLIGHTSCHOOLCANDIDATES.GOV,Federal Agency,Department of Homeland Security,Rockville,MD
+FLOODSMART.GOV,Federal Agency,Department of Homeland Security,Bluemont,VA
+HOMELANDSECURITY.GOV,Federal Agency,Department of Homeland Security,Washington,DC
+ICE.GOV,Federal Agency,Department of Homeland Security,Washington,DC
+LISTO.GOV,Federal Agency,Department of Homeland Security,Washington,DC
+LLIS.GOV,Federal Agency,Department of Homeland Security,Washington,DC
+NMSC.GOV,Federal Agency,Department of Homeland Security,St Augustine,FL
+READY.GOV,Federal Agency,Department of Homeland Security,Washington,DC
+READYBUSINESS.GOV,Federal Agency,Department of Homeland Security,Washington,DC
+SAFECOMPROGRAM.GOV,Federal Agency,Department of Homeland Security,Washington,DC
+SAFETYACT.GOV,Federal Agency,Department of Homeland Security,Washington,DC
+SECRETSERVICE.GOV,Federal Agency,Department of Homeland Security,Washington D.C.,DC
+TSA.GOV,Federal Agency,Department of Homeland Security,Arlington,VA
+US-CERT.GOV,Federal Agency,Department of Homeland Security,Washington,DC
+USCG.GOV,Federal Agency,Department of Homeland Security,Alexandria,VA
+USCIS.GOV,Federal Agency,Department of Homeland Security,Washington,DC
+USSS.GOV,Federal Agency,Department of Homeland Security,Washington,DC
+DISASTERHOUSING.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC
+FHA.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC
+GINNIEMAE.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC
+HOMESALES.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC
+HUD.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC
+HUDOIG.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC
+HUDUSER.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC
+NATIONALHOUSING.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC
+NATIONALHOUSINGLOCATOR.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC
+NHL.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC
+NLS.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC
+ADA.GOV,Federal Agency,Department of Justice,Rockville,MD
+ADR.GOV,Federal Agency,Department of Justice,Rockville,MD
+AMBERALERT.GOV,Federal Agency,Department of Justice,Potomac,MD
+ATF.GOV,Federal Agency,Department of Justice,Washington,DC
+BIOMETRICCOE.GOV,Federal Agency,Department of Justice,Clarksburg,WV
+BJA.GOV,Federal Agency,Department of Justice,Washington ,DC
+BJS.GOV,Federal Agency,Department of Justice,Washington,DC
+BOP.GOV,Federal Agency,Department of Justice,Washington,DC
+CRIMESOLUTIONS.GOV,Federal Agency,Department of Justice,Washinton ,DC
+CRIMEVICTIMS.GOV,Federal Agency,Department of Justice,Potomac,MD
+CYBERCRIME.GOV,Federal Agency,Department of Justice,Washington,DC
+DEA.GOV,Federal Agency,Department of Justice,Rockville,MD
+DEADIVERSION.GOV,Federal Agency,Department of Justice,Potomac,MD
+DEALS.GOV,Federal Agency,Department of Justice,Washington,DC
+DNA.GOV,Federal Agency,Department of Justice,Potomac,MD
+DSAC.GOV,Federal Agency,Department of Justice,Potomac,MD
+ESPANOLFORLAWENFORCEMENT.GOV,Federal Agency,Department of Justice,Potomac,MD
+FARA.GOV,Federal Agency,Department of Justice,potomac,MD
+FBI.GOV,Federal Agency,Department of Justice,Washington,DC
+FBIJOBS.GOV,Federal Agency,Department of Justice,Washington,DC
+FIRSTFREEDOM.GOV,Federal Agency,Department of Justice,Potomac,MD
+FOIA.GOV,Federal Agency,Department of Justice,Washington,DC
+FORFEITURE.GOV,Federal Agency,Department of Justice,Potomac,MD
+FPI.GOV,Federal Agency,Department of Justice,Washington,DC
+GETSMARTABOUTDRUGS.GOV,Federal Agency,Department of Justice,Potomac,MD
+HELPINGAMERICASYOUTH.GOV,Federal Agency,Department of Justice,Potomac,MD
+IC3.GOV,Federal Agency,Department of Justice,Fairmont,WV
+INTERPOL.GOV,Federal Agency,Department of Justice,Potomac,MD
+IPRCENTER.GOV,Federal Agency,Department of Justice,Washington,DC
+JUSTICE.GOV,Federal Agency,Department of Justice,Rockville,MD
+JUSTTHINKTWICE.GOV,Federal Agency,Department of Justice,Potomac,MD
+JUVENILECOUNCIL.GOV,Federal Agency,Department of Justice,Potomac,MD
+LEP.GOV,Federal Agency,Department of Justice,Rockville,MD
+LOOKSTOOGOODTOBETRUE.GOV,Federal Agency,Department of Justice,Fairmont,WV
+MALWAREINVESTIGATOR.GOV,Federal Agency,Department of Justice,Washington,DC
+MEDALOFVALOR.GOV,Federal Agency,Department of Justice,Potomac,MD
+NAMUS.GOV,Federal Agency,Department of Justice,Potomac,MD
+NATIONALGANGCENTER.GOV,Federal Agency,Department of Justice,Tallahassee,FL
+NCIRC.GOV,Federal Agency,Department of Justice,Tallahassee,FL
+NCJRS.GOV,Federal Agency,Department of Justice,Potomac,MD
+NIBIN.GOV,Federal Agency,Department of Justice,Washington,DC
+NICIC.GOV,Federal Agency,Department of Justice,Washington,DC
+NIEM.GOV,Federal Agency,Department of Justice,Tallahassee,FL
+NIJ.GOV,Federal Agency,Department of Justice,Washington,DC
+NMVTIS.GOV,Federal Agency,Department of Justice,Washington,DC
+NSOPW.GOV,Federal Agency,Department of Justice,Washington,DC
+NVTC.GOV,Federal Agency,Department of Justice,Washington,DC
+OJJDP.GOV,Federal Agency,Department of Justice,Potomac,MD
+OJP.GOV,Federal Agency,Department of Justice,Washington,DC
+OVC.GOV,Federal Agency,Department of Justice,Potomac,MD
+OVCTTAC.GOV,Federal Agency,Department of Justice,Potomac,MD
+PROJECTSAFECHILDHOOD.GOV,Federal Agency,Department of Justice,Potomac,MD
+PROJECTSAFENEIGHBORHOODS.GOV,Federal Agency,Department of Justice,Rockville,MD
+PSOB.GOV,Federal Agency,Department of Justice,Potomac,MD
+RCFL.GOV,Federal Agency,Department of Justice,McLean,VA
+REENTRY.GOV,Federal Agency,Department of Justice,Potomac,MD
+SCRA.GOV,Federal Agency,Department of Justice,Potomac,MD
+SERVICEMEMBERS.GOV,Federal Agency,Department of Justice,Potomac,MD
+SMART.GOV,Federal Agency,Department of Justice,Washington,DC
+STOPFRAUD.GOV,Federal Agency,Department of Justice,Rockville,MD
+TRIBALJUSTICEANDSAFETY.GOV,Federal Agency,Department of Justice,Potomac,MD
+UCRDATATOOL.GOV,Federal Agency,Department of Justice,Washington,DC
+UNICOR.GOV,Federal Agency,Department of Justice,Washington,DC
+USDOJ.GOV,Federal Agency,Department of Justice,Rockville,MD
+USERRA.GOV,Federal Agency,Department of Justice,Potpmac,MD
+USMARSHALS.GOV,Federal Agency,Department of Justice,Rockville,MD
+VCF.GOV,Federal Agency,Department of Justice,Washington,DC
+VEHICLEHISTORY.GOV,Federal Agency,Department of Justice,Potomac,MD
+VOTE.GOV,Federal Agency,Department of Justice,Washington,DC
+AMERICASHEROESATWORK.GOV,Federal Agency,Department of Labor,Washington,DC
+AUTOCOMMUNITIES.GOV,Federal Agency,Department of Labor,Washington,DC
+BENEFITS.GOV,Federal Agency,Department of Labor,Washington,DC
+BLS.GOV,Federal Agency,Department of Labor,Washington,DC
+DISABILITY.GOV,Federal Agency,Department of Labor,Washington,DC
+DOL-ESA.GOV,Federal Agency,Department of Labor,Washington,DC
+DOL.GOV,Federal Agency,Department of Labor,Washington,DC
+DOLETA.GOV,Federal Agency,Department of Labor,Washington,DC
+GOVBENEFITS.GOV,Federal Agency,Department of Labor,Washington,DC
+GOVLOANS.GOV,Federal Agency,Department of Labor,Washington,DC
+JOBCORPS.GOV,Federal Agency,Department of Labor,Austin,TX
+LABOR.GOV,Federal Agency,Department of Labor,Washington,DC
+MSHA.GOV,Federal Agency,Department of Labor,Arlington,VA
+MYNEXTMOVE.GOV,Federal Agency,Department of Labor,Washington,DC
+OSHA.GOV,Federal Agency,Department of Labor,Washington,DC
+UNIONREPORTS.GOV,Federal Agency,Department of Labor,Washington,DC
+VETERANS.GOV,Federal Agency,Department of Labor,Washington,DC
+WHISTLEBLOWERS.GOV,Federal Agency,Department of Labor,Washington,DC
+WRP.GOV,Federal Agency,Department of Labor,Washington,DC
+YOUTHRULES.GOV,Federal Agency,Department of Labor,Washington,DC
+AMERICA.GOV,Federal Agency,Department of State,Washington,DC
+CIVILIANRESPONSECORPS.GOV,Federal Agency,Department of State,Washington,DC
+CONTINENTALSHELF.GOV,Federal Agency,Department of State,Washington,DC
+CWC.GOV,Federal Agency,Department of State,Washington,DC
+ECOPARTNERSHIPS.GOV,Federal Agency,Department of State,Washington,DC
+FAN.GOV,Federal Agency,Department of State,Washington,DC
+FOREIGNASSISTANCE.GOV,Federal Agency,Department of State,Washington,DC
+FSGB.GOV,Federal Agency,Department of State,Washington,DC
+GHI.GOV,Federal Agency,Department of State,Washington,DC
+HUMANRIGHTS.GOV,Federal Agency,Department of State,Washington ,DC
+IAWG.GOV,Federal Agency,Department of State,Washington,DC
+IBWC.GOV,Federal Agency,Department of State,El Paso,TX
+ICASS.GOV,Federal Agency,Department of State,Washington,DC
+OSAC.GOV,Federal Agency,Department of State,Washington,DC
+PEPFAR.GOV,Federal Agency,Department of State,Washington,DC
+STATE.GOV,Federal Agency,Department of State,Washington,DC
+USCONSULATE.GOV,Federal Agency,Department of State,Washington,DC
+USEMBASSY-MEXICO.GOV,Federal Agency,Department of State,Mexico City,11
+USEMBASSY.GOV,Federal Agency,Department of State,Washington,DC
+USINT.GOV,Federal Agency,Department of State,Washington,DC
+USMISSION.GOV,Federal Agency,Department of State,Washington,DC
+USVPP.GOV,Federal Agency,Department of State,Washington,DC
+ABANDONEDMINES.GOV,Federal Agency,Department of the Interior,Washington,DC
+ACWI.GOV,Federal Agency,Department of the Interior,Reston,VA
+ALASKACENTERS.GOV,Federal Agency,Department of the Interior,Washington,DC
+AMERICANLATINOMUSEUM.GOV,Federal Agency,Department of the Interior,Washington,WV
+AMERICASGREATOUTDOORS.GOV,Federal Agency,Department of the Interior,Washington,DC
+ANSTASKFORCE.GOV,Federal Agency,Department of the Interior,Arlington,VA
+BIA.GOV,Federal Agency,Department of the Interior,Reston,VA
+BIOECO.GOV,Federal Agency,Department of the Interior,Denver,CO
+BLM.GOV,Federal Agency,Department of the Interior,Denver,CO
+BLMNTL.GOV,Federal Agency,Department of the Interior,Denver,CO
+BOEM.GOV,Federal Agency,Department of the Interior,Herndon,VA
+BOEMRE.GOV,Federal Agency,Department of the Interior,Herndon,VA
+BOR.GOV,Federal Agency,Department of the Interior,Denver,CO
+BSEE.GOV,Federal Agency,Department of the Interior,Herndon,VA
+COAST2050.GOV,Federal Agency,Department of the Interior,Lafayette,LA
+CORALREEF.GOV,Federal Agency,Department of the Interior,Denver,CO
+CUPCAO.GOV,Federal Agency,Department of the Interior,Denver,CO
+DOI.GOV,Federal Agency,Department of the Interior,Washington,DC
+DOIOIG.GOV,Federal Agency,Department of the Interior,RESTON,VA
+EARTHQUAKE.GOV,Federal Agency,Department of the Interior,Menlo Park,CA
+EVERGLADESRESTORATION.GOV,Federal Agency,Department of the Interior,Davie,FL
+EVERYKID.GOV,Federal Agency,Department of the Interior,Washington DC,DC
+FCG.GOV,Federal Agency,Department of the Interior,Denver,CO
+FGDC.GOV,Federal Agency,Department of the Interior,Reston,VA
+FIRECODE.GOV,Federal Agency,Department of the Interior,Boise,ID
+FIRELEADERSHIP.GOV,Federal Agency,Department of the Interior,Boise,ID
+FIRENET.GOV,Federal Agency,Department of the Interior,Boise,ID
+FIRESCIENCE.GOV,Federal Agency,Department of the Interior,Boise,ID
+FWS.GOV,Federal Agency,Department of the Interior,Lakewood,CO
+GCDAMP.GOV,Federal Agency,Department of the Interior,Denver,CO
+GCMRC.GOV,Federal Agency,Department of the Interior,Flagstaff,AZ
+GEOCOMMUNICATOR.GOV,Federal Agency,Department of the Interior,Denver,CO
+GEOMAC.GOV,Federal Agency,Department of the Interior,Denver,CO
+GEOPLATFORM.GOV,Federal Agency,Department of the Interior,Washington,DC
+IAT.GOV,Federal Agency,Department of the Interior,Boise,ID
+INDIANAFFAIRS.GOV,Federal Agency,Department of the Interior,Reston,VA
+INTERIOR.GOV,Federal Agency,Department of the Interior,Washington,DC
+INVASIVESPECIES.GOV,Federal Agency,Department of the Interior,Washington,DC
+JEM.GOV,Federal Agency,Department of the Interior,Lafayett,LA
+KLAMATHRESTORATION.GOV,Federal Agency,Department of the Interior,Yreka,CA
+LACOAST.GOV,Federal Agency,Department of the Interior,Lafayette,LA
+LANDFIRE.GOV,Federal Agency,Department of the Interior,Sioux Falls,SD
+LANDIMAGING.GOV,Federal Agency,Department of the Interior,Reston,VA
+LCA.GOV,Federal Agency,Department of the Interior,Lafayette,LA
+LCRMSCP.GOV,Federal Agency,Department of the Interior,Denver,CO
+LMVSCI.GOV,Federal Agency,Department of the Interior,Lafayette,LA
+LOWERMISSISSIPPIVALLEYSCIENCE.GOV,Federal Agency,Department of the Interior,Lafayette,LA
+MAPAPLANET.GOV,Federal Agency,Department of the Interior,Flagstaff,AZ
+MARINE.GOV,Federal Agency,Department of the Interior,Camarillo,CA
+MITIGATIONCOMMISSION.GOV,Federal Agency,Department of the Interior,Denver,CO
+MMS.GOV,Federal Agency,Department of the Interior,Herndon,VA
+MRGO.GOV,Federal Agency,Department of the Interior,Lafayette,LA
+MRLC.GOV,Federal Agency,Department of the Interior,Sioux Falls,SD
+NATIONALATLAS.GOV,Federal Agency,Department of the Interior,Reston,VA
+NATIONALMAP.GOV,Federal Agency,Department of the Interior,Reston,VA
+NATIVEONESTOP.GOV,Federal Agency,Department of the Interior,Reston,VA
+NBC.GOV,Federal Agency,Department of the Interior,Denver,CO
+NDEP.GOV,Federal Agency,Department of the Interior,Reston,VA
+NDOP.GOV,Federal Agency,Department of the Interior,Reston,VA
+NEMI.GOV,Federal Agency,Department of the Interior,Middleton,WI
+NFPORS.GOV,Federal Agency,Department of the Interior,Washington,DC
+NIFC.GOV,Federal Agency,Department of the Interior,Boise,ID
+NOLAENVIRONMENTAL.GOV,Federal Agency,Department of the Interior,Lafayette,LA
+NPS.GOV,Federal Agency,Department of the Interior,WASHINGTON DC,DC
+ONHIR.GOV,Federal Agency,Department of the Interior,Flagstaff,AZ
+ONRR.GOV,Federal Agency,Department of the Interior,Herndon,VA
+OSM.GOV,Federal Agency,Department of the Interior,Washington,DC
+OSMRE.GOV,Federal Agency,Department of the Interior,Washington,DC
+PIEDRASBLANCAS.GOV,Federal Agency,Department of the Interior,Sacramento,CA
+REPORTBAND.GOV,Federal Agency,Department of the Interior,Laurel,MD
+RIVERS.GOV,Federal Agency,Department of the Interior,Burbank,WA
+SAFECOM.GOV,Federal Agency,Department of the Interior,Boise,ID
+SCIENCEBASE.GOV,Federal Agency,Department of the Interior,Denver,CO
+SIERRAWILD.GOV,Federal Agency,Department of the Interior,Yosemite,CA
+SNAP.GOV,Federal Agency,Department of the Interior,Washington,DC
+USBR.GOV,Federal Agency,Department of the Interior,Denver,CO
+USGS.GOV,Federal Agency,Department of the Interior,Reston,VA
+UTAHFIREINFO.GOV,Federal Agency,Department of the Interior,Denver,CO
+VOLCANO.GOV,Federal Agency,Department of the Interior,Anchorage,AK
+VOLUNTEER.GOV,Federal Agency,Department of the Interior,Reston,VA
+WATERMONITOR.GOV,Federal Agency,Department of the Interior,Reston,VA
+WILDLIFEADAPTATIONSTRATEGY.GOV,Federal Agency,Department of the Interior,Arlington,VA
+WLCI.GOV,Federal Agency,Department of the Interior,Denver,CO
+YOUTHGO.GOV,Federal Agency,Department of the Interior,Shepherdstown,WV
+AMA.GOV,Federal Agency,Department of the Treasury,Washington,DC
+AMERICATHEBEAUTIFULQUARTERS.GOV,Federal Agency,Department of the Treasury,Washington,DC
+ASAP.GOV,Federal Agency,Department of the Treasury,Washington,DC
+AYUDACONMIBANCO.GOV,Federal Agency,Department of the Treasury,Washington,DC
+BANKANSWERS.GOV,Federal Agency,Department of the Treasury,Washington,DC
+BANKCUSTOMER.GOV,Federal Agency,Department of the Treasury,Washington,DC
+BANKCUSTOMERASSISTANCE.GOV,Federal Agency,Department of the Treasury,Washington,DC
+BANKHELP.GOV,Federal Agency,Department of the Treasury,Washington,DC
+BANKNET.GOV,Federal Agency,Department of the Treasury,Washington,DC
+BEP.GOV,Federal Agency,Department of the Treasury,Washington,DC
+BFEM.GOV,Federal Agency,Department of the Treasury,Washington,DC
+BONDPRO.GOV,Federal Agency,Department of the Treasury,Washington,DC
+CCAC.GOV,Federal Agency,Department of the Treasury,Washington,DC
+CDFIFUND.GOV,Federal Agency,Department of the Treasury,Washington,DC
+COMPLAINTREFERRALEXPRESS.GOV,Federal Agency,Department of the Treasury,Washington,DC
+COMPTROLLEROFTHECURRENCY.GOV,Federal Agency,Department of the Treasury,Washington,DC
+DIRECTOASUCUENTA.GOV,Federal Agency,Department of the Treasury,Washington,DC
+EFTPS.GOV,Federal Agency,Department of the Treasury,Washington,DC
+ETA-FIND.GOV,Federal Agency,Department of the Treasury,DALLAS,TX
+ETHICSBURG.GOV,Federal Agency,Department of the Treasury,Parkersburg,WV
+EYENOTE.GOV,Federal Agency,Department of the Treasury,Washington,DC
+FEDERALINVESTMENTS.GOV,Federal Agency,Department of the Treasury,Pakersburg,WV
+FEDERALSPENDING.GOV,Federal Agency,Department of the Treasury,Washington,DC
+FEDINVEST.GOV,Federal Agency,Department of the Treasury,Parkersburg,WV
+FEDSPENDING.GOV,Federal Agency,Department of the Treasury,Washington,DC
+FINANCIALRESEARCH.GOV,Federal Agency,Department of the Treasury,Washington,DC
+FINANCIALSTABILITY.GOV,Federal Agency,Department of the Treasury,Washington,DC
+FINCEN.GOV,Federal Agency,Department of the Treasury,Vienna,VA
+FSOC.GOV,Federal Agency,Department of the Treasury,Washington,DC
+FTTESTTWAI.GOV,Federal Agency,Department of the Treasury,Hyattsville,MD
+GODIRECT.GOV,Federal Agency,Department of the Treasury,Washington,DC
+GWA.GOV,Federal Agency,Department of the Treasury,Hyattsville,MD
+HELPWITHMYBANK.GOV,Federal Agency,Department of the Treasury,Washington,DC
+HELPWITHMYCHECKINGACCOUNT.GOV,Federal Agency,Department of the Treasury,Washington,DC
+HELPWITHMYCREDITCARD.GOV,Federal Agency,Department of the Treasury,Washington,DC
+HELPWITHMYCREDITCARDBANK.GOV,Federal Agency,Department of the Treasury,Washington,DC
+HELPWITHMYMORTGAGE.GOV,Federal Agency,Department of the Treasury,Washington,DC
+HELPWITHMYMORTGAGEBANK.GOV,Federal Agency,Department of the Treasury,Washington,DC
+IPAC.GOV,Federal Agency,Department of the Treasury,Boston,MA
+IPP.GOV,Federal Agency,Department of the Treasury,McLean,VA
+IRS.GOV,Federal Agency,Department of the Treasury,McLean,VA
+IRSAUCTIONS.GOV,Federal Agency,Department of the Treasury,McLean,VA
+IRSNET.GOV,Federal Agency,Department of the Treasury,McLean,VA
+IRSSALES.GOV,Federal Agency,Department of the Treasury,McLean,VA
+IRSVIDEOS.GOV,Federal Agency,Department of the Treasury,Washington,DC
+ITS.GOV,Federal Agency,Department of the Treasury,McLean,VA
+MAKINGHOMEAFFORDABLE.GOV,Federal Agency,Department of the Treasury,Washington,DC
+MHA.GOV,Federal Agency,Department of the Treasury,Washington,DC
+MONEYFACTORY.GOV,Federal Agency,Department of the Treasury,Washington,DC
+MONEYFACTORYSTORE.GOV,Federal Agency,Department of the Treasury,Washington,DC
+MSB.GOV,Federal Agency,Department of the Treasury,Vienna,VA
+MYMONEY.GOV,Federal Agency,Department of the Treasury,Washington,DC
+MYRA.GOV,Federal Agency,Department of the Treasury,Washington,DC
+NATIONALBANK.GOV,Federal Agency,Department of the Treasury,McLean,VA
+NATIONALBANKHELP.GOV,Federal Agency,Department of the Treasury,Washington,DC
+NATIONALBANKNET.GOV,Federal Agency,Department of the Treasury,Washington,DC
+NAVYCASH.GOV,Federal Agency,Department of the Treasury,McLean,VA
+OCC.GOV,Federal Agency,Department of the Treasury,Washington,DC
+OCCHELPS.GOV,Federal Agency,Department of the Treasury,Washington,DC
+OCCNET.GOV,Federal Agency,Department of the Treasury,Landover,MD
+OTS.GOV,Federal Agency,Department of the Treasury,McLean,VA
+PATRIOTBONDS.GOV,Federal Agency,Department of the Treasury,Parkersburg,WV
+PAY.GOV,Federal Agency,Department of the Treasury,Washington,DC
+PRACOMMENT.GOV,Federal Agency,Department of the Treasury,Washington,DC
+QATESTTWAI.GOV,Federal Agency,Department of the Treasury,Hyattsville,MD
+SAVINGSBOND.GOV,Federal Agency,Department of the Treasury,Mclean,VA
+SAVINGSBONDS.GOV,Federal Agency,Department of the Treasury,McLean,VA
+SAVINGSBONDWIZARD.GOV,Federal Agency,Department of the Treasury,Mclean,VA
+SIGTARP.GOV,Federal Agency,Department of the Treasury,Washington,DC
+SLGS.GOV,Federal Agency,Department of the Treasury,Mclean,VA
+TAAPS.GOV,Federal Agency,Department of the Treasury,Mclean,VA
+TAX.GOV,Federal Agency,Department of the Treasury,McLean,VA
+TCIS.GOV,Federal Agency,Department of the Treasury,Washington,DC
+TIGTA.GOV,Federal Agency,Department of the Treasury,Washington,DC
+TIGTANET.GOV,Federal Agency,Department of the Treasury,McLean,VA
+TRANSPARENCY.GOV,Federal Agency,Department of the Treasury,Washington,DC
+TREAS.GOV,Federal Agency,Department of the Treasury,Washington,DC
+TREASLOCKBOX.GOV,Federal Agency,Department of the Treasury,Washington,DC
+TREASURY.FED.US,Federal Agency,Department of the Treasury,Washington,DC
+TREASURY.GOV,Federal Agency,Department of the Treasury,Washington,DC
+TREASURYAUCTION.GOV,Federal Agency,Department of the Treasury,Parkersburg,WV
+TREASURYAUCTIONS.GOV,Federal Agency,Department of the Treasury,Mclean,VA
+TREASURYDIRECT.GOV,Federal Agency,Department of the Treasury,McLean,VA
+TREASURYECM.GOV,Federal Agency,Department of the Treasury,Washington,DC
+TREASURYHUNT.GOV,Federal Agency,Department of the Treasury,Parkersburg,WV
+TREASURYSCAMS.GOV,Federal Agency,Department of the Treasury,Mclean,VA
+TRS.GOV,Federal Agency,Department of the Treasury,Washington,DC
+TTB.GOV,Federal Agency,Department of the Treasury,Washington,DC
+TTBONLINE.GOV,Federal Agency,Department of the Treasury,McLean,VA
+TTLPLUS.GOV,Federal Agency,Department of the Treasury,St. Louis,MO
+TWAI.GOV,Federal Agency,Department of the Treasury,Washington,DC
+USASPENDING.GOV,Federal Agency,Department of the Treasury,Washington,DC
+USDEBITCARD.GOV,Federal Agency,Department of the Treasury,Mclean,VA
+USMINT.GOV,Federal Agency,Department of the Treasury,Washington,DC
+USTREAS.GOV,Federal Agency,Department of the Treasury,McLean,VA
+VERIFYPAYMENT.GOV,Federal Agency,Department of the Treasury,Parkersburg,WV
+WIZARD.GOV,Federal Agency,Department of the Treasury,Mclean,VA
+WORKPLACE.GOV,Federal Agency,Department of the Treasury,Washington,DC
+911.GOV,Federal Agency,Department of Transportation,Washington,DC
+BTS.GOV,Federal Agency,Department of Transportation,Washington,DC
+CFLHD.GOV,Federal Agency,Department of Transportation,Lakewood,CO
+DISTRACTEDDRIVING.GOV,Federal Agency,Department of Transportation,Washington,DC
+DISTRACTION.GOV,Federal Agency,Department of Transportation,Washington,DC
+DOT.GOV,Federal Agency,Department of Transportation,Washington,DC
+DOTIDEAHUB.GOV,Federal Agency,Department of Transportation,Washington,DC
+DOTTRAFFICRECORDS.GOV,Federal Agency,Department of Transportation,Room 2202,DC
+EMS.GOV,Federal Agency,Department of Transportation,Washington,DC
+ESC.GOV,Federal Agency,Department of Transportation,Oklahoma City,OK
+FAA.GOV,Federal Agency,Department of Transportation,Washington,DC
+FAASAFETY.GOV,Federal Agency,Department of Transportation,Washington,DC
+ITALLADDSUP.GOV,Federal Agency,Department of Transportation,Washington,DC
+JCCBI.GOV,Federal Agency,Department of Transportation,Oklahoma City,OK
+MARVIEW.GOV,Federal Agency,Department of Transportation,Washington,DC
+MDA.GOV,Federal Agency,Department of Transportation,Washington,DC
+NHTSA.GOV,Federal Agency,Department of Transportation,Washington,DC
+NTDPROGRAM.GOV,Federal Agency,Department of Transportation,Washington,DC
+PLAINLANGUAGE.GOV,Federal Agency,Department of Transportation,Washington,DC
+PROTECTYOURMOVE.GOV,Federal Agency,Department of Transportation,Washington,DC
+SAFERCAR.GOV,Federal Agency,Department of Transportation,Washington,DC
+SAFERTRUCK.GOV,Federal Agency,Department of Transportation,Washington,DC
+SHARETHEROADSAFELY.GOV,Federal Agency,Department of Transportation,Washington,DC
+STRONGPORTS.GOV,Federal Agency,Department of Transportation,Washington,DC
+SUSTAINABLECOMMUNITIES.GOV,Federal Agency,Department of Transportation,Washington,DC
+TFHRC.GOV,Federal Agency,Department of Transportation,Mclean,VA
+TRAFFICSAFETYMARKETING.GOV,Federal Agency,Department of Transportation,Washington,DC
+TRANSPORTATION.GOV,Federal Agency,Department of Transportation,Washington,DC
+UNITEDWERIDE.GOV,Federal Agency,Department of Transportation,Washington,DC
+CDCO.GOV,Federal Agency,Department of Veterans Affairs,Austin,TX
+NATIONALRESOURCEDIRECTORY.GOV,Federal Agency,Department of Veterans Affairs,Washington,DC
+NRD.GOV,Federal Agency,Department of Veterans Affairs,Washington,DC
+VA.GOV,Federal Agency,Department of Veterans Affairs,Washington,DC
+VETBIZ.GOV,Federal Agency,Department of Veterans Affairs,Washington,DC
+VETS.GOV,Federal Agency,Department of Veterans Affairs,Washington,DC
+DNI.GOV,Federal Agency,Director of National Intelligence,McLean,VA
+IARPA-IDEAS.GOV,Federal Agency,Director of National Intelligence,Washington,DC
+IARPA.GOV,Federal Agency,Director of National Intelligence,College Park,MD
+ICJOINTDUTY.GOV,Federal Agency,Director of National Intelligence,Washington,DC
+INTELINK.GOV,Federal Agency,Director of National Intelligence,Ft. George G. Meade,MD
+INTELLIGENCE.GOV,Federal Agency,Director of National Intelligence,Washington,DC
+ISE.GOV,Federal Agency,Director of National Intelligence,Washington ,DC
+NCIX.GOV,Federal Agency,Director of National Intelligence,Washington,DC
+NCSC.GOV,Federal Agency,Director of National Intelligence,Bethesda,MD
+NMIC.GOV,Federal Agency,Director of National Intelligence,Washington,DC
+ODNI.GOV,Federal Agency,Director of National Intelligence,Washington,DC
+OSIS.GOV,Federal Agency,Director of National Intelligence,Fort George G. Meade,MD
+PIX.GOV,Federal Agency,Director of National Intelligence,Washington,DC
+QART.GOV,Federal Agency,Director of National Intelligence,Washington,DC
+UGOV.GOV,Federal Agency,Director of National Intelligence,Fort George G Meade,MD
+AIRNOW.GOV,Federal Agency,Environmental Protection Agency,Durham,NC
+CBI-EPA.GOV,Federal Agency,Environmental Protection Agency,Durham,NC
+ENERGYSTAR.GOV,Federal Agency,Environmental Protection Agency,Washington,DC
+EPA.GOV,Federal Agency,Environmental Protection Agency,Research Triangle Park,NC
+FDMS.GOV,Federal Agency,Environmental Protection Agency,Washington,DC
+FEDCENTER.GOV,Federal Agency,Environmental Protection Agency,Champaign,IL
+FRTR.GOV,Federal Agency,Environmental Protection Agency,Omaha,NE
+GREENGOV.GOV,Federal Agency,Environmental Protection Agency, Washington,DC
+OFEE.GOV,Federal Agency,Environmental Protection Agency,Washington,DC
+REGULATION.GOV,Federal Agency,Environmental Protection Agency,Washington,DC
+REGULATIONS.GOV,Federal Agency,Environmental Protection Agency,Washington,DC
+RELOCATEFEDS.GOV,Federal Agency,Environmental Protection Agency,Cincinnati,OH
+SUSTAINABILITY.GOV,Federal Agency,Environmental Protection Agency,Washington,DC
+URBANWATERS.GOV,Federal Agency,Environmental Protection Agency,Washington,DC
+EEOC.GOV,Federal Agency,Equal Employment Opportunity Commission,Washington,DC
+AIDREFUGEES.GOV,Federal Agency,Executive Office of the President,Washington,DC
+ASTRONGMIDDLECLASS.GOV,Federal Agency,Executive Office of the President,Washington,DC
+BUDGET.GOV,Federal Agency,Executive Office of the President,Washington,DC
+CHANGE.GOV,Federal Agency,Executive Office of the President,Arlington,VA
+EARMARKS.GOV,Federal Agency,Executive Office of the President,Washington,DC
+EGOV.GOV,Federal Agency,Executive Office of the President,Washington,DC
+EOP.GOV,Federal Agency,Executive Office of the President,Washington,DC
+ETHICS.GOV,Federal Agency,Executive Office of the President,Washington ,DC
+EXRWH.GOV,Federal Agency,Executive Office of the President,Washington,DC
+FISCALCOMMISSION.GOV,Federal Agency,Executive Office of the President,Washington,DC
+HC.GOV,Federal Agency,Executive Office of the President,Washington,DC
+ITDASHBOARD.GOV,Federal Agency,Executive Office of the President,Washington,DC
+JOININGFORCES.GOV,Federal Agency,Executive Office of the President,Washington,DC
+LETSMOVE.GOV,Federal Agency,Executive Office of the President,Washington,DC
+MAX.GOV,Federal Agency,Executive Office of the President,NW,WA
+NEPA.GOV,Federal Agency,Executive Office of the President,Washington,DC
+NOTALONE.GOV,Federal Agency,Executive Office of the President,Washington,DC
+NSTIC.GOV,Federal Agency,Executive Office of the President,Gaithersburg,MD
+OMB.GOV,Federal Agency,Executive Office of the President,Washington,DC
+OMBLOG.GOV,Federal Agency,Executive Office of the President,Washington,DC
+ONDCP.GOV,Federal Agency,Executive Office of the President,Washington,DC
+OSTP.GOV,Federal Agency,Executive Office of the President,Washington,DC
+PAYMENTACCURACY.GOV,Federal Agency,Executive Office of the President,Washington,DC
+PCI.GOV,Federal Agency,Executive Office of the President,Washington,DC
+PRESIDIO.GOV,Federal Agency,Executive Office of the President,San Francisco,CA
+PRESIDIOTRUST.GOV,Federal Agency,Executive Office of the President,San Francisco,CA
+REACHHIGHER.GOV,Federal Agency,Executive Office of the President,Washington,DC
+SAVE.GOV,Federal Agency,Executive Office of the President,Washington,DC
+SAVEAWARD.GOV,Federal Agency,Executive Office of the President,Washington,DC
+STRONGMIDDLECLASS.GOV,Federal Agency,Executive Office of the President,Washington,DC
+USTR.GOV,Federal Agency,Executive Office of the President,Washington,DC
+WH.GOV,Federal Agency,Executive Office of the President,Washington,DC
+WHITEHOUSE.GOV,Federal Agency,Executive Office of the President,Washington,DC
+WHITEHOUSEDRUGPOLICY.GOV,Federal Agency,Executive Office of the President,Washington,DC
+EXIM.GOV,Federal Agency,Export/Import Bank of the U.S.,Washington,DC
+EXIMCOOP.GOV,Federal Agency,Export/Import Bank of the U.S.,Washington,DC
+FCA.GOV,Federal Agency,Farm Credit Administration,McLean,VA
+FCSIC.GOV,Federal Agency,Farm Credit Administration,McLean,VA
+BROADBAND.GOV,Federal Agency,Federal Communications Commission,Washington,DC
+BROADBANDMAP.GOV,Federal Agency,Federal Communications Commission,Washington,DC
+DTV.GOV,Federal Agency,Federal Communications Commission,Washington,DC
+FCC.GOV,Federal Agency,Federal Communications Commission,Washington,DC
+FCCUNIVERSITY.GOV,Federal Agency,Federal Communications Commission,Washington,DC
+LIFELINE.GOV,Federal Agency,Federal Communications Commission,Washington,DC
+NBM.GOV,Federal Agency,Federal Communications Commission,Washington,DC
+OPENINTERNET.GOV,Federal Agency,Federal Communications Commission,Washington,DC
+ECONOMICINCLUSION.GOV,Federal Agency,Federal Deposit Insurance Corporation,Arlington,VA
+FDIC.GOV,Federal Agency,Federal Deposit Insurance Corporation,Arlington,VA
+FDICBETS.GOV,Federal Agency,Federal Deposit Insurance Corporation,Arlington,VA
+FDICCONNECT.GOV,Federal Agency,Federal Deposit Insurance Corporation,Arlington,VA
+FDICIG.GOV,Federal Agency,Federal Deposit Insurance Corporation,Arlington,VA
+FDICOIG.GOV,Federal Agency,Federal Deposit Insurance Corporation,Washington,DC
+FDICSALES.GOV,Federal Agency,Federal Deposit Insurance Corporation,Arlington,VA
+FDICSEGURO.GOV,Federal Agency,Federal Deposit Insurance Corporation,Arlington,VA
+MYFDIC.GOV,Federal Agency,Federal Deposit Insurance Corporation,Arlington,VA
+MYFDICINSURANCE.GOV,Federal Agency,Federal Deposit Insurance Corporation,Arlington,VA
+FEC.GOV,Federal Agency,Federal Elections Commission,Washington,DC
+FERC.GOV,Federal Agency,Federal Energy Regulatory Commission,Washington,DC
+FERCALT.GOV,Federal Agency,Federal Energy Regulatory Commission,Washington,DC
+FHFA.GOV,Federal Agency,Federal Housing Finance Agency,Washington,DC
+FHFB.GOV,Federal Agency,Federal Housing Finance Agency,Washington,DC
+HARP.GOV,Federal Agency,Federal Housing Finance Agency,Washington,DC
+OFHEO.GOV,Federal Agency,Federal Housing Finance Agency,Washington,DC
+FHFAOIG.GOV,Federal Agency,Federal Housing Finance Agency Office of Inspector General,Washington,DC
+FLRA.GOV,Federal Agency,Federal Labor Relations Authority,Washington,DC
+FMC.GOV,Federal Agency,Federal Maritime Commission,Washington,DC
+FMCS.GOV,Federal Agency,Federal Mediation and Conciliation Service,Washington,DC
+FBIIC.GOV,Federal Agency,Federal Reserve System,Washington,DC
+FEDCENTENNIAL.GOV,Federal Agency,Federal Reserve System,Washington,DC
+FEDERALRESERVE.GOV,Federal Agency,Federal Reserve System,Washington,DC
+FEDERALRESERVE100.GOV,Federal Agency,Federal Reserve System,Washington ,DC
+FEDERALRESERVE2013.GOV,Federal Agency,Federal Reserve System,Washington,DC
+FEDERALRESERVECENTENNIAL.GOV,Federal Agency,Federal Reserve System,Washington ,DC
+FEDERALRESERVECENTENNIALCELEBRATION.GOV,Federal Agency,Federal Reserve System,Washington,DC
+FEDERALRESERVECONSUMERHELP.GOV,Federal Agency,Federal Reserve System,Washington,DC
+FEDPARTNERSHIP.GOV,Federal Agency,Federal Reserve System,Washington,DC
+FFIEC.GOV,Federal Agency,Federal Reserve System,Washington,DC
+FRB.FED.US,Federal Agency,Federal Reserve System,Washington,DC
+FRB.GOV,Federal Agency,Federal Reserve System,Washington,DC
+FRS.GOV,Federal Agency,Federal Reserve System,Washington,DC
+NEWMONEY.GOV,Federal Agency,Federal Reserve System,Washington,DC
+USCURRENCY.GOV,Federal Agency,Federal Reserve System,Washington,DC
+EXPLORETSP.GOV,Federal Agency,Federal Retirement Thrift Investment Board,Washington,DC
+FRTIB.GOV,Federal Agency,Federal Retirement Thrift Investment Board,Washington,DC
+FRTIBTEST.GOV,Federal Agency,Federal Retirement Thrift Investment Board,Washigton,DC
+TSP.GOV,Federal Agency,Federal Retirement Thrift Investment Board,Washington,DC
+TSPTEST.GOV,Federal Agency,Federal Retirement Thrift Investment Board,Washington,DC
+ADMONGO.GOV,Federal Agency,Federal Trade Commission,Washington,DC
+ALERTAENLINEA.GOV,Federal Agency,Federal Trade Commission,Washington,DC
+ANNUALCREDITREPORT.GOV,Federal Agency,Federal Trade Commission,Washington,DC
+CONSUMER.GOV,Federal Agency,Federal Trade Commission,Washington,DC
+CONSUMERSENTINEL.GOV,Federal Agency,Federal Trade Commission,Washington,DC
+CONSUMERSENTINELNETWORK.GOV,Federal Agency,Federal Trade Commission,Washington,DC
+CONSUMIDOR.GOV,Federal Agency,Federal Trade Commission,Washington,DC
+DONOTCALL.GOV,Federal Agency,Federal Trade Commission,Washington,DC
+DONTSERVETEENS.GOV,Federal Agency,Federal Trade Commission,Washington,DC
+ECONSUMER.GOV,Federal Agency,Federal Trade Commission,Washington,DC
+FREECREDITREPORT.GOV,Federal Agency,Federal Trade Commission,Washington,DC
+FTC.GOV,Federal Agency,Federal Trade Commission,Washington,DC
+FTCCOMPLAINTASSISTANT.GOV,Federal Agency,Federal Trade Commission,Washington,DC
+FTCEFILE.GOV,Federal Agency,Federal Trade Commission,Washington,DC
+HSR.GOV,Federal Agency,Federal Trade Commission,Washington,DC
+IDENTITYTHEFT.GOV,Federal Agency,Federal Trade Commission,Washington,DC
+IDTHEFT.GOV,Federal Agency,Federal Trade Commission,Washington,DC
+NCPW.GOV,Federal Agency,Federal Trade Commission,Washington,DC
+ONGUARDONLINE.GOV,Federal Agency,Federal Trade Commission,Washington,DC
+ONLINEONGUARD.GOV,Federal Agency,Federal Trade Commission,Washington,DC
+PROTECCIONDELCONSUMIDOR.GOV,Federal Agency,Federal Trade Commission,Washington,DC
+ROBODEIDENTIDAD.GOV,Federal Agency,Federal Trade Commission,Washington,DC
+SENTINEL.GOV,Federal Agency,Federal Trade Commission,Washington,DC
+UCE.GOV,Federal Agency,Federal Trade Commission,Washington,DC
+USICN.GOV,Federal Agency,Federal Trade Commission,Washington,DC
+18F.GOV,Federal Agency,General Services Administration,Washington,DC
+ACQUISITION.GOV,Federal Agency,General Services Administration,Arlington,VA
+ADVANTAGE.GOV,Federal Agency,General Services Administration,Washington,DC
+AFADVANTAGE.GOV,Federal Agency,General Services Administration,Washington,DC
+AMERICANJOBCENTER.GOV,Federal Agency,General Services Administration,Washington,DC
+BUSINESSUSA.GOV,Federal Agency,General Services Administration,Washington,DC
+BUYACCESSIBLE.GOV,Federal Agency,General Services Administration,Washington,DC
+CAO.GOV,Federal Agency,General Services Administration,Washington,DC
+CBCA.GOV,Federal Agency,General Services Administration,Washington,DC
+CCR.GOV,Federal Agency,General Services Administration,Battle Creek,MI
+CFDA.GOV,Federal Agency,General Services Administration,Washington,DC
+CFO.GOV,Federal Agency,General Services Administration,Washington,DC
+CFOC.GOV,Federal Agency,General Services Administration,Washington,DC
+CHALLENGE.GOV,Federal Agency,General Services Administration,Washington,DC
+CHALLENGES.GOV,Federal Agency,General Services Administration,Washington,DC
+CIO.GOV,Federal Agency,General Services Administration,Washington,DC
+CLOUD.GOV,Federal Agency,General Services Administration,Washington,DC
+COMPUTERS4LEARNING.GOV,Federal Agency,General Services Administration,Arlington,VA
+COMPUTERSFORLEARNING.GOV,Federal Agency,General Services Administration,Arlington,VA
+CONNECT.GOV,Federal Agency,General Services Administration,Washington,DC
+CONSUMERACTION.GOV,Federal Agency,General Services Administration,Washington,DC
+CONTRACTDIRECTORY.GOV,Federal Agency,General Services Administration,Arlington,VA
+CPARS.GOV,Federal Agency,General Services Administration,Washington,DC
+DATA.GOV,Federal Agency,General Services Administration,Washington,DC
+DIGITALGOV.GOV,Federal Agency,General Services Administration,Washington,DC
+DOTGOV.GOV,Federal Agency,General Services Administration,Fairfax,VA
+EAC.GOV,Federal Agency,General Services Administration,Washington,DC
+ECPIC.GOV,Federal Agency,General Services Administration,Washington,DC
+EISENHOWERMEMORIAL.GOV,Federal Agency,General Services Administration,Washington,DC
+EPLS.GOV,Federal Agency,General Services Administration,Arlington,VA
+ESRS.GOV,Federal Agency,General Services Administration,arlington,VA
+EVERYKIDINAPARK.GOV,Federal Agency,General Services Administration,Washington DC,DC
+FACA.GOV,Federal Agency,General Services Administration,Washington,DC
+FACADATABASE.GOV,Federal Agency,General Services Administration,Washington,DC
+FAI.GOV,Federal Agency,General Services Administration,Washington,DC
+FAPIIS.GOV,Federal Agency,General Services Administration,Washington,DC
+FAQ.GOV,Federal Agency,General Services Administration,Washington,DC
+FBO.GOV,Federal Agency,General Services Administration,Arlington,VA
+FED.US,Federal Agency,General Services Administration,Washington,DC
+FEDBIZOPPS.GOV,Federal Agency,General Services Administration,Arlington,VA
+FEDIDCARD.GOV,Federal Agency,General Services Administration,Washington,DC
+FEDINFO.GOV,Federal Agency,General Services Administration,Washington,DC
+FEDRAMP.GOV,Federal Agency,General Services Administration,Washington,DC
+FEDROOMS.GOV,Federal Agency,General Services Administration,Arlington,VA
+FIDO.GOV,Federal Agency,General Services Administration,Washington,DC
+FIRSTGOV.GOV,Federal Agency,General Services Administration,Washington,DC
+FMI.GOV,Federal Agency,General Services Administration,Washington,DC
+FORMS.GOV,Federal Agency,General Services Administration,Washington,DC
+FPDS.GOV,Federal Agency,General Services Administration,Arlington,VA
+FPKI-LAB.GOV,Federal Agency,General Services Administration,Washington,DC
+FPKI.GOV,Federal Agency,General Services Administration,Washington,DC
+FRPP-PA.GOV,Federal Agency,General Services Administration,WASHINGTON,DC
+FSD.GOV,Federal Agency,General Services Administration,Arlington,VA
+FSRS.GOV,Federal Agency,General Services Administration,Crystal City,VA
+GOBIERNO.GOV,Federal Agency,General Services Administration,Washington,DC
+GOBIERNOUSA.GOV,Federal Agency,General Services Administration,Washington,DC
+GOVSALES.GOV,Federal Agency,General Services Administration,Arlington,VA
+GSA.GOV,Federal Agency,General Services Administration,Washington,DC
+GSAADVANTAGE.GOV,Federal Agency,General Services Administration,Washington,DC
+GSAAUCTIONS.GOV,Federal Agency,General Services Administration,Washington,DC
+GSADVANTAGE.GOV,Federal Agency,General Services Administration,Washington,DC
+GSAIG.GOV,Federal Agency,General Services Administration,Washington,DC
+GSAXCESS.GOV,Federal Agency,General Services Administration,Arlington,VA
+HOWTO.GOV,Federal Agency,General Services Administration,Washington,DC
+IDMANAGEMENT.GOV,Federal Agency,General Services Administration,Washington,DC
+INFO.GOV,Federal Agency,General Services Administration,Washington,DC
+JOBCENTER.GOV,Federal Agency,General Services Administration,Washington,DC
+KIDS.GOV,Federal Agency,General Services Administration,Washington,DC
+LEARNPERFORMANCE.GOV,Federal Agency,General Services Administration,Washington,DC
+MYUSA.GOV,Federal Agency,General Services Administration,Washington,DC
+NBRC.GOV,Federal Agency,General Services Administration,Bangor,ME
+NETWORX.GOV,Federal Agency,General Services Administration,Fairfax,VA
+NIC.GOV,Federal Agency,General Services Administration,Fairfax,VA
+PARTNER4SOLUTIONS.GOV,Federal Agency,General Services Administration,Washington,DC
+PCLOB.GOV,Federal Agency,General Services Administration,Washington,DC
+PERFORMANCE.GOV,Federal Agency,General Services Administration,Washington,DC
+PIC.GOV,Federal Agency,General Services Administration,Washington,DC
+PIF.GOV,Federal Agency,General Services Administration,Washington,DC
+PPIRS.GOV,Federal Agency,General Services Administration,Washington,DC
+PRESIDENTIALINNOVATIONFELLOWS.GOV,Federal Agency,General Services Administration,Washington,DC
+PTT.GOV,Federal Agency,General Services Administration,Washington D.C.,DC
+REALESTATESALES.GOV,Federal Agency,General Services Administration,Washington,DC
+REALPROPERTYPROFILE.GOV,Federal Agency,General Services Administration,Washington,DC
+REGINFO.GOV,Federal Agency,General Services Administration,Washington,DC
+ROCIS.GOV,Federal Agency,General Services Administration,Washington,DC
+SAM.GOV,Federal Agency,General Services Administration,Arlington,VA
+SANDBOX.GOV,Federal Agency,General Services Administration,Washinton,DC
+SBST.GOV,Federal Agency,General Services Administration,Washington,DC
+SECTION508.GOV,Federal Agency,General Services Administration,Washington,DC
+SFTOOL.GOV,Federal Agency,General Services Administration,Chicago,IL
+STRATEGICSOURCING.GOV,Federal Agency,General Services Administration,Arlington,VA
+SUPPORTTHEVOTER.GOV,Federal Agency,General Services Administration,WASHINGTON,DC
+UNITEDSTATES.GOV,Federal Agency,General Services Administration,Washington,DC
+US.GOV,Federal Agency,General Services Administration,Washington,DC
+USA.GOV,Federal Agency,General Services Administration,Washington,DC
+USAGOV.GOV,Federal Agency,General Services Administration,Washington,DC
+USAPERFORMANCE.GOV,Federal Agency,General Services Administration,Washington,DC
+USCIRF.GOV,Federal Agency,General Services Administration,Washington,DC
+USGOVERNMENT.GOV,Federal Agency,General Services Administration,Washington,DC
+USIP.GOV,Federal Agency,General Services Administration,Washington,DC
+VEF.GOV,Federal Agency,General Services Administration,Arlington,VA
+VITM.GOV,Federal Agency,General Services Administration,Arlington,VA
+BROWSETOPICS.GOV,Federal Agency,Government Printing Office,Washington,DC
+CONGRESSIONALDIRECTORY.GOV,Federal Agency,Government Printing Office,Washington,DC
+CONGRESSIONALRECORD.GOV,Federal Agency,Government Printing Office,Washington,DC
+ECFR.GOV,Federal Agency,Government Printing Office,Washington,DC
+FDLP.GOV,Federal Agency,Government Printing Office,Washington,DC
+FDSYS.GOV,Federal Agency,Government Printing Office,Washington,DC
+FEDERALREGISTER.GOV,Federal Agency,Government Printing Office,Washington,DC
+FEDREG.GOV,Federal Agency,Government Printing Office,Washington,DC
+FMSHRC.GOV,Federal Agency,Government Printing Office,Washington,DC
+GOVINFO.GOV,Federal Agency,Government Printing Office,Washington,DC
+GPO.GOV,Federal Agency,Government Printing Office,Washington,DC
+GPOACCESS.GOV,Federal Agency,Government Printing Office,Washington,DC
+HOUSECALENDAR.GOV,Federal Agency,Government Printing Office,Washington,DC
+OFR.GOV,Federal Agency,Government Printing Office,Washington,DC
+OPENWORLD.GOV,Federal Agency,Government Printing Office,Washington,DC
+PRESIDENTIALDOCUMENTS.GOV,Federal Agency,Government Printing Office,Washington,DC
+SENATECALENDAR.GOV,Federal Agency,Government Printing Office,Washington,DC
+STOPFAKES.GOV,Federal Agency,Government Printing Office,Washington,DC
+USCAPITOLPOLICE.GOV,Federal Agency,Government Printing Office,Washington,DC
+USCC.GOV,Federal Agency,Government Printing Office,Washington,DC
+USCCR.GOV,Federal Agency,Government Printing Office,Washington,DC
+USCODE.GOV,Federal Agency,Government Printing Office,Washington,DC
+USGOVERNMENTMANUAL.GOV,Federal Agency,Government Printing Office,College Park,MD
+WELCOMETOUSA.GOV,Federal Agency,Government Printing Office,Washington,DC
+RESTORETHEGULF.GOV,Federal Agency,Gulf Coast Ecosystem Restoration Council (GCERC),Silver Spring,MD
+TRUMAN.GOV,Federal Agency,Harry S. Truman Scholarship Foundation,Washington,DC
+IMLS.GOV,Federal Agency,Institute of Museum and Library Services,Washington,DC
+IAF.GOV,Federal Agency,Inter-American Foundation,Washington,DC
+BBG.GOV,Federal Agency,International Broadcasting Bureau,Washington,DC
+IBB.GOV,Federal Agency,International Broadcasting Bureau,Washington,DC
+VOA.GOV,Federal Agency,International Broadcasting Bureau,Washington,DC
+JAMESMADISON.GOV,Federal Agency,James Madison Memorial Fellowship Foundation,Alexandria,VA
+LSC.GOV,Federal Agency,Legal Services Corporation,Washington,DC
+AFRICANAMERICANHISTORYMONTH.GOV,Federal Agency,Library of Congress,Washington,DC
+AMERICANMEMORY.GOV,Federal Agency,Library of Congress,Washington,DC
+AMERICASLIBRARY.GOV,Federal Agency,Library of Congress,Washington,DC
+AMERICASSTORY.GOV,Federal Agency,Library of Congress,Washington,DC
+AMERICASTORY.GOV,Federal Agency,Library of Congress,Washington,DC
+ASIANPACIFICHERITAGE.GOV,Federal Agency,Library of Congress,Washington,DC
+CAPITOLHILL.GOV,Federal Agency,Library of Congress,Washington,DC
+COMMISSION.GOV,Federal Agency,Library of Congress,Washington,DC
+CONGRESS.GOV,Federal Agency,Library of Congress,Washington,DC
+COPYRIGHT.GOV,Federal Agency,Library of Congress,Washington,DC
+CRS.GOV,Federal Agency,Library of Congress,Washington,DC
+DIGITALPRESERVATION.GOV,Federal Agency,Library of Congress,Washington,DC
+DIGITALSTEWARDSHIP.GOV,Federal Agency,Library of Congress,Washington,DC
+DIGITIZATIONGUIDELINES.GOV,Federal Agency,Library of Congress,Washington,DC
+HILL.GOV,Federal Agency,Library of Congress,Washington,DC
+HISPANICHERITAGEMONTH.GOV,Federal Agency,Library of Congress,Washington,DC
+JEWISHHERITAGE.GOV,Federal Agency,Library of Congress,Washington,DC
+JEWISHHERITAGEMONTH.GOV,Federal Agency,Library of Congress,Washington,DC
+LAW.GOV,Federal Agency,Library of Congress,Washington,DC
+LCTL.GOV,Federal Agency,Library of Congress,Washington,DC
+LEGISLATIVE.GOV,Federal Agency,Library of Congress,Washington,DC
+LEGISLATIVEBRANCH.GOV,Federal Agency,Library of Congress,Washington,DC
+LIBRARY-OF-CONGRESS.GOV,Federal Agency,Library of Congress,Washington,DC
+LIBRARYOFCONGRESS.GOV,Federal Agency,Library of Congress,Washington,DC
+LIS.GOV,Federal Agency,Library of Congress,Washington,DC
+LITERACY.GOV,Federal Agency,Library of Congress,Washington,DC
+LOC.GOV,Federal Agency,Library of Congress,Washington,DC
+LOCIMAGES.GOV,Federal Agency,Library of Congress,Washington,DC
+LOCSTORE.GOV,Federal Agency,Library of Congress,Washington,DC
+LOCTPS.GOV,Federal Agency,Library of Congress,Washington,DC
+MYLOC.GOV,Federal Agency,Library of Congress,Washington,DC
+NATIVEAMERICANHERITAGEMONTH.GOV,Federal Agency,Library of Congress,Washington,DC
+NDSA.GOV,Federal Agency,Library of Congress,Washington,DC
+PRIMARYSOURCES.GOV,Federal Agency,Library of Congress,Washington,DC
+READ.GOV,Federal Agency,Library of Congress,Washington,DC
+SECTION108.GOV,Federal Agency,Library of Congress,Washington,DC
+TEACHINGPRIMARYSOURCES.GOV,Federal Agency,Library of Congress,Washington,DC
+TEACHINGWITHPRIMARYSOURCES.GOV,Federal Agency,Library of Congress,Washington,DC
+THOMAS.GOV,Federal Agency,Library of Congress,Washington,DC
+TPS.GOV,Federal Agency,Library of Congress,Washington,DC
+UNITEDSTATESCONGRESS.GOV,Federal Agency,Library of Congress,Washington,DC
+USCONGRESS.GOV,Federal Agency,Library of Congress,Washington,DC
+WDL.GOV,Federal Agency,Library of Congress,Washington,DC
+WOMENSHISTORYMONTH.GOV,Federal Agency,Library of Congress,Washington,DC
+WORLDDIGITALLIBRARY.GOV,Federal Agency,Library of Congress,Washington,DC
+MMC.GOV,Federal Agency,Marine Mammal Commission,Bethesda,MD
+MACPAC.GOV,Federal Agency,Medicaid and CHIP Payment and Access Commission,Washington,DC
+MEDPAC.GOV,Federal Agency,Medical Payment Advisory Commission,Washington,DC
+MSPB.GOV,Federal Agency,Merit Systems Protection Board,Washington,DC
+MCC.GOV,Federal Agency,Millennium Challenge Corporation,Washington,DC
+ECR.GOV,Federal Agency,Morris K. Udall Foundation,Tucson,AZ
+UDALL.GOV,Federal Agency,Morris K. Udall Foundation,Tucson,AZ
+GLOBE.GOV,Federal Agency,National Aeronautics and Space Administration,Greenbelt,MD
+NASA.GOV,Federal Agency,National Aeronautics and Space Administration,MSFC,AL
+NSWP.GOV,Federal Agency,National Aeronautics and Space Administration,MSFC,AL
+SCIJINKS.GOV,Federal Agency,National Aeronautics and Space Administration,MSFC,AL
+USGEO.GOV,Federal Agency,National Aeronautics and Space Administration,MSFC,AL
+9-11COMMISSION.GOV,Federal Agency,National Archives and Records Administration,College Park,MD
+911COMMISSION.GOV,Federal Agency,National Archives and Records Administration,College Park,MD
+ARCHIVES.GOV,Federal Agency,National Archives and Records Administration,College Park,MD
+CLINTONLIBRARY.GOV,Federal Agency,National Archives and Records Administration,Little Rock,AR
+EMERGENCY-FEDERAL-REGISTER.GOV,Federal Agency,National Archives and Records Administration,College Park,MD
+FCIC.GOV,Federal Agency,National Archives and Records Administration,College Park,MD
+FORDLIBRARYMUSEUM.GOV,Federal Agency,National Archives and Records Administration,College Park,MD
+FRC.GOV,Federal Agency,National Archives and Records Administration,College Park,MD
+GEORGEWBUSHLIBRARY.GOV,Federal Agency,National Archives and Records Administration,College Park,MD
+HISTORY.GOV,Federal Agency,National Archives and Records Administration,College Park,MD
+JIMMYCARTERLIBRARY.GOV,Federal Agency,National Archives and Records Administration,College,MD
+NARA-AT-WORK.GOV,Federal Agency,National Archives and Records Administration,College Park,MD
+NARA.GOV,Federal Agency,National Archives and Records Administration,College Park,MD
+NIXONLIBRARY.GOV,Federal Agency,National Archives and Records Administration,College Park,MD
+OGIS.GOV,Federal Agency,National Archives and Records Administration,College Park,MD
+OURDOCUMENTS.GOV,Federal Agency,National Archives and Records Administration,College Park,MD
+REAGANLIBRARY.GOV,Federal Agency,National Archives and Records Administration,College Park,MD
+RECORDSMANAGEMENT.GOV,Federal Agency,National Archives and Records Administration,College Park,MD
+WARTIMECONTRACTING.GOV,Federal Agency,National Archives and Records Administration,College Park,MD
+WEBHARVEST.GOV,Federal Agency,National Archives and Records Administration,College Park,MD
+NCPC.GOV,Federal Agency,National Capital Planning Commission,Washington,DC
+NCD.GOV,Federal Agency,National Council on Disability,Washington,DC
+MYCREDITUNION.GOV,Federal Agency,National Credit Union Administration,Alexandria,VA
+NCUA.GOV,Federal Agency,National Credit Union Administration,Alexandria,VA
+ARTS.GOV,Federal Agency,National Endowment for the Arts,Washington,DC
+NEA.GOV,Federal Agency,National Endowment for the Arts,Washington,DC
+HUMANITIES.GOV,Federal Agency,National Endowment for the Humanities,Washington,DC
+NEH.GOV,Federal Agency,National Endowment for the Humanities,Washington,DC
+PCAH.GOV,Federal Agency,National Endowment for the Humanities,Washington,DC
+WETHEPEOPLE.GOV,Federal Agency,National Endowment for the Humanities,Washington,DC
+NGA.GOV,Federal Agency,National Gallery of Art,Washington,DC
+NIGC.GOV,Federal Agency,National Indian Gaming Commission,Washington,DC
+NLRB.GOV,Federal Agency,National Labor Relations Board,Washington,DC
+NMB.GOV,Federal Agency,National Mediation Board,Washington,DC
+NANO.GOV,Federal Agency,National Nanotechnology Coordination Office,Arlington,VA
+ARCTIC.GOV,Federal Agency,National Science Foundation,Arlington,VA
+ARCTICGAS.GOV,Federal Agency,National Science Foundation,Washington,DC
+NSF.GOV,Federal Agency,National Science Foundation,Arlington,VA
+RESEARCH.GOV,Federal Agency,National Science Foundation,Arlington,VA
+SAC.GOV,Federal Agency,National Science Foundation,Arlington,VA
+SBIR.GOV,Federal Agency,National Science Foundation,Arlington,VA
+SCIENCE360.GOV,Federal Agency,National Science Foundation,Arlington,VA
+USAP.GOV,Federal Agency,National Science Foundation,Arlington,VA
+INTELLIGENCECAREERS.GOV,Federal Agency,National Security Agency,Ft. Meade,MD
+LPS.GOV,Federal Agency,National Security Agency,College Park,MD
+NTSB.GOV,Federal Agency,National Transportation Safety Board,Washington,DC
+ITRD.GOV,Federal Agency,Networking Information Technology Research and Development (NITRD),Arlington,VA
+NITRD.GOV,Federal Agency,Networking Information Technology Research and Development (NITRD),Arlington,VA
+HERITAGEABROAD.GOV,Federal Agency,Non-Federal Agency,Washington,DC
+IAB.GOV,Federal Agency,Non-Federal Agency,Quantico,VA
+JUSFC.GOV,Federal Agency,Non-Federal Agency,Washington,DC
+NWTRB.GOV,Federal Agency,Non-Federal Agency,Arlington,VA
+PPPL.GOV,Federal Agency,Non-Federal Agency,Princeton,NJ
+SERVEINDIANA.GOV,Federal Agency,Non-Federal Agency,Indianapolis,IN
+SJI.GOV,Federal Agency,Non-Federal Agency,Reston,VA
+WMATC.GOV,Federal Agency,Non-Federal Agency,Silver Spring,MD
+NRC-GATEWAY.GOV,Federal Agency,Nuclear Regulatory Commission,Rockville,MD
+NRC.GOV,Federal Agency,Nuclear Regulatory Commission,Rockville,MD
+OSHRC.GOV,Federal Agency,Occupational Safety & Health Review Commission,Washington,DC
+INTEGRITY.GOV,Federal Agency,Office of Government Ethics,Washington,DC
+APPLICATIONMANAGER.GOV,Federal Agency,Office of Personnel Management,Macon,GA
+CHCOC.GOV,Federal Agency,Office of Personnel Management,Washington,DC
+E-QIP.GOV,Federal Agency,Office of Personnel Management,Washington,DC
+EMPLOYEEEXPRESS.GOV,Federal Agency,Office of Personnel Management,Macon,GA
+FEB.GOV,Federal Agency,Office of Personnel Management,Washington,DC
+FEDERALJOBS.GOV,Federal Agency,Office of Personnel Management,Macon,GA
+FEDJOBS.GOV,Federal Agency,Office of Personnel Management,Macon,GA
+FEDSHIREVETS.GOV,Federal Agency,Office of Personnel Management,Washington,DC
+FEGLI.GOV,Federal Agency,Office of Personnel Management,Washington,DC
+FSAFEDS.GOV,Federal Agency,Office of Personnel Management,Washington,DC
+GOLEARN.GOV,Federal Agency,Office of Personnel Management,Washington,DC
+GOVERNMENTJOBS.GOV,Federal Agency,Office of Personnel Management,Macon,GA
+HRU.GOV,Federal Agency,Office of Personnel Management,Washington,DC
+LMRCOUNCIL.GOV,Federal Agency,Office of Personnel Management,Washington,DC
+OPM.GOV,Federal Agency,Office of Personnel Management,Macon,GA
+PAC.GOV,Federal Agency,Office of Personnel Management,Washington,DC
+PMF.GOV,Federal Agency,Office of Personnel Management,Washington,DC
+TELEWORK.GOV,Federal Agency,Office of Personnel Management,Washington,DC
+UNLOCKTALENT.GOV,Federal Agency,Office of Personnel Management,Washington,DC
+USAJOBS.GOV,Federal Agency,Office of Personnel Management,Washington,DC
+USALEARNING.GOV,Federal Agency,Office of Personnel Management,Washington,DC
+USASTAFFING.GOV,Federal Agency,Office of Personnel Management,Macon,GA
+OPIC.GOV,Federal Agency,Overseas Private Investment Corporation,Washington,DC
+PBGC.GOV,Federal Agency,Pension Benefit Guaranty Corporation,Washington,DC
+PRC.GOV,Federal Agency,Postal Rate Commission,Washington,DC
+RRB.GOV,Federal Agency,Railroad Retirement Board,Chicago,IL
+EDUCATIONJOBSFUND.GOV,Federal Agency,Recovery Accountability and Transparency Board,Washington,DC
+FEDERALACCOUNTABILITY.GOV,Federal Agency,Recovery Accountability and Transparency Board,Washington,DC
+FEDERALREPORTING.GOV,Federal Agency,Recovery Accountability and Transparency Board,Washington,DC
+FEDERALTRANSPARENCY.GOV,Federal Agency,Recovery Accountability and Transparency Board,Washington ,DC
+RATB.GOV,Federal Agency,Recovery Accountability and Transparency Board,WASHINGTON,DC
+RECOVERY.GOV,Federal Agency,Recovery Accountability and Transparency Board,Washington,DC
+404.GOV,Federal Agency,Securities and Exchange Commission,Alexandria,VA
+INVESTOR.GOV,Federal Agency,Securities and Exchange Commission,Alexandria,VA
+SEC.GOV,Federal Agency,Securities and Exchange Commission,Alexandria,VA
+SSS.GOV,Federal Agency,Selective Service System,Arlington,VA
+BUSINESS.GOV,Federal Agency,Small Business Administration,Washington,DC
+HSA.GOV,Federal Agency,Small Business Administration,Washington,DC
+NWBC.GOV,Federal Agency,Small Business Administration,Washington,DC
+ONLINEWBC.GOV,Federal Agency,Small Business Administration,Washington,DC
+SBA.GOV,Federal Agency,Small Business Administration,Washington,DC
+WOMENBIZ.GOV,Federal Agency,Small Business Administration,Washington,DC
+ITIS.GOV,Federal Agency,Smithsonian Institution,Washington,DC
+SEGUROSOCIAL.GOV,Federal Agency,Social Security Administration,Baltimore,MD
+SOCIALSECURITY.GOV,Federal Agency,Social Security Administration,Baltimore,MD
+SSA.GOV,Federal Agency,Social Security Administration,Baltimore,MD
+SSAB.GOV,Federal Agency,Social Security Advisory Board,WASHINGTON,DC
+STENNIS.GOV,Federal Agency,Stennis Center for Public Service,Starkville,MS
+TVA.GOV,Federal Agency,Tennessee Valley Authority,Knoxville,TN
+TVAOIG.GOV,Federal Agency,Tennessee Valley Authority,Knoxville,TN
+TSC.GOV,Federal Agency,Terrorist Screening Center,Washington,DC
+PTF.GOV,Federal Agency,The Intelligence Community,Washington,DC
+BANKRUPTCY.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC
+CAVC.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC
+DCSC.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC
+FEDCIR.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC
+FEDERALCOURTS.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC
+FEDERALPROBATION.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC
+FEDERALRULES.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC
+FJC.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC
+JUDICIALCONFERENCE.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC
+NMCOURT.FED.US,Federal Agency,The Judicial Branch (Courts),Albuquerque,NM
+PACER.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC
+SC-US.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC
+SCINET-TEST.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC
+SCINET.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC
+SCUS.GOV,Federal Agency,The Judicial Branch (Courts),WASHINGTON,DC
+SUPREME-COURT.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC
+SUPREMECOURT.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC
+SUPREMECOURTUS.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC
+USBANKRUPTCY.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC
+USC.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC
+USCAVC.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC
+USCOURTS.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC
+USCVA.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC
+USPROBATION.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC
+USSC.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC
+USTAXCOURT.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC
+VETAPP.GOV,Federal Agency,The Judicial Branch (Courts),Washington,DC
+AOC.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+CAPITAL.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+CAPITOL.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+CAPITOLFLAGS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+CBO.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+CBONEWS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+CECC.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+CHINA-COMMISSION.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+CHINACOMMISSION.GOV,Federal Agency,The Legislative Branch (Congress),Washington,MD
+CITIZENCOSPONSORS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+CITIZENS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+COSPONSOR.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+CSCE.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+DEMOCRATICLEADER.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+DEMOCRATICWHIP.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+DEMOCRATS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+DEMS.GOV,Federal Agency,The Legislative Branch (Congress),Washington DC,DC
+ESECLAB.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+FASAB.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+GAO.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+GAONET.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+GOP.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+GOPCONFERENCE.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+GOPLEADER.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+HOUSE.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+HOUSECOMMUNICATIONS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+HOUSEDEMOCRATS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+HOUSEDEMS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+HOUSELIVE.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+HOUSENEWSLETTERS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+JCT.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+LISTENSTOYOU.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+MAJORITYLEADER.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+MAJORITYWHIP.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+PDBCECC.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+PPDCECC.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+REPUBLICANS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+SENATE.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+SENATERESTAURANTS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+SPEAKER.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+TAXREFORM.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+USBG.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+USCAPITAL.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+USCAPITOL.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+USCAPITOLVISITORCENTER.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+USCVC.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+VISITTHECAPITAL.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+VISITTHECAPITOL.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+WORLDWAR1CENTENNIAL.GOV,Federal Agency,The United States World War One Centennial Commission,Washington,DC
+ACCESS-BOARD.GOV,Federal Agency,U. S. Access Board,Washington,DC
+USHMM.GOV,Federal Agency,U. S. Holocaust Memorial Museum,Washington,DC
+USITC.GOV,Federal Agency,U. S. International Trade Commission,Washington,DC
+OSC.GOV,Federal Agency,U. S. Office of Special Counsel,Washington,DC
+OSCNET.GOV,Federal Agency,U. S. Office of Special Counsel,Washington,DC
+PEACECORE.GOV,Federal Agency,U. S. Peace Corps,Washington,DC
+PEACECORP.GOV,Federal Agency,U. S. Peace Corps,Washington,DC
+PEACECORPS.GOV,Federal Agency,U. S. Peace Corps,Washington,DC
+CHANGEOFADDRESS.GOV,Federal Agency,U. S. Postal Service,Washington,DC
+MAIL.GOV,Federal Agency,U. S. Postal Service,Raleigh,NC
+POSTOFFICE.GOV,Federal Agency,U. S. Postal Service,Raleigh,NC
+PURCHASING.GOV,Federal Agency,U. S. Postal Service,Raleigh,NC
+USPIS.GOV,Federal Agency,U. S. Postal Service,Arlington,VA
+USPS.GOV,Federal Agency,U. S. Postal Service,Raleigh,NC
+CHILDRENINADVERSITY.GOV,Federal Agency,U.S. Agency for International Development,Washington,DC
+DFAFACTS.GOV,Federal Agency,U.S. Agency for International Development,Washington,DC
+FEEDTHEFUTURE.GOV,Federal Agency,U.S. Agency for International Development,Washington,DC
+FIGHTINGMALARIA.GOV,Federal Agency,U.S. Agency for International Development,Washington,DC
+LETGIRLSLEARN.GOV,Federal Agency,U.S. Agency for International Development,Washington,DC
+NEGLECTEDDISEASES.GOV,Federal Agency,U.S. Agency for International Development,Washington,DC
+OFDA.GOV,Federal Agency,U.S. Agency for International Development,Washington,DC
+PMI.GOV,Federal Agency,U.S. Agency for International Development,Washington,DC
+USAID.GOV,Federal Agency,U.S. Agency for International Development,Washington,DC
+USAIDALLNET.GOV,Federal Agency,U.S. Agency for International Development,Arlington,VA
+USCP.GOV,Federal Agency,U.S. Capitol Police,Washington,DC
+CHEMSAFETY.GOV,Federal Agency,U.S. Chemical Safety and Hazard Investigation Board,Washington,DC
+CSB.GOV,Federal Agency,U.S. Chemical Safety and Hazard Investigation Board,Washington,DC
+SAFETYVIDEOS.GOV,Federal Agency,U.S. Chemical Safety and Hazard Investigation Board,Washington,DC
+CFA.GOV,Federal Agency,U.S. Commission of Fine Arts,Washington,DC
+PEACECORPSOIG.GOV,Federal Agency,"U.S. Postal Service, Office of Inspector General",Washington,DC
+USPSOIG.GOV,Federal Agency,"U.S. Postal Service, Office of Inspector General",Arlington,VA
+USTDA.GOV,Federal Agency,U.S. Trade and Development Agency,Arlington,VA
+CARBONCYCLESCIENCE.GOV,Federal Agency,United Stated Global Change Research Program,Washington,DC
+GLOBALCHANGE.GOV,Federal Agency,United Stated Global Change Research Program,Washington,DC
+IPCC-WG2.GOV,Federal Agency,United Stated Global Change Research Program,Stanford,CA
+USGCRP.GOV,Federal Agency,United Stated Global Change Research Program,Washington,DC
+OGE.GOV,Federal Agency,United States Office of Government Ethics,Washington,DC
+USOGE.GOV,Federal Agency,United States Office of Government Ethics,Washington,DC
+ICH.GOV,Federal Agency,US Interagency Council on Homelessness,washington,DC
+USICH.GOV,Federal Agency,US Interagency Council on Homelessness,Washington,DC
+PHC-NSN.GOV,Native Sovereign Nation,Department of the Interior,Princeton,ME
+29PALMSBOMI-NSN.GOV,Native Sovereign Nation,Indian Affairs,Coachella,CA
+ABSENTEESHAWNEETRIBE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Shawnee,OK
+AGUACALIENTE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Palm Springs,CA
+AHA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Hogansburg,NY
+BADRIVER-NSN.GOV,Native Sovereign Nation,Indian Affairs,Odanah,WI
+BARONA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Lakeside,CA
+BEARRIVER-NSN.GOV,Native Sovereign Nation,Indian Affairs,Loleta,CA
+BIHASITKA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Sitka,AK
+BLUELAKERANCHERIA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Blue Lake,CA
+BOISFORTE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Nett Lake,MN
+BRB-NSN.GOV,Native Sovereign Nation,Indian Affairs,LOLETA,CA
+BURNSPAIUTE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Burns,OR
+CABAZONINDIANS-NSN.GOV,Native Sovereign Nation,Indian Affairs,Indio,CA
+CADDONATION-NSN.GOV,Native Sovereign Nation,Indian Affairs,Binger,OK
+CALIFORNIAVALLEYMIWOKTRIBE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Stockton,CA
+CAMPO-NSN.GOV,Native Sovereign Nation,Indian Affairs,Campo,CA
+CAYUGANATION-NSN.GOV,Native Sovereign Nation,Indian Affairs,Seneca Falls ,NY
+CDATRIBE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Plummer,ID
+CHEROKEE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Tahlequah,OK
+CHICKASAW-GOVERNMENT-NSN.GOV,Native Sovereign Nation,Indian Affairs,Ada,OK
+CHICKASAW-NSN.GOV,Native Sovereign Nation,Indian Affairs,Ada,OK
+CHICKASAWARTISANS-NSN.GOV,Native Sovereign Nation,Indian Affairs,Ada,OK
+CHICKASAWGOVERNMENT-NSN.GOV,Native Sovereign Nation,Indian Affairs,Ada,OK
+CHICKASAWJUDICIAL-NSN.GOV,Native Sovereign Nation,Indian Affairs,Ada,OK
+CHICKASAWLEGISLATURE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Ada,OK
+CHICKASAWNATION-NSN.GOV,Native Sovereign Nation,Indian Affairs,Ada,OK
+CHICKASAWTRIBE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Ada,OK
+CHILKOOT-NSN.GOV,Native Sovereign Nation,Indian Affairs,Haines,AK
+CHITIMACHA.GOV,Native Sovereign Nation,Indian Affairs,Charenton,LA
+CHUKCHANSI-NSN.GOV,Native Sovereign Nation,Indian Affairs,Fresno,CA
+CIT-NSN.GOV,Native Sovereign Nation,Indian Affairs,Havasu Lake,CA
+COLUSA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Colusa,CA
+COYOTEVALLEY-NSN.GOV,Native Sovereign Nation,Indian Affairs,Redwood valley,CA
+CRHC-NSN.GOV,Native Sovereign Nation,Indian Affairs,Chico,CA
+CRIT-NSN.GOV,Native Sovereign Nation,Indian Affairs,Parker,AZ
+CROW-NSN.GOV,Native Sovereign Nation,Indian Affairs,Crow Agency,MT
+CRST-NSN.GOV,Native Sovereign Nation,Indian Affairs,EAGLE BUTTE,SD
+EKLUTNA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Chugiak,AK
+ELYSHOSHONETRIBE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Ely,NV
+ESTOO-NSN.GOV,Native Sovereign Nation,Indian Affairs,Wyandotte,OK
+EWIIAAPAAYP-NSN.GOV,Native Sovereign Nation,Indian Affairs,Alpine,CA
+EYAK-NSN.GOV,Native Sovereign Nation,Indian Affairs,Cordova,AK
+FCP-NSN.GOV,Native Sovereign Nation,Indian Affairs,Crandon,WI
+FCPOTAWATOMI-NSN.GOV,Native Sovereign Nation,Indian Affairs,Crandon,WI
+FORTSILLAPACHE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Apache,OK
+GILARIVER-NSN.GOV,Native Sovereign Nation,Indian Affairs,Sacaton,AZ
+GLT-NSN.GOV,Native Sovereign Nation,Indian Affairs,Dorr,MI
+GUNLAKETRIBE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Dorr,MI
+HANNAHVILLEPOTAWATOMI-NSN.GOV,Native Sovereign Nation,Indian Affairs,Wilson,MI
+HAVASUPAI-NSN.GOV,Native Sovereign Nation,Indian Affairs,Supai,AZ
+HOOPA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Hoopa,CA
+HOPI-NSN.GOV,Native Sovereign Nation,Indian Affairs,Kykotsmovi,AZ
+HPULTRIBE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Upper Lake,CA
+HUALAPAI-NSN.GOV,Native Sovereign Nation,Indian Affairs,Peach Springs,AZ
+IIPAYNATION-NSN.GOV,Native Sovereign Nation,Indian Affairs,santa ysabel,CA
+ISLETAPUEBLO-NSN.GOV,Native Sovereign Nation,Indian Affairs,Isleta,NM
+JACKSONRANCHERIA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Jackson,CA
+KAIBABPAIUTE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Fredonia,AZ
+KAWAIKA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Laguna,NM
+KAYENTATOWNSHIP-NSN.GOV,Native Sovereign Nation,Indian Affairs,Kayenta,AZ
+KBIC-NSN.GOV,Native Sovereign Nation,Indian Affairs,Baraga,MI
+KENAITZE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Kenai,AK
+KEWEENAWBAY-NSN.GOV,Native Sovereign Nation,Indian Affairs,Baraga,MI
+KTIK-NSN.GOV,Native Sovereign Nation,Indian Affairs,Horton,KS
+LAGUNA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Laguna,NM
+LAGUNAPUEBLO-NSN.GOV,Native Sovereign Nation,Indian Affairs,Laguna,NM
+LAJOLLA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Pauma Valley,CA
+LCO-NSN.GOV,Native Sovereign Nation,Indian Affairs,Hayward,WI
+LTBBODAWA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Harbor Springs,MI
+LUMMI-NSN.GOV,Native Sovereign Nation,Indian Affairs,Bellingham,WA
+MASHANTUCKET-NSN.GOV,Native Sovereign Nation,Indian Affairs,Mashantucket,CT
+MASHANTUCKETPEQUOT-NSN.GOV,Native Sovereign Nation,Indian Affairs,Mashantucket,CT
+MASHANTUCKETWESTERNPEQUOT-NSN.GOV,Native Sovereign Nation,Indian Affairs,Mashantucket,CT
+MCN-NSN.GOV,Native Sovereign Nation,Indian Affairs,Okmulgee,OK
+MECHOOPDA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Chico,CA
+MENOMINEE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Keshena,WI
+MESAGRANDEBAND-NSN.GOV,Native Sovereign Nation,Indian Affairs,SantaYsabel,CA
+MESKWAKI-NSN.GOV,Native Sovereign Nation,Indian Affairs,Tama,IA
+MICCOSUKEE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Miami,FL
+MICMAC-NSN.GOV,Native Sovereign Nation,Indian Affairs,Presque Isle,ME
+MIDDLETOWNRANCHERIA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Middletown,CA
+MILLELACSBAND-NSN.GOV,Native Sovereign Nation,Indian Affairs,Onamia,MN
+MOAPABANDOFPAIUTES-NSN.GOV,Native Sovereign Nation,Indian Affairs,Moapa,NV
+MOHICAN-NSN.GOV,Native Sovereign Nation,Indian Affairs,Bowler,WI
+MORONGO-NSN.GOV,Native Sovereign Nation,Indian Affairs,Banning,CA
+MPGE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Mashantucket,CT
+MPTN-NSN.GOV,Native Sovereign Nation,Indian Affairs,Mashantucket,CT
+MUSCOGEENATION-NSN.GOV,Native Sovereign Nation,Indian Affairs,Okmulgee,OK
+NCIHA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Ukiah,CA
+NFR-NSN.GOV,Native Sovereign Nation,Indian Affairs,North Fork,CA
+NFRIHA-NSN.GOV,Native Sovereign Nation,Indian Affairs,North Fork,CA
+NINILCHIKTRIBE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Ninilchik,AK
+NISQUALLY-NSN.GOV,Native Sovereign Nation,Indian Affairs,Olympia,WA
+NOOKSACK-NSN.GOV,Native Sovereign Nation,Indian Affairs,Deming,WA
+NORTHFORKRANCHERIA-NSN.GOV,Native Sovereign Nation,Indian Affairs,North Fork ,CA
+NVB-NSN.GOV,Native Sovereign Nation,Indian Affairs,Barrow,AK
+OHKAYOWINGEH-NSN.GOV,Native Sovereign Nation,Indian Affairs,San Juan Pueblo,NM
+OMAHA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Macy,NE
+ONEIDA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Oneida,WI
+OSAGECONGRESS-NSN.GOV,Native Sovereign Nation,Indian Affairs,Pawhuska,OK
+OSAGENATION-NSN.GOV,Native Sovereign Nation,Indian Affairs,Pawhuska,OK
+PASCUAYAQUI-NSN.GOV,Native Sovereign Nation,Indian Affairs,Tucson,AZ
+PASKENTA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Corning,CA
+PAUMA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Pauma Valley,CA
+PCI-NSN.GOV,Native Sovereign Nation,Indian Affairs,Atmore,AL
+PECHANGA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Temecula,CA
+PEQUOT-NSN.GOV,Native Sovereign Nation,Indian Affairs,Mashantucket,CT
+PICAYUNERANCHERIA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Coarsegold,CA
+POARCHCREEKINDIANS-NSN.GOV,Native Sovereign Nation,Indian Affairs,ATMORE,AL
+POKAGONBAND-NSN.GOV,Native Sovereign Nation,Indian Affairs,DOWAGIAC,MI
+POL-NSN.GOV,Native Sovereign Nation,Indian Affairs,Laguna,NM
+QVIR-NSN.GOV,Native Sovereign Nation,Indian Affairs,Fort jones,CA
+RAMONA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Anza,CA
+REDCLIFF-NSN.GOV,Native Sovereign Nation,Indian Affairs,Bayfield,WI
+ROSEBUDSIOUXTRIBE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Rosebud,SD
+RST-NSN.GOV,Native Sovereign Nation,Indian Affairs,Rosebud,SD
+RSTWATER-NSN.GOV,Native Sovereign Nation,Indian Affairs,Rosebud,SD
+SACANDFOXNATION-NSN.GOV,Native Sovereign Nation,Indian Affairs,Stroud,OK
+SANMANUEL-NSN.GOV,Native Sovereign Nation,Indian Affairs,Highland,CA
+SANTAANA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Santa Ana,NM
+SANTAROSACAHUILLA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Anza,CA
+SCAT-NSN.GOV,Native Sovereign Nation,Indian Affairs,Peridot,AZ
+SCC-NSN.GOV,Native Sovereign Nation,Indian Affairs,Crandon,WI
+SEMINOLENATION-NSN.GOV,Native Sovereign Nation,Indian Affairs,Wewoka,OK
+SHOALWATERBAY-NSN.GOV,Native Sovereign Nation,Indian Affairs,Tokeland,WA
+SIR-NSN.GOV,Native Sovereign Nation,Indian Affairs,Susanville,CA
+SITKATRIBE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Sitka,AK
+SNO-NSN.GOV,Native Sovereign Nation,Indian Affairs,Wewoka,OK
+SOBOBA-NSN.GOV,Native Sovereign Nation,Indian Affairs,San Jacinto,CA
+SOUTHERNUTE-NSN.GOV,Native Sovereign Nation,Indian Affairs,IGNACIO,CO
+SRMT-NSN.GOV,Native Sovereign Nation,Indian Affairs,Akwesasne,NY
+SRPMIC-NSN.GOV,Native Sovereign Nation,Indian Affairs,Scottsdale,AZ
+SUSANVILLEINDIANRANCHERIA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Susanville,CA
+SWINOMISH-NSN.GOV,Native Sovereign Nation,Indian Affairs,La Conner,WA
+SWO-NSN.GOV,Native Sovereign Nation,Indian Affairs,Agency Village,SD
+SYCUAN-NSN.GOV,Native Sovereign Nation,Indian Affairs,El Cajon,CA
+TACHI-YOKUT-NSN.GOV,Native Sovereign Nation,Indian Affairs,Lemoore,CA
+TAMAYA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Santa Ana,NM
+TMDCI-NSN.GOV,Native Sovereign Nation,Indian Affairs,Thermal,CA
+TOLOWA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Smith River,CA
+TONATION-NSN.GOV,Native Sovereign Nation,Indian Affairs,Sells,AZ
+TULALIP-NSN.GOV,Native Sovereign Nation,Indian Affairs,Tulalip,WA
+TULALIPAIR-NSN.GOV,Native Sovereign Nation,Indian Affairs,Tulalip,WA
+TULALIPTRIBES-NSN.GOV,Native Sovereign Nation,Indian Affairs,Tulalip,WA
+TULERIVERTRIBE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Porterville,CA
+TWENTYNINEPALMSBOMI-NSN.GOV,Native Sovereign Nation,Indian Affairs,Coachella,CA
+UKB-NSN.GOV,Native Sovereign Nation,Indian Affairs,Tahlequah,OK
+UPPERSIOUXCOMMUNITY-NSN.GOV,Native Sovereign Nation,Indian Affairs,Granite Falls,MN
+VIEJAS-NSN.GOV,Native Sovereign Nation,Indian Affairs,Alpine,CA
+WESTERNPEQUOT-NSN.GOV,Native Sovereign Nation,Indian Affairs,Mashantucket,CT
+WHITEEARTH-NSN.GOV,Native Sovereign Nation,Indian Affairs,Ogema,MN
+WILTONRANCHERIA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Elk Grove,CA
+WINNEMUCCAINDIANCOLONYOFNEVADA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Winnemucca,NV
+WYANDOTTE-NATION-NSN.GOV,Native Sovereign Nation,Indian Affairs,Wyandotte,OK
+YAKAMAFISH-NSN.GOV,Native Sovereign Nation,Indian Affairs,Toppenish,WA
+YAKAMANATION-NSN.GOV,Native Sovereign Nation,Indian Affairs,Toppenish,WA
+YOCHADEHE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Brooks,CA
+YPT-NSN.GOV,Native Sovereign Nation,Indian Affairs,Yerington,NV
+CHILKAT-NSN.GOV,Native Sovereign Nation,Non-Federal Agency,Haines,AK
+DINEH-NSN.GOV,Native Sovereign Nation,Non-Federal Agency,Window Rock,AZ
+LRBOI-NSN.GOV,Native Sovereign Nation,Non-Federal Agency,Manistee,MI
+NAVAJO-NSN.GOV,Native Sovereign Nation,Non-Federal Agency,Window Rock,AZ
+YDSP-NSN.GOV,Native Sovereign Nation,Non-Federal Agency,El Pas,TX
+MTC.GOV,State/Local Govt,Multistate Tax Commission,Washington,DC
+511MAINE.GOV,State/Local Govt,Non-Federal Agency,Augusta,ME
+511NY.GOV,State/Local Govt,Non-Federal Agency,Albany,NY
+511TX.GOV,State/Local Govt,Non-Federal Agency,Austin,TX
+511WI.GOV,State/Local Govt,Non-Federal Agency,Madison,WI
+ABLETN.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN
+ACCESSTN.GOV,State/Local Govt,Non-Federal Agency,NASHVILLE,TN
+ADAMSCOUNTYMS.GOV,State/Local Govt,Non-Federal Agency,Natchez,MS
+ADRCNJ.GOV,State/Local Govt,Non-Federal Agency,Mercerville,NJ
+AGAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AK.GOV,State/Local Govt,Non-Federal Agency,Juneau,AK
+AKAEROSPACE.GOV,State/Local Govt,Non-Federal Agency,Anchorage,AK
+AKLEG.GOV,State/Local Govt,Non-Federal Agency,Juneau,AK
+AL-LEGISLATURE.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL
+AL.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL
+ALABAMA.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL
+ALABAMAAGELINE.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL
+ALABAMACONNECT.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL
+ALABAMADA.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL
+ALABAMADEMENTIA.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL
+ALABAMAHOUSEPHOTOS.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL
+ALABAMASMP.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL
+ALABAMAVOTES.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL
+ALABPP.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL
+ALACOP.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL
+ALACOURT.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL
+ALADA.GOV,State/Local Govt,Non-Federal Agency,Mongomery,AL
+ALADNA.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL
+ALAPPEALS.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL
+ALASAFE.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL
+ALASKA.GOV,State/Local Govt,Non-Federal Agency,Juneau,AK
+ALASKACARE.GOV,State/Local Govt,Non-Federal Agency,Juneau,AK
+ALBUQUERQUE-NM.GOV,State/Local Govt,Non-Federal Agency,Albuquerque,NM
+ALDOI.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL
+ALEA.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL
+ALEXANDERCOUNTYNC.GOV,State/Local Govt,Non-Federal Agency,Taylorsville,NC
+ALEXANDRIANJ.GOV,State/Local Govt,Non-Federal Agency,Milford,NJ
+ALGONAC-MI.GOV,State/Local Govt,Non-Federal Agency,Algonac,MI
+ALHOUSE.GOV,State/Local Govt,Non-Federal Agency,Montgomery ,AL
+ALLENDALENJ.GOV,State/Local Govt,Non-Federal Agency,Allendale,NJ
+ALPHARETTA-GA.GOV,State/Local Govt,Non-Federal Agency,Alpharetta,GA
+ALSENATE.GOV,State/Local Govt,Non-Federal Agency,Montgomery ,AL
+ALTOONAPA.GOV,State/Local Govt,Non-Federal Agency,Altoona,PA
+AMERICANSAMOA.GOV,State/Local Govt,Non-Federal Agency,Pago Pago,AS
+AMESBURYMA.GOV,State/Local Govt,Non-Federal Agency,Amesbury,MA
+AMITECOUNTYMS.GOV,State/Local Govt,Non-Federal Agency,Liberty,MS
+ANNAPOLIS.GOV,State/Local Govt,Non-Federal Agency,Annapolis,MD
+ANNAPOLISMD.GOV,State/Local Govt,Non-Federal Agency,Annapolis,MD
+ANTIOCHTOWNSHIP-IL.GOV,State/Local Govt,Non-Federal Agency,Lake Villa,IL
+ANTIOCHTOWNSHIPIL.GOV,State/Local Govt,Non-Federal Agency,Lake Villa,IL
+AQMD.GOV,State/Local Govt,Non-Federal Agency,Diamond Bar,CA
+AR.GOV,State/Local Govt,Non-Federal Agency,Little Rock,AR
+ARCHDALE-NC.GOV,State/Local Govt,Non-Federal Agency,ARCHDALE,NC
+ARCOURTS.GOV,State/Local Govt,Non-Federal Agency,Little Rock,AR
+ARIZONA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+ARIZONAJOBCONNECTION.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+ARIZONASERVES.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+ARIZONATURBOCOURT.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+ARKANSAS.GOV,State/Local Govt,Non-Federal Agency,Little Rock,AR
+ARKANSASAG.GOV,State/Local Govt,Non-Federal Agency,Little Rock,AR
+ARKANSASED.GOV,State/Local Govt,Non-Federal Agency,Little Rock,AR
+ARKLEGAUDIT.GOV,State/Local Govt,Non-Federal Agency,Little Rock,AR
+ARTREASURY.GOV,State/Local Govt,Non-Federal Agency,Litlte Rock,AR
+ARTRS.GOV,State/Local Govt,Non-Federal Agency,Little Rock,AR
+AS.GOV,State/Local Govt,Non-Federal Agency,Pago Pago,AS
+ASAFERFLORIDA.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL
+ASEPA.GOV,State/Local Govt,Non-Federal Agency,Pago Pago,AS
+ASHEVILLENC.GOV,State/Local Govt,Non-Federal Agency,Asheville,NC
+ATHOMEILLINOIS.GOV,State/Local Govt,Non-Federal Agency,Chicago,IL
+ATLASALABAMA.GOV,State/Local Govt,Non-Federal Agency,TUSCALOOSA,AL
+ATTORNEYGENERAL.GOV,State/Local Govt,Non-Federal Agency,Harrisburg,PA
+AUBURNNY.GOV,State/Local Govt,Non-Federal Agency,Auburn,NY
+AUBURNWA.GOV,State/Local Govt,Non-Federal Agency,Auburn,WA
+AUGUSTAGA.GOV,State/Local Govt,Non-Federal Agency,Augusta,GA
+AURORATEXAS.GOV,State/Local Govt,Non-Federal Agency,Rhome,TX
+AVON-MA.GOV,State/Local Govt,Non-Federal Agency,Avon,MA
+AZ-ACOIHC.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZ-FHSD.GOV,State/Local Govt,Non-Federal Agency,Fountain Hills,AZ
+AZ.GOV,State/Local Govt,Non-Federal Agency,Phoeniz,AZ
+AZ511.GOV,State/Local Govt,Non-Federal Agency,Pheonix,AZ
+AZ529.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZ911.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZABRC.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZACCOUNTANCY.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZACTIC.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZAFIS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZAG.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZAHCCCS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZARTS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZASRS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZAUDITOR.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZBN.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZBNP.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZBOA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZBOC.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZBOEC.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZBOF.GOV,State/Local Govt,Non-Federal Agency,PHOENIX,AZ
+AZBORDERTRASH.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZBOTA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZBOXINGANDMMA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZBROADBAND.GOV,State/Local Govt,Non-Federal Agency,PHOENIX,AZ
+AZBTR.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZCAAA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZCANCERCONTROL.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZCC.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZCIA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZCJC.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZCLEANELECTIONS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZCLIMATECHANGE.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZCOOP.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZCORPCOM.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZCORPCOMM.GOV,State/Local Govt,Non-Federal Agency,Phoenxi,AZ
+AZCORRECTIONS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZCOURTDOCS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZCOURTS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZCVD.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZDA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZDAARS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZDCS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZDDPC.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZDEMA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZDEQ.GOV,State/Local Govt,Non-Federal Agency,Phx,AZ
+AZDES.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZDFI.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZDHS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZDIABETES.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZDJC.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZDO.GOV,State/Local Govt,Non-Federal Agency,Scottsdale,AZ
+AZDOA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZDOC.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZDOH.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZDOHS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZDOR.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZDOSH.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZDOT.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZDPS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZDVS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZDWM.GOV,State/Local Govt,Non-Federal Agency,Glendale,AZ
+AZECDH.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZED.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZEIN.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZENERGY.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZENVIROKIDS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZEPIP.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZFIRSTTHINGSFIRST.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZFTF.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZGADA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZGAMING.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZGFD.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZGITA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZGOHS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZGOVERNOR.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZGRANTS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZGU.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZGUARD.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZHC.GOV,State/Local Govt,Non-Federal Agency,Pheonix,AZ
+AZHEALTH.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZHIGHERED.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZHOUSE.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZHOUSING.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZHS.GOV,State/Local Govt,Non-Federal Agency,Tempe,AZ
+AZICA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZINSURANCE.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZINVESTOR.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZJOBCONNECTION.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZJUVED.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZKIDSCARE.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZKIDSNEEDU.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZLAND.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZLEG.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZLGMA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZLIBRARY.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZLINKS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZLIQUOR.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZLOTTERY.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZMAG.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZMD.GOV,State/Local Govt,Non-Federal Agency,Scottsdale,AZ
+AZMFRF.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZMINORITYHEALTH.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZMORTGAGERESOURCE.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZMYFAMILYBENEFITS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZND.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZNET.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZOCA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZOSPB.GOV,State/Local Govt,Non-Federal Agency,phoenix,AZ
+AZOT.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZPA.GOV,State/Local Govt,Non-Federal Agency,Scottsdale,AZ
+AZPARKS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZPCRPD.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZPH.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZPHARMACY.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZPOST.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZPPSE.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZPSIC.GOV,State/Local Govt,Non-Federal Agency,PHOENIX,AZ
+AZQUALITYFIRST.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZRACING.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZRE.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZRECOVERY.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZRECYCLES.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZREPORTCARD.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZROC.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZRRA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZRUCO.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZSAL.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZSENATE.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZSF.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZSFB.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZSHARE.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZSOS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZSTATEJOBS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZSTATEPARKS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZSTATS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZSTEPSUP.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZSUMMERFOOD.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZSURPLUS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZTAXES.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZTRANSPORTATIONBOARD.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZTREASURER.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZTREASURY.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZTTT.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZTURBOCOURT.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZUI.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZUITAX.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZUNCLAIMED.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZVOICES.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZWATER.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZWATERBANK.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZWIC.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZWIFA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZWPF.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZYES.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+B4WV.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV
+BAAQMD.GOV,State/Local Govt,Non-Federal Agency,San Francisco,CA
+BABYARIZONA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+BAKERSFIELD-CA.GOV,State/Local Govt,Non-Federal Agency,Bakersfield,CA
+BARHARBORMAINE.GOV,State/Local Govt,Non-Federal Agency,Bar Harbor,ME
+BART.GOV,State/Local Govt,Non-Federal Agency,Oakland,CA
+BASSLAKEWI.GOV,State/Local Govt,Non-Federal Agency,Hayward,WI
+BATONROUGELA.GOV,State/Local Govt,Non-Federal Agency,Baton Rouge,LA
+BATTLEFIELDMO.GOV,State/Local Govt,Non-Federal Agency,Battlefield,MO
+BAYCOUNTY-MI.GOV,State/Local Govt,Non-Federal Agency,Bay City,MI
+BCCIRCLK.GOV,State/Local Govt,Non-Federal Agency,Princeton,IL
+BEAUXARTS-WA.GOV,State/Local Govt,Non-Federal Agency,Beaux Arts,WA
+BECKEMEYERIL.GOV,State/Local Govt,Non-Federal Agency,Beckemeyer,IL
+BEGA-DC.GOV,State/Local Govt,Non-Federal Agency,Washington,DC
+BELMONT.GOV,State/Local Govt,Non-Federal Agency,Belmont,CA
+BENBROOK-TX.GOV,State/Local Govt,Non-Federal Agency,Benbrook,TX
+BEREADYUTAH.GOV,State/Local Govt,Non-Federal Agency,Salt Lake City,UT
+BERRYVILLEVA.GOV,State/Local Govt,Non-Federal Agency,Berryville,VA
+BETHLEHEM-PA.GOV,State/Local Govt,Non-Federal Agency,Bethlehem,PA
+BIGFLATSNY.GOV,State/Local Govt,Non-Federal Agency,Big Flats,NY
+BIGHORNCOUNTYWY.GOV,State/Local Govt,Non-Federal Agency,Basin,WY
+BLACKSBURG.GOV,State/Local Govt,Non-Federal Agency,Blacksburg,VA
+BLISSFIELDMICHIGAN.GOV,State/Local Govt,Non-Federal Agency,Blissfield,MI
+BLNC.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+BLOOMINGTONMN.GOV,State/Local Govt,Non-Federal Agency,Bloomington,MN
+BOATIDAHO.GOV,State/Local Govt,Non-Federal Agency,Boise,ID
+BOIMI.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI
+BOONEVILLE-MS.GOV,State/Local Govt,Non-Federal Agency,Booneville,MS
+BOULDER-CO.GOV,State/Local Govt,Non-Federal Agency,Boulder,CO
+BOULDERCITY-NV.GOV,State/Local Govt,Non-Federal Agency,Boulder City,NV
+BOULDERCITYNV.GOV,State/Local Govt,Non-Federal Agency,Boulder City,NV
+BOULDERCOUNTY-CO.GOV,State/Local Govt,Non-Federal Agency,Boulder,CO
+BOUNTIFULUTAH.GOV,State/Local Govt,Non-Federal Agency,Bountiful,UT
+BOW-NH.GOV,State/Local Govt,Non-Federal Agency,Bow,NH
+BRAINTREEMA.GOV,State/Local Govt,Non-Federal Agency,Braintree,MA
+BRANDCOLORADO.GOV,State/Local Govt,Non-Federal Agency,Boulder,CO
+BREWERMAINE.GOV,State/Local Govt,Non-Federal Agency,Brewer,ME
+BRIDGEWATERNJ.GOV,State/Local Govt,Non-Federal Agency,Bridgewater,NJ
+BRIGHTONCO.GOV,State/Local Govt,Non-Federal Agency,Brighton,CO
+BROCKTON-MA.GOV,State/Local Govt,Non-Federal Agency,Brockton,MA
+BROOKINGSCOUNTYSD.GOV,State/Local Govt,Non-Federal Agency,Brookings,SD
+BROOMFIELDCO.GOV,State/Local Govt,Non-Federal Agency,Broomfield,CO
+BRUNSWICKMD.GOV,State/Local Govt,Non-Federal Agency,Brunswick,MD
+BRYANTX.GOV,State/Local Govt,Non-Federal Agency,Bryan,TX
+BUCHANAN-VA.GOV,State/Local Govt,Non-Federal Agency,BUCHANAN,VA
+BURKECOUNTY-GA.GOV,State/Local Govt,Non-Federal Agency,Waynesboro,GA
+BURLINGTONND.GOV,State/Local Govt,Non-Federal Agency,Burlington,ND
+BURLINGTONWA.GOV,State/Local Govt,Non-Federal Agency,Burlington,WA
+BUSINESS4WV.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV
+BUYNJBONDS.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ
+CA.GOV,State/Local Govt,Non-Federal Agency,Rancho Cordova,CA
+CAHWNET.GOV,State/Local Govt,Non-Federal Agency,Sacramento,CA
+CALAISVERMONT.GOV,State/Local Govt,Non-Federal Agency,East Calais,VT
+CALIFORNIA.GOV,State/Local Govt,Non-Federal Agency,Rancho Cordova,CA
+CALIFORNIADESERT.GOV,State/Local Govt,Non-Federal Agency,Barstow,CA
+CAMBRIDGERETIREMENTMA.GOV,State/Local Govt,Non-Federal Agency,Cambridge,MA
+CAMDENCOUNTYGA.GOV,State/Local Govt,Non-Federal Agency,Woodbine,GA
+CAMPBELLCA.GOV,State/Local Govt,Non-Federal Agency,Campbell,CA
+CANANDAIGUANEWYORK.GOV,State/Local Govt,Non-Federal Agency,Canandaigua,NY
+CAPITALREGION.GOV,State/Local Govt,Non-Federal Agency,Fairfax,VA
+CAPITALREGIONUPDATES.GOV,State/Local Govt,Non-Federal Agency,Fairfax,VA
+CASAAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+CASWELLCOUNTYNC.GOV,State/Local Govt,Non-Federal Agency,Yanceyville,NC
+CELINA-TX.GOV,State/Local Govt,Non-Federal Agency,Celina,TX
+CENTERLINE.GOV,State/Local Govt,Non-Federal Agency,Center Line,MI
+CHAMPAIGN-IL.GOV,State/Local Govt,Non-Federal Agency,Champaign,IL
+CHANDLERAZ.GOV,State/Local Govt,Non-Federal Agency,Chandler,AZ
+CHEROKEECOUNTY-NC.GOV,State/Local Govt,Non-Federal Agency,Murphy,NC
+CHESTERFIELD.GOV,State/Local Govt,Non-Federal Agency,Chesterfield,VA
+CHESTERFIELDCOUNTY.GOV,State/Local Govt,Non-Federal Agency,Chesterfield,VA
+CHESTERVT.GOV,State/Local Govt,Non-Federal Agency,Chester,VT
+CHIAMASS.GOV,State/Local Govt,Non-Federal Agency,Boston,MA
+CHIPPEWACOUNTYMI.GOV,State/Local Govt,Non-Federal Agency,Sault Ste Marie,MI
+CHOOSEIDAHO.GOV,State/Local Govt,Non-Federal Agency,Boise,ID
+CHULAVISTACA.GOV,State/Local Govt,Non-Federal Agency,Chula Vista,CA
+CITYOFAUBURNWA.GOV,State/Local Govt,Non-Federal Agency,Auburn,WA
+CITYOFBOSTON.GOV,State/Local Govt,Non-Federal Agency,Boston,MA
+CITYOFCHAMPAIGN-IL.GOV,State/Local Govt,Non-Federal Agency,Champaign,IL
+CITYOFCODY-WY.GOV,State/Local Govt,Non-Federal Agency,Cody,WY
+CITYOFFARGO-ND.GOV,State/Local Govt,Non-Federal Agency,Fargo,ND
+CITYOFGROTON-CT.GOV,State/Local Govt,Non-Federal Agency,Groton,CT
+CITYOFHAYWARD-CA.GOV,State/Local Govt,Non-Federal Agency,Hayward,CA
+CITYOFHONDO-TX.GOV,State/Local Govt,Non-Federal Agency,Hondo,TX
+CITYOFHOUSTON.GOV,State/Local Govt,Non-Federal Agency,Houston,TX
+CITYOFHUNTSVILLETX.GOV,State/Local Govt,Non-Federal Agency,Huntsville,TX
+CITYOFIRONDALEAL.GOV,State/Local Govt,Non-Federal Agency,Irondale,AL
+CITYOFLADUE-MO.GOV,State/Local Govt,Non-Federal Agency,Ladue,MO
+CITYOFMENASHA-WI.GOV,State/Local Govt,Non-Federal Agency,Menasha,WI
+CITYOFNOVI-MI.GOV,State/Local Govt,Non-Federal Agency,Novi,MI
+CITYOFOLYMPIA-WA.GOV,State/Local Govt,Non-Federal Agency,Olympia,WA
+CITYOFOLYMPIAWA.GOV,State/Local Govt,Non-Federal Agency,Olympia,WA
+CITYOFPASSAICNJ.GOV,State/Local Govt,Non-Federal Agency,Passaic,NJ
+CITYOFRENONV.GOV,State/Local Govt,Non-Federal Agency,Reno,NV
+CITYOFROCHESTER.GOV,State/Local Govt,Non-Federal Agency,Rochester,NY
+CITYOFSAFFORD-AZ.GOV,State/Local Govt,Non-Federal Agency,Safford,AZ
+CITYOFSANTAANA-CA.GOV,State/Local Govt,Non-Federal Agency,Santa Ana,CA
+CITYOFSEATTLE.GOV,State/Local Govt,Non-Federal Agency,Seattle,WA
+CITYOFSTMARYSPA.GOV,State/Local Govt,Non-Federal Agency,St. Marys,PA
+CITYOFSUNRISEFL.GOV,State/Local Govt,Non-Federal Agency,Sunrise,FL
+CITYOFSUNRISEFLORIDA.GOV,State/Local Govt,Non-Federal Agency,Sunrise,FL
+CITYOFWARRENPA.GOV,State/Local Govt,Non-Federal Agency,Warren,PA
+CITYOFWESTPALMBEACH-FL.GOV,State/Local Govt,Non-Federal Agency,West Palm Beach,FL
+CITYOLYMPIA-WA.GOV,State/Local Govt,Non-Federal Agency,Olympia,WA
+CITYOLYMPIAWA.GOV,State/Local Govt,Non-Federal Agency,Olympia,WA
+CLAIMITTN.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN
+CLARKECOUNTY.GOV,State/Local Govt,Non-Federal Agency,Berryville,VA
+CLATSOPCOUNTYOR.GOV,State/Local Govt,Non-Federal Agency,Astoria,OR
+CLAYCOUNTYIN.GOV,State/Local Govt,Non-Federal Agency,Brazil,IN
+CLEVELANDWI.GOV,State/Local Govt,Non-Federal Agency,Cleveland,WI
+CLINTONTOWNSHIP-MI.GOV,State/Local Govt,Non-Federal Agency,Clinton Township,MI
+CO.GOV,State/Local Govt,Non-Federal Agency,Lakewood,CO
+COAG.GOV,State/Local Govt,Non-Federal Agency,Denver,CO
+COBBCOUNTYGA.GOV,State/Local Govt,Non-Federal Agency,Marietta,GA
+COBERTURAMEDICAILLINOIS.GOV,State/Local Govt,Non-Federal Agency,Chicago,IL
+COCICJIS.GOV,State/Local Govt,Non-Federal Agency,Golden,CO
+CODOT.GOV,State/Local Govt,Non-Federal Agency,Denver,CO
+COHOES-NY.GOV,State/Local Govt,Non-Federal Agency,Cohoes,NY
+COLLEGEDALETN.GOV,State/Local Govt,Non-Federal Agency,Collegedale,TN
+COLLEGEGOALARIZONA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+COLLEGEGOALOREGON.GOV,State/Local Govt,Non-Federal Agency,Eugene,OR
+COLLIERCOUNTYFL.GOV,State/Local Govt,Non-Federal Agency,Naples,FL
+COLORADO.GOV,State/Local Govt,Non-Federal Agency,Lakewood,CO
+COLORADOATTORNEYGENERAL.GOV,State/Local Govt,Non-Federal Agency,Denver,CO
+COLORADOJUDICIAL.GOV,State/Local Govt,Non-Federal Agency,Denver,CO
+COLORADOJUDICIALPERFORMANCE.GOV,State/Local Govt,Non-Federal Agency,Denver,CO
+COLORADOLABORLAW.GOV,State/Local Govt,Non-Federal Agency,Denver,CO
+COLORADOPOST.GOV,State/Local Govt,Non-Federal Agency,Denver,CO
+COLORADOPOSTGRANTS.GOV,State/Local Govt,Non-Federal Agency,Denver,CO
+COLORADORCJC.GOV,State/Local Govt,Non-Federal Agency,Denver,CO
+COLORADOUI.GOV,State/Local Govt,Non-Federal Agency,Denver,CO
+COLORADOWORKS.GOV,State/Local Govt,Non-Federal Agency,Denver,CO
+COLUMBIASC.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC
+COMPARECAREWV.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV
+CONCORD-MA.GOV,State/Local Govt,Non-Federal Agency,Concord,MA
+CONNECTINGALABAMA.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL
+CONNECTND.GOV,State/Local Govt,Non-Federal Agency,Bisamarck,ND
+COPIAHCOUNTYMS.GOV,State/Local Govt,Non-Federal Agency,Hazlehurst,MS
+CORUNNA-MI.GOV,State/Local Govt,Non-Federal Agency,Corunna,MI
+COSIPA.GOV,State/Local Govt,Non-Federal Agency,Denver,CO
+COUNCILBLUFFS-IA.GOV,State/Local Govt,Non-Federal Agency,Council Bluffs,IA
+COUNTYOFVENTURACA.GOV,State/Local Govt,Non-Federal Agency,VENTURA,CA
+COURTNEWSOHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+COURTSWV.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV
+COVERTENNESSEE.GOV,State/Local Govt,Non-Federal Agency,NASHVILLE,TN
+COVERTN.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN
+COWORKFORCE.GOV,State/Local Govt,Non-Federal Agency,Denver,CO
+CRAWFORDCOUNTYMO.GOV,State/Local Govt,Non-Federal Agency,Steelville,MO
+CRESTEDBUTTE-CO.GOV,State/Local Govt,Non-Federal Agency,Crested Butte,CO
+CRYSTALMN.GOV,State/Local Govt,Non-Federal Agency,Crystal,MN
+CSIMT.GOV,State/Local Govt,Non-Federal Agency,Helena,MT
+CSTX.GOV,State/Local Govt,Non-Federal Agency,College Station,TX
+CT.GOV,State/Local Govt,Non-Federal Agency,Hartford,CT
+CTALERT.GOV,State/Local Govt,Non-Federal Agency,Middletown,CT
+CTBROWNFIELDS.GOV,State/Local Govt,Non-Federal Agency,Hartford,CT
+CTGROWN.GOV,State/Local Govt,Non-Federal Agency,Hartford,CT
+CTPROBATE.GOV,State/Local Govt,Non-Federal Agency,West Hartford,CT
+DA16CO.GOV,State/Local Govt,Non-Federal Agency,LA JUNTA,CO
+DANVILLE-VA.GOV,State/Local Govt,Non-Federal Agency,Danville,VA
+DARIENCT.GOV,State/Local Govt,Non-Federal Agency,Darien,CT
+DAVISCOUNTYUTAH.GOV,State/Local Govt,Non-Federal Agency,Farmington,UT
+DC.GOV,State/Local Govt,Non-Federal Agency,Washington,DC
+DCAPPEALS.GOV,State/Local Govt,Non-Federal Agency,Washington,DC
+DCCODE.GOV,State/Local Govt,Non-Federal Agency,Washington,DC
+DCCOUNCIL.GOV,State/Local Govt,Non-Federal Agency,Washington,DC
+DCCOURT.GOV,State/Local Govt,Non-Federal Agency,Washington,DC
+DCCOURTS.GOV,State/Local Govt,Non-Federal Agency,Washington,DC
+DCCOURTSNEWS.GOV,State/Local Govt,Non-Federal Agency,Washington,DC
+DE.GOV,State/Local Govt,Non-Federal Agency,Dover,DE
+DEBTREPORTINGIOWA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+DECATUR-AL.GOV,State/Local Govt,Non-Federal Agency,Decatur,AL
+DEL.GOV,State/Local Govt,Non-Federal Agency,Dover,DE
+DELAWARE.GOV,State/Local Govt,Non-Federal Agency,Dover,DE
+DELAWAREINSURANCE.GOV,State/Local Govt,Non-Federal Agency,Dover,DE
+DELDOT.GOV,State/Local Govt,Non-Federal Agency,Dover,DE
+DESMOINESWA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,WA
+DESOTOTEXAS.GOV,State/Local Govt,Non-Federal Agency,DeSoto,TX
+DETROITMI.GOV,State/Local Govt,Non-Federal Agency,Detroit,MI
+DEVAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+DEXTERMI.GOV,State/Local Govt,Non-Federal Agency,Dexter,MI
+DICKINSON-TX.GOV,State/Local Govt,Non-Federal Agency,Dickinson,TX
+DIGITALARIZONA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+DIGITALAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+DMG.GOV,State/Local Govt,Non-Federal Agency,Barstow,CA
+DNSSECOHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+DNSTESTOHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+DOJMT.GOV,State/Local Govt,Non-Federal Agency,Helena,MT
+DORAL-FL.GOV,State/Local Govt,Non-Federal Agency,Doral,FL
+DOSEOFREALITYWI.GOV,State/Local Govt,Non-Federal Agency,Madison,WI
+DOUBLECHECKIOWA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+DRACUTMA.GOV,State/Local Govt,Non-Federal Agency,Dracut,MA
+DRIVENC.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+DUDLEYMA.GOV,State/Local Govt,Non-Federal Agency,Dudley,MA
+DUMASTX.GOV,State/Local Govt,Non-Federal Agency,Dumas,TX
+DUNELLEN-NJ.GOV,State/Local Govt,Non-Federal Agency,Dunellen,NJ
+DURHAMNC.GOV,State/Local Govt,Non-Federal Agency,Durham,NC
+DUTCHESSNY.GOV,State/Local Govt,Non-Federal Agency,Poughkeepsie,NY
+DWGPA.GOV,State/Local Govt,Non-Federal Agency,Delaware Water Gap,PA
+EASTHAM-MA.GOV,State/Local Govt,Non-Federal Agency,Eastham,MA
+EASTON-PA.GOV,State/Local Govt,Non-Federal Agency,Easton,PA
+EASTVALLEYFUSIONCENTERAZ.GOV,State/Local Govt,Non-Federal Agency,Mesa,AZ
+EASTWINDSOR-CT.GOV,State/Local Govt,Non-Federal Agency,Broad Brook,CT
+EAUCLAIREWI.GOV,State/Local Govt,Non-Federal Agency,Eau Claire,WI
+EDGECOMBECOUNTYNC.GOV,State/Local Govt,Non-Federal Agency,Tarboro,NC
+EDGEWOODKY.GOV,State/Local Govt,Non-Federal Agency,Edgewood,KY
+EDUCATEIOWA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+EFILETEXAS.GOV,State/Local Govt,Non-Federal Agency,Austin,TX
+EGREMONT-MA.GOV,State/Local Govt,Non-Federal Agency,Egremont,MA
+EHAWAII.GOV,State/Local Govt,Non-Federal Agency,Honolulu,HI
+EISGATEWAYPACIFICWA.GOV,State/Local Govt,Non-Federal Agency,Lacey,WA
+ELBERTCOUNTY-CO.GOV,State/Local Govt,Non-Federal Agency,Kiowa,CO
+ELEARNINGNC.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+ELIZABETHTOWNKY.GOV,State/Local Govt,Non-Federal Agency,Elizabethtown,KY
+ELMONTECA.GOV,State/Local Govt,Non-Federal Agency,El Monte,CA
+EMANUELCO-GA.GOV,State/Local Govt,Non-Federal Agency,Swainsboro,GA
+ENFIELD-CT.GOV,State/Local Govt,Non-Federal Agency,Enfield,CT
+ERIECOUNTYPA.GOV,State/Local Govt,Non-Federal Agency,Erie,PA
+EUGENE-OR.GOV,State/Local Govt,Non-Federal Agency,Eugene,OR
+EVFCAZ.GOV,State/Local Govt,Non-Federal Agency,Mesa,AZ
+EVFUSIONCENTERAZ.GOV,State/Local Govt,Non-Federal Agency,Mesa,AZ
+EWYOMING.GOV,State/Local Govt,Non-Federal Agency,Cheyenne,WY
+EXPLOREMAINE.GOV,State/Local Govt,Non-Federal Agency,Augusta,ME
+FAIRFAXCOUNTY.GOV,State/Local Govt,Non-Federal Agency,Fairfax,VA
+FAIRFAXCOUNTYVA.GOV,State/Local Govt,Non-Federal Agency,Fairfax,VA
+FAIRHAVEN-MA.GOV,State/Local Govt,Non-Federal Agency,Fairhaven,MA
+FAMILYRESOURCEAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+FARGO-ND.GOV,State/Local Govt,Non-Federal Agency,Fargo,ND
+FAYETTECOUNTYGA.GOV,State/Local Govt,Non-Federal Agency,Fayetteville,GA
+FAYETTEVILLE-GA.GOV,State/Local Govt,Non-Federal Agency,Fayetteville,GA
+FILELOCAL-WA.GOV,State/Local Govt,Non-Federal Agency,Seattle,WA
+FIRESTONECO.GOV,State/Local Govt,Non-Federal Agency,Firestone,CO
+FIRSTNETME.GOV,State/Local Govt,Non-Federal Agency,Augusta,ME
+FIRSTTHINGSFIRSTAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+FISHKILL-NY.GOV,State/Local Govt,Non-Federal Agency,Fishkill,NY
+FL.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL
+FLBOARDOFMEDICINE.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL
+FLCENSUS.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL
+FLCOURTS1.GOV,State/Local Govt,Non-Federal Agency,Pensacola,FL
+FLDOI.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL
+FLHEALTH.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL
+FLHEALTH125.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL
+FLHEALTHCOMPLAINT.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL
+FLHEALTHSOURCE.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL
+FLHISTORICCAPITOL.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL
+FLHL.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL
+FLHOUSE.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL
+FLHSMV.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL
+FLLEG.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL
+FLLEGISLATIVEMAILINGS.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL
+FLORIDA.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL
+FLORIDAABUSEHOTLINE.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL
+FLORIDAHEALTH.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL
+FLORIDAHEALTHFINDER.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL
+FLORIDALOBBYIST.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL
+FLORIDANET.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL
+FLORIDAOPC.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL
+FLORIDAPACE.GOV,State/Local Govt,Non-Federal Agency,Kissimmee,FL
+FLORIDAREDISTRICTING.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL
+FLORIDASACUPUNCTURE.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL
+FLORIDASATHLETICTRAINING.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL
+FLORIDASCHIROPRACTICMEDICINE.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL
+FLORIDASCHOOLBUSSAFETY.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL
+FLORIDASCLINICALLABS.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL
+FLORIDASDENTISTRY.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL
+FLORIDASENATE.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL
+FLORIDASHEALTH.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL
+FLORIDASHEARINGAIDSPECIALISTS.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL
+FLORIDASMASSAGETHERAPY.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL
+FLORIDASMENTALHEALTHPROFESSIONS.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL
+FLORIDASNURSING.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL
+FLORIDASNURSINGHOMEADMIN.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL
+FLORIDASOCCUPATIONALTHERAPY.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL
+FLORIDASOPTICIANRY.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL
+FLORIDASOPTOMETRY.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL
+FLORIDASORTHOTISTSPROSTHETISTS.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL
+FLORIDASOSTEOPATHICMEDICINE.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL
+FLORIDASPHARMACY.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL
+FLORIDASPHYSICALTHERAPY.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL
+FLORIDASPODIATRICMEDICINE.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL
+FLORIDASPSYCHOLOGY.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL
+FLORIDASRESPIRATORYCARE.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL
+FLORIDASSPEECHAUDIOLOGY.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL
+FLORIDASUNSETREVIEWS.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL
+FLORIDASUNSHINE.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL
+FLRCM.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL
+FLSENATE.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL
+FLSUNSHINE.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL
+FLWG.GOV,State/Local Govt,Non-Federal Agency,Opa Locka,FL
+FOIA-DC.GOV,State/Local Govt,Non-Federal Agency,Washington,DC
+FOIAXPRESS-DC.GOV,State/Local Govt,Non-Federal Agency,Washington,DC
+FORTLAUDERDALE.GOV,State/Local Govt,Non-Federal Agency,Fort Lauderdale,FL
+FRAMES.GOV,State/Local Govt,Non-Federal Agency,Moscow,ID
+FRANKLIN-NJ.GOV,State/Local Govt,Non-Federal Agency,Someret,NJ
+FRANKLINNJ.GOV,State/Local Govt,Non-Federal Agency,Somerset,NJ
+FRANKLINWI.GOV,State/Local Govt,Non-Federal Agency,Franklin,WI
+FREEPORTFLORIDA.GOV,State/Local Govt,Non-Federal Agency,Freeport,FL
+FREMONT.GOV,State/Local Govt,Non-Federal Agency,Fremont,CA
+FREMONTCOUNTYWY.GOV,State/Local Govt,Non-Federal Agency,Lander,WY
+FRESHFROMFLORIDA.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL
+FRESNO.GOV,State/Local Govt,Non-Federal Agency,Fresno,CA
+FRISCOTEXAS.GOV,State/Local Govt,Non-Federal Agency,Frisco,TX
+FRISCOTX.GOV,State/Local Govt,Non-Federal Agency,Frisco,TX
+FUTUREREADYIOWA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+GA.GOV,State/Local Govt,Non-Federal Agency,Atlanta,GA
+GACOURTS.GOV,State/Local Govt,Non-Federal Agency,Atlanta,GA
+GADOL.GOV,State/Local Govt,Non-Federal Agency,Atlanta,GA
+GAITHERSBURGMD.GOV,State/Local Govt,Non-Federal Agency,Gaithersburg,MD
+GARDNER-MA.GOV,State/Local Govt,Non-Federal Agency,GARDNER,MA
+GATREES.GOV,State/Local Govt,Non-Federal Agency,Dry Branch,GA
+GAUTIER-MS.GOV,State/Local Govt,Non-Federal Agency,Gautier,MS
+GEARUPIOWA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+GEARUPTN.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN
+GEORGETOWNMA.GOV,State/Local Govt,Non-Federal Agency,Georgetown,MA
+GEORGIA.GOV,State/Local Govt,Non-Federal Agency,Atlanta,GA
+GEORGIACOURTS.GOV,State/Local Govt,Non-Federal Agency,Atlanta,GA
+GEORGIAHEALTHINFO.GOV,State/Local Govt,Non-Federal Agency,Atlanta,GA
+GETCOVEREDILLINOIS.GOV,State/Local Govt,Non-Federal Agency,Chicago,IL
+GETKANSASBENEFITS.GOV,State/Local Govt,Non-Federal Agency,Topeka,KS
+GETREADYHAWAII.GOV,State/Local Govt,Non-Federal Agency,Honolulu,HI
+GILBERTAZ.GOV,State/Local Govt,Non-Federal Agency,Gilbert,AZ
+GIS10SERVICEMT.GOV,State/Local Govt,Non-Federal Agency,Helena,MT
+GISSERVICEMT.GOV,State/Local Govt,Non-Federal Agency,Helena,MT
+GISTESTSERVICEMT.GOV,State/Local Govt,Non-Federal Agency,Helena,MT
+GLYNNCOUNTY-GA.GOV,State/Local Govt,Non-Federal Agency,Brunswick,GA
+GOCC.GOV,State/Local Govt,Non-Federal Agency,Corvallis,OR
+GOVOTEVERMONT.GOV,State/Local Govt,Non-Federal Agency,Montpelier,VT
+GRANBY-CT.GOV,State/Local Govt,Non-Federal Agency,Granby,CT
+GRAYSONCOUNTYVA.GOV,State/Local Govt,Non-Federal Agency,Independence,VA
+GREATIOWATREASUREHUNT.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+GREENSBORO-NC.GOV,State/Local Govt,Non-Federal Agency,Greensboro,NC
+GREENSVILLECOUNTYVA.GOV,State/Local Govt,Non-Federal Agency,Emporia,VA
+GRFDAZ.GOV,State/Local Govt,Non-Federal Agency,Tucson,AZ
+GRINNELLIOWA.GOV,State/Local Govt,Non-Federal Agency,Grinnell,IA
+GUAM.GOV,State/Local Govt,Non-Federal Agency,Agana,GU
+HADDONFIELD-NJ.GOV,State/Local Govt,Non-Federal Agency,Haddonfield,NJ
+HAMILTON-NY.GOV,State/Local Govt,Non-Federal Agency,HAMILTON,NY
+HAMILTONMA.GOV,State/Local Govt,Non-Federal Agency,So. Hamilton,MA
+HAMILTONTN.GOV,State/Local Govt,Non-Federal Agency,Chattanooga,TN
+HAMPTONNH.GOV,State/Local Govt,Non-Federal Agency,Hampton,NH
+HAMPTONVA.GOV,State/Local Govt,Non-Federal Agency,Hampton,VA
+HANOVER.GOV,State/Local Govt,Non-Federal Agency,Hanover,VA
+HANOVERCOUNTY.GOV,State/Local Govt,Non-Federal Agency,Hanover,VA
+HANOVERCOUNTYVA.GOV,State/Local Govt,Non-Federal Agency,Hanover,VA
+HARFORDCOUNTYMD.GOV,State/Local Govt,Non-Federal Agency,Bel Air,MD
+HARMARTOWNSHIP-PA.GOV,State/Local Govt,Non-Federal Agency,Freeport,PA
+HARRINGTONPARKNJ.GOV,State/Local Govt,Non-Federal Agency,HARRINGTON PARK,NJ
+HARRISON-NY.GOV,State/Local Govt,Non-Federal Agency,Harrison,NY
+HARRISONCOUNTY-MS.GOV,State/Local Govt,Non-Federal Agency,Gulfport,MS
+HARRISONTWP-PA.GOV,State/Local Govt,Non-Federal Agency,Natrona Heights,PA
+HAWAII.GOV,State/Local Govt,Non-Federal Agency,Honolulu,HI
+HAYESTOWNSHIPMI.GOV,State/Local Govt,Non-Federal Agency,Charlevoix,MI
+HAYWARD-CA.GOV,State/Local Govt,Non-Federal Agency,Hayward,CA
+HCSHERIFF.GOV,State/Local Govt,Non-Federal Agency,Chattanooga,TN
+HEALTH-E-ARIZONA-PLUS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+HEALTH-E-ARIZONAPLUS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+HEALTHCAREHELPMASS.GOV,State/Local Govt,Non-Federal Agency,Boston,MA
+HEALTHEARIZONA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+HEALTHEARIZONAPLUS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+HEALTHVERMONT.GOV,State/Local Govt,Non-Federal Agency,Burlington,VT
+HEALTHYIOWA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+HEALTHYSD.GOV,State/Local Govt,Non-Federal Agency,Pierre,SD
+HEALTHYTEETHAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+HI.GOV,State/Local Govt,Non-Federal Agency,Honolulu,HI
+HIGHPOINT-NC.GOV,State/Local Govt,Non-Federal Agency,High Point,NC
+HIGHPOINTNC.GOV,State/Local Govt,Non-Federal Agency,High Point,NC
+HIJOSSALUDABLESOREGON.GOV,State/Local Govt,Non-Federal Agency,Salem,OR
+HIREACOLORADOVET.GOV,State/Local Govt,Non-Federal Agency,Denver,CO
+HOMEAGAINNEVADA.GOV,State/Local Govt,Non-Federal Agency,Las Vegas,NV
+HOMEBASEIOWA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+HOMEMEANSNEVADA.GOV,State/Local Govt,Non-Federal Agency,Las Vegas,NV
+HONDO-TX.GOV,State/Local Govt,Non-Federal Agency,Hondo,TX
+HONOLULU.GOV,State/Local Govt,Non-Federal Agency,Honolulu,HI
+HOUSTONTX.GOV,State/Local Govt,Non-Federal Agency,Houston,TX
+HUNTSVILLETX.GOV,State/Local Govt,Non-Federal Agency,Huntsville,TX
+HURONTOWNSHIP-MI.GOV,State/Local Govt,Non-Federal Agency,New Boston,MI
+IA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IAABATEDOC.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IAHEALTHLINK.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IASHP.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IASIMPLEABATE.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IAVOTERS.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+ID.GOV,State/Local Govt,Non-Federal Agency,Boise,ID
+IDAHO.GOV,State/Local Govt,Non-Federal Agency,Boise,ID
+IDAHOBYWAYS.GOV,State/Local Govt,Non-Federal Agency,Boise,ID
+IDAHOPREPARES.GOV,State/Local Govt,Non-Federal Agency,Boise,ID
+IDAHOVOTES.GOV,State/Local Govt,Non-Federal Agency,Boise,ID
+IDAHOWORKS.GOV,State/Local Govt,Non-Federal Agency,Boise,ID
+IHAVEAPLANIOWA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IJOBSIOWA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IL.GOV,State/Local Govt,Non-Federal Agency,Springfield,IL
+ILATTORNEYGENERAL.GOV,State/Local Govt,Non-Federal Agency,Chicago,IL
+ILGA.GOV,State/Local Govt,Non-Federal Agency,Springfield,IL
+ILLINOIS-HISTORY.GOV,State/Local Govt,Non-Federal Agency,Springfield,IL
+ILLINOIS.GOV,State/Local Govt,Non-Federal Agency,Springfield,IL
+ILLINOISATTORNEYGENERAL.GOV,State/Local Govt,Non-Federal Agency,Chicago,IL
+ILLINOISCOMPTROLLER.GOV,State/Local Govt,Non-Federal Agency,Springfield,IL
+ILLINOISCOURTS.GOV,State/Local Govt,Non-Federal Agency,Springfield,IL
+ILLINOISHISTORY.GOV,State/Local Govt,Non-Federal Agency,Springfield,IL
+ILLINOISTREASURER.GOV,State/Local Govt,Non-Federal Agency,Springfield,IL
+ILSOS.GOV,State/Local Govt,Non-Federal Agency,Springfield,IL
+IN.GOV,State/Local Govt,Non-Federal Agency,Indianapolis,IN
+INCOURTS.GOV,State/Local Govt,Non-Federal Agency,Indianapolis,IN
+INDEPENDENCEMO.GOV,State/Local Govt,Non-Federal Agency,Independence,MO
+INDIANA.GOV,State/Local Govt,Non-Federal Agency,Indianapolis,IN
+INDIANAMOTORSPORTS.GOV,State/Local Govt,Non-Federal Agency,Indianapolis,IN
+INDIANAUNCLAIMED.GOV,State/Local Govt,Non-Federal Agency,Indianapolis,IN
+INDIANHEADPARK-IL.GOV,State/Local Govt,Non-Federal Agency,Indian Head Park,IL
+INNOCENCECOMMISSION-NC.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+INTEGRATEAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+INVESTINIOWA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IOWA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IOWAAGING.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IOWAAGRICULTURE.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IOWAATTORNEYGENERAL.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IOWACHILDSUPPORT.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IOWACLEANAIR.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IOWACOLLEGEAID.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IOWACOLLEGEAIDDATACENTER.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IOWACORE.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IOWACOURTS.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IOWACULTURE.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IOWADIVISIONOFLABOR.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IOWADNR.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IOWADOT.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IOWAELECTRICAL.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IOWAELEVATORS.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IOWAFINANCEAUTHORITY.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IOWAFINANCIALAIDAPPLICATION.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IOWAFORMS.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IOWAFRAUDFIGHTERS.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IOWAGRANTS.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IOWAGREATPLACES.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IOWAJNC.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IOWAJQC.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IOWALIFT.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IOWALMI.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IOWAMORTGAGEHELP.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IOWANEXT.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IOWAOSHA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IOWAPIB.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IOWAPMA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IOWASMOKEFREEAIR.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IOWASTEM.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IOWATAXANDTAGS.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IOWATEST.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IOWATITLEGUARANTY.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IOWATREASURER.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IOWAWORKCOMP.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IOWAWORKFORCE.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IOWAWORKFORCEDEVELOPMENT.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+JACKSONVILLENC.GOV,State/Local Govt,Non-Federal Agency,Jacksonville,NC
+JASPERINDIANA.GOV,State/Local Govt,Non-Federal Agency,Jasper,IN
+JERSEYCITYNJ.GOV,State/Local Govt,Non-Federal Agency,Jersey City,NJ
+JOBS4TN.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN
+JOBSFORTN.GOV,State/Local Govt,Non-Federal Agency,38401,TN
+JUDNJ.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ
+KANAWHACOUNTYWV.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV
+KANSAS.GOV,State/Local Govt,Non-Federal Agency,Topeka,KS
+KANSASCITYMO.GOV,State/Local Govt,Non-Federal Agency,Kansas City,MO
+KANSASEMPLOYER.GOV,State/Local Govt,Non-Federal Agency,Topeka,KS
+KANSASMONEY.GOV,State/Local Govt,Non-Federal Agency,Topeka,KS
+KANSASREADY.GOV,State/Local Govt,Non-Federal Agency,Topeka,KS
+KANSASTAG.GOV,State/Local Govt,Non-Federal Agency,Topeka,KS
+KCMO.GOV,State/Local Govt,Non-Federal Agency,Kansas City,MO
+KDHEKS.GOV,State/Local Govt,Non-Federal Agency,Topeka,KS
+KEITHCOUNTYNE.GOV,State/Local Govt,Non-Federal Agency,Ogallala,NE
+KENTCOUNTYMI.GOV,State/Local Govt,Non-Federal Agency,Grand Rapids,MI
+KENTUCKY.GOV,State/Local Govt,Non-Federal Agency,Frankfort,KY
+KIDCENTRALTENNESSEE.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN
+KIDCENTRALTN.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN
+KPL.GOV,State/Local Govt,Non-Federal Agency,KALAMAZOO,MI
+KS.GOV,State/Local Govt,Non-Federal Agency,Topeka,KS
+KSDA.GOV,State/Local Govt,Non-Federal Agency,Topeka,KS
+KSHOUSINGCORP.GOV,State/Local Govt,Non-Federal Agency,Topeka,KS
+KSREADY.GOV,State/Local Govt,Non-Federal Agency,Topeka,KS
+KY.GOV,State/Local Govt,Non-Federal Agency,Frankfort,KY
+LA.GOV,State/Local Govt,Non-Federal Agency,Baton Rouge,LA
+LAFASTSTART.GOV,State/Local Govt,Non-Federal Agency,Baton Rouge,LA
+LAFAYETTELA.GOV,State/Local Govt,Non-Federal Agency,Lafayette,LA
+LAGUNAHILLSCA.GOV,State/Local Govt,Non-Federal Agency,Laguna Hills,CA
+LAJUDICIAL.GOV,State/Local Govt,Non-Federal Agency,New Orleans,LA
+LAKECOUNTYFL.GOV,State/Local Govt,Non-Federal Agency,Tavares,FL
+LAKEJACKSON-TX.GOV,State/Local Govt,Non-Federal Agency,Lake Jackson,TX
+LAKEPARK-FL.GOV,State/Local Govt,Non-Federal Agency,Lake Park,FL
+LAKEPARKFLORIDA.GOV,State/Local Govt,Non-Federal Agency,Lake Park,FL
+LAKESITETN.GOV,State/Local Govt,Non-Federal Agency,Lakesite,TN
+LAMOINE-ME.GOV,State/Local Govt,Non-Federal Agency,Lamoine,ME
+LANCASTERCOUNTYPA.GOV,State/Local Govt,Non-Federal Agency,Lancaster,PA
+LASVEGASNEVADA.GOV,State/Local Govt,Non-Federal Agency,Las Vegas,NV
+LEADERSHIPAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+LEADVILLE-CO.GOV,State/Local Govt,Non-Federal Agency,Leadville,CO
+LEESBURGVA.GOV,State/Local Govt,Non-Federal Agency,Leesburg,VA
+LEGMT.GOV,State/Local Govt,Non-Federal Agency,Helena,MT
+LEXINGTON-MA.GOV,State/Local Govt,Non-Federal Agency,Lexington,MA
+LEXINGTONMA.GOV,State/Local Govt,Non-Federal Agency,Lexington,MA
+LGADMI.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI
+LGO-VI.GOV,State/Local Govt,Non-Federal Agency,St. Thomas,VI
+LICENSEDINIOWA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+LINCOLNSHIREIL.GOV,State/Local Govt,Non-Federal Agency,Lincolnshire,IL
+LISTOVIRGINIA.GOV,State/Local Govt,Non-Federal Agency,Richmond,VA
+LIVEHEALTHYNEVADA.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV
+LODI.GOV,State/Local Govt,Non-Federal Agency,Lodi,CA
+LODICA.GOV,State/Local Govt,Non-Federal Agency,Lodi,CA
+LOGANTOWNSHIP-PA.GOV,State/Local Govt,Non-Federal Agency,Altoona,PA
+LONDONBRITAINTOWNSHIP-PA.GOV,State/Local Govt,Non-Federal Agency,Landenberg,PA
+LONGVIEW-WA.GOV,State/Local Govt,Non-Federal Agency,Longview,WA
+LONGVIEWWA.GOV,State/Local Govt,Non-Federal Agency,Longview,WA
+LOSGATOSCA.GOV,State/Local Govt,Non-Federal Agency,Los Gatos,CA
+LOSLUNASNM.GOV,State/Local Govt,Non-Federal Agency,Los Lunas,NM
+LOUDOUNCOUNTYVA.GOV,State/Local Govt,Non-Federal Agency,Leesburg,VA
+LOUISIANA.GOV,State/Local Govt,Non-Federal Agency,Baton Rouge,LA
+LOUISIANAENTERTAINMENT.GOV,State/Local Govt,Non-Federal Agency,Baton Rouge,LA
+LOUISIANAFASTSTART.GOV,State/Local Govt,Non-Federal Agency,Baton Rouge,LA
+LOUISIANAMAP.GOV,State/Local Govt,Non-Federal Agency,Baton Rouge,LA
+LOUISIANAMUSIC.GOV,State/Local Govt,Non-Federal Agency,Baton Rouge,LA
+LOWELL-OR.GOV,State/Local Govt,Non-Federal Agency,Lowell,OR
+LOWELLMA.GOV,State/Local Govt,Non-Federal Agency,Lowell,MA
+LOWERPAXTON-PA.GOV,State/Local Govt,Non-Federal Agency,Harrisburg,PA
+LOXAHATCHEEGROVESFL.GOV,State/Local Govt,Non-Federal Agency,Loxahatchee Groves,FL
+LYNCHBURGVA.GOV,State/Local Govt,Non-Federal Agency,Lynchburg,VA
+MA.GOV,State/Local Govt,Non-Federal Agency,Boston,MA
+MAHOUSE.GOV,State/Local Govt,Non-Federal Agency,Boston,MA
+MAINE.GOV,State/Local Govt,Non-Federal Agency,Augusta,ME
+MAINEDOT.GOV,State/Local Govt,Non-Federal Agency,Augusta,ME
+MAINEFLU.GOV,State/Local Govt,Non-Federal Agency,Augusta,ME
+MAINEFORESTSERVICE.GOV,State/Local Govt,Non-Federal Agency,AUGUSTA,ME
+MAINEPUBLICHEALTH.GOV,State/Local Govt,Non-Federal Agency,Augusta,ME
+MAINEQUALITYFORUM.GOV,State/Local Govt,Non-Federal Agency,Augusta,ME
+MAINESERVICECOMMISSION.GOV,State/Local Govt,Non-Federal Agency,Augusta,ME
+MAJURY.GOV,State/Local Govt,Non-Federal Agency,Boston,MA
+MAKINGCOLORADO.GOV,State/Local Govt,Non-Federal Agency,Boulder,CO
+MALEGISLATURE.GOV,State/Local Govt,Non-Federal Agency,Boston,MA
+MALIBU-CA.GOV,State/Local Govt,Non-Federal Agency,Malibu,CA
+MANITOUSPRINGS-CO.GOV,State/Local Govt,Non-Federal Agency,Colorado Springs,CO
+MANSFIELD-TX.GOV,State/Local Govt,Non-Federal Agency,Mansfield,TX
+MAPWV.GOV,State/Local Govt,Non-Federal Agency,Morgantown,WV
+MARICOPA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+MARIETTAGA.GOV,State/Local Govt,Non-Federal Agency,Marietta,GA
+MARIETTAGEORGIA.GOV,State/Local Govt,Non-Federal Agency,Marietta,GA
+MARSHFIELD-MA.GOV,State/Local Govt,Non-Federal Agency,Marshfield,MA
+MARYLAND.GOV,State/Local Govt,Non-Federal Agency,Annapolis,MD
+MARYLANDCOURTS.GOV,State/Local Govt,Non-Federal Agency,Annapolis,MD
+MARYLANDHEALTHCONNECTION.GOV,State/Local Govt,Non-Federal Agency,Baltimore,MD
+MARYLANDSOS.GOV,State/Local Govt,Non-Federal Agency,ANNAPOLIS,MD
+MASENATE.GOV,State/Local Govt,Non-Federal Agency,Boston,MA
+MASS.GOV,State/Local Govt,Non-Federal Agency,Boston,MA
+MASSACHUSETTS.GOV,State/Local Govt,Non-Federal Agency,Boston,MA
+MASTICBEACHVILLAGENY.GOV,State/Local Govt,Non-Federal Agency,Mastic Beach,NY
+MATTHEWSNC.GOV,State/Local Govt,Non-Federal Agency,Matthews,NC
+MAURYCOUNTY-TN.GOV,State/Local Govt,Non-Federal Agency,Columbia,TN
+MCAC-MD.GOV,State/Local Govt,Non-Federal Agency,Calverton ,MD
+MD.GOV,State/Local Govt,Non-Federal Agency,Annapolis,MD
+MDCAC.GOV,State/Local Govt,Non-Federal Agency,Woodlawn,MD
+MDCACDOM.GOV,State/Local Govt,Non-Federal Agency,Woodlawn,MD
+MDCOURTS.GOV,State/Local Govt,Non-Federal Agency,Annapolis,MD
+ME.GOV,State/Local Govt,Non-Federal Agency,Augusta,ME
+MEASURETN.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN
+MEDCMI.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI
+MENTORMICHIGAN.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI
+MESQUITENV.GOV,State/Local Govt,Non-Federal Agency,Mesquite,NV
+MGCBMI.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI
+MHB.GOV,State/Local Govt,Non-Federal Agency,Mobile,AL
+MI.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI
+MI365.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI
+MIAMI-FL.GOV,State/Local Govt,Non-Federal Agency,Miami,FL
+MIAMIAZ.GOV,State/Local Govt,Non-Federal Agency,Miami,AZ
+MIBUSINESS1STOP.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI
+MIBUSINESSONESTOP.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI
+MICH.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI
+MICHIGAN.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI
+MICHIGANIDC.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI
+MIDDLESEXBORO-NJ.GOV,State/Local Govt,Non-Federal Agency,Middlesex,NJ
+MILLENNIUMBULKEISWA.GOV,State/Local Govt,Non-Federal Agency,Lacey,WA
+MILLERSBURGKY.GOV,State/Local Govt,Non-Federal Agency,Millersburg,KY
+MILTON-FREEWATER-OR.GOV,State/Local Govt,Non-Federal Agency,Milton-Freewater,OR
+MILWAUKEE.GOV,State/Local Govt,Non-Federal Agency,Milwaukee,WI
+MINNESOTA.GOV,State/Local Govt,Non-Federal Agency,St. Paul,MN
+MIRAMAR-FL.GOV,State/Local Govt,Non-Federal Agency,Miramar,FL
+MISSISSIPPI.GOV,State/Local Govt,Non-Federal Agency,Jackson,MS
+MISSOURI.GOV,State/Local Govt,Non-Federal Agency,Jefferson City,MO
+MISSOURIINVESTORPROTECTION.GOV,State/Local Govt,Non-Federal Agency,Jefferson City,MO
+MN.GOV,State/Local Govt,Non-Federal Agency,St. Paul,MN
+MNCOURTS.GOV,State/Local Govt,Non-Federal Agency,St. Paul,MN
+MNDISABILITY.GOV,State/Local Govt,Non-Federal Agency,St. Paul,MN
+MNDNR.GOV,State/Local Govt,Non-Federal Agency,St. Paul,MN
+MNDOT.GOV,State/Local Govt,Non-Federal Agency,St. Paul,MN
+MNHOUSING.GOV,State/Local Govt,Non-Federal Agency,St. Paul,MN
+MO.GOV,State/Local Govt,Non-Federal Agency,Jefferson City,MO
+MOAPPED.GOV,State/Local Govt,Non-Federal Agency,St. Louis,MO
+MODOT.GOV,State/Local Govt,Non-Federal Agency,Jefferson City,MO
+MONROECOUNTYPA.GOV,State/Local Govt,Non-Federal Agency,Stroudsburg,PA
+MONSON-MA.GOV,State/Local Govt,Non-Federal Agency,Monson,MA
+MONTANA.GOV,State/Local Govt,Non-Federal Agency,Helena,MT
+MOORECOUNTYNC.GOV,State/Local Govt,Non-Federal Agency,Carthage,NC
+MOPROSECUTORS.GOV,State/Local Govt,Non-Federal Agency,Jefferson City,MO
+MORIARTYNM.GOV,State/Local Govt,Non-Federal Agency,Moriarty,NM
+MORTON-IL.GOV,State/Local Govt,Non-Federal Agency,Morton,IL
+MOUNTPROSPECT-IL.GOV,State/Local Govt,Non-Federal Agency,Mount Prospect,IL
+MOUNTPROSPECTIL.GOV,State/Local Govt,Non-Federal Agency,Mount Prospect,IL
+MRCOG-NM.GOV,State/Local Govt,Non-Federal Agency,Albuquerque,NM
+MS.GOV,State/Local Govt,Non-Federal Agency,Jackson,MS
+MSHOMEHELP.GOV,State/Local Govt,Non-Federal Agency,Jackson,MS
+MSLMI.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI
+MSPADMI.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI
+MT.GOV,State/Local Govt,Non-Federal Agency,Helena,MT
+MUNDELEIN-IL.GOV,State/Local Govt,Non-Federal Agency,Mundelein,IL
+MUNDYTWP-MI.GOV,State/Local Govt,Non-Federal Agency,Swartz Creek,MI
+MURRAYCOUNTYGA.GOV,State/Local Govt,Non-Federal Agency,Chatsworth,GA
+MVPD.GOV,State/Local Govt,Non-Federal Agency,Mountain View,CA
+MYALABAMA.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL
+MYALASKA.GOV,State/Local Govt,Non-Federal Agency,Juneau,AK
+MYFLORIDA.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL
+MYFLORIDACENSUS.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL
+MYFLORIDAHOUSE.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL
+MYHAWAII.GOV,State/Local Govt,Non-Federal Agency,Honolulu,HI
+MYIN.GOV,State/Local Govt,Non-Federal Agency,Indianapolis,IN
+MYINDIANA.GOV,State/Local Govt,Non-Federal Agency,Indianapolis,IN
+MYNCRETIREMENT.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+MYNEVADA.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV
+MYOHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+MYSC.GOV,State/Local Govt,Non-Federal Agency,Cloumbia,SC
+MYTENNESSEE.GOV,State/Local Govt,Non-Federal Agency,Smyrna,TN
+NAPA-CA.GOV,State/Local Govt,Non-Federal Agency,Napa,CA
+NASHCOUNTYNC.GOV,State/Local Govt,Non-Federal Agency,Nashville,NC
+NASSAUCOUNTYNY.GOV,State/Local Govt,Non-Federal Agency,Mineola,NY
+NATICKMA.GOV,State/Local Govt,Non-Federal Agency,Natick,MA
+NATRONACOUNTY-WY.GOV,State/Local Govt,Non-Federal Agency,Casper,WY
+NAVASOTATX.GOV,State/Local Govt,Non-Federal Agency,Navasota,TX
+NAZARETHBOROUGHPA.GOV,State/Local Govt,Non-Federal Agency,Nazareth,PA
+NC.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+NCAGR.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+NCBAR.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+NCBROADBAND.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+NCCARELINK.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+NCCERTIFIEDPARALEGAL.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+NCCIVILWAR150.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+NCCOB.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+NCCPABOARD.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+NCCRIMELAB.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+NCDCI.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+NCDCR.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+NCDENR.GOV,State/Local Govt,Non-Federal Agency,RALEIGH,NC
+NCDHHS.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+NCDOI.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+NCDOJ.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+NCDOT.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+NCDPS.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+NCESC.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+NCFINDOFFENDER.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+NCFORECLOSUREPREVENTION.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+NCFORESTPRODUCTS.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+NCFORESTSERVICE.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+NCGRANTS.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+NCICAC.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+NCISAAC.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+NCLAMP.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+NCLAP.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+NCLAWSPECIALISTS.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+NCMORTGAGEHELP.GOV,State/Local Govt,Non-Federal Agency,27609,NC
+NCONEMAP.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+NCOPENBOOK.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+NCPARKS.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+NCPUBLICSCHOOLS.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+NCREC.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+NCRETIREMENT.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+NCSBE.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+NCSBI.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+NCSMARTGRID.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+NCSTATE.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+NCSTATEBAR.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+NCTREASURER.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+NCVISION25.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+NCWORKS.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+ND.GOV,State/Local Govt,Non-Federal Agency,Bismarck,ND
+NDCENSUS.GOV,State/Local Govt,Non-Federal Agency,Bismarck,ND
+NDCLOUD.GOV,State/Local Govt,Non-Federal Agency,Bismarck,North Dakota
+NDCOURTS.GOV,State/Local Govt,Non-Federal Agency,Bismarck,ND
+NDDATACENTER.GOV,State/Local Govt,Non-Federal Agency,Bismarck,ND
+NDDOHPRESSROOM.GOV,State/Local Govt,Non-Federal Agency,Bismarck,ND
+NDHAN.GOV,State/Local Govt,Non-Federal Agency,Bismarck,ND
+NDHEALTH.GOV,State/Local Govt,Non-Federal Agency,Bismarck,ND
+NDPANDEMICFLU.GOV,State/Local Govt,Non-Federal Agency,Bismarck,ND
+NDSTUDIES.GOV,State/Local Govt,Non-Federal Agency,Bismarck,ND
+NE.GOV,State/Local Govt,Non-Federal Agency,Lincoln,NE
+NEBRASKA.GOV,State/Local Govt,Non-Federal Agency,Lincoln,NE
+NEBRASKACORN.GOV,State/Local Govt,Non-Federal Agency,Lincoln,NE
+NEBRASKALEGISLATURE.GOV,State/Local Govt,Non-Federal Agency,Lincoln,NE
+NEBRASKAMAP.GOV,State/Local Govt,Non-Federal Agency,Lincoln,NE
+NEBRASKASPENDING.GOV,State/Local Govt,Non-Federal Agency,Lincoln,NE
+NEBRASKAUNICAMERAL.GOV,State/Local Govt,Non-Federal Agency,Lincoln,NE
+NEHEALTHINSURANCEINFO.GOV,State/Local Govt,Non-Federal Agency,Lincoln,NE
+NELSONCOUNTY-VA.GOV,State/Local Govt,Non-Federal Agency,Lovingston,VA
+NETWORKMARYLAND.GOV,State/Local Govt,Non-Federal Agency,Annapolis,MD
+NETWORKNEBRASKA.GOV,State/Local Govt,Non-Federal Agency,Lincoln,NE
+NEVADA.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV
+NEVADAGUARD.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV
+NEVADAHOMEAGAIN.GOV,State/Local Govt,Non-Federal Agency,Las Vegas,NV
+NEVADAREADY.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV
+NEVADATREASURER.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV
+NEWENGLAND511.GOV,State/Local Govt,Non-Federal Agency,Montpelier,VT
+NEWFIELDSNH.GOV,State/Local Govt,Non-Federal Agency,Newfields,NH
+NEWHAMPSHIRE.GOV,State/Local Govt,Non-Federal Agency,Concord,NH
+NEWJERSEY.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ
+NEWJERSEYBUSINESS.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ
+NEWJERSEYHOMEKEEPER.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ
+NEWMEXICO.GOV,State/Local Govt,Non-Federal Agency,Santa Fe,NM
+NEWTONMA.GOV,State/Local Govt,Non-Federal Agency,Newton,MA
+NEWWINDSOR-NY.GOV,State/Local Govt,Non-Federal Agency,New Windsor,NY
+NEWYORKHEALTH.GOV,State/Local Govt,Non-Federal Agency,Albany,NY
+NEXTCHAPTERTN.GOV,State/Local Govt,Non-Federal Agency,Smyrna,TN
+NH.GOV,State/Local Govt,Non-Federal Agency,Concord,NH
+NIAGARACOUNTY-NY.GOV,State/Local Govt,Non-Federal Agency,LOCKPORT,NY
+NICHOLSHILLS-OK.GOV,State/Local Govt,Non-Federal Agency,Nichols Hills,OK
+NJ.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ
+NJ2.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ
+NJALERT.GOV,State/Local Govt,Non-Federal Agency,Hamilton,NJ
+NJCANCER.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ
+NJCCC.GOV,State/Local Govt,Non-Federal Agency,Atlantic City,NJ
+NJCCR.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ
+NJCIVILRIGHTS.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ
+NJCONSUMERAFFAIRS.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ
+NJCOURTS.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ
+NJDOC.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ
+NJFLUPANDEMIC.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ
+NJHAS.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ
+NJHMFA.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ
+NJHOMEKEEPER.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ
+NJHOMELANDSECURITY.GOV,State/Local Govt,Non-Federal Agency,Hamilton,NJ
+NJHOUSING.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ
+NJHOUSINGRESOURCECENTER.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ
+NJHRC.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ
+NJHUMANTRAFFICKING.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ
+NJJUD.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ
+NJMEADOWLANDS.GOV,State/Local Govt,Non-Federal Agency,Lyndhurst,NJ
+NJMEDICALBOARD.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ
+NJMVC.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ
+NJMVCONLINE.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ
+NJOHSP.GOV,State/Local Govt,Non-Federal Agency,Hamilton,NJ
+NJPAAD.GOV,State/Local Govt,Non-Federal Agency,Mercerville,NJ
+NJSDA.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ
+NJSECURITIES.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ
+NJSENIORGOLD.GOV,State/Local Govt,Non-Federal Agency,Mercerville,NJ
+NJSHC.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ
+NJSNAP.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ
+NJSPEAKUP.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ
+NJSRGOLD.GOV,State/Local Govt,Non-Federal Agency,Mercerville,NJ
+NJSTART.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ
+NM.GOV,State/Local Govt,Non-Federal Agency,Santa Fe,NM
+NMAG.GOV,State/Local Govt,Non-Federal Agency,Santa Fe,NM
+NMCOURTS.GOV,State/Local Govt,Non-Federal Agency,Santa Fe,NM
+NMLEGIS.GOV,State/Local Govt,Non-Federal Agency,Santa Fe,NM
+NMSTO.GOV,State/Local Govt,Non-Federal Agency,Santa Fe,NM
+NORTH-DAKOTA.GOV,State/Local Govt,Non-Federal Agency,Bismarck,ND
+NORTHCAROLINA.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+NORTHDAKOTA.GOV,State/Local Govt,Non-Federal Agency,Bismarck,ND
+NORTHHAMPTON-NH.GOV,State/Local Govt,Non-Federal Agency,North Hampton,NH
+NORTHMIAMIFL.GOV,State/Local Govt,Non-Federal Agency,North Miami,FL
+NORTHUNIONTOWNSHIP-PA.GOV,State/Local Govt,Non-Federal Agency,Lemont Furnace,PA
+NOSCAMNC.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+NV.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV
+NVCOURTS.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV
+NVDPSPUB.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV
+NVEASE.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV
+NVGGMS.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV
+NVPREPAID.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV
+NVSEXOFFENDERS.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV
+NVSILVERFLUME.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV
+NVSOS.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV
+NY.GOV,State/Local Govt,Non-Federal Agency,Albany,NY
+NYALERT.GOV,State/Local Govt,Non-Federal Agency,Albany,NY
+NYASSEMBLY.GOV,State/Local Govt,Non-Federal Agency,Albany,NY
+NYC-NY.GOV,State/Local Govt,Non-Federal Agency,Brooklyn,NY
+NYC.GOV,State/Local Govt,Non-Federal Agency,Brooklyn,NY
+NYCOURTHELP.GOV,State/Local Govt,Non-Federal Agency,Troy,NY
+NYCOURTS.GOV,State/Local Govt,Non-Federal Agency,Troy,NY
+NYGOVOFFICE.GOV,State/Local Govt,Non-Federal Agency,Albany,NY
+NYHALLOFGOVERNORS.GOV,State/Local Govt,Non-Federal Agency,Albany,NY
+NYHEALTH.GOV,State/Local Govt,Non-Federal Agency,Albany,NY
+NYHOUSINGSEARCH.GOV,State/Local Govt,Non-Federal Agency,Albany,NY
+NYJUROR.GOV,State/Local Govt,Non-Federal Agency,New York,NY
+NYOPENFORBUSINESS.GOV,State/Local Govt,Non-Federal Agency,Albany,NY
+NYPA.GOV,State/Local Govt,Non-Federal Agency,WHITE PLAINS,NY
+NYPREPARE.GOV,State/Local Govt,Non-Federal Agency,Albany,NY
+NYSCANALS.GOV,State/Local Govt,Non-Federal Agency,Albany,NY
+NYSDOT.GOV,State/Local Govt,Non-Federal Agency,Albany,NY
+NYSED.GOV,State/Local Govt,Non-Federal Agency,Albany,NY
+NYSENATE.GOV,State/Local Govt,Non-Federal Agency,Albany,NY
+NYSTART.GOV,State/Local Govt,Non-Federal Agency,Albany,NY
+NYSTAX.GOV,State/Local Govt,Non-Federal Agency,Albany,NY
+NYSTHRUWAY.GOV,State/Local Govt,Non-Federal Agency,Albany,NY
+OCFODC.GOV,State/Local Govt,Non-Federal Agency,Washington,DC
+OCPR.GOV,State/Local Govt,Non-Federal Agency,San Juan,PR
+ODESSA-TX.GOV,State/Local Govt,Non-Federal Agency,Odessa,TX
+OGALLALA-NE.GOV,State/Local Govt,Non-Federal Agency,Ogallala,NE
+OH.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+OHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+OHIOAGRICULTURE.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+OHIOANALYTICS.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+OHIOATTORNEYGENERAL.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+OHIOAUDITOR.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+OHIOBMV.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+OHIOCENTERFORNURSING.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+OHIOCHECKBOOK.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+OHIOCOURTOFCLAIMS.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+OHIOCOURTS.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+OHIODNR.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+OHIOHERETOHELP.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+OHIOHOUSE.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+OHIOHOUSINGLOCATOR.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+OHIOJOBS.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+OHIOJUDICIALCENTER.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+OHIOMEANSACCESSIBILITY.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+OHIOMEANSJOBS.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+OHIOMEANSTRAINING.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+OHIOMEANSVETERANSJOBS.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+OHIONOSMOKELAW.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+OHIOPMP.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+OHIORED.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+OHIORESPONDS.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+OHIOSAFEID.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+OHIOSECRETARYOFSTATE.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+OHIOSENATE.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+OHIOSUPREMECOURT.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+OHIOTHIRDFRONTIER.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+OHIOTPES.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+OHIOTREASURER.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+OHIOVALUESVETERANS.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+OHIOVALUESVETS.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+OHIOVET.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+OHIOVETERANSHOME.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+OHIOVETHOF.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+OHIOVETS.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+OHIOVETSHOF.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+OHIOWOMENVETS.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+OK.GOV,State/Local Govt,Non-Federal Agency,Oklahoma City,OK
+OKBENEFITS.GOV,State/Local Govt,Non-Federal Agency,Oklahoma City,OK
+OKC.GOV,State/Local Govt,Non-Federal Agency,Oklahoma City,OK
+OKCOMMERCE.GOV,State/Local Govt,Non-Federal Agency,Oklahoma city,OK
+OKDHS.GOV,State/Local Govt,Non-Federal Agency,Oklahoma City,OK
+OKDRS.GOV,State/Local Govt,Non-Federal Agency,Oklahoma City,OK
+OKGEOSURVEY1.GOV,State/Local Govt,Non-Federal Agency,Norman,OK
+OKHOUSE.GOV,State/Local Govt,Non-Federal Agency,Oklahoma City,OK
+OKLAHOMA.GOV,State/Local Govt,Non-Federal Agency,Oklahoma City,OK
+OKLAHOMABENEFITS.GOV,State/Local Govt,Non-Federal Agency,Oklahoma City,OK
+OKLAHOMAWORKS.GOV,State/Local Govt,Non-Federal Agency,Oklahoma City,OK
+OKLATOURISM.GOV,State/Local Govt,Non-Federal Agency,Oklahoma City,OK
+OKLEGISLATURE.GOV,State/Local Govt,Non-Federal Agency,Oklahoma City,OK
+OKSENATE.GOV,State/Local Govt,Non-Federal Agency,Oklahoma City,OK
+OLATHEKS.GOV,State/Local Govt,Non-Federal Agency,Olathe,KS
+OLDLYME-CT.GOV,State/Local Govt,Non-Federal Agency,Old Lyme,CT
+OLYMPIA-WA.GOV,State/Local Govt,Non-Federal Agency,Olympia,WA
+OLYMPIAWA.GOV,State/Local Govt,Non-Federal Agency,Olympia,WA
+ONESTOPFLORIDA.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL
+ONSLOWCOUNTYNC.GOV,State/Local Govt,Non-Federal Agency,Jacksonville,NC
+OPC-DC.GOV,State/Local Govt,Non-Federal Agency,Washington,DC
+OPELIKA-AL.GOV,State/Local Govt,Non-Federal Agency,Opelika,AL
+OPEN-DC.GOV,State/Local Govt,Non-Federal Agency,Washington,DC
+OPENOHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+OR-MEDICAID.GOV,State/Local Govt,Non-Federal Agency,Salem,OR
+OR.GOV,State/Local Govt,Non-Federal Agency,Salem,OR
+ORANGE-CT.GOV,State/Local Govt,Non-Federal Agency,Orange,CT
+ORCLIMATECHANGE.GOV,State/Local Govt,Non-Federal Agency,Salem,OR
+OREGON.GOV,State/Local Govt,Non-Federal Agency,Salem,OR
+OREGONATTORNEYGENERAL.GOV,State/Local Govt,Non-Federal Agency,Salem,OR
+OREGONBENEFITSONLINE.GOV,State/Local Govt,Non-Federal Agency,Salem,OR
+OREGONBUDGET.GOV,State/Local Govt,Non-Federal Agency,Salem,OR
+OREGONCHILDSUPPORT.GOV,State/Local Govt,Non-Federal Agency,Salem,OR
+OREGONCONSUMER.GOV,State/Local Govt,Non-Federal Agency,Salem,OR
+OREGONFORESTRY.GOV,State/Local Govt,Non-Federal Agency,Salem,OR
+OREGONHEALTHCARE.GOV,State/Local Govt,Non-Federal Agency,Salem,OR
+OREGONHEALTHYKIDS.GOV,State/Local Govt,Non-Federal Agency,Salem,OR
+OREGONHOMEOWNERSUPPORT.GOV,State/Local Govt,Non-Federal Agency,Salem,OR
+OREGONLEGISLATURE.GOV,State/Local Govt,Non-Federal Agency,Salem,OR
+OREGONMETRO.GOV,State/Local Govt,Non-Federal Agency,Portland,OR
+OREGONMOTORVOTER.GOV,State/Local Govt,Non-Federal Agency,Salem,OR
+OREGONRX.GOV,State/Local Govt,Non-Federal Agency,Salem,OR
+OREGONSTUDENTAID.GOV,State/Local Govt,Non-Federal Agency,Salem,OR
+OREGONUSF.GOV,State/Local Govt,Non-Federal Agency,Salem,OR
+OREGONVOTES.GOV,State/Local Govt,Non-Federal Agency,Salem,OR
+ORHEALTHCARE.GOV,State/Local Govt,Non-Federal Agency,Salem,OR
+OSE-CT.GOV,State/Local Govt,Non-Federal Agency,Hartford,CT
+OTAYWATER.GOV,State/Local Govt,Non-Federal Agency,Spring Valley,CA
+OUTDOORNEBRASKA.GOV,State/Local Govt,Non-Federal Agency,Lincoln,NE
+OVERLANDPARKKS.GOV,State/Local Govt,Non-Federal Agency,Overland Park,KS
+OXFORD-CT.GOV,State/Local Govt,Non-Federal Agency,Oxford,CT
+PA.GOV,State/Local Govt,Non-Federal Agency,Harrisburg,PA
+PA529.GOV,State/Local Govt,Non-Federal Agency,Harrisburg,PA
+PA529ABLE.GOV,State/Local Govt,Non-Federal Agency,Harrisburg,PA
+PAABLE.GOV,State/Local Govt,Non-Federal Agency,Harrisburg,PA
+PAACPAMMMI.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI
+PAAUDITOR.GOV,State/Local Govt,Non-Federal Agency,Harrisburg,PA
+PACIFICFLYWAY.GOV,State/Local Govt,Non-Federal Agency,Vancouver,WA
+PACIFICWA.GOV,State/Local Govt,Non-Federal Agency,Pacific,WA
+PADILLABAY.GOV,State/Local Govt,Non-Federal Agency,MOUNT VERNON,WA
+PAHOUSE.GOV,State/Local Govt,Non-Federal Agency,Harrisburg,PA
+PAINVEST.GOV,State/Local Govt,Non-Federal Agency,Harrisburg,PA
+PALMBEACHCOUNTYTAXCOLLECTOR-FL.GOV,State/Local Govt,Non-Federal Agency,West Palm Beach,FL
+PALOALTO-CA.GOV,State/Local Govt,Non-Federal Agency,Palo Alto,CA
+PANYNJ.GOV,State/Local Govt,Non-Federal Agency,New York,NY
+PAOPENFORBUSINESS.GOV,State/Local Govt,Non-Federal Agency,Harrisburg,PA
+PARTNERSFORHEALTHTN.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN
+PASEN.GOV,State/Local Govt,Non-Federal Agency,Harrisburg,PA
+PASENATE.GOV,State/Local Govt,Non-Federal Agency,Harrisburg,PA
+PATREASURY.GOV,State/Local Govt,Non-Federal Agency,Harrisburg,PA
+PAULDING.GOV,State/Local Govt,Non-Federal Agency,Dallas,GA
+PAY4COLLEGEARIZONA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+PAYIOWA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+PEACHTREECORNERSGA.GOV,State/Local Govt,Non-Federal Agency,PEACHTREE CORNERS,GA
+PEMBINACOUNTYND.GOV,State/Local Govt,Non-Federal Agency,Cavalier,ND
+PENNSYLVANIA.GOV,State/Local Govt,Non-Federal Agency,Harrisburg,PA
+PEORIAAZ.GOV,State/Local Govt,Non-Federal Agency,Peoria,AZ
+PEQUOTLAKES-MN.GOV,State/Local Govt,Non-Federal Agency,Pequot Lakes,MN
+PERRY-GA.GOV,State/Local Govt,Non-Federal Agency,Perry,GA
+PERRY-WI.GOV,State/Local Govt,Non-Federal Agency,Mount Horeb,WI
+PHILIPSBURGMT.GOV,State/Local Govt,Non-Federal Agency,Philipsburg,MT
+PHOENIX.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+PIERMONT-NY.GOV,State/Local Govt,Non-Federal Agency,Piermont,NY
+PILOTPOINTAK.GOV,State/Local Govt,Non-Federal Agency,Pilot Point,AK
+PINECREST-FL.GOV,State/Local Govt,Non-Federal Agency,Pinecrest,FL
+PINELLASCOUNTY-FL.GOV,State/Local Govt,Non-Federal Agency,Clearwater,FL
+PINELLASCOUNTYFL.GOV,State/Local Govt,Non-Federal Agency,Clearwater,FL
+PINETOPLAKESIDEAZ.GOV,State/Local Govt,Non-Federal Agency,LAKESIDE,AZ
+PLAINVILLE-CT.GOV,State/Local Govt,Non-Federal Agency,Plainville,CT
+PLANO.GOV,State/Local Govt,Non-Federal Agency,Plano,TX
+PLATTSBURG-MO.GOV,State/Local Govt,Non-Federal Agency,Plattsburg,MO
+POCONOPA.GOV,State/Local Govt,Non-Federal Agency,Tannersville,PA
+POMFRETCT.GOV,State/Local Govt,Non-Federal Agency,Pomfret Center,CT
+PORTAGE-MI.GOV,State/Local Govt,Non-Federal Agency,Portage,MI
+PORTAGEMI.GOV,State/Local Govt,Non-Federal Agency,Portage,MI
+PORTSMOUTHVA.GOV,State/Local Govt,Non-Federal Agency,Portsmouth,VA
+POYNETTE-WI.GOV,State/Local Govt,Non-Federal Agency,Poynette,WI
+PR.GOV,State/Local Govt,Non-Federal Agency,San Juan,PR
+PREVENTHAIAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+PRINCEGEORGECOUNTYVA.GOV,State/Local Govt,Non-Federal Agency,Prince George,VA
+PROVINCETOWN-MA.GOV,State/Local Govt,Non-Federal Agency,Provincetown,MA
+PUERTORICO.GOV,State/Local Govt,Non-Federal Agency,San Juan,PR
+PULASKICOUNTYVA.GOV,State/Local Govt,Non-Federal Agency,Pulaski,VA
+PULLMAN-WA.GOV,State/Local Govt,Non-Federal Agency,Pullman,WA
+PUTNAMCOUNTYTN.GOV,State/Local Govt,Non-Federal Agency,Cookeville,TN
+QAAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+QUALITYFIRSTAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+RAMAPO-NY.GOV,State/Local Govt,Non-Federal Agency,Suffern,NY
+READYALABAMA.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL
+READYNH.GOV,State/Local Govt,Non-Federal Agency,Concord,NH
+READYVIRGINIA.GOV,State/Local Govt,Non-Federal Agency,Richmond,VA
+READYWV.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV
+RECYCLEOHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+REDDING-CA.GOV,State/Local Govt,Non-Federal Agency,Redding,CA
+REDISTRICTINGFLORIDA.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL
+REEDSBURGWI.GOV,State/Local Govt,Non-Federal Agency,Reedsburg,WI
+REGISTERTOVOTENV.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV
+RELAYUTAH.GOV,State/Local Govt,Non-Federal Agency,Salt Lake City,UT
+RENO.GOV,State/Local Govt,Non-Federal Agency,Reno,NV
+RENTONWA.GOV,State/Local Govt,Non-Federal Agency,Renton,WA
+REPORTITTN.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN
+RETIREREADYTN.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN
+RHODEISLAND.GOV,State/Local Govt,Non-Federal Agency,Providence,RI
+RI.GOV,State/Local Govt,Non-Federal Agency,Providence,RI
+RIALTOCA.GOV,State/Local Govt,Non-Federal Agency,Rialto,CA
+RICHLANDMS.GOV,State/Local Govt,Non-Federal Agency,Richland,MS
+RIDESHAREWI.GOV,State/Local Govt,Non-Federal Agency,Madison,WI
+RIDESHAREWISCONSIN.GOV,State/Local Govt,Non-Federal Agency,Madison,WI
+RIORANCHONM.GOV,State/Local Govt,Non-Federal Agency,Rio Rancho,NM
+RIPSGA.GOV,State/Local Govt,Non-Federal Agency,North Scituate,RI
+RISP.GOV,State/Local Govt,Non-Federal Agency,North Scituate,RI
+RIVERTONWY.GOV,State/Local Govt,Non-Federal Agency,Riverton,WY
+ROANOKECOUNTY-VA.GOV,State/Local Govt,Non-Federal Agency,Roanoke,VA
+ROANOKECOUNTYVA.GOV,State/Local Govt,Non-Federal Agency,Roanoke,VA
+ROANOKECOUNTYVIRGINIA.GOV,State/Local Govt,Non-Federal Agency,Roanoke,VA
+ROCHELLEPARKNJ.GOV,State/Local Govt,Non-Federal Agency,Rochelle Park,NJ
+ROCHESTERMN.GOV,State/Local Govt,Non-Federal Agency,Rochester,MN
+ROCKINGHAMCOUNTYVA.GOV,State/Local Govt,Non-Federal Agency,Harrisonburg,VA
+ROCKISLANDTOWNSHIPIL.GOV,State/Local Govt,Non-Federal Agency,Rock Island,IL
+ROGERSMN.GOV,State/Local Govt,Non-Federal Agency,Rogers,MN
+ROMI.GOV,State/Local Govt,Non-Federal Agency,Royal Oak,MI
+ROWANCOUNTYNC.GOV,State/Local Govt,Non-Federal Agency,Salisbury,NC
+ROYALOAKMI.GOV,State/Local Govt,Non-Federal Agency,Royal Oak,MI
+RSA-AL.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL
+RULEWATCHOHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+SACOMAINE.GOV,State/Local Govt,Non-Federal Agency,Saco,ME
+SAFEHOMEALABAMA.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL
+SAFERFLORIDAHIGHWAYS.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL
+SAFERFLORIDAROADS.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL
+SAFESD.GOV,State/Local Govt,Non-Federal Agency,Pierre,SD
+SAFFORD-AZ.GOV,State/Local Govt,Non-Federal Agency,Safford,AZ
+SALINA-KS.GOV,State/Local Govt,Non-Federal Agency,Salina,KS
+SANDIEGO.GOV,State/Local Govt,Non-Federal Agency,San Diego,CA
+SANDPOINTIDAHO.GOV,State/Local Govt,Non-Federal Agency,Sandpoint,ID
+SANNET.GOV,State/Local Govt,Non-Federal Agency,San Diego,CA
+SANTAANA-CA.GOV,State/Local Govt,Non-Federal Agency,Santa Ana,CA
+SANTABARBARACA.GOV,State/Local Govt,Non-Federal Agency,Santa Barbara,CA
+SAOMT.GOV,State/Local Govt,Non-Federal Agency,Helena,MT
+SAVEMYHOMEAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+SAVEOURHOMEAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+SC.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC
+SCAG.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC
+SCCONSUMER.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC
+SCDEW.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC
+SCDHEC.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC
+SCDHHS.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC
+SCDPS.GOV,State/Local Govt,Non-Federal Agency,Blythewood,SC
+SCFC.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC
+SCHELP.GOV,State/Local Govt,Non-Federal Agency,Columbia`,SC
+SCHOHARIECOUNTY-NY.GOV,State/Local Govt,Non-Federal Agency,Schoharie,NY
+SCHOUSE.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC
+SCNEWHIRE.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC
+SCOH.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+SCOHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+SCOTTCOUNTYIOWA.GOV,State/Local Govt,Non-Federal Agency,Davenport,IA
+SCOTTCOUNTYMS.GOV,State/Local Govt,Non-Federal Agency,Forest,MS
+SCOTTSDALEAZ.GOV,State/Local Govt,Non-Federal Agency,Scottsdale,AZ
+SCQUITLINE.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC
+SCSENATE.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC
+SCSERV.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC
+SCSTATEHOUSE.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC
+SD.GOV,State/Local Govt,Non-Federal Agency,Pierre,SD
+SDAUDITOR.GOV,State/Local Govt,Non-Federal Agency,Pierre,SD
+SDBMOE.GOV,State/Local Govt,Non-Federal Agency,Pierre,SD
+SDSOS.GOV,State/Local Govt,Non-Federal Agency,Pierre,SD
+SDTREASURER.GOV,State/Local Govt,Non-Federal Agency,Pierre,SD
+SEATTLE.GOV,State/Local Govt,Non-Federal Agency,Seattle,WA
+SEDGWICK.GOV,State/Local Govt,Non-Federal Agency,Wichita,KS
+SEELYVILLE-IN.GOV,State/Local Govt,Non-Federal Agency,Seelyville,IN
+SEMINOLECOUNTYFL.GOV,State/Local Govt,Non-Federal Agency,Sanford,FL
+SERVEALABAMA.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL
+SERVEIDAHO.GOV,State/Local Govt,Non-Federal Agency,Boise,ID
+SERVEOHIO.GOV,State/Local Govt,Non-Federal Agency,Columb us,OH
+SERVGA.GOV,State/Local Govt,Non-Federal Agency,Atlanta,GA
+SFWMD.GOV,State/Local Govt,Non-Federal Agency,West Palm Beach,FL
+SHAFTSBURYVT.GOV,State/Local Govt,Non-Federal Agency,Shaftsbury,VT
+SHAPINGNEWJERSEY.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ
+SHAPINGNJ.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ
+SHAREOHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+SHOWLOWAZ.GOV,State/Local Govt,Non-Federal Agency,Show Low,AZ
+SHREWSBURY-MA.GOV,State/Local Govt,Non-Federal Agency,Shrewsbury,MA
+SIMSBURY-CT.GOV,State/Local Govt,Non-Federal Agency,Simsbury,CT
+SMITHTOWNNY.GOV,State/Local Govt,Non-Federal Agency,Smithtown,NY
+SNOHOMISHCOUNTYWA.GOV,State/Local Govt,Non-Federal Agency,Everett,WA
+SOCORRONM.GOV,State/Local Govt,Non-Federal Agency,Socorro,NM
+SOUTHCAROLINA.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC
+SOUTHERNSHORES-NC.GOV,State/Local Govt,Non-Federal Agency,Southern Shores,NC
+SOUTHOLDTOWNNY.GOV,State/Local Govt,Non-Federal Agency,Southold,NY
+SPACEFLORIDA.GOV,State/Local Govt,Non-Federal Agency,Cape Canaveral,FL
+SPRINGFIELDMO.GOV,State/Local Govt,Non-Federal Agency,Springfield,MO
+STAGINGAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+STATEOFSOUTHCAROLINA.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC
+STATEOFWV.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV
+STAYSAFENEBRASKA.GOV,State/Local Govt,Non-Federal Agency,Lincoln,NE
+STCHARLESIL.GOV,State/Local Govt,Non-Federal Agency,St. Charles,IL
+STONECOUNTYMS.GOV,State/Local Govt,Non-Federal Agency,Wiggins,MS
+STOPFRAUDCOLORADO.GOV,State/Local Govt,Non-Federal Agency,Denver,CO
+STOUGHTON-MA.GOV,State/Local Govt,Non-Federal Agency,Stoughton,MA
+STOW-MA.GOV,State/Local Govt,Non-Federal Agency,Stow,MA
+STPAULSNC.GOV,State/Local Govt,Non-Federal Agency,St. Pauls,NC
+STURTEVANT-WI.GOV,State/Local Govt,Non-Federal Agency,Sturtevant,WI
+SUFFOLKCOUNTYNY.GOV,State/Local Govt,Non-Federal Agency,Hauppauge,NY
+SULLIVANCOUNTYNH.GOV,State/Local Govt,Non-Federal Agency,Newport,NH
+SUNRISEFL.GOV,State/Local Govt,Non-Federal Agency,Sunrise,FL
+SUNRISEFLORIDA.GOV,State/Local Govt,Non-Federal Agency,Sunrise,FL
+SUPREMECOURTOFOHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+SUTTON-NH.GOV,State/Local Govt,Non-Federal Agency,Sutton,NH
+SWEETHOMEALABAMA.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL
+TAKOMAPARKMD.GOV,State/Local Govt,Non-Federal Agency,Takoma Park,MD
+TAPPAHANNOCK-VA.GOV,State/Local Govt,Non-Federal Agency,Tappahannock,VA
+TCCC.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC
+TEACHIOWA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+TEAMGA.GOV,State/Local Govt,Non-Federal Agency,Atlanta,GA
+TEAMGEORGIA.GOV,State/Local Govt,Non-Federal Agency,Atlanta,GA
+TEAMTN.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN
+TENNESSEE.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN
+TENNESSEECOLLEGEADVISER.GOV,State/Local Govt,Non-Federal Agency,Smyrna,TN
+TENNESSEECOLLEGEADVISOR.GOV,State/Local Govt,Non-Federal Agency,Smyrna,TN
+TENNESSEEIIS.GOV,State/Local Govt,Non-Federal Agency,Smyrna,TN
+TENNESSEEPROMISE.GOV,State/Local Govt,Non-Federal Agency,Smyrna,TN
+TENNESSEERECONNECT.GOV,State/Local Govt,Non-Federal Agency,Smyrna,TN
+TESTOHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+TEWKSBURY-MA.GOV,State/Local Govt,Non-Federal Agency,Tewksbury,MA
+TEXAS.GOV,State/Local Govt,Non-Federal Agency,Austin,TX
+TEXAS511.GOV,State/Local Govt,Non-Federal Agency,Austin,TX
+TEXASAGRICULTURE.GOV,State/Local Govt,Non-Federal Agency,Austin,TX
+TEXASATTORNEYGENERAL.GOV,State/Local Govt,Non-Federal Agency,Austin,TX
+TEXASCHILDRENSCOMMISSION.GOV,State/Local Govt,Non-Federal Agency,Austin,TX
+TEXASFIGHTSIDTHEFT.GOV,State/Local Govt,Non-Federal Agency,Austin,TX
+TEXASFILE.GOV,State/Local Govt,Non-Federal Agency,Austin,TX
+TEXASONLINE.GOV,State/Local Govt,Non-Federal Agency,Austin,TX
+TEXASSTATEPARKS.GOV,State/Local Govt,Non-Federal Agency,Austin,TX
+TEXASSUPREMECOURTCOMMISSION.GOV,State/Local Govt,Non-Federal Agency,Austin,TX
+THA.GOV,State/Local Govt,Non-Federal Agency,Topeka,KS
+THEFTAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+THERIGHTCALLIOWA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+THESTATEOFSOUTHCAROLINA.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC
+TN.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN
+TNAG.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN
+TNCOLLEGEADVISER.GOV,State/Local Govt,Non-Federal Agency,Smyrna,TN
+TNCOLLEGEADVISOR.GOV,State/Local Govt,Non-Federal Agency,Smyrna,TN
+TNCOURTS.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN
+TNECD.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN
+TNEDU.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN
+TNIIS.GOV,State/Local Govt,Non-Federal Agency,Smyrna,TN
+TNK12.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN
+TNPROMISE.GOV,State/Local Govt,Non-Federal Agency,Smyrna,TN
+TNQUITLINE.GOV,State/Local Govt,Non-Federal Agency,Smyrna,TN
+TNREADY.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN
+TNRECONNECT.GOV,State/Local Govt,Non-Federal Agency,Smyrna,TN
+TNTOOLKIT.GOV,State/Local Govt,Non-Federal Agency,Smyrna,TN
+TNTREASURY.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN
+TNVACATION.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN
+TOMGREENCOUNTYTX.GOV,State/Local Govt,Non-Federal Agency,San Angelo,TX
+TOURISMOHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+TOWERLAKES-IL.GOV,State/Local Govt,Non-Federal Agency,Tower Lakes,IL
+TOWNOFDUNNWI.GOV,State/Local Govt,Non-Federal Agency,McFarland,WI
+TOWNOFGOLDENMEADOW-LA.GOV,State/Local Govt,Non-Federal Agency,Golden Meadow,LA
+TOWNOFKEENENY.GOV,State/Local Govt,Non-Federal Agency,Keene,NY
+TOWNOFRAMAPO-NY.GOV,State/Local Govt,Non-Federal Agency,Suffern,NY
+TOWNOFRIVERHEADNY.GOV,State/Local Govt,Non-Federal Agency,Riverhead,NY
+TOWNOFSMYRNA-TN.GOV,State/Local Govt,Non-Federal Agency,Smyrna,TN
+TOWNOFTROUTVILLE-VA.GOV,State/Local Govt,Non-Federal Agency,Troutville,VA
+TOWNOFWALLINGFORD-CT.GOV,State/Local Govt,Non-Federal Agency,Wallingford,CT
+TOWNOFWINGATENC.GOV,State/Local Govt,Non-Federal Agency,Wingate,NC
+TRANSPARENCYFLORIDA.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL
+TRANSPARENCYWV.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV
+TRUSTTENNESSEE.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN
+TRUSTTN.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN
+TTD.GOV,State/Local Govt,Non-Federal Agency,East Norwalk,CT
+TUCSONAZ.GOV,State/Local Govt,Non-Federal Agency,Tucson,AZ
+TUPPERLAKENY.GOV,State/Local Govt,Non-Federal Agency,Tupper Lake,NY
+TUSCALOOSA-AL.GOV,State/Local Govt,Non-Federal Agency,Tuscaloosa,AL
+TX.GOV,State/Local Govt,Non-Federal Agency,Austin,TX
+TX511.GOV,State/Local Govt,Non-Federal Agency,Austin,TX
+TXAG.GOV,State/Local Govt,Non-Federal Agency,Austin,TX
+TXCOURTS.GOV,State/Local Govt,Non-Federal Agency,Austin,TX
+TXDMV.GOV,State/Local Govt,Non-Federal Agency,Austin,TX
+TXDOT.GOV,State/Local Govt,Non-Federal Agency,Austin,TX
+TXDPS.GOV,State/Local Govt,Non-Federal Agency,Austin,TX
+TXFILE.GOV,State/Local Govt,Non-Federal Agency,Austin,TX
+TXMAP.GOV,State/Local Govt,Non-Federal Agency,Austin,TX
+TXOAG.GOV,State/Local Govt,Non-Federal Agency,Austin,TX
+UNITYNH.GOV,State/Local Govt,Non-Federal Agency,Charlestown,NH
+US41WISCONSIN.GOV,State/Local Govt,Non-Federal Agency,Madison,WI
+UTAH.GOV,State/Local Govt,Non-Federal Agency,Salt Lake City,UT
+UTAHLAKE.GOV,State/Local Govt,Non-Federal Agency,Salt Lake City,UT
+UTAHTRUST.GOV,State/Local Govt,Non-Federal Agency,North Salt Lake,UT
+UTCOURTS.GOV,State/Local Govt,Non-Federal Agency,Salt Lake City,UT
+VACOURTS.GOV,State/Local Govt,Non-Federal Agency,Richmond,VA
+VAEMERGENCY.GOV,State/Local Govt,Non-Federal Agency,Richmond,VA
+VBHIL.GOV,State/Local Govt,Non-Federal Agency,Barrington Hills,IL
+VERMONT.GOV,State/Local Govt,Non-Federal Agency,Montpelier,VT
+VERMONTHEALTHCONNECT.GOV,State/Local Govt,Non-Federal Agency,Montpelier,VT
+VERMONTTAXAMNESTY.GOV,State/Local Govt,Non-Federal Agency,Montpelier,VT
+VERMONTTREASURER.GOV,State/Local Govt,Non-Federal Agency,Montpelier,VT
+VERMONTVOTESFORKIDS.GOV,State/Local Govt,Non-Federal Agency,Montpelier,VT
+VERNONTWP-PA.GOV,State/Local Govt,Non-Federal Agency,Meadville,PA
+VI.GOV,State/Local Govt,Non-Federal Agency,St. Thomas,VI
+VIALERT.GOV,State/Local Govt,Non-Federal Agency,St. Thomas,VI
+VIBIR.GOV,State/Local Govt,Non-Federal Agency,St. Thomas,VI
+VIDOL.GOV,State/Local Govt,Non-Federal Agency,St. Thomas,VI
+VIHFA.GOV,State/Local Govt,Non-Federal Agency,St. Thomas,VI
+VILLAGEOFDUNLAP-IL.GOV,State/Local Govt,Non-Federal Agency,Dunlap,IL
+VILLAGEOFPENINSULA-OH.GOV,State/Local Govt,Non-Federal Agency,Peninsula,OH
+VILLAGEOFSCOTIANY.GOV,State/Local Govt,Non-Federal Agency,Scotia,NY
+VINTONVA.GOV,State/Local Govt,Non-Federal Agency,Vinton,VA
+VIRGINIA.GOV,State/Local Govt,Non-Federal Agency,Chester,VA
+VIRGINIACAPITAL.GOV,State/Local Govt,Non-Federal Agency,Richmond,VA
+VIRGINIACAPITOL.GOV,State/Local Govt,Non-Federal Agency,Richmond,VA
+VIRGINIAGENERALASSEMBLY.GOV,State/Local Govt,Non-Federal Agency,Richmond,VA
+VIRGINIASTATEPARKS.GOV,State/Local Govt,Non-Federal Agency,Richmond,VA
+VISITIDAHO.GOV,State/Local Govt,Non-Federal Agency,Boise,ID
+VISITNEBRASKA.GOV,State/Local Govt,Non-Federal Agency,Lincoln,NE
+VISITNH.GOV,State/Local Govt,Non-Federal Agency,Concord,NH
+VISITWYO.GOV,State/Local Govt,Non-Federal Agency,Cheyenne,WY
+VISITWYOMING.GOV,State/Local Govt,Non-Federal Agency,Cheyenne,WY
+VITEMA.GOV,State/Local Govt,Non-Federal Agency,St. Thomas,VI
+VIVOTE.GOV,State/Local Govt,Non-Federal Agency,St Croix,VI
+VOLUNTEERLOUISIANA.GOV,State/Local Govt,Non-Federal Agency,Baton Rouge,LA
+VOTETEXAS.GOV,State/Local Govt,Non-Federal Agency,Austin,TX
+VT.GOV,State/Local Govt,Non-Federal Agency,Montpelier,VT
+VTALERT.GOV,State/Local Govt,Non-Federal Agency,Montpelier,VT
+WA.GOV,State/Local Govt,Non-Federal Agency,Olympia,WA
+WAKECOUNTYNC.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+WALDOCOUNTYME.GOV,State/Local Govt,Non-Federal Agency,Belfast,ME
+WALLAWALLAWA.GOV,State/Local Govt,Non-Federal Agency,Walla Walla,WA
+WALPOLE-MA.GOV,State/Local Govt,Non-Federal Agency,Walpole,MA
+WALTONCOUNTYGA.GOV,State/Local Govt,Non-Federal Agency,Monroe,GA
+WARRACRES-OK.GOV,State/Local Govt,Non-Federal Agency,Warr Acres,OK
+WARRENPA.GOV,State/Local Govt,Non-Federal Agency,Warren,PA
+WASHINGTON-NC.GOV,State/Local Govt,Non-Federal Agency,Washington,NC
+WASHINGTON.GOV,State/Local Govt,Non-Federal Agency,Olympia,WA
+WASHINGTONCOUNTYNY.GOV,State/Local Govt,Non-Federal Agency,Fort Edward,NY
+WASHINGTONDC.GOV,State/Local Govt,Non-Federal Agency,"Washington,",DC
+WASHINGTONNC.GOV,State/Local Govt,Non-Federal Agency,Washington,NC
+WASHINGTONPA.GOV,State/Local Govt,Non-Federal Agency,Washington,PA
+WASHINGTONSTATE.GOV,State/Local Govt,Non-Federal Agency,Olympia,WA
+WASHINGTONVILLE-NY.GOV,State/Local Govt,Non-Federal Agency,Washingtonville,NY
+WASHTENAWCOUNTY-MI.GOV,State/Local Govt,Non-Federal Agency,Ann Arbor,MI
+WATAUGACOUNTYNC.GOV,State/Local Govt,Non-Federal Agency,Boone,NC
+WAUKESHACOUNTY-WI.GOV,State/Local Govt,Non-Federal Agency,Waukesha,WI
+WAUKESHACOUNTY.GOV,State/Local Govt,Non-Federal Agency,Waukesha,WI
+WAYNECOUNTYMS.GOV,State/Local Govt,Non-Federal Agency,Waynesboro,MS
+WCNYH.GOV,State/Local Govt,Non-Federal Agency,New YOrk,NY
+WEBBCOUNTYTX.GOV,State/Local Govt,Non-Federal Agency,Laredo,TX
+WELCOMEHOMEILLINOIS.GOV,State/Local Govt,Non-Federal Agency,Chicago,IL
+WENHAMMA.GOV,State/Local Govt,Non-Federal Agency,Wenham,MA
+WESTBENDWI.GOV,State/Local Govt,Non-Federal Agency,West Bend,WI
+WESTCHESTERCOUNTYNY.GOV,State/Local Govt,Non-Federal Agency,White Plains,NY
+WESTFORKAR.GOV,State/Local Govt,Non-Federal Agency,West Fork,AR
+WESTMINSTER-CA.GOV,State/Local Govt,Non-Federal Agency,Westminster,CA
+WESTMORELANDTN.GOV,State/Local Govt,Non-Federal Agency,Westmoreland,TN
+WESTVALLEYCITY-UT.GOV,State/Local Govt,Non-Federal Agency,West Valley City,UT
+WHITMAN-MA.GOV,State/Local Govt,Non-Federal Agency,Whitman,MA
+WHYNEVADA.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV
+WI-TIME.GOV,State/Local Govt,Non-Federal Agency,Madison,WI
+WI-WORCS.GOV,State/Local Govt,Non-Federal Agency,Madison,WI
+WI.GOV,State/Local Govt,Non-Federal Agency,Madison,WI
+WIBADGERTRACS.GOV,State/Local Govt,Non-Federal Agency,Madison,WI
+WICONNECTIONS2030.GOV,State/Local Govt,Non-Federal Agency,Madison,WI
+WICOURTS.GOV,State/Local Govt,Non-Federal Agency,MADISON,WI
+WIGRANTS.GOV,State/Local Govt,Non-Federal Agency,Madison,WI
+WILAWLIBRARY.GOV,State/Local Govt,Non-Federal Agency,Madison,WI
+WILDOHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+WILLIAMSBURGVA.GOV,State/Local Govt,Non-Federal Agency,Williamsburg,VA
+WILMINGTON-NC.GOV,State/Local Govt,Non-Federal Agency,Wilmington,NC
+WILMINGTONNC.GOV,State/Local Govt,Non-Federal Agency,Wilmington,NC
+WINTERGARDEN-FL.GOV,State/Local Govt,Non-Federal Agency,Winter Garden,FL
+WINTERPORTMAINE.GOV,State/Local Govt,Non-Federal Agency,Winterport,ME
+WINTERSPRINGSFL.GOV,State/Local Govt,Non-Federal Agency,Winter Springs,FL
+WISC.GOV,State/Local Govt,Non-Federal Agency,Madison,WI
+WISCONSIN.GOV,State/Local Govt,Non-Federal Agency,Madison,WI
+WISCONSINCRIMEALERT.GOV,State/Local Govt,Non-Federal Agency,Madison,WI
+WISCONSINDMV.GOV,State/Local Govt,Non-Federal Agency,Madison,WI
+WISCONSINDOT.GOV,State/Local Govt,Non-Federal Agency,Madison,WI
+WISCONSINFREIGHTPLAN.GOV,State/Local Govt,Non-Federal Agency,Madison,WI
+WISCONSINRAILPLAN.GOV,State/Local Govt,Non-Federal Agency,Madison,WI
+WISCONSINROUNDABOUTS.GOV,State/Local Govt,Non-Federal Agency,Madison,WI
+WMATA.GOV,State/Local Govt,Non-Federal Agency,Washington,DC
+WORKFORNC.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+WSDOT.GOV,State/Local Govt,Non-Federal Agency,Olympia,WA
+WV.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV
+WVAGO.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV
+WVCOMMERCE.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV
+WVCONSUMERPROTECTION.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV
+WVCSI.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV
+WVDHSEM.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV
+WVDMV.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV
+WVDNR.GOV,State/Local Govt,Non-Federal Agency,South Charleston,WV
+WVHOUSE.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV
+WVINSURANCE.GOV,State/Local Govt,Non-Federal Agency,Charleson,WV
+WVLEGISLATURE.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV
+WVOASIS.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV
+WVOT.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV
+WVOTA.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV
+WVPRESIDENT.GOV,State/Local Govt,Non-Federal Agency,Morgantown,WV
+WVPURCHASING.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV
+WVREVENUE.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV
+WVSAO.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV
+WVSENATE.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV
+WVSENIORSERVICES.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV
+WVSP.GOV,State/Local Govt,Non-Federal Agency,South Charleston,WV
+WVSPEAKER.GOV,State/Local Govt,Non-Federal Agency,Morgantown,WV
+WVSTO.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV
+WVSURPLUS.GOV,State/Local Govt,Non-Federal Agency,Dunbar,WV
+WVTAX.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV
+WY.GOV,State/Local Govt,Non-Federal Agency,Cheyenne,WY
+WYCAMPAIGNFINANCE.GOV,State/Local Govt,Non-Federal Agency,Cheyenne,WY
+WYINVESTORAWARENESS.GOV,State/Local Govt,Non-Federal Agency,Cheyenne,WY
+WYO.GOV,State/Local Govt,Non-Federal Agency,Cheyenne,WY
+WYOBOARDS.GOV,State/Local Govt,Non-Federal Agency,Cheyenne,WY
+WYOLEG.GOV,State/Local Govt,Non-Federal Agency,Cheyenne,WY
+WYOMING.GOV,State/Local Govt,Non-Federal Agency,Cheyenne,WY
+WYOMINGAGCARE.GOV,State/Local Govt,Non-Federal Agency,Cheyenne,WY
+WYOMINGFOSTERCARE.GOV,State/Local Govt,Non-Federal Agency,Cheyenne,WY
+WYOMINGLMI.GOV,State/Local Govt,Non-Federal Agency,cheyenne,WY
+WYOMINGOFFICEOFTOURISM.GOV,State/Local Govt,Non-Federal Agency,Cheyenne,WY
+WYOREG.GOV,State/Local Govt,Non-Federal Agency,cheyenne,WY
+WYWINDFALL.GOV,State/Local Govt,Non-Federal Agency,cheyenne,WY
+YADKINCOUNTY.GOV,State/Local Govt,Non-Federal Agency,Yadkinville,NC
+YADKINCOUNTYNC.GOV,State/Local Govt,Non-Federal Agency,Yadkinville,NC
+YAMHILLCOUNTY-OR.GOV,State/Local Govt,Non-Federal Agency,McMinnville,OR
+YANCEYVILLENC.GOV,State/Local Govt,Non-Federal Agency,Roxboro,NC
+YUCAIPA-CA.GOV,State/Local Govt,Non-Federal Agency,Yucaipa,CA
+ZAPATACOUNTYTX.GOV,State/Local Govt,Non-Federal Agency,Zapata,TX
+ZEROINWISCONSIN.GOV,State/Local Govt,Non-Federal Agency,Madison,WI
+ZIONSVILLE-IN.GOV,State/Local Govt,Non-Federal Agency,Zionsville,IN
+PENNDOT.GOV,State/Local Govt,Pennsylvania Department of Transportation.,Harrisburg,PA

--- a/dotgov-domains/2015-11-03-native.csv
+++ b/dotgov-domains/2015-11-03-native.csv
@@ -1,0 +1,165 @@
+Domain Name,Domain Type,Agency,City,State
+PHC-NSN.GOV,Native Sovereign Nation,Department of the Interior,Princeton,ME
+29PALMSBOMI-NSN.GOV,Native Sovereign Nation,Indian Affairs,Coachella,CA
+ABSENTEESHAWNEETRIBE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Shawnee,OK
+AGUACALIENTE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Palm Springs,CA
+AHA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Hogansburg,NY
+BADRIVER-NSN.GOV,Native Sovereign Nation,Indian Affairs,Odanah,WI
+BARONA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Lakeside,CA
+BEARRIVER-NSN.GOV,Native Sovereign Nation,Indian Affairs,Loleta,CA
+BIHASITKA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Sitka,AK
+BLUELAKERANCHERIA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Blue Lake,CA
+BOISFORTE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Nett Lake,MN
+BRB-NSN.GOV,Native Sovereign Nation,Indian Affairs,LOLETA,CA
+BURNSPAIUTE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Burns,OR
+CABAZONINDIANS-NSN.GOV,Native Sovereign Nation,Indian Affairs,Indio,CA
+CADDONATION-NSN.GOV,Native Sovereign Nation,Indian Affairs,Binger,OK
+CALIFORNIAVALLEYMIWOKTRIBE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Stockton,CA
+CAMPO-NSN.GOV,Native Sovereign Nation,Indian Affairs,Campo,CA
+CAYUGANATION-NSN.GOV,Native Sovereign Nation,Indian Affairs,Seneca Falls ,NY
+CDATRIBE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Plummer,ID
+CHEROKEE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Tahlequah,OK
+CHICKASAW-GOVERNMENT-NSN.GOV,Native Sovereign Nation,Indian Affairs,Ada,OK
+CHICKASAW-NSN.GOV,Native Sovereign Nation,Indian Affairs,Ada,OK
+CHICKASAWARTISANS-NSN.GOV,Native Sovereign Nation,Indian Affairs,Ada,OK
+CHICKASAWGOVERNMENT-NSN.GOV,Native Sovereign Nation,Indian Affairs,Ada,OK
+CHICKASAWJUDICIAL-NSN.GOV,Native Sovereign Nation,Indian Affairs,Ada,OK
+CHICKASAWLEGISLATURE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Ada,OK
+CHICKASAWNATION-NSN.GOV,Native Sovereign Nation,Indian Affairs,Ada,OK
+CHICKASAWTRIBE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Ada,OK
+CHILKOOT-NSN.GOV,Native Sovereign Nation,Indian Affairs,Haines,AK
+CHITIMACHA.GOV,Native Sovereign Nation,Indian Affairs,Charenton,LA
+CHUKCHANSI-NSN.GOV,Native Sovereign Nation,Indian Affairs,Fresno,CA
+CIT-NSN.GOV,Native Sovereign Nation,Indian Affairs,Havasu Lake,CA
+COLUSA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Colusa,CA
+COYOTEVALLEY-NSN.GOV,Native Sovereign Nation,Indian Affairs,Redwood valley,CA
+CRHC-NSN.GOV,Native Sovereign Nation,Indian Affairs,Chico,CA
+CRIT-NSN.GOV,Native Sovereign Nation,Indian Affairs,Parker,AZ
+CROW-NSN.GOV,Native Sovereign Nation,Indian Affairs,Crow Agency,MT
+CRST-NSN.GOV,Native Sovereign Nation,Indian Affairs,EAGLE BUTTE,SD
+EKLUTNA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Chugiak,AK
+ELYSHOSHONETRIBE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Ely,NV
+ESTOO-NSN.GOV,Native Sovereign Nation,Indian Affairs,Wyandotte,OK
+EWIIAAPAAYP-NSN.GOV,Native Sovereign Nation,Indian Affairs,Alpine,CA
+EYAK-NSN.GOV,Native Sovereign Nation,Indian Affairs,Cordova,AK
+FCP-NSN.GOV,Native Sovereign Nation,Indian Affairs,Crandon,WI
+FCPOTAWATOMI-NSN.GOV,Native Sovereign Nation,Indian Affairs,Crandon,WI
+FORTSILLAPACHE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Apache,OK
+GILARIVER-NSN.GOV,Native Sovereign Nation,Indian Affairs,Sacaton,AZ
+GLT-NSN.GOV,Native Sovereign Nation,Indian Affairs,Dorr,MI
+GUNLAKETRIBE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Dorr,MI
+HANNAHVILLEPOTAWATOMI-NSN.GOV,Native Sovereign Nation,Indian Affairs,Wilson,MI
+HAVASUPAI-NSN.GOV,Native Sovereign Nation,Indian Affairs,Supai,AZ
+HOOPA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Hoopa,CA
+HOPI-NSN.GOV,Native Sovereign Nation,Indian Affairs,Kykotsmovi,AZ
+HPULTRIBE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Upper Lake,CA
+HUALAPAI-NSN.GOV,Native Sovereign Nation,Indian Affairs,Peach Springs,AZ
+IIPAYNATION-NSN.GOV,Native Sovereign Nation,Indian Affairs,santa ysabel,CA
+ISLETAPUEBLO-NSN.GOV,Native Sovereign Nation,Indian Affairs,Isleta,NM
+JACKSONRANCHERIA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Jackson,CA
+KAIBABPAIUTE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Fredonia,AZ
+KAWAIKA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Laguna,NM
+KAYENTATOWNSHIP-NSN.GOV,Native Sovereign Nation,Indian Affairs,Kayenta,AZ
+KBIC-NSN.GOV,Native Sovereign Nation,Indian Affairs,Baraga,MI
+KENAITZE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Kenai,AK
+KEWEENAWBAY-NSN.GOV,Native Sovereign Nation,Indian Affairs,Baraga,MI
+KTIK-NSN.GOV,Native Sovereign Nation,Indian Affairs,Horton,KS
+LAGUNA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Laguna,NM
+LAGUNAPUEBLO-NSN.GOV,Native Sovereign Nation,Indian Affairs,Laguna,NM
+LAJOLLA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Pauma Valley,CA
+LCO-NSN.GOV,Native Sovereign Nation,Indian Affairs,Hayward,WI
+LTBBODAWA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Harbor Springs,MI
+LUMMI-NSN.GOV,Native Sovereign Nation,Indian Affairs,Bellingham,WA
+MASHANTUCKET-NSN.GOV,Native Sovereign Nation,Indian Affairs,Mashantucket,CT
+MASHANTUCKETPEQUOT-NSN.GOV,Native Sovereign Nation,Indian Affairs,Mashantucket,CT
+MASHANTUCKETWESTERNPEQUOT-NSN.GOV,Native Sovereign Nation,Indian Affairs,Mashantucket,CT
+MCN-NSN.GOV,Native Sovereign Nation,Indian Affairs,Okmulgee,OK
+MECHOOPDA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Chico,CA
+MENOMINEE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Keshena,WI
+MESAGRANDEBAND-NSN.GOV,Native Sovereign Nation,Indian Affairs,SantaYsabel,CA
+MESKWAKI-NSN.GOV,Native Sovereign Nation,Indian Affairs,Tama,IA
+MICCOSUKEE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Miami,FL
+MICMAC-NSN.GOV,Native Sovereign Nation,Indian Affairs,Presque Isle,ME
+MIDDLETOWNRANCHERIA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Middletown,CA
+MILLELACSBAND-NSN.GOV,Native Sovereign Nation,Indian Affairs,Onamia,MN
+MOAPABANDOFPAIUTES-NSN.GOV,Native Sovereign Nation,Indian Affairs,Moapa,NV
+MOHICAN-NSN.GOV,Native Sovereign Nation,Indian Affairs,Bowler,WI
+MORONGO-NSN.GOV,Native Sovereign Nation,Indian Affairs,Banning,CA
+MPGE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Mashantucket,CT
+MPTN-NSN.GOV,Native Sovereign Nation,Indian Affairs,Mashantucket,CT
+MUSCOGEENATION-NSN.GOV,Native Sovereign Nation,Indian Affairs,Okmulgee,OK
+NCIHA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Ukiah,CA
+NFR-NSN.GOV,Native Sovereign Nation,Indian Affairs,North Fork,CA
+NFRIHA-NSN.GOV,Native Sovereign Nation,Indian Affairs,North Fork,CA
+NINILCHIKTRIBE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Ninilchik,AK
+NISQUALLY-NSN.GOV,Native Sovereign Nation,Indian Affairs,Olympia,WA
+NOOKSACK-NSN.GOV,Native Sovereign Nation,Indian Affairs,Deming,WA
+NORTHFORKRANCHERIA-NSN.GOV,Native Sovereign Nation,Indian Affairs,North Fork ,CA
+NVB-NSN.GOV,Native Sovereign Nation,Indian Affairs,Barrow,AK
+OHKAYOWINGEH-NSN.GOV,Native Sovereign Nation,Indian Affairs,San Juan Pueblo,NM
+OMAHA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Macy,NE
+ONEIDA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Oneida,WI
+OSAGECONGRESS-NSN.GOV,Native Sovereign Nation,Indian Affairs,Pawhuska,OK
+OSAGENATION-NSN.GOV,Native Sovereign Nation,Indian Affairs,Pawhuska,OK
+PASCUAYAQUI-NSN.GOV,Native Sovereign Nation,Indian Affairs,Tucson,AZ
+PASKENTA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Corning,CA
+PAUMA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Pauma Valley,CA
+PCI-NSN.GOV,Native Sovereign Nation,Indian Affairs,Atmore,AL
+PECHANGA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Temecula,CA
+PEQUOT-NSN.GOV,Native Sovereign Nation,Indian Affairs,Mashantucket,CT
+PICAYUNERANCHERIA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Coarsegold,CA
+POARCHCREEKINDIANS-NSN.GOV,Native Sovereign Nation,Indian Affairs,ATMORE,AL
+POKAGONBAND-NSN.GOV,Native Sovereign Nation,Indian Affairs,DOWAGIAC,MI
+POL-NSN.GOV,Native Sovereign Nation,Indian Affairs,Laguna,NM
+QVIR-NSN.GOV,Native Sovereign Nation,Indian Affairs,Fort jones,CA
+RAMONA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Anza,CA
+REDCLIFF-NSN.GOV,Native Sovereign Nation,Indian Affairs,Bayfield,WI
+ROSEBUDSIOUXTRIBE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Rosebud,SD
+RST-NSN.GOV,Native Sovereign Nation,Indian Affairs,Rosebud,SD
+RSTWATER-NSN.GOV,Native Sovereign Nation,Indian Affairs,Rosebud,SD
+SACANDFOXNATION-NSN.GOV,Native Sovereign Nation,Indian Affairs,Stroud,OK
+SANMANUEL-NSN.GOV,Native Sovereign Nation,Indian Affairs,Highland,CA
+SANTAANA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Santa Ana,NM
+SANTAROSACAHUILLA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Anza,CA
+SCAT-NSN.GOV,Native Sovereign Nation,Indian Affairs,Peridot,AZ
+SCC-NSN.GOV,Native Sovereign Nation,Indian Affairs,Crandon,WI
+SEMINOLENATION-NSN.GOV,Native Sovereign Nation,Indian Affairs,Wewoka,OK
+SHOALWATERBAY-NSN.GOV,Native Sovereign Nation,Indian Affairs,Tokeland,WA
+SIR-NSN.GOV,Native Sovereign Nation,Indian Affairs,Susanville,CA
+SITKATRIBE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Sitka,AK
+SNO-NSN.GOV,Native Sovereign Nation,Indian Affairs,Wewoka,OK
+SOBOBA-NSN.GOV,Native Sovereign Nation,Indian Affairs,San Jacinto,CA
+SOUTHERNUTE-NSN.GOV,Native Sovereign Nation,Indian Affairs,IGNACIO,CO
+SRMT-NSN.GOV,Native Sovereign Nation,Indian Affairs,Akwesasne,NY
+SRPMIC-NSN.GOV,Native Sovereign Nation,Indian Affairs,Scottsdale,AZ
+SUSANVILLEINDIANRANCHERIA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Susanville,CA
+SWINOMISH-NSN.GOV,Native Sovereign Nation,Indian Affairs,La Conner,WA
+SWO-NSN.GOV,Native Sovereign Nation,Indian Affairs,Agency Village,SD
+SYCUAN-NSN.GOV,Native Sovereign Nation,Indian Affairs,El Cajon,CA
+TACHI-YOKUT-NSN.GOV,Native Sovereign Nation,Indian Affairs,Lemoore,CA
+TAMAYA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Santa Ana,NM
+TMDCI-NSN.GOV,Native Sovereign Nation,Indian Affairs,Thermal,CA
+TOLOWA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Smith River,CA
+TONATION-NSN.GOV,Native Sovereign Nation,Indian Affairs,Sells,AZ
+TULALIP-NSN.GOV,Native Sovereign Nation,Indian Affairs,Tulalip,WA
+TULALIPAIR-NSN.GOV,Native Sovereign Nation,Indian Affairs,Tulalip,WA
+TULALIPTRIBES-NSN.GOV,Native Sovereign Nation,Indian Affairs,Tulalip,WA
+TULERIVERTRIBE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Porterville,CA
+TWENTYNINEPALMSBOMI-NSN.GOV,Native Sovereign Nation,Indian Affairs,Coachella,CA
+UKB-NSN.GOV,Native Sovereign Nation,Indian Affairs,Tahlequah,OK
+UPPERSIOUXCOMMUNITY-NSN.GOV,Native Sovereign Nation,Indian Affairs,Granite Falls,MN
+VIEJAS-NSN.GOV,Native Sovereign Nation,Indian Affairs,Alpine,CA
+WESTERNPEQUOT-NSN.GOV,Native Sovereign Nation,Indian Affairs,Mashantucket,CT
+WHITEEARTH-NSN.GOV,Native Sovereign Nation,Indian Affairs,Ogema,MN
+WILTONRANCHERIA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Elk Grove,CA
+WINNEMUCCAINDIANCOLONYOFNEVADA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Winnemucca,NV
+WYANDOTTE-NATION-NSN.GOV,Native Sovereign Nation,Indian Affairs,Wyandotte,OK
+YAKAMAFISH-NSN.GOV,Native Sovereign Nation,Indian Affairs,Toppenish,WA
+YAKAMANATION-NSN.GOV,Native Sovereign Nation,Indian Affairs,Toppenish,WA
+YOCHADEHE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Brooks,CA
+YPT-NSN.GOV,Native Sovereign Nation,Indian Affairs,Yerington,NV
+CHILKAT-NSN.GOV,Native Sovereign Nation,Non-Federal Agency,Haines,AK
+DINEH-NSN.GOV,Native Sovereign Nation,Non-Federal Agency,Window Rock,AZ
+LRBOI-NSN.GOV,Native Sovereign Nation,Non-Federal Agency,Manistee,MI
+NAVAJO-NSN.GOV,Native Sovereign Nation,Non-Federal Agency,Window Rock,AZ
+YDSP-NSN.GOV,Native Sovereign Nation,Non-Federal Agency,El Pas,TX

--- a/dotgov-domains/2015-11-03-state-local.csv
+++ b/dotgov-domains/2015-11-03-state-local.csv
@@ -1,0 +1,1514 @@
+Domain Name,Domain Type,Agency,City,State
+PENNDOT.GOV,State/Local Govt,Pennsylvania Department of Transportation.,Harrisburg,PA
+MTC.GOV,State/Local Govt,Multistate Tax Commission,Washington,DC
+511MAINE.GOV,State/Local Govt,Non-Federal Agency,Augusta,ME
+511NY.GOV,State/Local Govt,Non-Federal Agency,Albany,NY
+511TX.GOV,State/Local Govt,Non-Federal Agency,Austin,TX
+511WI.GOV,State/Local Govt,Non-Federal Agency,Madison,WI
+ABLETN.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN
+ACCESSTN.GOV,State/Local Govt,Non-Federal Agency,NASHVILLE,TN
+ADAMSCOUNTYMS.GOV,State/Local Govt,Non-Federal Agency,Natchez,MS
+ADRCNJ.GOV,State/Local Govt,Non-Federal Agency,Mercerville,NJ
+AGAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AK.GOV,State/Local Govt,Non-Federal Agency,Juneau,AK
+AKAEROSPACE.GOV,State/Local Govt,Non-Federal Agency,Anchorage,AK
+AKLEG.GOV,State/Local Govt,Non-Federal Agency,Juneau,AK
+AL-LEGISLATURE.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL
+AL.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL
+ALABAMA.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL
+ALABAMAAGELINE.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL
+ALABAMACONNECT.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL
+ALABAMADA.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL
+ALABAMADEMENTIA.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL
+ALABAMAHOUSEPHOTOS.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL
+ALABAMASMP.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL
+ALABAMAVOTES.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL
+ALABPP.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL
+ALACOP.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL
+ALACOURT.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL
+ALADA.GOV,State/Local Govt,Non-Federal Agency,Mongomery,AL
+ALADNA.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL
+ALAPPEALS.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL
+ALASAFE.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL
+ALASKA.GOV,State/Local Govt,Non-Federal Agency,Juneau,AK
+ALASKACARE.GOV,State/Local Govt,Non-Federal Agency,Juneau,AK
+ALBUQUERQUE-NM.GOV,State/Local Govt,Non-Federal Agency,Albuquerque,NM
+ALDOI.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL
+ALEA.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL
+ALEXANDERCOUNTYNC.GOV,State/Local Govt,Non-Federal Agency,Taylorsville,NC
+ALEXANDRIANJ.GOV,State/Local Govt,Non-Federal Agency,Milford,NJ
+ALGONAC-MI.GOV,State/Local Govt,Non-Federal Agency,Algonac,MI
+ALHOUSE.GOV,State/Local Govt,Non-Federal Agency,Montgomery ,AL
+ALLENDALENJ.GOV,State/Local Govt,Non-Federal Agency,Allendale,NJ
+ALPHARETTA-GA.GOV,State/Local Govt,Non-Federal Agency,Alpharetta,GA
+ALSENATE.GOV,State/Local Govt,Non-Federal Agency,Montgomery ,AL
+ALTOONAPA.GOV,State/Local Govt,Non-Federal Agency,Altoona,PA
+AMERICANSAMOA.GOV,State/Local Govt,Non-Federal Agency,Pago Pago,AS
+AMESBURYMA.GOV,State/Local Govt,Non-Federal Agency,Amesbury,MA
+AMITECOUNTYMS.GOV,State/Local Govt,Non-Federal Agency,Liberty,MS
+ANNAPOLIS.GOV,State/Local Govt,Non-Federal Agency,Annapolis,MD
+ANNAPOLISMD.GOV,State/Local Govt,Non-Federal Agency,Annapolis,MD
+ANTIOCHTOWNSHIP-IL.GOV,State/Local Govt,Non-Federal Agency,Lake Villa,IL
+ANTIOCHTOWNSHIPIL.GOV,State/Local Govt,Non-Federal Agency,Lake Villa,IL
+AQMD.GOV,State/Local Govt,Non-Federal Agency,Diamond Bar,CA
+AR.GOV,State/Local Govt,Non-Federal Agency,Little Rock,AR
+ARCHDALE-NC.GOV,State/Local Govt,Non-Federal Agency,ARCHDALE,NC
+ARCOURTS.GOV,State/Local Govt,Non-Federal Agency,Little Rock,AR
+ARIZONA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+ARIZONAJOBCONNECTION.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+ARIZONASERVES.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+ARIZONATURBOCOURT.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+ARKANSAS.GOV,State/Local Govt,Non-Federal Agency,Little Rock,AR
+ARKANSASAG.GOV,State/Local Govt,Non-Federal Agency,Little Rock,AR
+ARKANSASED.GOV,State/Local Govt,Non-Federal Agency,Little Rock,AR
+ARKLEGAUDIT.GOV,State/Local Govt,Non-Federal Agency,Little Rock,AR
+ARTREASURY.GOV,State/Local Govt,Non-Federal Agency,Litlte Rock,AR
+ARTRS.GOV,State/Local Govt,Non-Federal Agency,Little Rock,AR
+AS.GOV,State/Local Govt,Non-Federal Agency,Pago Pago,AS
+ASAFERFLORIDA.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL
+ASEPA.GOV,State/Local Govt,Non-Federal Agency,Pago Pago,AS
+ASHEVILLENC.GOV,State/Local Govt,Non-Federal Agency,Asheville,NC
+ATHOMEILLINOIS.GOV,State/Local Govt,Non-Federal Agency,Chicago,IL
+ATLASALABAMA.GOV,State/Local Govt,Non-Federal Agency,TUSCALOOSA,AL
+ATTORNEYGENERAL.GOV,State/Local Govt,Non-Federal Agency,Harrisburg,PA
+AUBURNNY.GOV,State/Local Govt,Non-Federal Agency,Auburn,NY
+AUBURNWA.GOV,State/Local Govt,Non-Federal Agency,Auburn,WA
+AUGUSTAGA.GOV,State/Local Govt,Non-Federal Agency,Augusta,GA
+AURORATEXAS.GOV,State/Local Govt,Non-Federal Agency,Rhome,TX
+AVON-MA.GOV,State/Local Govt,Non-Federal Agency,Avon,MA
+AZ-ACOIHC.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZ-FHSD.GOV,State/Local Govt,Non-Federal Agency,Fountain Hills,AZ
+AZ.GOV,State/Local Govt,Non-Federal Agency,Phoeniz,AZ
+AZ511.GOV,State/Local Govt,Non-Federal Agency,Pheonix,AZ
+AZ529.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZ911.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZABRC.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZACCOUNTANCY.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZACTIC.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZAFIS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZAG.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZAHCCCS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZARTS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZASRS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZAUDITOR.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZBN.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZBNP.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZBOA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZBOC.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZBOEC.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZBOF.GOV,State/Local Govt,Non-Federal Agency,PHOENIX,AZ
+AZBORDERTRASH.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZBOTA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZBOXINGANDMMA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZBROADBAND.GOV,State/Local Govt,Non-Federal Agency,PHOENIX,AZ
+AZBTR.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZCAAA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZCANCERCONTROL.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZCC.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZCIA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZCJC.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZCLEANELECTIONS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZCLIMATECHANGE.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZCOOP.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZCORPCOM.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZCORPCOMM.GOV,State/Local Govt,Non-Federal Agency,Phoenxi,AZ
+AZCORRECTIONS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZCOURTDOCS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZCOURTS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZCVD.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZDA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZDAARS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZDCS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZDDPC.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZDEMA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZDEQ.GOV,State/Local Govt,Non-Federal Agency,Phx,AZ
+AZDES.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZDFI.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZDHS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZDIABETES.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZDJC.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZDO.GOV,State/Local Govt,Non-Federal Agency,Scottsdale,AZ
+AZDOA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZDOC.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZDOH.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZDOHS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZDOR.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZDOSH.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZDOT.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZDPS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZDVS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZDWM.GOV,State/Local Govt,Non-Federal Agency,Glendale,AZ
+AZECDH.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZED.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZEIN.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZENERGY.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZENVIROKIDS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZEPIP.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZFIRSTTHINGSFIRST.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZFTF.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZGADA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZGAMING.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZGFD.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZGITA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZGOHS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZGOVERNOR.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZGRANTS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZGU.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZGUARD.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZHC.GOV,State/Local Govt,Non-Federal Agency,Pheonix,AZ
+AZHEALTH.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZHIGHERED.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZHOUSE.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZHOUSING.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZHS.GOV,State/Local Govt,Non-Federal Agency,Tempe,AZ
+AZICA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZINSURANCE.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZINVESTOR.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZJOBCONNECTION.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZJUVED.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZKIDSCARE.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZKIDSNEEDU.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZLAND.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZLEG.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZLGMA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZLIBRARY.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZLINKS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZLIQUOR.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZLOTTERY.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZMAG.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZMD.GOV,State/Local Govt,Non-Federal Agency,Scottsdale,AZ
+AZMFRF.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZMINORITYHEALTH.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZMORTGAGERESOURCE.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZMYFAMILYBENEFITS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZND.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZNET.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZOCA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZOSPB.GOV,State/Local Govt,Non-Federal Agency,phoenix,AZ
+AZOT.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZPA.GOV,State/Local Govt,Non-Federal Agency,Scottsdale,AZ
+AZPARKS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZPCRPD.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZPH.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZPHARMACY.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZPOST.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZPPSE.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZPSIC.GOV,State/Local Govt,Non-Federal Agency,PHOENIX,AZ
+AZQUALITYFIRST.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZRACING.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZRE.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZRECOVERY.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZRECYCLES.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZREPORTCARD.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZROC.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZRRA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZRUCO.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZSAL.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZSENATE.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZSF.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZSFB.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZSHARE.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZSOS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZSTATEJOBS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZSTATEPARKS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZSTATS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZSTEPSUP.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZSUMMERFOOD.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZSURPLUS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZTAXES.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZTRANSPORTATIONBOARD.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZTREASURER.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZTREASURY.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZTTT.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZTURBOCOURT.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZUI.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZUITAX.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZUNCLAIMED.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZVOICES.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZWATER.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZWATERBANK.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZWIC.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZWIFA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZWPF.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+AZYES.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+B4WV.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV
+BAAQMD.GOV,State/Local Govt,Non-Federal Agency,San Francisco,CA
+BABYARIZONA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+BAKERSFIELD-CA.GOV,State/Local Govt,Non-Federal Agency,Bakersfield,CA
+BARHARBORMAINE.GOV,State/Local Govt,Non-Federal Agency,Bar Harbor,ME
+BART.GOV,State/Local Govt,Non-Federal Agency,Oakland,CA
+BASSLAKEWI.GOV,State/Local Govt,Non-Federal Agency,Hayward,WI
+BATONROUGELA.GOV,State/Local Govt,Non-Federal Agency,Baton Rouge,LA
+BATTLEFIELDMO.GOV,State/Local Govt,Non-Federal Agency,Battlefield,MO
+BAYCOUNTY-MI.GOV,State/Local Govt,Non-Federal Agency,Bay City,MI
+BCCIRCLK.GOV,State/Local Govt,Non-Federal Agency,Princeton,IL
+BEAUXARTS-WA.GOV,State/Local Govt,Non-Federal Agency,Beaux Arts,WA
+BECKEMEYERIL.GOV,State/Local Govt,Non-Federal Agency,Beckemeyer,IL
+BEGA-DC.GOV,State/Local Govt,Non-Federal Agency,Washington,DC
+BELMONT.GOV,State/Local Govt,Non-Federal Agency,Belmont,CA
+BENBROOK-TX.GOV,State/Local Govt,Non-Federal Agency,Benbrook,TX
+BEREADYUTAH.GOV,State/Local Govt,Non-Federal Agency,Salt Lake City,UT
+BERRYVILLEVA.GOV,State/Local Govt,Non-Federal Agency,Berryville,VA
+BETHLEHEM-PA.GOV,State/Local Govt,Non-Federal Agency,Bethlehem,PA
+BIGFLATSNY.GOV,State/Local Govt,Non-Federal Agency,Big Flats,NY
+BIGHORNCOUNTYWY.GOV,State/Local Govt,Non-Federal Agency,Basin,WY
+BLACKSBURG.GOV,State/Local Govt,Non-Federal Agency,Blacksburg,VA
+BLISSFIELDMICHIGAN.GOV,State/Local Govt,Non-Federal Agency,Blissfield,MI
+BLNC.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+BLOOMINGTONMN.GOV,State/Local Govt,Non-Federal Agency,Bloomington,MN
+BOATIDAHO.GOV,State/Local Govt,Non-Federal Agency,Boise,ID
+BOIMI.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI
+BOONEVILLE-MS.GOV,State/Local Govt,Non-Federal Agency,Booneville,MS
+BOULDER-CO.GOV,State/Local Govt,Non-Federal Agency,Boulder,CO
+BOULDERCITY-NV.GOV,State/Local Govt,Non-Federal Agency,Boulder City,NV
+BOULDERCITYNV.GOV,State/Local Govt,Non-Federal Agency,Boulder City,NV
+BOULDERCOUNTY-CO.GOV,State/Local Govt,Non-Federal Agency,Boulder,CO
+BOUNTIFULUTAH.GOV,State/Local Govt,Non-Federal Agency,Bountiful,UT
+BOW-NH.GOV,State/Local Govt,Non-Federal Agency,Bow,NH
+BRAINTREEMA.GOV,State/Local Govt,Non-Federal Agency,Braintree,MA
+BRANDCOLORADO.GOV,State/Local Govt,Non-Federal Agency,Boulder,CO
+BREWERMAINE.GOV,State/Local Govt,Non-Federal Agency,Brewer,ME
+BRIDGEWATERNJ.GOV,State/Local Govt,Non-Federal Agency,Bridgewater,NJ
+BRIGHTONCO.GOV,State/Local Govt,Non-Federal Agency,Brighton,CO
+BROCKTON-MA.GOV,State/Local Govt,Non-Federal Agency,Brockton,MA
+BROOKINGSCOUNTYSD.GOV,State/Local Govt,Non-Federal Agency,Brookings,SD
+BROOMFIELDCO.GOV,State/Local Govt,Non-Federal Agency,Broomfield,CO
+BRUNSWICKMD.GOV,State/Local Govt,Non-Federal Agency,Brunswick,MD
+BRYANTX.GOV,State/Local Govt,Non-Federal Agency,Bryan,TX
+BUCHANAN-VA.GOV,State/Local Govt,Non-Federal Agency,BUCHANAN,VA
+BURKECOUNTY-GA.GOV,State/Local Govt,Non-Federal Agency,Waynesboro,GA
+BURLINGTONND.GOV,State/Local Govt,Non-Federal Agency,Burlington,ND
+BURLINGTONWA.GOV,State/Local Govt,Non-Federal Agency,Burlington,WA
+BUSINESS4WV.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV
+BUYNJBONDS.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ
+CA.GOV,State/Local Govt,Non-Federal Agency,Rancho Cordova,CA
+CAHWNET.GOV,State/Local Govt,Non-Federal Agency,Sacramento,CA
+CALAISVERMONT.GOV,State/Local Govt,Non-Federal Agency,East Calais,VT
+CALIFORNIA.GOV,State/Local Govt,Non-Federal Agency,Rancho Cordova,CA
+CALIFORNIADESERT.GOV,State/Local Govt,Non-Federal Agency,Barstow,CA
+CAMBRIDGERETIREMENTMA.GOV,State/Local Govt,Non-Federal Agency,Cambridge,MA
+CAMDENCOUNTYGA.GOV,State/Local Govt,Non-Federal Agency,Woodbine,GA
+CAMPBELLCA.GOV,State/Local Govt,Non-Federal Agency,Campbell,CA
+CANANDAIGUANEWYORK.GOV,State/Local Govt,Non-Federal Agency,Canandaigua,NY
+CAPITALREGION.GOV,State/Local Govt,Non-Federal Agency,Fairfax,VA
+CAPITALREGIONUPDATES.GOV,State/Local Govt,Non-Federal Agency,Fairfax,VA
+CASAAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+CASWELLCOUNTYNC.GOV,State/Local Govt,Non-Federal Agency,Yanceyville,NC
+CELINA-TX.GOV,State/Local Govt,Non-Federal Agency,Celina,TX
+CENTERLINE.GOV,State/Local Govt,Non-Federal Agency,Center Line,MI
+CHAMPAIGN-IL.GOV,State/Local Govt,Non-Federal Agency,Champaign,IL
+CHANDLERAZ.GOV,State/Local Govt,Non-Federal Agency,Chandler,AZ
+CHEROKEECOUNTY-NC.GOV,State/Local Govt,Non-Federal Agency,Murphy,NC
+CHESTERFIELD.GOV,State/Local Govt,Non-Federal Agency,Chesterfield,VA
+CHESTERFIELDCOUNTY.GOV,State/Local Govt,Non-Federal Agency,Chesterfield,VA
+CHESTERVT.GOV,State/Local Govt,Non-Federal Agency,Chester,VT
+CHIAMASS.GOV,State/Local Govt,Non-Federal Agency,Boston,MA
+CHIPPEWACOUNTYMI.GOV,State/Local Govt,Non-Federal Agency,Sault Ste Marie,MI
+CHOOSEIDAHO.GOV,State/Local Govt,Non-Federal Agency,Boise,ID
+CHULAVISTACA.GOV,State/Local Govt,Non-Federal Agency,Chula Vista,CA
+CITYOFAUBURNWA.GOV,State/Local Govt,Non-Federal Agency,Auburn,WA
+CITYOFBOSTON.GOV,State/Local Govt,Non-Federal Agency,Boston,MA
+CITYOFCHAMPAIGN-IL.GOV,State/Local Govt,Non-Federal Agency,Champaign,IL
+CITYOFCODY-WY.GOV,State/Local Govt,Non-Federal Agency,Cody,WY
+CITYOFFARGO-ND.GOV,State/Local Govt,Non-Federal Agency,Fargo,ND
+CITYOFGROTON-CT.GOV,State/Local Govt,Non-Federal Agency,Groton,CT
+CITYOFHAYWARD-CA.GOV,State/Local Govt,Non-Federal Agency,Hayward,CA
+CITYOFHONDO-TX.GOV,State/Local Govt,Non-Federal Agency,Hondo,TX
+CITYOFHOUSTON.GOV,State/Local Govt,Non-Federal Agency,Houston,TX
+CITYOFHUNTSVILLETX.GOV,State/Local Govt,Non-Federal Agency,Huntsville,TX
+CITYOFIRONDALEAL.GOV,State/Local Govt,Non-Federal Agency,Irondale,AL
+CITYOFLADUE-MO.GOV,State/Local Govt,Non-Federal Agency,Ladue,MO
+CITYOFMENASHA-WI.GOV,State/Local Govt,Non-Federal Agency,Menasha,WI
+CITYOFNOVI-MI.GOV,State/Local Govt,Non-Federal Agency,Novi,MI
+CITYOFOLYMPIA-WA.GOV,State/Local Govt,Non-Federal Agency,Olympia,WA
+CITYOFOLYMPIAWA.GOV,State/Local Govt,Non-Federal Agency,Olympia,WA
+CITYOFPASSAICNJ.GOV,State/Local Govt,Non-Federal Agency,Passaic,NJ
+CITYOFRENONV.GOV,State/Local Govt,Non-Federal Agency,Reno,NV
+CITYOFROCHESTER.GOV,State/Local Govt,Non-Federal Agency,Rochester,NY
+CITYOFSAFFORD-AZ.GOV,State/Local Govt,Non-Federal Agency,Safford,AZ
+CITYOFSANTAANA-CA.GOV,State/Local Govt,Non-Federal Agency,Santa Ana,CA
+CITYOFSEATTLE.GOV,State/Local Govt,Non-Federal Agency,Seattle,WA
+CITYOFSTMARYSPA.GOV,State/Local Govt,Non-Federal Agency,St. Marys,PA
+CITYOFSUNRISEFL.GOV,State/Local Govt,Non-Federal Agency,Sunrise,FL
+CITYOFSUNRISEFLORIDA.GOV,State/Local Govt,Non-Federal Agency,Sunrise,FL
+CITYOFWARRENPA.GOV,State/Local Govt,Non-Federal Agency,Warren,PA
+CITYOFWESTPALMBEACH-FL.GOV,State/Local Govt,Non-Federal Agency,West Palm Beach,FL
+CITYOLYMPIA-WA.GOV,State/Local Govt,Non-Federal Agency,Olympia,WA
+CITYOLYMPIAWA.GOV,State/Local Govt,Non-Federal Agency,Olympia,WA
+CLAIMITTN.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN
+CLARKECOUNTY.GOV,State/Local Govt,Non-Federal Agency,Berryville,VA
+CLATSOPCOUNTYOR.GOV,State/Local Govt,Non-Federal Agency,Astoria,OR
+CLAYCOUNTYIN.GOV,State/Local Govt,Non-Federal Agency,Brazil,IN
+CLEVELANDWI.GOV,State/Local Govt,Non-Federal Agency,Cleveland,WI
+CLINTONTOWNSHIP-MI.GOV,State/Local Govt,Non-Federal Agency,Clinton Township,MI
+CO.GOV,State/Local Govt,Non-Federal Agency,Lakewood,CO
+COAG.GOV,State/Local Govt,Non-Federal Agency,Denver,CO
+COBBCOUNTYGA.GOV,State/Local Govt,Non-Federal Agency,Marietta,GA
+COBERTURAMEDICAILLINOIS.GOV,State/Local Govt,Non-Federal Agency,Chicago,IL
+COCICJIS.GOV,State/Local Govt,Non-Federal Agency,Golden,CO
+CODOT.GOV,State/Local Govt,Non-Federal Agency,Denver,CO
+COHOES-NY.GOV,State/Local Govt,Non-Federal Agency,Cohoes,NY
+COLLEGEDALETN.GOV,State/Local Govt,Non-Federal Agency,Collegedale,TN
+COLLEGEGOALARIZONA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+COLLEGEGOALOREGON.GOV,State/Local Govt,Non-Federal Agency,Eugene,OR
+COLLIERCOUNTYFL.GOV,State/Local Govt,Non-Federal Agency,Naples,FL
+COLORADO.GOV,State/Local Govt,Non-Federal Agency,Lakewood,CO
+COLORADOATTORNEYGENERAL.GOV,State/Local Govt,Non-Federal Agency,Denver,CO
+COLORADOJUDICIAL.GOV,State/Local Govt,Non-Federal Agency,Denver,CO
+COLORADOJUDICIALPERFORMANCE.GOV,State/Local Govt,Non-Federal Agency,Denver,CO
+COLORADOLABORLAW.GOV,State/Local Govt,Non-Federal Agency,Denver,CO
+COLORADOPOST.GOV,State/Local Govt,Non-Federal Agency,Denver,CO
+COLORADOPOSTGRANTS.GOV,State/Local Govt,Non-Federal Agency,Denver,CO
+COLORADORCJC.GOV,State/Local Govt,Non-Federal Agency,Denver,CO
+COLORADOUI.GOV,State/Local Govt,Non-Federal Agency,Denver,CO
+COLORADOWORKS.GOV,State/Local Govt,Non-Federal Agency,Denver,CO
+COLUMBIASC.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC
+COMPARECAREWV.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV
+CONCORD-MA.GOV,State/Local Govt,Non-Federal Agency,Concord,MA
+CONNECTINGALABAMA.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL
+CONNECTND.GOV,State/Local Govt,Non-Federal Agency,Bisamarck,ND
+COPIAHCOUNTYMS.GOV,State/Local Govt,Non-Federal Agency,Hazlehurst,MS
+CORUNNA-MI.GOV,State/Local Govt,Non-Federal Agency,Corunna,MI
+COSIPA.GOV,State/Local Govt,Non-Federal Agency,Denver,CO
+COUNCILBLUFFS-IA.GOV,State/Local Govt,Non-Federal Agency,Council Bluffs,IA
+COUNTYOFVENTURACA.GOV,State/Local Govt,Non-Federal Agency,VENTURA,CA
+COURTNEWSOHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+COURTSWV.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV
+COVERTENNESSEE.GOV,State/Local Govt,Non-Federal Agency,NASHVILLE,TN
+COVERTN.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN
+COWORKFORCE.GOV,State/Local Govt,Non-Federal Agency,Denver,CO
+CRAWFORDCOUNTYMO.GOV,State/Local Govt,Non-Federal Agency,Steelville,MO
+CRESTEDBUTTE-CO.GOV,State/Local Govt,Non-Federal Agency,Crested Butte,CO
+CRYSTALMN.GOV,State/Local Govt,Non-Federal Agency,Crystal,MN
+CSIMT.GOV,State/Local Govt,Non-Federal Agency,Helena,MT
+CSTX.GOV,State/Local Govt,Non-Federal Agency,College Station,TX
+CT.GOV,State/Local Govt,Non-Federal Agency,Hartford,CT
+CTALERT.GOV,State/Local Govt,Non-Federal Agency,Middletown,CT
+CTBROWNFIELDS.GOV,State/Local Govt,Non-Federal Agency,Hartford,CT
+CTGROWN.GOV,State/Local Govt,Non-Federal Agency,Hartford,CT
+CTPROBATE.GOV,State/Local Govt,Non-Federal Agency,West Hartford,CT
+DA16CO.GOV,State/Local Govt,Non-Federal Agency,LA JUNTA,CO
+DANVILLE-VA.GOV,State/Local Govt,Non-Federal Agency,Danville,VA
+DARIENCT.GOV,State/Local Govt,Non-Federal Agency,Darien,CT
+DAVISCOUNTYUTAH.GOV,State/Local Govt,Non-Federal Agency,Farmington,UT
+DC.GOV,State/Local Govt,Non-Federal Agency,Washington,DC
+DCAPPEALS.GOV,State/Local Govt,Non-Federal Agency,Washington,DC
+DCCODE.GOV,State/Local Govt,Non-Federal Agency,Washington,DC
+DCCOUNCIL.GOV,State/Local Govt,Non-Federal Agency,Washington,DC
+DCCOURT.GOV,State/Local Govt,Non-Federal Agency,Washington,DC
+DCCOURTS.GOV,State/Local Govt,Non-Federal Agency,Washington,DC
+DCCOURTSNEWS.GOV,State/Local Govt,Non-Federal Agency,Washington,DC
+DE.GOV,State/Local Govt,Non-Federal Agency,Dover,DE
+DEBTREPORTINGIOWA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+DECATUR-AL.GOV,State/Local Govt,Non-Federal Agency,Decatur,AL
+DEL.GOV,State/Local Govt,Non-Federal Agency,Dover,DE
+DELAWARE.GOV,State/Local Govt,Non-Federal Agency,Dover,DE
+DELAWAREINSURANCE.GOV,State/Local Govt,Non-Federal Agency,Dover,DE
+DELDOT.GOV,State/Local Govt,Non-Federal Agency,Dover,DE
+DESMOINESWA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,WA
+DESOTOTEXAS.GOV,State/Local Govt,Non-Federal Agency,DeSoto,TX
+DETROITMI.GOV,State/Local Govt,Non-Federal Agency,Detroit,MI
+DEVAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+DEXTERMI.GOV,State/Local Govt,Non-Federal Agency,Dexter,MI
+DICKINSON-TX.GOV,State/Local Govt,Non-Federal Agency,Dickinson,TX
+DIGITALARIZONA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+DIGITALAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+DMG.GOV,State/Local Govt,Non-Federal Agency,Barstow,CA
+DNSSECOHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+DNSTESTOHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+DOJMT.GOV,State/Local Govt,Non-Federal Agency,Helena,MT
+DORAL-FL.GOV,State/Local Govt,Non-Federal Agency,Doral,FL
+DOSEOFREALITYWI.GOV,State/Local Govt,Non-Federal Agency,Madison,WI
+DOUBLECHECKIOWA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+DRACUTMA.GOV,State/Local Govt,Non-Federal Agency,Dracut,MA
+DRIVENC.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+DUDLEYMA.GOV,State/Local Govt,Non-Federal Agency,Dudley,MA
+DUMASTX.GOV,State/Local Govt,Non-Federal Agency,Dumas,TX
+DUNELLEN-NJ.GOV,State/Local Govt,Non-Federal Agency,Dunellen,NJ
+DURHAMNC.GOV,State/Local Govt,Non-Federal Agency,Durham,NC
+DUTCHESSNY.GOV,State/Local Govt,Non-Federal Agency,Poughkeepsie,NY
+DWGPA.GOV,State/Local Govt,Non-Federal Agency,Delaware Water Gap,PA
+EASTHAM-MA.GOV,State/Local Govt,Non-Federal Agency,Eastham,MA
+EASTON-PA.GOV,State/Local Govt,Non-Federal Agency,Easton,PA
+EASTVALLEYFUSIONCENTERAZ.GOV,State/Local Govt,Non-Federal Agency,Mesa,AZ
+EASTWINDSOR-CT.GOV,State/Local Govt,Non-Federal Agency,Broad Brook,CT
+EAUCLAIREWI.GOV,State/Local Govt,Non-Federal Agency,Eau Claire,WI
+EDGECOMBECOUNTYNC.GOV,State/Local Govt,Non-Federal Agency,Tarboro,NC
+EDGEWOODKY.GOV,State/Local Govt,Non-Federal Agency,Edgewood,KY
+EDUCATEIOWA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+EFILETEXAS.GOV,State/Local Govt,Non-Federal Agency,Austin,TX
+EGREMONT-MA.GOV,State/Local Govt,Non-Federal Agency,Egremont,MA
+EHAWAII.GOV,State/Local Govt,Non-Federal Agency,Honolulu,HI
+EISGATEWAYPACIFICWA.GOV,State/Local Govt,Non-Federal Agency,Lacey,WA
+ELBERTCOUNTY-CO.GOV,State/Local Govt,Non-Federal Agency,Kiowa,CO
+ELEARNINGNC.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+ELIZABETHTOWNKY.GOV,State/Local Govt,Non-Federal Agency,Elizabethtown,KY
+ELMONTECA.GOV,State/Local Govt,Non-Federal Agency,El Monte,CA
+EMANUELCO-GA.GOV,State/Local Govt,Non-Federal Agency,Swainsboro,GA
+ENFIELD-CT.GOV,State/Local Govt,Non-Federal Agency,Enfield,CT
+ERIECOUNTYPA.GOV,State/Local Govt,Non-Federal Agency,Erie,PA
+EUGENE-OR.GOV,State/Local Govt,Non-Federal Agency,Eugene,OR
+EVFCAZ.GOV,State/Local Govt,Non-Federal Agency,Mesa,AZ
+EVFUSIONCENTERAZ.GOV,State/Local Govt,Non-Federal Agency,Mesa,AZ
+EWYOMING.GOV,State/Local Govt,Non-Federal Agency,Cheyenne,WY
+EXPLOREMAINE.GOV,State/Local Govt,Non-Federal Agency,Augusta,ME
+FAIRFAXCOUNTY.GOV,State/Local Govt,Non-Federal Agency,Fairfax,VA
+FAIRFAXCOUNTYVA.GOV,State/Local Govt,Non-Federal Agency,Fairfax,VA
+FAIRHAVEN-MA.GOV,State/Local Govt,Non-Federal Agency,Fairhaven,MA
+FAMILYRESOURCEAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+FARGO-ND.GOV,State/Local Govt,Non-Federal Agency,Fargo,ND
+FAYETTECOUNTYGA.GOV,State/Local Govt,Non-Federal Agency,Fayetteville,GA
+FAYETTEVILLE-GA.GOV,State/Local Govt,Non-Federal Agency,Fayetteville,GA
+FILELOCAL-WA.GOV,State/Local Govt,Non-Federal Agency,Seattle,WA
+FIRESTONECO.GOV,State/Local Govt,Non-Federal Agency,Firestone,CO
+FIRSTNETME.GOV,State/Local Govt,Non-Federal Agency,Augusta,ME
+FIRSTTHINGSFIRSTAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+FISHKILL-NY.GOV,State/Local Govt,Non-Federal Agency,Fishkill,NY
+FL.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL
+FLBOARDOFMEDICINE.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL
+FLCENSUS.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL
+FLCOURTS1.GOV,State/Local Govt,Non-Federal Agency,Pensacola,FL
+FLDOI.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL
+FLHEALTH.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL
+FLHEALTH125.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL
+FLHEALTHCOMPLAINT.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL
+FLHEALTHSOURCE.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL
+FLHISTORICCAPITOL.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL
+FLHL.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL
+FLHOUSE.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL
+FLHSMV.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL
+FLLEG.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL
+FLLEGISLATIVEMAILINGS.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL
+FLORIDA.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL
+FLORIDAABUSEHOTLINE.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL
+FLORIDAHEALTH.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL
+FLORIDAHEALTHFINDER.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL
+FLORIDALOBBYIST.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL
+FLORIDANET.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL
+FLORIDAOPC.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL
+FLORIDAPACE.GOV,State/Local Govt,Non-Federal Agency,Kissimmee,FL
+FLORIDAREDISTRICTING.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL
+FLORIDASACUPUNCTURE.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL
+FLORIDASATHLETICTRAINING.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL
+FLORIDASCHIROPRACTICMEDICINE.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL
+FLORIDASCHOOLBUSSAFETY.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL
+FLORIDASCLINICALLABS.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL
+FLORIDASDENTISTRY.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL
+FLORIDASENATE.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL
+FLORIDASHEALTH.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL
+FLORIDASHEARINGAIDSPECIALISTS.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL
+FLORIDASMASSAGETHERAPY.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL
+FLORIDASMENTALHEALTHPROFESSIONS.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL
+FLORIDASNURSING.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL
+FLORIDASNURSINGHOMEADMIN.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL
+FLORIDASOCCUPATIONALTHERAPY.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL
+FLORIDASOPTICIANRY.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL
+FLORIDASOPTOMETRY.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL
+FLORIDASORTHOTISTSPROSTHETISTS.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL
+FLORIDASOSTEOPATHICMEDICINE.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL
+FLORIDASPHARMACY.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL
+FLORIDASPHYSICALTHERAPY.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL
+FLORIDASPODIATRICMEDICINE.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL
+FLORIDASPSYCHOLOGY.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL
+FLORIDASRESPIRATORYCARE.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL
+FLORIDASSPEECHAUDIOLOGY.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL
+FLORIDASUNSETREVIEWS.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL
+FLORIDASUNSHINE.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL
+FLRCM.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL
+FLSENATE.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL
+FLSUNSHINE.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL
+FLWG.GOV,State/Local Govt,Non-Federal Agency,Opa Locka,FL
+FOIA-DC.GOV,State/Local Govt,Non-Federal Agency,Washington,DC
+FOIAXPRESS-DC.GOV,State/Local Govt,Non-Federal Agency,Washington,DC
+FORTLAUDERDALE.GOV,State/Local Govt,Non-Federal Agency,Fort Lauderdale,FL
+FRAMES.GOV,State/Local Govt,Non-Federal Agency,Moscow,ID
+FRANKLIN-NJ.GOV,State/Local Govt,Non-Federal Agency,Someret,NJ
+FRANKLINNJ.GOV,State/Local Govt,Non-Federal Agency,Somerset,NJ
+FRANKLINWI.GOV,State/Local Govt,Non-Federal Agency,Franklin,WI
+FREEPORTFLORIDA.GOV,State/Local Govt,Non-Federal Agency,Freeport,FL
+FREMONT.GOV,State/Local Govt,Non-Federal Agency,Fremont,CA
+FREMONTCOUNTYWY.GOV,State/Local Govt,Non-Federal Agency,Lander,WY
+FRESHFROMFLORIDA.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL
+FRESNO.GOV,State/Local Govt,Non-Federal Agency,Fresno,CA
+FRISCOTEXAS.GOV,State/Local Govt,Non-Federal Agency,Frisco,TX
+FRISCOTX.GOV,State/Local Govt,Non-Federal Agency,Frisco,TX
+FUTUREREADYIOWA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+GA.GOV,State/Local Govt,Non-Federal Agency,Atlanta,GA
+GACOURTS.GOV,State/Local Govt,Non-Federal Agency,Atlanta,GA
+GADOL.GOV,State/Local Govt,Non-Federal Agency,Atlanta,GA
+GAITHERSBURGMD.GOV,State/Local Govt,Non-Federal Agency,Gaithersburg,MD
+GARDNER-MA.GOV,State/Local Govt,Non-Federal Agency,GARDNER,MA
+GATREES.GOV,State/Local Govt,Non-Federal Agency,Dry Branch,GA
+GAUTIER-MS.GOV,State/Local Govt,Non-Federal Agency,Gautier,MS
+GEARUPIOWA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+GEARUPTN.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN
+GEORGETOWNMA.GOV,State/Local Govt,Non-Federal Agency,Georgetown,MA
+GEORGIA.GOV,State/Local Govt,Non-Federal Agency,Atlanta,GA
+GEORGIACOURTS.GOV,State/Local Govt,Non-Federal Agency,Atlanta,GA
+GEORGIAHEALTHINFO.GOV,State/Local Govt,Non-Federal Agency,Atlanta,GA
+GETCOVEREDILLINOIS.GOV,State/Local Govt,Non-Federal Agency,Chicago,IL
+GETKANSASBENEFITS.GOV,State/Local Govt,Non-Federal Agency,Topeka,KS
+GETREADYHAWAII.GOV,State/Local Govt,Non-Federal Agency,Honolulu,HI
+GILBERTAZ.GOV,State/Local Govt,Non-Federal Agency,Gilbert,AZ
+GIS10SERVICEMT.GOV,State/Local Govt,Non-Federal Agency,Helena,MT
+GISSERVICEMT.GOV,State/Local Govt,Non-Federal Agency,Helena,MT
+GISTESTSERVICEMT.GOV,State/Local Govt,Non-Federal Agency,Helena,MT
+GLYNNCOUNTY-GA.GOV,State/Local Govt,Non-Federal Agency,Brunswick,GA
+GOCC.GOV,State/Local Govt,Non-Federal Agency,Corvallis,OR
+GOVOTEVERMONT.GOV,State/Local Govt,Non-Federal Agency,Montpelier,VT
+GRANBY-CT.GOV,State/Local Govt,Non-Federal Agency,Granby,CT
+GRAYSONCOUNTYVA.GOV,State/Local Govt,Non-Federal Agency,Independence,VA
+GREATIOWATREASUREHUNT.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+GREENSBORO-NC.GOV,State/Local Govt,Non-Federal Agency,Greensboro,NC
+GREENSVILLECOUNTYVA.GOV,State/Local Govt,Non-Federal Agency,Emporia,VA
+GRFDAZ.GOV,State/Local Govt,Non-Federal Agency,Tucson,AZ
+GRINNELLIOWA.GOV,State/Local Govt,Non-Federal Agency,Grinnell,IA
+GUAM.GOV,State/Local Govt,Non-Federal Agency,Agana,GU
+HADDONFIELD-NJ.GOV,State/Local Govt,Non-Federal Agency,Haddonfield,NJ
+HAMILTON-NY.GOV,State/Local Govt,Non-Federal Agency,HAMILTON,NY
+HAMILTONMA.GOV,State/Local Govt,Non-Federal Agency,So. Hamilton,MA
+HAMILTONTN.GOV,State/Local Govt,Non-Federal Agency,Chattanooga,TN
+HAMPTONNH.GOV,State/Local Govt,Non-Federal Agency,Hampton,NH
+HAMPTONVA.GOV,State/Local Govt,Non-Federal Agency,Hampton,VA
+HANOVER.GOV,State/Local Govt,Non-Federal Agency,Hanover,VA
+HANOVERCOUNTY.GOV,State/Local Govt,Non-Federal Agency,Hanover,VA
+HANOVERCOUNTYVA.GOV,State/Local Govt,Non-Federal Agency,Hanover,VA
+HARFORDCOUNTYMD.GOV,State/Local Govt,Non-Federal Agency,Bel Air,MD
+HARMARTOWNSHIP-PA.GOV,State/Local Govt,Non-Federal Agency,Freeport,PA
+HARRINGTONPARKNJ.GOV,State/Local Govt,Non-Federal Agency,HARRINGTON PARK,NJ
+HARRISON-NY.GOV,State/Local Govt,Non-Federal Agency,Harrison,NY
+HARRISONCOUNTY-MS.GOV,State/Local Govt,Non-Federal Agency,Gulfport,MS
+HARRISONTWP-PA.GOV,State/Local Govt,Non-Federal Agency,Natrona Heights,PA
+HAWAII.GOV,State/Local Govt,Non-Federal Agency,Honolulu,HI
+HAYESTOWNSHIPMI.GOV,State/Local Govt,Non-Federal Agency,Charlevoix,MI
+HAYWARD-CA.GOV,State/Local Govt,Non-Federal Agency,Hayward,CA
+HCSHERIFF.GOV,State/Local Govt,Non-Federal Agency,Chattanooga,TN
+HEALTH-E-ARIZONA-PLUS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+HEALTH-E-ARIZONAPLUS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+HEALTHCAREHELPMASS.GOV,State/Local Govt,Non-Federal Agency,Boston,MA
+HEALTHEARIZONA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+HEALTHEARIZONAPLUS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+HEALTHVERMONT.GOV,State/Local Govt,Non-Federal Agency,Burlington,VT
+HEALTHYIOWA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+HEALTHYSD.GOV,State/Local Govt,Non-Federal Agency,Pierre,SD
+HEALTHYTEETHAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+HI.GOV,State/Local Govt,Non-Federal Agency,Honolulu,HI
+HIGHPOINT-NC.GOV,State/Local Govt,Non-Federal Agency,High Point,NC
+HIGHPOINTNC.GOV,State/Local Govt,Non-Federal Agency,High Point,NC
+HIJOSSALUDABLESOREGON.GOV,State/Local Govt,Non-Federal Agency,Salem,OR
+HIREACOLORADOVET.GOV,State/Local Govt,Non-Federal Agency,Denver,CO
+HOMEAGAINNEVADA.GOV,State/Local Govt,Non-Federal Agency,Las Vegas,NV
+HOMEBASEIOWA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+HOMEMEANSNEVADA.GOV,State/Local Govt,Non-Federal Agency,Las Vegas,NV
+HONDO-TX.GOV,State/Local Govt,Non-Federal Agency,Hondo,TX
+HONOLULU.GOV,State/Local Govt,Non-Federal Agency,Honolulu,HI
+HOUSTONTX.GOV,State/Local Govt,Non-Federal Agency,Houston,TX
+HUNTSVILLETX.GOV,State/Local Govt,Non-Federal Agency,Huntsville,TX
+HURONTOWNSHIP-MI.GOV,State/Local Govt,Non-Federal Agency,New Boston,MI
+IA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IAABATEDOC.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IAHEALTHLINK.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IASHP.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IASIMPLEABATE.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IAVOTERS.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+ID.GOV,State/Local Govt,Non-Federal Agency,Boise,ID
+IDAHO.GOV,State/Local Govt,Non-Federal Agency,Boise,ID
+IDAHOBYWAYS.GOV,State/Local Govt,Non-Federal Agency,Boise,ID
+IDAHOPREPARES.GOV,State/Local Govt,Non-Federal Agency,Boise,ID
+IDAHOVOTES.GOV,State/Local Govt,Non-Federal Agency,Boise,ID
+IDAHOWORKS.GOV,State/Local Govt,Non-Federal Agency,Boise,ID
+IHAVEAPLANIOWA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IJOBSIOWA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IL.GOV,State/Local Govt,Non-Federal Agency,Springfield,IL
+ILATTORNEYGENERAL.GOV,State/Local Govt,Non-Federal Agency,Chicago,IL
+ILGA.GOV,State/Local Govt,Non-Federal Agency,Springfield,IL
+ILLINOIS-HISTORY.GOV,State/Local Govt,Non-Federal Agency,Springfield,IL
+ILLINOIS.GOV,State/Local Govt,Non-Federal Agency,Springfield,IL
+ILLINOISATTORNEYGENERAL.GOV,State/Local Govt,Non-Federal Agency,Chicago,IL
+ILLINOISCOMPTROLLER.GOV,State/Local Govt,Non-Federal Agency,Springfield,IL
+ILLINOISCOURTS.GOV,State/Local Govt,Non-Federal Agency,Springfield,IL
+ILLINOISHISTORY.GOV,State/Local Govt,Non-Federal Agency,Springfield,IL
+ILLINOISTREASURER.GOV,State/Local Govt,Non-Federal Agency,Springfield,IL
+ILSOS.GOV,State/Local Govt,Non-Federal Agency,Springfield,IL
+IN.GOV,State/Local Govt,Non-Federal Agency,Indianapolis,IN
+INCOURTS.GOV,State/Local Govt,Non-Federal Agency,Indianapolis,IN
+INDEPENDENCEMO.GOV,State/Local Govt,Non-Federal Agency,Independence,MO
+INDIANA.GOV,State/Local Govt,Non-Federal Agency,Indianapolis,IN
+INDIANAMOTORSPORTS.GOV,State/Local Govt,Non-Federal Agency,Indianapolis,IN
+INDIANAUNCLAIMED.GOV,State/Local Govt,Non-Federal Agency,Indianapolis,IN
+INDIANHEADPARK-IL.GOV,State/Local Govt,Non-Federal Agency,Indian Head Park,IL
+INNOCENCECOMMISSION-NC.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+INTEGRATEAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+INVESTINIOWA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IOWA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IOWAAGING.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IOWAAGRICULTURE.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IOWAATTORNEYGENERAL.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IOWACHILDSUPPORT.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IOWACLEANAIR.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IOWACOLLEGEAID.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IOWACOLLEGEAIDDATACENTER.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IOWACORE.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IOWACOURTS.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IOWACULTURE.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IOWADIVISIONOFLABOR.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IOWADNR.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IOWADOT.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IOWAELECTRICAL.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IOWAELEVATORS.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IOWAFINANCEAUTHORITY.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IOWAFINANCIALAIDAPPLICATION.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IOWAFORMS.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IOWAFRAUDFIGHTERS.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IOWAGRANTS.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IOWAGREATPLACES.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IOWAJNC.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IOWAJQC.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IOWALIFT.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IOWALMI.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IOWAMORTGAGEHELP.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IOWANEXT.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IOWAOSHA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IOWAPIB.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IOWAPMA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IOWASMOKEFREEAIR.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IOWASTEM.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IOWATAXANDTAGS.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IOWATEST.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IOWATITLEGUARANTY.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IOWATREASURER.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IOWAWORKCOMP.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IOWAWORKFORCE.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+IOWAWORKFORCEDEVELOPMENT.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+JACKSONVILLENC.GOV,State/Local Govt,Non-Federal Agency,Jacksonville,NC
+JASPERINDIANA.GOV,State/Local Govt,Non-Federal Agency,Jasper,IN
+JERSEYCITYNJ.GOV,State/Local Govt,Non-Federal Agency,Jersey City,NJ
+JOBS4TN.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN
+JOBSFORTN.GOV,State/Local Govt,Non-Federal Agency,38401,TN
+JUDNJ.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ
+KANAWHACOUNTYWV.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV
+KANSAS.GOV,State/Local Govt,Non-Federal Agency,Topeka,KS
+KANSASCITYMO.GOV,State/Local Govt,Non-Federal Agency,Kansas City,MO
+KANSASEMPLOYER.GOV,State/Local Govt,Non-Federal Agency,Topeka,KS
+KANSASMONEY.GOV,State/Local Govt,Non-Federal Agency,Topeka,KS
+KANSASREADY.GOV,State/Local Govt,Non-Federal Agency,Topeka,KS
+KANSASTAG.GOV,State/Local Govt,Non-Federal Agency,Topeka,KS
+KCMO.GOV,State/Local Govt,Non-Federal Agency,Kansas City,MO
+KDHEKS.GOV,State/Local Govt,Non-Federal Agency,Topeka,KS
+KEITHCOUNTYNE.GOV,State/Local Govt,Non-Federal Agency,Ogallala,NE
+KENTCOUNTYMI.GOV,State/Local Govt,Non-Federal Agency,Grand Rapids,MI
+KENTUCKY.GOV,State/Local Govt,Non-Federal Agency,Frankfort,KY
+KIDCENTRALTENNESSEE.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN
+KIDCENTRALTN.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN
+KPL.GOV,State/Local Govt,Non-Federal Agency,KALAMAZOO,MI
+KS.GOV,State/Local Govt,Non-Federal Agency,Topeka,KS
+KSDA.GOV,State/Local Govt,Non-Federal Agency,Topeka,KS
+KSHOUSINGCORP.GOV,State/Local Govt,Non-Federal Agency,Topeka,KS
+KSREADY.GOV,State/Local Govt,Non-Federal Agency,Topeka,KS
+KY.GOV,State/Local Govt,Non-Federal Agency,Frankfort,KY
+LA.GOV,State/Local Govt,Non-Federal Agency,Baton Rouge,LA
+LAFASTSTART.GOV,State/Local Govt,Non-Federal Agency,Baton Rouge,LA
+LAFAYETTELA.GOV,State/Local Govt,Non-Federal Agency,Lafayette,LA
+LAGUNAHILLSCA.GOV,State/Local Govt,Non-Federal Agency,Laguna Hills,CA
+LAJUDICIAL.GOV,State/Local Govt,Non-Federal Agency,New Orleans,LA
+LAKECOUNTYFL.GOV,State/Local Govt,Non-Federal Agency,Tavares,FL
+LAKEJACKSON-TX.GOV,State/Local Govt,Non-Federal Agency,Lake Jackson,TX
+LAKEPARK-FL.GOV,State/Local Govt,Non-Federal Agency,Lake Park,FL
+LAKEPARKFLORIDA.GOV,State/Local Govt,Non-Federal Agency,Lake Park,FL
+LAKESITETN.GOV,State/Local Govt,Non-Federal Agency,Lakesite,TN
+LAMOINE-ME.GOV,State/Local Govt,Non-Federal Agency,Lamoine,ME
+LANCASTERCOUNTYPA.GOV,State/Local Govt,Non-Federal Agency,Lancaster,PA
+LASVEGASNEVADA.GOV,State/Local Govt,Non-Federal Agency,Las Vegas,NV
+LEADERSHIPAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+LEADVILLE-CO.GOV,State/Local Govt,Non-Federal Agency,Leadville,CO
+LEESBURGVA.GOV,State/Local Govt,Non-Federal Agency,Leesburg,VA
+LEGMT.GOV,State/Local Govt,Non-Federal Agency,Helena,MT
+LEXINGTON-MA.GOV,State/Local Govt,Non-Federal Agency,Lexington,MA
+LEXINGTONMA.GOV,State/Local Govt,Non-Federal Agency,Lexington,MA
+LGADMI.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI
+LGO-VI.GOV,State/Local Govt,Non-Federal Agency,St. Thomas,VI
+LICENSEDINIOWA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+LINCOLNSHIREIL.GOV,State/Local Govt,Non-Federal Agency,Lincolnshire,IL
+LISTOVIRGINIA.GOV,State/Local Govt,Non-Federal Agency,Richmond,VA
+LIVEHEALTHYNEVADA.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV
+LODI.GOV,State/Local Govt,Non-Federal Agency,Lodi,CA
+LODICA.GOV,State/Local Govt,Non-Federal Agency,Lodi,CA
+LOGANTOWNSHIP-PA.GOV,State/Local Govt,Non-Federal Agency,Altoona,PA
+LONDONBRITAINTOWNSHIP-PA.GOV,State/Local Govt,Non-Federal Agency,Landenberg,PA
+LONGVIEW-WA.GOV,State/Local Govt,Non-Federal Agency,Longview,WA
+LONGVIEWWA.GOV,State/Local Govt,Non-Federal Agency,Longview,WA
+LOSGATOSCA.GOV,State/Local Govt,Non-Federal Agency,Los Gatos,CA
+LOSLUNASNM.GOV,State/Local Govt,Non-Federal Agency,Los Lunas,NM
+LOUDOUNCOUNTYVA.GOV,State/Local Govt,Non-Federal Agency,Leesburg,VA
+LOUISIANA.GOV,State/Local Govt,Non-Federal Agency,Baton Rouge,LA
+LOUISIANAENTERTAINMENT.GOV,State/Local Govt,Non-Federal Agency,Baton Rouge,LA
+LOUISIANAFASTSTART.GOV,State/Local Govt,Non-Federal Agency,Baton Rouge,LA
+LOUISIANAMAP.GOV,State/Local Govt,Non-Federal Agency,Baton Rouge,LA
+LOUISIANAMUSIC.GOV,State/Local Govt,Non-Federal Agency,Baton Rouge,LA
+LOWELL-OR.GOV,State/Local Govt,Non-Federal Agency,Lowell,OR
+LOWELLMA.GOV,State/Local Govt,Non-Federal Agency,Lowell,MA
+LOWERPAXTON-PA.GOV,State/Local Govt,Non-Federal Agency,Harrisburg,PA
+LOXAHATCHEEGROVESFL.GOV,State/Local Govt,Non-Federal Agency,Loxahatchee Groves,FL
+LYNCHBURGVA.GOV,State/Local Govt,Non-Federal Agency,Lynchburg,VA
+MA.GOV,State/Local Govt,Non-Federal Agency,Boston,MA
+MAHOUSE.GOV,State/Local Govt,Non-Federal Agency,Boston,MA
+MAINE.GOV,State/Local Govt,Non-Federal Agency,Augusta,ME
+MAINEDOT.GOV,State/Local Govt,Non-Federal Agency,Augusta,ME
+MAINEFLU.GOV,State/Local Govt,Non-Federal Agency,Augusta,ME
+MAINEFORESTSERVICE.GOV,State/Local Govt,Non-Federal Agency,AUGUSTA,ME
+MAINEPUBLICHEALTH.GOV,State/Local Govt,Non-Federal Agency,Augusta,ME
+MAINEQUALITYFORUM.GOV,State/Local Govt,Non-Federal Agency,Augusta,ME
+MAINESERVICECOMMISSION.GOV,State/Local Govt,Non-Federal Agency,Augusta,ME
+MAJURY.GOV,State/Local Govt,Non-Federal Agency,Boston,MA
+MAKINGCOLORADO.GOV,State/Local Govt,Non-Federal Agency,Boulder,CO
+MALEGISLATURE.GOV,State/Local Govt,Non-Federal Agency,Boston,MA
+MALIBU-CA.GOV,State/Local Govt,Non-Federal Agency,Malibu,CA
+MANITOUSPRINGS-CO.GOV,State/Local Govt,Non-Federal Agency,Colorado Springs,CO
+MANSFIELD-TX.GOV,State/Local Govt,Non-Federal Agency,Mansfield,TX
+MAPWV.GOV,State/Local Govt,Non-Federal Agency,Morgantown,WV
+MARICOPA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+MARIETTAGA.GOV,State/Local Govt,Non-Federal Agency,Marietta,GA
+MARIETTAGEORGIA.GOV,State/Local Govt,Non-Federal Agency,Marietta,GA
+MARSHFIELD-MA.GOV,State/Local Govt,Non-Federal Agency,Marshfield,MA
+MARYLAND.GOV,State/Local Govt,Non-Federal Agency,Annapolis,MD
+MARYLANDCOURTS.GOV,State/Local Govt,Non-Federal Agency,Annapolis,MD
+MARYLANDHEALTHCONNECTION.GOV,State/Local Govt,Non-Federal Agency,Baltimore,MD
+MARYLANDSOS.GOV,State/Local Govt,Non-Federal Agency,ANNAPOLIS,MD
+MASENATE.GOV,State/Local Govt,Non-Federal Agency,Boston,MA
+MASS.GOV,State/Local Govt,Non-Federal Agency,Boston,MA
+MASSACHUSETTS.GOV,State/Local Govt,Non-Federal Agency,Boston,MA
+MASTICBEACHVILLAGENY.GOV,State/Local Govt,Non-Federal Agency,Mastic Beach,NY
+MATTHEWSNC.GOV,State/Local Govt,Non-Federal Agency,Matthews,NC
+MAURYCOUNTY-TN.GOV,State/Local Govt,Non-Federal Agency,Columbia,TN
+MCAC-MD.GOV,State/Local Govt,Non-Federal Agency,Calverton ,MD
+MD.GOV,State/Local Govt,Non-Federal Agency,Annapolis,MD
+MDCAC.GOV,State/Local Govt,Non-Federal Agency,Woodlawn,MD
+MDCACDOM.GOV,State/Local Govt,Non-Federal Agency,Woodlawn,MD
+MDCOURTS.GOV,State/Local Govt,Non-Federal Agency,Annapolis,MD
+ME.GOV,State/Local Govt,Non-Federal Agency,Augusta,ME
+MEASURETN.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN
+MEDCMI.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI
+MENTORMICHIGAN.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI
+MESQUITENV.GOV,State/Local Govt,Non-Federal Agency,Mesquite,NV
+MGCBMI.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI
+MHB.GOV,State/Local Govt,Non-Federal Agency,Mobile,AL
+MI.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI
+MI365.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI
+MIAMI-FL.GOV,State/Local Govt,Non-Federal Agency,Miami,FL
+MIAMIAZ.GOV,State/Local Govt,Non-Federal Agency,Miami,AZ
+MIBUSINESS1STOP.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI
+MIBUSINESSONESTOP.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI
+MICH.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI
+MICHIGAN.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI
+MICHIGANIDC.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI
+MIDDLESEXBORO-NJ.GOV,State/Local Govt,Non-Federal Agency,Middlesex,NJ
+MILLENNIUMBULKEISWA.GOV,State/Local Govt,Non-Federal Agency,Lacey,WA
+MILLERSBURGKY.GOV,State/Local Govt,Non-Federal Agency,Millersburg,KY
+MILTON-FREEWATER-OR.GOV,State/Local Govt,Non-Federal Agency,Milton-Freewater,OR
+MILWAUKEE.GOV,State/Local Govt,Non-Federal Agency,Milwaukee,WI
+MINNESOTA.GOV,State/Local Govt,Non-Federal Agency,St. Paul,MN
+MIRAMAR-FL.GOV,State/Local Govt,Non-Federal Agency,Miramar,FL
+MISSISSIPPI.GOV,State/Local Govt,Non-Federal Agency,Jackson,MS
+MISSOURI.GOV,State/Local Govt,Non-Federal Agency,Jefferson City,MO
+MISSOURIINVESTORPROTECTION.GOV,State/Local Govt,Non-Federal Agency,Jefferson City,MO
+MN.GOV,State/Local Govt,Non-Federal Agency,St. Paul,MN
+MNCOURTS.GOV,State/Local Govt,Non-Federal Agency,St. Paul,MN
+MNDISABILITY.GOV,State/Local Govt,Non-Federal Agency,St. Paul,MN
+MNDNR.GOV,State/Local Govt,Non-Federal Agency,St. Paul,MN
+MNDOT.GOV,State/Local Govt,Non-Federal Agency,St. Paul,MN
+MNHOUSING.GOV,State/Local Govt,Non-Federal Agency,St. Paul,MN
+MO.GOV,State/Local Govt,Non-Federal Agency,Jefferson City,MO
+MOAPPED.GOV,State/Local Govt,Non-Federal Agency,St. Louis,MO
+MODOT.GOV,State/Local Govt,Non-Federal Agency,Jefferson City,MO
+MONROECOUNTYPA.GOV,State/Local Govt,Non-Federal Agency,Stroudsburg,PA
+MONSON-MA.GOV,State/Local Govt,Non-Federal Agency,Monson,MA
+MONTANA.GOV,State/Local Govt,Non-Federal Agency,Helena,MT
+MOORECOUNTYNC.GOV,State/Local Govt,Non-Federal Agency,Carthage,NC
+MOPROSECUTORS.GOV,State/Local Govt,Non-Federal Agency,Jefferson City,MO
+MORIARTYNM.GOV,State/Local Govt,Non-Federal Agency,Moriarty,NM
+MORTON-IL.GOV,State/Local Govt,Non-Federal Agency,Morton,IL
+MOUNTPROSPECT-IL.GOV,State/Local Govt,Non-Federal Agency,Mount Prospect,IL
+MOUNTPROSPECTIL.GOV,State/Local Govt,Non-Federal Agency,Mount Prospect,IL
+MRCOG-NM.GOV,State/Local Govt,Non-Federal Agency,Albuquerque,NM
+MS.GOV,State/Local Govt,Non-Federal Agency,Jackson,MS
+MSHOMEHELP.GOV,State/Local Govt,Non-Federal Agency,Jackson,MS
+MSLMI.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI
+MSPADMI.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI
+MT.GOV,State/Local Govt,Non-Federal Agency,Helena,MT
+MUNDELEIN-IL.GOV,State/Local Govt,Non-Federal Agency,Mundelein,IL
+MUNDYTWP-MI.GOV,State/Local Govt,Non-Federal Agency,Swartz Creek,MI
+MURRAYCOUNTYGA.GOV,State/Local Govt,Non-Federal Agency,Chatsworth,GA
+MVPD.GOV,State/Local Govt,Non-Federal Agency,Mountain View,CA
+MYALABAMA.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL
+MYALASKA.GOV,State/Local Govt,Non-Federal Agency,Juneau,AK
+MYFLORIDA.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL
+MYFLORIDACENSUS.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL
+MYFLORIDAHOUSE.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL
+MYHAWAII.GOV,State/Local Govt,Non-Federal Agency,Honolulu,HI
+MYIN.GOV,State/Local Govt,Non-Federal Agency,Indianapolis,IN
+MYINDIANA.GOV,State/Local Govt,Non-Federal Agency,Indianapolis,IN
+MYNCRETIREMENT.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+MYNEVADA.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV
+MYOHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+MYSC.GOV,State/Local Govt,Non-Federal Agency,Cloumbia,SC
+MYTENNESSEE.GOV,State/Local Govt,Non-Federal Agency,Smyrna,TN
+NAPA-CA.GOV,State/Local Govt,Non-Federal Agency,Napa,CA
+NASHCOUNTYNC.GOV,State/Local Govt,Non-Federal Agency,Nashville,NC
+NASSAUCOUNTYNY.GOV,State/Local Govt,Non-Federal Agency,Mineola,NY
+NATICKMA.GOV,State/Local Govt,Non-Federal Agency,Natick,MA
+NATRONACOUNTY-WY.GOV,State/Local Govt,Non-Federal Agency,Casper,WY
+NAVASOTATX.GOV,State/Local Govt,Non-Federal Agency,Navasota,TX
+NAZARETHBOROUGHPA.GOV,State/Local Govt,Non-Federal Agency,Nazareth,PA
+NC.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+NCAGR.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+NCBAR.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+NCBROADBAND.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+NCCARELINK.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+NCCERTIFIEDPARALEGAL.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+NCCIVILWAR150.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+NCCOB.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+NCCPABOARD.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+NCCRIMELAB.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+NCDCI.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+NCDCR.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+NCDENR.GOV,State/Local Govt,Non-Federal Agency,RALEIGH,NC
+NCDHHS.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+NCDOI.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+NCDOJ.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+NCDOT.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+NCDPS.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+NCESC.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+NCFINDOFFENDER.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+NCFORECLOSUREPREVENTION.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+NCFORESTPRODUCTS.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+NCFORESTSERVICE.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+NCGRANTS.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+NCICAC.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+NCISAAC.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+NCLAMP.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+NCLAP.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+NCLAWSPECIALISTS.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+NCMORTGAGEHELP.GOV,State/Local Govt,Non-Federal Agency,27609,NC
+NCONEMAP.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+NCOPENBOOK.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+NCPARKS.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+NCPUBLICSCHOOLS.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+NCREC.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+NCRETIREMENT.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+NCSBE.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+NCSBI.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+NCSMARTGRID.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+NCSTATE.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+NCSTATEBAR.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+NCTREASURER.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+NCVISION25.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+NCWORKS.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+ND.GOV,State/Local Govt,Non-Federal Agency,Bismarck,ND
+NDCENSUS.GOV,State/Local Govt,Non-Federal Agency,Bismarck,ND
+NDCLOUD.GOV,State/Local Govt,Non-Federal Agency,Bismarck,North Dakota
+NDCOURTS.GOV,State/Local Govt,Non-Federal Agency,Bismarck,ND
+NDDATACENTER.GOV,State/Local Govt,Non-Federal Agency,Bismarck,ND
+NDDOHPRESSROOM.GOV,State/Local Govt,Non-Federal Agency,Bismarck,ND
+NDHAN.GOV,State/Local Govt,Non-Federal Agency,Bismarck,ND
+NDHEALTH.GOV,State/Local Govt,Non-Federal Agency,Bismarck,ND
+NDPANDEMICFLU.GOV,State/Local Govt,Non-Federal Agency,Bismarck,ND
+NDSTUDIES.GOV,State/Local Govt,Non-Federal Agency,Bismarck,ND
+NE.GOV,State/Local Govt,Non-Federal Agency,Lincoln,NE
+NEBRASKA.GOV,State/Local Govt,Non-Federal Agency,Lincoln,NE
+NEBRASKACORN.GOV,State/Local Govt,Non-Federal Agency,Lincoln,NE
+NEBRASKALEGISLATURE.GOV,State/Local Govt,Non-Federal Agency,Lincoln,NE
+NEBRASKAMAP.GOV,State/Local Govt,Non-Federal Agency,Lincoln,NE
+NEBRASKASPENDING.GOV,State/Local Govt,Non-Federal Agency,Lincoln,NE
+NEBRASKAUNICAMERAL.GOV,State/Local Govt,Non-Federal Agency,Lincoln,NE
+NEHEALTHINSURANCEINFO.GOV,State/Local Govt,Non-Federal Agency,Lincoln,NE
+NELSONCOUNTY-VA.GOV,State/Local Govt,Non-Federal Agency,Lovingston,VA
+NETWORKMARYLAND.GOV,State/Local Govt,Non-Federal Agency,Annapolis,MD
+NETWORKNEBRASKA.GOV,State/Local Govt,Non-Federal Agency,Lincoln,NE
+NEVADA.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV
+NEVADAGUARD.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV
+NEVADAHOMEAGAIN.GOV,State/Local Govt,Non-Federal Agency,Las Vegas,NV
+NEVADAREADY.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV
+NEVADATREASURER.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV
+NEWENGLAND511.GOV,State/Local Govt,Non-Federal Agency,Montpelier,VT
+NEWFIELDSNH.GOV,State/Local Govt,Non-Federal Agency,Newfields,NH
+NEWHAMPSHIRE.GOV,State/Local Govt,Non-Federal Agency,Concord,NH
+NEWJERSEY.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ
+NEWJERSEYBUSINESS.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ
+NEWJERSEYHOMEKEEPER.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ
+NEWMEXICO.GOV,State/Local Govt,Non-Federal Agency,Santa Fe,NM
+NEWTONMA.GOV,State/Local Govt,Non-Federal Agency,Newton,MA
+NEWWINDSOR-NY.GOV,State/Local Govt,Non-Federal Agency,New Windsor,NY
+NEWYORKHEALTH.GOV,State/Local Govt,Non-Federal Agency,Albany,NY
+NEXTCHAPTERTN.GOV,State/Local Govt,Non-Federal Agency,Smyrna,TN
+NH.GOV,State/Local Govt,Non-Federal Agency,Concord,NH
+NIAGARACOUNTY-NY.GOV,State/Local Govt,Non-Federal Agency,LOCKPORT,NY
+NICHOLSHILLS-OK.GOV,State/Local Govt,Non-Federal Agency,Nichols Hills,OK
+NJ.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ
+NJ2.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ
+NJALERT.GOV,State/Local Govt,Non-Federal Agency,Hamilton,NJ
+NJCANCER.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ
+NJCCC.GOV,State/Local Govt,Non-Federal Agency,Atlantic City,NJ
+NJCCR.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ
+NJCIVILRIGHTS.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ
+NJCONSUMERAFFAIRS.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ
+NJCOURTS.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ
+NJDOC.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ
+NJFLUPANDEMIC.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ
+NJHAS.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ
+NJHMFA.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ
+NJHOMEKEEPER.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ
+NJHOMELANDSECURITY.GOV,State/Local Govt,Non-Federal Agency,Hamilton,NJ
+NJHOUSING.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ
+NJHOUSINGRESOURCECENTER.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ
+NJHRC.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ
+NJHUMANTRAFFICKING.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ
+NJJUD.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ
+NJMEADOWLANDS.GOV,State/Local Govt,Non-Federal Agency,Lyndhurst,NJ
+NJMEDICALBOARD.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ
+NJMVC.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ
+NJMVCONLINE.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ
+NJOHSP.GOV,State/Local Govt,Non-Federal Agency,Hamilton,NJ
+NJPAAD.GOV,State/Local Govt,Non-Federal Agency,Mercerville,NJ
+NJSDA.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ
+NJSECURITIES.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ
+NJSENIORGOLD.GOV,State/Local Govt,Non-Federal Agency,Mercerville,NJ
+NJSHC.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ
+NJSNAP.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ
+NJSPEAKUP.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ
+NJSRGOLD.GOV,State/Local Govt,Non-Federal Agency,Mercerville,NJ
+NJSTART.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ
+NM.GOV,State/Local Govt,Non-Federal Agency,Santa Fe,NM
+NMAG.GOV,State/Local Govt,Non-Federal Agency,Santa Fe,NM
+NMCOURTS.GOV,State/Local Govt,Non-Federal Agency,Santa Fe,NM
+NMLEGIS.GOV,State/Local Govt,Non-Federal Agency,Santa Fe,NM
+NMSTO.GOV,State/Local Govt,Non-Federal Agency,Santa Fe,NM
+NORTH-DAKOTA.GOV,State/Local Govt,Non-Federal Agency,Bismarck,ND
+NORTHCAROLINA.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+NORTHDAKOTA.GOV,State/Local Govt,Non-Federal Agency,Bismarck,ND
+NORTHHAMPTON-NH.GOV,State/Local Govt,Non-Federal Agency,North Hampton,NH
+NORTHMIAMIFL.GOV,State/Local Govt,Non-Federal Agency,North Miami,FL
+NORTHUNIONTOWNSHIP-PA.GOV,State/Local Govt,Non-Federal Agency,Lemont Furnace,PA
+NOSCAMNC.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+NV.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV
+NVCOURTS.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV
+NVDPSPUB.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV
+NVEASE.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV
+NVGGMS.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV
+NVPREPAID.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV
+NVSEXOFFENDERS.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV
+NVSILVERFLUME.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV
+NVSOS.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV
+NY.GOV,State/Local Govt,Non-Federal Agency,Albany,NY
+NYALERT.GOV,State/Local Govt,Non-Federal Agency,Albany,NY
+NYASSEMBLY.GOV,State/Local Govt,Non-Federal Agency,Albany,NY
+NYC-NY.GOV,State/Local Govt,Non-Federal Agency,Brooklyn,NY
+NYC.GOV,State/Local Govt,Non-Federal Agency,Brooklyn,NY
+NYCOURTHELP.GOV,State/Local Govt,Non-Federal Agency,Troy,NY
+NYCOURTS.GOV,State/Local Govt,Non-Federal Agency,Troy,NY
+NYGOVOFFICE.GOV,State/Local Govt,Non-Federal Agency,Albany,NY
+NYHALLOFGOVERNORS.GOV,State/Local Govt,Non-Federal Agency,Albany,NY
+NYHEALTH.GOV,State/Local Govt,Non-Federal Agency,Albany,NY
+NYHOUSINGSEARCH.GOV,State/Local Govt,Non-Federal Agency,Albany,NY
+NYJUROR.GOV,State/Local Govt,Non-Federal Agency,New York,NY
+NYOPENFORBUSINESS.GOV,State/Local Govt,Non-Federal Agency,Albany,NY
+NYPA.GOV,State/Local Govt,Non-Federal Agency,WHITE PLAINS,NY
+NYPREPARE.GOV,State/Local Govt,Non-Federal Agency,Albany,NY
+NYSCANALS.GOV,State/Local Govt,Non-Federal Agency,Albany,NY
+NYSDOT.GOV,State/Local Govt,Non-Federal Agency,Albany,NY
+NYSED.GOV,State/Local Govt,Non-Federal Agency,Albany,NY
+NYSENATE.GOV,State/Local Govt,Non-Federal Agency,Albany,NY
+NYSTART.GOV,State/Local Govt,Non-Federal Agency,Albany,NY
+NYSTAX.GOV,State/Local Govt,Non-Federal Agency,Albany,NY
+NYSTHRUWAY.GOV,State/Local Govt,Non-Federal Agency,Albany,NY
+OCFODC.GOV,State/Local Govt,Non-Federal Agency,Washington,DC
+OCPR.GOV,State/Local Govt,Non-Federal Agency,San Juan,PR
+ODESSA-TX.GOV,State/Local Govt,Non-Federal Agency,Odessa,TX
+OGALLALA-NE.GOV,State/Local Govt,Non-Federal Agency,Ogallala,NE
+OH.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+OHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+OHIOAGRICULTURE.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+OHIOANALYTICS.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+OHIOATTORNEYGENERAL.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+OHIOAUDITOR.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+OHIOBMV.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+OHIOCENTERFORNURSING.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+OHIOCHECKBOOK.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+OHIOCOURTOFCLAIMS.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+OHIOCOURTS.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+OHIODNR.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+OHIOHERETOHELP.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+OHIOHOUSE.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+OHIOHOUSINGLOCATOR.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+OHIOJOBS.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+OHIOJUDICIALCENTER.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+OHIOMEANSACCESSIBILITY.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+OHIOMEANSJOBS.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+OHIOMEANSTRAINING.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+OHIOMEANSVETERANSJOBS.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+OHIONOSMOKELAW.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+OHIOPMP.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+OHIORED.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+OHIORESPONDS.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+OHIOSAFEID.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+OHIOSECRETARYOFSTATE.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+OHIOSENATE.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+OHIOSUPREMECOURT.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+OHIOTHIRDFRONTIER.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+OHIOTPES.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+OHIOTREASURER.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+OHIOVALUESVETERANS.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+OHIOVALUESVETS.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+OHIOVET.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+OHIOVETERANSHOME.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+OHIOVETHOF.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+OHIOVETS.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+OHIOVETSHOF.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+OHIOWOMENVETS.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+OK.GOV,State/Local Govt,Non-Federal Agency,Oklahoma City,OK
+OKBENEFITS.GOV,State/Local Govt,Non-Federal Agency,Oklahoma City,OK
+OKC.GOV,State/Local Govt,Non-Federal Agency,Oklahoma City,OK
+OKCOMMERCE.GOV,State/Local Govt,Non-Federal Agency,Oklahoma city,OK
+OKDHS.GOV,State/Local Govt,Non-Federal Agency,Oklahoma City,OK
+OKDRS.GOV,State/Local Govt,Non-Federal Agency,Oklahoma City,OK
+OKGEOSURVEY1.GOV,State/Local Govt,Non-Federal Agency,Norman,OK
+OKHOUSE.GOV,State/Local Govt,Non-Federal Agency,Oklahoma City,OK
+OKLAHOMA.GOV,State/Local Govt,Non-Federal Agency,Oklahoma City,OK
+OKLAHOMABENEFITS.GOV,State/Local Govt,Non-Federal Agency,Oklahoma City,OK
+OKLAHOMAWORKS.GOV,State/Local Govt,Non-Federal Agency,Oklahoma City,OK
+OKLATOURISM.GOV,State/Local Govt,Non-Federal Agency,Oklahoma City,OK
+OKLEGISLATURE.GOV,State/Local Govt,Non-Federal Agency,Oklahoma City,OK
+OKSENATE.GOV,State/Local Govt,Non-Federal Agency,Oklahoma City,OK
+OLATHEKS.GOV,State/Local Govt,Non-Federal Agency,Olathe,KS
+OLDLYME-CT.GOV,State/Local Govt,Non-Federal Agency,Old Lyme,CT
+OLYMPIA-WA.GOV,State/Local Govt,Non-Federal Agency,Olympia,WA
+OLYMPIAWA.GOV,State/Local Govt,Non-Federal Agency,Olympia,WA
+ONESTOPFLORIDA.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL
+ONSLOWCOUNTYNC.GOV,State/Local Govt,Non-Federal Agency,Jacksonville,NC
+OPC-DC.GOV,State/Local Govt,Non-Federal Agency,Washington,DC
+OPELIKA-AL.GOV,State/Local Govt,Non-Federal Agency,Opelika,AL
+OPEN-DC.GOV,State/Local Govt,Non-Federal Agency,Washington,DC
+OPENOHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+OR-MEDICAID.GOV,State/Local Govt,Non-Federal Agency,Salem,OR
+OR.GOV,State/Local Govt,Non-Federal Agency,Salem,OR
+ORANGE-CT.GOV,State/Local Govt,Non-Federal Agency,Orange,CT
+ORCLIMATECHANGE.GOV,State/Local Govt,Non-Federal Agency,Salem,OR
+OREGON.GOV,State/Local Govt,Non-Federal Agency,Salem,OR
+OREGONATTORNEYGENERAL.GOV,State/Local Govt,Non-Federal Agency,Salem,OR
+OREGONBENEFITSONLINE.GOV,State/Local Govt,Non-Federal Agency,Salem,OR
+OREGONBUDGET.GOV,State/Local Govt,Non-Federal Agency,Salem,OR
+OREGONCHILDSUPPORT.GOV,State/Local Govt,Non-Federal Agency,Salem,OR
+OREGONCONSUMER.GOV,State/Local Govt,Non-Federal Agency,Salem,OR
+OREGONFORESTRY.GOV,State/Local Govt,Non-Federal Agency,Salem,OR
+OREGONHEALTHCARE.GOV,State/Local Govt,Non-Federal Agency,Salem,OR
+OREGONHEALTHYKIDS.GOV,State/Local Govt,Non-Federal Agency,Salem,OR
+OREGONHOMEOWNERSUPPORT.GOV,State/Local Govt,Non-Federal Agency,Salem,OR
+OREGONLEGISLATURE.GOV,State/Local Govt,Non-Federal Agency,Salem,OR
+OREGONMETRO.GOV,State/Local Govt,Non-Federal Agency,Portland,OR
+OREGONMOTORVOTER.GOV,State/Local Govt,Non-Federal Agency,Salem,OR
+OREGONRX.GOV,State/Local Govt,Non-Federal Agency,Salem,OR
+OREGONSTUDENTAID.GOV,State/Local Govt,Non-Federal Agency,Salem,OR
+OREGONUSF.GOV,State/Local Govt,Non-Federal Agency,Salem,OR
+OREGONVOTES.GOV,State/Local Govt,Non-Federal Agency,Salem,OR
+ORHEALTHCARE.GOV,State/Local Govt,Non-Federal Agency,Salem,OR
+OSE-CT.GOV,State/Local Govt,Non-Federal Agency,Hartford,CT
+OTAYWATER.GOV,State/Local Govt,Non-Federal Agency,Spring Valley,CA
+OUTDOORNEBRASKA.GOV,State/Local Govt,Non-Federal Agency,Lincoln,NE
+OVERLANDPARKKS.GOV,State/Local Govt,Non-Federal Agency,Overland Park,KS
+OXFORD-CT.GOV,State/Local Govt,Non-Federal Agency,Oxford,CT
+PA.GOV,State/Local Govt,Non-Federal Agency,Harrisburg,PA
+PA529.GOV,State/Local Govt,Non-Federal Agency,Harrisburg,PA
+PA529ABLE.GOV,State/Local Govt,Non-Federal Agency,Harrisburg,PA
+PAABLE.GOV,State/Local Govt,Non-Federal Agency,Harrisburg,PA
+PAACPAMMMI.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI
+PAAUDITOR.GOV,State/Local Govt,Non-Federal Agency,Harrisburg,PA
+PACIFICFLYWAY.GOV,State/Local Govt,Non-Federal Agency,Vancouver,WA
+PACIFICWA.GOV,State/Local Govt,Non-Federal Agency,Pacific,WA
+PADILLABAY.GOV,State/Local Govt,Non-Federal Agency,MOUNT VERNON,WA
+PAHOUSE.GOV,State/Local Govt,Non-Federal Agency,Harrisburg,PA
+PAINVEST.GOV,State/Local Govt,Non-Federal Agency,Harrisburg,PA
+PALMBEACHCOUNTYTAXCOLLECTOR-FL.GOV,State/Local Govt,Non-Federal Agency,West Palm Beach,FL
+PALOALTO-CA.GOV,State/Local Govt,Non-Federal Agency,Palo Alto,CA
+PANYNJ.GOV,State/Local Govt,Non-Federal Agency,New York,NY
+PAOPENFORBUSINESS.GOV,State/Local Govt,Non-Federal Agency,Harrisburg,PA
+PARTNERSFORHEALTHTN.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN
+PASEN.GOV,State/Local Govt,Non-Federal Agency,Harrisburg,PA
+PASENATE.GOV,State/Local Govt,Non-Federal Agency,Harrisburg,PA
+PATREASURY.GOV,State/Local Govt,Non-Federal Agency,Harrisburg,PA
+PAULDING.GOV,State/Local Govt,Non-Federal Agency,Dallas,GA
+PAY4COLLEGEARIZONA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+PAYIOWA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+PEACHTREECORNERSGA.GOV,State/Local Govt,Non-Federal Agency,PEACHTREE CORNERS,GA
+PEMBINACOUNTYND.GOV,State/Local Govt,Non-Federal Agency,Cavalier,ND
+PENNSYLVANIA.GOV,State/Local Govt,Non-Federal Agency,Harrisburg,PA
+PEORIAAZ.GOV,State/Local Govt,Non-Federal Agency,Peoria,AZ
+PEQUOTLAKES-MN.GOV,State/Local Govt,Non-Federal Agency,Pequot Lakes,MN
+PERRY-GA.GOV,State/Local Govt,Non-Federal Agency,Perry,GA
+PERRY-WI.GOV,State/Local Govt,Non-Federal Agency,Mount Horeb,WI
+PHILIPSBURGMT.GOV,State/Local Govt,Non-Federal Agency,Philipsburg,MT
+PHOENIX.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+PIERMONT-NY.GOV,State/Local Govt,Non-Federal Agency,Piermont,NY
+PILOTPOINTAK.GOV,State/Local Govt,Non-Federal Agency,Pilot Point,AK
+PINECREST-FL.GOV,State/Local Govt,Non-Federal Agency,Pinecrest,FL
+PINELLASCOUNTY-FL.GOV,State/Local Govt,Non-Federal Agency,Clearwater,FL
+PINELLASCOUNTYFL.GOV,State/Local Govt,Non-Federal Agency,Clearwater,FL
+PINETOPLAKESIDEAZ.GOV,State/Local Govt,Non-Federal Agency,LAKESIDE,AZ
+PLAINVILLE-CT.GOV,State/Local Govt,Non-Federal Agency,Plainville,CT
+PLANO.GOV,State/Local Govt,Non-Federal Agency,Plano,TX
+PLATTSBURG-MO.GOV,State/Local Govt,Non-Federal Agency,Plattsburg,MO
+POCONOPA.GOV,State/Local Govt,Non-Federal Agency,Tannersville,PA
+POMFRETCT.GOV,State/Local Govt,Non-Federal Agency,Pomfret Center,CT
+PORTAGE-MI.GOV,State/Local Govt,Non-Federal Agency,Portage,MI
+PORTAGEMI.GOV,State/Local Govt,Non-Federal Agency,Portage,MI
+PORTSMOUTHVA.GOV,State/Local Govt,Non-Federal Agency,Portsmouth,VA
+POYNETTE-WI.GOV,State/Local Govt,Non-Federal Agency,Poynette,WI
+PR.GOV,State/Local Govt,Non-Federal Agency,San Juan,PR
+PREVENTHAIAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+PRINCEGEORGECOUNTYVA.GOV,State/Local Govt,Non-Federal Agency,Prince George,VA
+PROVINCETOWN-MA.GOV,State/Local Govt,Non-Federal Agency,Provincetown,MA
+PUERTORICO.GOV,State/Local Govt,Non-Federal Agency,San Juan,PR
+PULASKICOUNTYVA.GOV,State/Local Govt,Non-Federal Agency,Pulaski,VA
+PULLMAN-WA.GOV,State/Local Govt,Non-Federal Agency,Pullman,WA
+PUTNAMCOUNTYTN.GOV,State/Local Govt,Non-Federal Agency,Cookeville,TN
+QAAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+QUALITYFIRSTAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+RAMAPO-NY.GOV,State/Local Govt,Non-Federal Agency,Suffern,NY
+READYALABAMA.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL
+READYNH.GOV,State/Local Govt,Non-Federal Agency,Concord,NH
+READYVIRGINIA.GOV,State/Local Govt,Non-Federal Agency,Richmond,VA
+READYWV.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV
+RECYCLEOHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+REDDING-CA.GOV,State/Local Govt,Non-Federal Agency,Redding,CA
+REDISTRICTINGFLORIDA.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL
+REEDSBURGWI.GOV,State/Local Govt,Non-Federal Agency,Reedsburg,WI
+REGISTERTOVOTENV.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV
+RELAYUTAH.GOV,State/Local Govt,Non-Federal Agency,Salt Lake City,UT
+RENO.GOV,State/Local Govt,Non-Federal Agency,Reno,NV
+RENTONWA.GOV,State/Local Govt,Non-Federal Agency,Renton,WA
+REPORTITTN.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN
+RETIREREADYTN.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN
+RHODEISLAND.GOV,State/Local Govt,Non-Federal Agency,Providence,RI
+RI.GOV,State/Local Govt,Non-Federal Agency,Providence,RI
+RIALTOCA.GOV,State/Local Govt,Non-Federal Agency,Rialto,CA
+RICHLANDMS.GOV,State/Local Govt,Non-Federal Agency,Richland,MS
+RIDESHAREWI.GOV,State/Local Govt,Non-Federal Agency,Madison,WI
+RIDESHAREWISCONSIN.GOV,State/Local Govt,Non-Federal Agency,Madison,WI
+RIORANCHONM.GOV,State/Local Govt,Non-Federal Agency,Rio Rancho,NM
+RIPSGA.GOV,State/Local Govt,Non-Federal Agency,North Scituate,RI
+RISP.GOV,State/Local Govt,Non-Federal Agency,North Scituate,RI
+RIVERTONWY.GOV,State/Local Govt,Non-Federal Agency,Riverton,WY
+ROANOKECOUNTY-VA.GOV,State/Local Govt,Non-Federal Agency,Roanoke,VA
+ROANOKECOUNTYVA.GOV,State/Local Govt,Non-Federal Agency,Roanoke,VA
+ROANOKECOUNTYVIRGINIA.GOV,State/Local Govt,Non-Federal Agency,Roanoke,VA
+ROCHELLEPARKNJ.GOV,State/Local Govt,Non-Federal Agency,Rochelle Park,NJ
+ROCHESTERMN.GOV,State/Local Govt,Non-Federal Agency,Rochester,MN
+ROCKINGHAMCOUNTYVA.GOV,State/Local Govt,Non-Federal Agency,Harrisonburg,VA
+ROCKISLANDTOWNSHIPIL.GOV,State/Local Govt,Non-Federal Agency,Rock Island,IL
+ROGERSMN.GOV,State/Local Govt,Non-Federal Agency,Rogers,MN
+ROMI.GOV,State/Local Govt,Non-Federal Agency,Royal Oak,MI
+ROWANCOUNTYNC.GOV,State/Local Govt,Non-Federal Agency,Salisbury,NC
+ROYALOAKMI.GOV,State/Local Govt,Non-Federal Agency,Royal Oak,MI
+RSA-AL.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL
+RULEWATCHOHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+SACOMAINE.GOV,State/Local Govt,Non-Federal Agency,Saco,ME
+SAFEHOMEALABAMA.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL
+SAFERFLORIDAHIGHWAYS.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL
+SAFERFLORIDAROADS.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL
+SAFESD.GOV,State/Local Govt,Non-Federal Agency,Pierre,SD
+SAFFORD-AZ.GOV,State/Local Govt,Non-Federal Agency,Safford,AZ
+SALINA-KS.GOV,State/Local Govt,Non-Federal Agency,Salina,KS
+SANDIEGO.GOV,State/Local Govt,Non-Federal Agency,San Diego,CA
+SANDPOINTIDAHO.GOV,State/Local Govt,Non-Federal Agency,Sandpoint,ID
+SANNET.GOV,State/Local Govt,Non-Federal Agency,San Diego,CA
+SANTAANA-CA.GOV,State/Local Govt,Non-Federal Agency,Santa Ana,CA
+SANTABARBARACA.GOV,State/Local Govt,Non-Federal Agency,Santa Barbara,CA
+SAOMT.GOV,State/Local Govt,Non-Federal Agency,Helena,MT
+SAVEMYHOMEAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+SAVEOURHOMEAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+SC.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC
+SCAG.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC
+SCCONSUMER.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC
+SCDEW.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC
+SCDHEC.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC
+SCDHHS.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC
+SCDPS.GOV,State/Local Govt,Non-Federal Agency,Blythewood,SC
+SCFC.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC
+SCHELP.GOV,State/Local Govt,Non-Federal Agency,Columbia`,SC
+SCHOHARIECOUNTY-NY.GOV,State/Local Govt,Non-Federal Agency,Schoharie,NY
+SCHOUSE.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC
+SCNEWHIRE.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC
+SCOH.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+SCOHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+SCOTTCOUNTYIOWA.GOV,State/Local Govt,Non-Federal Agency,Davenport,IA
+SCOTTCOUNTYMS.GOV,State/Local Govt,Non-Federal Agency,Forest,MS
+SCOTTSDALEAZ.GOV,State/Local Govt,Non-Federal Agency,Scottsdale,AZ
+SCQUITLINE.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC
+SCSENATE.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC
+SCSERV.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC
+SCSTATEHOUSE.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC
+SD.GOV,State/Local Govt,Non-Federal Agency,Pierre,SD
+SDAUDITOR.GOV,State/Local Govt,Non-Federal Agency,Pierre,SD
+SDBMOE.GOV,State/Local Govt,Non-Federal Agency,Pierre,SD
+SDSOS.GOV,State/Local Govt,Non-Federal Agency,Pierre,SD
+SDTREASURER.GOV,State/Local Govt,Non-Federal Agency,Pierre,SD
+SEATTLE.GOV,State/Local Govt,Non-Federal Agency,Seattle,WA
+SEDGWICK.GOV,State/Local Govt,Non-Federal Agency,Wichita,KS
+SEELYVILLE-IN.GOV,State/Local Govt,Non-Federal Agency,Seelyville,IN
+SEMINOLECOUNTYFL.GOV,State/Local Govt,Non-Federal Agency,Sanford,FL
+SERVEALABAMA.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL
+SERVEIDAHO.GOV,State/Local Govt,Non-Federal Agency,Boise,ID
+SERVEOHIO.GOV,State/Local Govt,Non-Federal Agency,Columb us,OH
+SERVGA.GOV,State/Local Govt,Non-Federal Agency,Atlanta,GA
+SFWMD.GOV,State/Local Govt,Non-Federal Agency,West Palm Beach,FL
+SHAFTSBURYVT.GOV,State/Local Govt,Non-Federal Agency,Shaftsbury,VT
+SHAPINGNEWJERSEY.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ
+SHAPINGNJ.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ
+SHAREOHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+SHOWLOWAZ.GOV,State/Local Govt,Non-Federal Agency,Show Low,AZ
+SHREWSBURY-MA.GOV,State/Local Govt,Non-Federal Agency,Shrewsbury,MA
+SIMSBURY-CT.GOV,State/Local Govt,Non-Federal Agency,Simsbury,CT
+SMITHTOWNNY.GOV,State/Local Govt,Non-Federal Agency,Smithtown,NY
+SNOHOMISHCOUNTYWA.GOV,State/Local Govt,Non-Federal Agency,Everett,WA
+SOCORRONM.GOV,State/Local Govt,Non-Federal Agency,Socorro,NM
+SOUTHCAROLINA.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC
+SOUTHERNSHORES-NC.GOV,State/Local Govt,Non-Federal Agency,Southern Shores,NC
+SOUTHOLDTOWNNY.GOV,State/Local Govt,Non-Federal Agency,Southold,NY
+SPACEFLORIDA.GOV,State/Local Govt,Non-Federal Agency,Cape Canaveral,FL
+SPRINGFIELDMO.GOV,State/Local Govt,Non-Federal Agency,Springfield,MO
+STAGINGAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+STATEOFSOUTHCAROLINA.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC
+STATEOFWV.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV
+STAYSAFENEBRASKA.GOV,State/Local Govt,Non-Federal Agency,Lincoln,NE
+STCHARLESIL.GOV,State/Local Govt,Non-Federal Agency,St. Charles,IL
+STONECOUNTYMS.GOV,State/Local Govt,Non-Federal Agency,Wiggins,MS
+STOPFRAUDCOLORADO.GOV,State/Local Govt,Non-Federal Agency,Denver,CO
+STOUGHTON-MA.GOV,State/Local Govt,Non-Federal Agency,Stoughton,MA
+STOW-MA.GOV,State/Local Govt,Non-Federal Agency,Stow,MA
+STPAULSNC.GOV,State/Local Govt,Non-Federal Agency,St. Pauls,NC
+STURTEVANT-WI.GOV,State/Local Govt,Non-Federal Agency,Sturtevant,WI
+SUFFOLKCOUNTYNY.GOV,State/Local Govt,Non-Federal Agency,Hauppauge,NY
+SULLIVANCOUNTYNH.GOV,State/Local Govt,Non-Federal Agency,Newport,NH
+SUNRISEFL.GOV,State/Local Govt,Non-Federal Agency,Sunrise,FL
+SUNRISEFLORIDA.GOV,State/Local Govt,Non-Federal Agency,Sunrise,FL
+SUPREMECOURTOFOHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+SUTTON-NH.GOV,State/Local Govt,Non-Federal Agency,Sutton,NH
+SWEETHOMEALABAMA.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL
+TAKOMAPARKMD.GOV,State/Local Govt,Non-Federal Agency,Takoma Park,MD
+TAPPAHANNOCK-VA.GOV,State/Local Govt,Non-Federal Agency,Tappahannock,VA
+TCCC.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC
+TEACHIOWA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+TEAMGA.GOV,State/Local Govt,Non-Federal Agency,Atlanta,GA
+TEAMGEORGIA.GOV,State/Local Govt,Non-Federal Agency,Atlanta,GA
+TEAMTN.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN
+TENNESSEE.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN
+TENNESSEECOLLEGEADVISER.GOV,State/Local Govt,Non-Federal Agency,Smyrna,TN
+TENNESSEECOLLEGEADVISOR.GOV,State/Local Govt,Non-Federal Agency,Smyrna,TN
+TENNESSEEIIS.GOV,State/Local Govt,Non-Federal Agency,Smyrna,TN
+TENNESSEEPROMISE.GOV,State/Local Govt,Non-Federal Agency,Smyrna,TN
+TENNESSEERECONNECT.GOV,State/Local Govt,Non-Federal Agency,Smyrna,TN
+TESTOHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+TEWKSBURY-MA.GOV,State/Local Govt,Non-Federal Agency,Tewksbury,MA
+TEXAS.GOV,State/Local Govt,Non-Federal Agency,Austin,TX
+TEXAS511.GOV,State/Local Govt,Non-Federal Agency,Austin,TX
+TEXASAGRICULTURE.GOV,State/Local Govt,Non-Federal Agency,Austin,TX
+TEXASATTORNEYGENERAL.GOV,State/Local Govt,Non-Federal Agency,Austin,TX
+TEXASCHILDRENSCOMMISSION.GOV,State/Local Govt,Non-Federal Agency,Austin,TX
+TEXASFIGHTSIDTHEFT.GOV,State/Local Govt,Non-Federal Agency,Austin,TX
+TEXASFILE.GOV,State/Local Govt,Non-Federal Agency,Austin,TX
+TEXASONLINE.GOV,State/Local Govt,Non-Federal Agency,Austin,TX
+TEXASSTATEPARKS.GOV,State/Local Govt,Non-Federal Agency,Austin,TX
+TEXASSUPREMECOURTCOMMISSION.GOV,State/Local Govt,Non-Federal Agency,Austin,TX
+THA.GOV,State/Local Govt,Non-Federal Agency,Topeka,KS
+THEFTAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
+THERIGHTCALLIOWA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA
+THESTATEOFSOUTHCAROLINA.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC
+TN.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN
+TNAG.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN
+TNCOLLEGEADVISER.GOV,State/Local Govt,Non-Federal Agency,Smyrna,TN
+TNCOLLEGEADVISOR.GOV,State/Local Govt,Non-Federal Agency,Smyrna,TN
+TNCOURTS.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN
+TNECD.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN
+TNEDU.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN
+TNIIS.GOV,State/Local Govt,Non-Federal Agency,Smyrna,TN
+TNK12.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN
+TNPROMISE.GOV,State/Local Govt,Non-Federal Agency,Smyrna,TN
+TNQUITLINE.GOV,State/Local Govt,Non-Federal Agency,Smyrna,TN
+TNREADY.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN
+TNRECONNECT.GOV,State/Local Govt,Non-Federal Agency,Smyrna,TN
+TNTOOLKIT.GOV,State/Local Govt,Non-Federal Agency,Smyrna,TN
+TNTREASURY.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN
+TNVACATION.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN
+TOMGREENCOUNTYTX.GOV,State/Local Govt,Non-Federal Agency,San Angelo,TX
+TOURISMOHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+TOWERLAKES-IL.GOV,State/Local Govt,Non-Federal Agency,Tower Lakes,IL
+TOWNOFDUNNWI.GOV,State/Local Govt,Non-Federal Agency,McFarland,WI
+TOWNOFGOLDENMEADOW-LA.GOV,State/Local Govt,Non-Federal Agency,Golden Meadow,LA
+TOWNOFKEENENY.GOV,State/Local Govt,Non-Federal Agency,Keene,NY
+TOWNOFRAMAPO-NY.GOV,State/Local Govt,Non-Federal Agency,Suffern,NY
+TOWNOFRIVERHEADNY.GOV,State/Local Govt,Non-Federal Agency,Riverhead,NY
+TOWNOFSMYRNA-TN.GOV,State/Local Govt,Non-Federal Agency,Smyrna,TN
+TOWNOFTROUTVILLE-VA.GOV,State/Local Govt,Non-Federal Agency,Troutville,VA
+TOWNOFWALLINGFORD-CT.GOV,State/Local Govt,Non-Federal Agency,Wallingford,CT
+TOWNOFWINGATENC.GOV,State/Local Govt,Non-Federal Agency,Wingate,NC
+TRANSPARENCYFLORIDA.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL
+TRANSPARENCYWV.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV
+TRUSTTENNESSEE.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN
+TRUSTTN.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN
+TTD.GOV,State/Local Govt,Non-Federal Agency,East Norwalk,CT
+TUCSONAZ.GOV,State/Local Govt,Non-Federal Agency,Tucson,AZ
+TUPPERLAKENY.GOV,State/Local Govt,Non-Federal Agency,Tupper Lake,NY
+TUSCALOOSA-AL.GOV,State/Local Govt,Non-Federal Agency,Tuscaloosa,AL
+TX.GOV,State/Local Govt,Non-Federal Agency,Austin,TX
+TX511.GOV,State/Local Govt,Non-Federal Agency,Austin,TX
+TXAG.GOV,State/Local Govt,Non-Federal Agency,Austin,TX
+TXCOURTS.GOV,State/Local Govt,Non-Federal Agency,Austin,TX
+TXDMV.GOV,State/Local Govt,Non-Federal Agency,Austin,TX
+TXDOT.GOV,State/Local Govt,Non-Federal Agency,Austin,TX
+TXDPS.GOV,State/Local Govt,Non-Federal Agency,Austin,TX
+TXFILE.GOV,State/Local Govt,Non-Federal Agency,Austin,TX
+TXMAP.GOV,State/Local Govt,Non-Federal Agency,Austin,TX
+TXOAG.GOV,State/Local Govt,Non-Federal Agency,Austin,TX
+UNITYNH.GOV,State/Local Govt,Non-Federal Agency,Charlestown,NH
+US41WISCONSIN.GOV,State/Local Govt,Non-Federal Agency,Madison,WI
+UTAH.GOV,State/Local Govt,Non-Federal Agency,Salt Lake City,UT
+UTAHLAKE.GOV,State/Local Govt,Non-Federal Agency,Salt Lake City,UT
+UTAHTRUST.GOV,State/Local Govt,Non-Federal Agency,North Salt Lake,UT
+UTCOURTS.GOV,State/Local Govt,Non-Federal Agency,Salt Lake City,UT
+VACOURTS.GOV,State/Local Govt,Non-Federal Agency,Richmond,VA
+VAEMERGENCY.GOV,State/Local Govt,Non-Federal Agency,Richmond,VA
+VBHIL.GOV,State/Local Govt,Non-Federal Agency,Barrington Hills,IL
+VERMONT.GOV,State/Local Govt,Non-Federal Agency,Montpelier,VT
+VERMONTHEALTHCONNECT.GOV,State/Local Govt,Non-Federal Agency,Montpelier,VT
+VERMONTTAXAMNESTY.GOV,State/Local Govt,Non-Federal Agency,Montpelier,VT
+VERMONTTREASURER.GOV,State/Local Govt,Non-Federal Agency,Montpelier,VT
+VERMONTVOTESFORKIDS.GOV,State/Local Govt,Non-Federal Agency,Montpelier,VT
+VERNONTWP-PA.GOV,State/Local Govt,Non-Federal Agency,Meadville,PA
+VI.GOV,State/Local Govt,Non-Federal Agency,St. Thomas,VI
+VIALERT.GOV,State/Local Govt,Non-Federal Agency,St. Thomas,VI
+VIBIR.GOV,State/Local Govt,Non-Federal Agency,St. Thomas,VI
+VIDOL.GOV,State/Local Govt,Non-Federal Agency,St. Thomas,VI
+VIHFA.GOV,State/Local Govt,Non-Federal Agency,St. Thomas,VI
+VILLAGEOFDUNLAP-IL.GOV,State/Local Govt,Non-Federal Agency,Dunlap,IL
+VILLAGEOFPENINSULA-OH.GOV,State/Local Govt,Non-Federal Agency,Peninsula,OH
+VILLAGEOFSCOTIANY.GOV,State/Local Govt,Non-Federal Agency,Scotia,NY
+VINTONVA.GOV,State/Local Govt,Non-Federal Agency,Vinton,VA
+VIRGINIA.GOV,State/Local Govt,Non-Federal Agency,Chester,VA
+VIRGINIACAPITAL.GOV,State/Local Govt,Non-Federal Agency,Richmond,VA
+VIRGINIACAPITOL.GOV,State/Local Govt,Non-Federal Agency,Richmond,VA
+VIRGINIAGENERALASSEMBLY.GOV,State/Local Govt,Non-Federal Agency,Richmond,VA
+VIRGINIASTATEPARKS.GOV,State/Local Govt,Non-Federal Agency,Richmond,VA
+VISITIDAHO.GOV,State/Local Govt,Non-Federal Agency,Boise,ID
+VISITNEBRASKA.GOV,State/Local Govt,Non-Federal Agency,Lincoln,NE
+VISITNH.GOV,State/Local Govt,Non-Federal Agency,Concord,NH
+VISITWYO.GOV,State/Local Govt,Non-Federal Agency,Cheyenne,WY
+VISITWYOMING.GOV,State/Local Govt,Non-Federal Agency,Cheyenne,WY
+VITEMA.GOV,State/Local Govt,Non-Federal Agency,St. Thomas,VI
+VIVOTE.GOV,State/Local Govt,Non-Federal Agency,St Croix,VI
+VOLUNTEERLOUISIANA.GOV,State/Local Govt,Non-Federal Agency,Baton Rouge,LA
+VOTETEXAS.GOV,State/Local Govt,Non-Federal Agency,Austin,TX
+VT.GOV,State/Local Govt,Non-Federal Agency,Montpelier,VT
+VTALERT.GOV,State/Local Govt,Non-Federal Agency,Montpelier,VT
+WA.GOV,State/Local Govt,Non-Federal Agency,Olympia,WA
+WAKECOUNTYNC.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+WALDOCOUNTYME.GOV,State/Local Govt,Non-Federal Agency,Belfast,ME
+WALLAWALLAWA.GOV,State/Local Govt,Non-Federal Agency,Walla Walla,WA
+WALPOLE-MA.GOV,State/Local Govt,Non-Federal Agency,Walpole,MA
+WALTONCOUNTYGA.GOV,State/Local Govt,Non-Federal Agency,Monroe,GA
+WARRACRES-OK.GOV,State/Local Govt,Non-Federal Agency,Warr Acres,OK
+WARRENPA.GOV,State/Local Govt,Non-Federal Agency,Warren,PA
+WASHINGTON-NC.GOV,State/Local Govt,Non-Federal Agency,Washington,NC
+WASHINGTON.GOV,State/Local Govt,Non-Federal Agency,Olympia,WA
+WASHINGTONCOUNTYNY.GOV,State/Local Govt,Non-Federal Agency,Fort Edward,NY
+WASHINGTONDC.GOV,State/Local Govt,Non-Federal Agency,"Washington,",DC
+WASHINGTONNC.GOV,State/Local Govt,Non-Federal Agency,Washington,NC
+WASHINGTONPA.GOV,State/Local Govt,Non-Federal Agency,Washington,PA
+WASHINGTONSTATE.GOV,State/Local Govt,Non-Federal Agency,Olympia,WA
+WASHINGTONVILLE-NY.GOV,State/Local Govt,Non-Federal Agency,Washingtonville,NY
+WASHTENAWCOUNTY-MI.GOV,State/Local Govt,Non-Federal Agency,Ann Arbor,MI
+WATAUGACOUNTYNC.GOV,State/Local Govt,Non-Federal Agency,Boone,NC
+WAUKESHACOUNTY-WI.GOV,State/Local Govt,Non-Federal Agency,Waukesha,WI
+WAUKESHACOUNTY.GOV,State/Local Govt,Non-Federal Agency,Waukesha,WI
+WAYNECOUNTYMS.GOV,State/Local Govt,Non-Federal Agency,Waynesboro,MS
+WCNYH.GOV,State/Local Govt,Non-Federal Agency,New YOrk,NY
+WEBBCOUNTYTX.GOV,State/Local Govt,Non-Federal Agency,Laredo,TX
+WELCOMEHOMEILLINOIS.GOV,State/Local Govt,Non-Federal Agency,Chicago,IL
+WENHAMMA.GOV,State/Local Govt,Non-Federal Agency,Wenham,MA
+WESTBENDWI.GOV,State/Local Govt,Non-Federal Agency,West Bend,WI
+WESTCHESTERCOUNTYNY.GOV,State/Local Govt,Non-Federal Agency,White Plains,NY
+WESTFORKAR.GOV,State/Local Govt,Non-Federal Agency,West Fork,AR
+WESTMINSTER-CA.GOV,State/Local Govt,Non-Federal Agency,Westminster,CA
+WESTMORELANDTN.GOV,State/Local Govt,Non-Federal Agency,Westmoreland,TN
+WESTVALLEYCITY-UT.GOV,State/Local Govt,Non-Federal Agency,West Valley City,UT
+WHITMAN-MA.GOV,State/Local Govt,Non-Federal Agency,Whitman,MA
+WHYNEVADA.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV
+WI-TIME.GOV,State/Local Govt,Non-Federal Agency,Madison,WI
+WI-WORCS.GOV,State/Local Govt,Non-Federal Agency,Madison,WI
+WI.GOV,State/Local Govt,Non-Federal Agency,Madison,WI
+WIBADGERTRACS.GOV,State/Local Govt,Non-Federal Agency,Madison,WI
+WICONNECTIONS2030.GOV,State/Local Govt,Non-Federal Agency,Madison,WI
+WICOURTS.GOV,State/Local Govt,Non-Federal Agency,MADISON,WI
+WIGRANTS.GOV,State/Local Govt,Non-Federal Agency,Madison,WI
+WILAWLIBRARY.GOV,State/Local Govt,Non-Federal Agency,Madison,WI
+WILDOHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
+WILLIAMSBURGVA.GOV,State/Local Govt,Non-Federal Agency,Williamsburg,VA
+WILMINGTON-NC.GOV,State/Local Govt,Non-Federal Agency,Wilmington,NC
+WILMINGTONNC.GOV,State/Local Govt,Non-Federal Agency,Wilmington,NC
+WINTERGARDEN-FL.GOV,State/Local Govt,Non-Federal Agency,Winter Garden,FL
+WINTERPORTMAINE.GOV,State/Local Govt,Non-Federal Agency,Winterport,ME
+WINTERSPRINGSFL.GOV,State/Local Govt,Non-Federal Agency,Winter Springs,FL
+WISC.GOV,State/Local Govt,Non-Federal Agency,Madison,WI
+WISCONSIN.GOV,State/Local Govt,Non-Federal Agency,Madison,WI
+WISCONSINCRIMEALERT.GOV,State/Local Govt,Non-Federal Agency,Madison,WI
+WISCONSINDMV.GOV,State/Local Govt,Non-Federal Agency,Madison,WI
+WISCONSINDOT.GOV,State/Local Govt,Non-Federal Agency,Madison,WI
+WISCONSINFREIGHTPLAN.GOV,State/Local Govt,Non-Federal Agency,Madison,WI
+WISCONSINRAILPLAN.GOV,State/Local Govt,Non-Federal Agency,Madison,WI
+WISCONSINROUNDABOUTS.GOV,State/Local Govt,Non-Federal Agency,Madison,WI
+WMATA.GOV,State/Local Govt,Non-Federal Agency,Washington,DC
+WORKFORNC.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
+WSDOT.GOV,State/Local Govt,Non-Federal Agency,Olympia,WA
+WV.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV
+WVAGO.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV
+WVCOMMERCE.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV
+WVCONSUMERPROTECTION.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV
+WVCSI.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV
+WVDHSEM.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV
+WVDMV.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV
+WVDNR.GOV,State/Local Govt,Non-Federal Agency,South Charleston,WV
+WVHOUSE.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV
+WVINSURANCE.GOV,State/Local Govt,Non-Federal Agency,Charleson,WV
+WVLEGISLATURE.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV
+WVOASIS.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV
+WVOT.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV
+WVOTA.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV
+WVPRESIDENT.GOV,State/Local Govt,Non-Federal Agency,Morgantown,WV
+WVPURCHASING.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV
+WVREVENUE.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV
+WVSAO.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV
+WVSENATE.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV
+WVSENIORSERVICES.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV
+WVSP.GOV,State/Local Govt,Non-Federal Agency,South Charleston,WV
+WVSPEAKER.GOV,State/Local Govt,Non-Federal Agency,Morgantown,WV
+WVSTO.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV
+WVSURPLUS.GOV,State/Local Govt,Non-Federal Agency,Dunbar,WV
+WVTAX.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV
+WY.GOV,State/Local Govt,Non-Federal Agency,Cheyenne,WY
+WYCAMPAIGNFINANCE.GOV,State/Local Govt,Non-Federal Agency,Cheyenne,WY
+WYINVESTORAWARENESS.GOV,State/Local Govt,Non-Federal Agency,Cheyenne,WY
+WYO.GOV,State/Local Govt,Non-Federal Agency,Cheyenne,WY
+WYOBOARDS.GOV,State/Local Govt,Non-Federal Agency,Cheyenne,WY
+WYOLEG.GOV,State/Local Govt,Non-Federal Agency,Cheyenne,WY
+WYOMING.GOV,State/Local Govt,Non-Federal Agency,Cheyenne,WY
+WYOMINGAGCARE.GOV,State/Local Govt,Non-Federal Agency,Cheyenne,WY
+WYOMINGFOSTERCARE.GOV,State/Local Govt,Non-Federal Agency,Cheyenne,WY
+WYOMINGLMI.GOV,State/Local Govt,Non-Federal Agency,cheyenne,WY
+WYOMINGOFFICEOFTOURISM.GOV,State/Local Govt,Non-Federal Agency,Cheyenne,WY
+WYOREG.GOV,State/Local Govt,Non-Federal Agency,cheyenne,WY
+WYWINDFALL.GOV,State/Local Govt,Non-Federal Agency,cheyenne,WY
+YADKINCOUNTY.GOV,State/Local Govt,Non-Federal Agency,Yadkinville,NC
+YADKINCOUNTYNC.GOV,State/Local Govt,Non-Federal Agency,Yadkinville,NC
+YAMHILLCOUNTY-OR.GOV,State/Local Govt,Non-Federal Agency,McMinnville,OR
+YANCEYVILLENC.GOV,State/Local Govt,Non-Federal Agency,Roxboro,NC
+YUCAIPA-CA.GOV,State/Local Govt,Non-Federal Agency,Yucaipa,CA
+ZAPATACOUNTYTX.GOV,State/Local Govt,Non-Federal Agency,Zapata,TX
+ZEROINWISCONSIN.GOV,State/Local Govt,Non-Federal Agency,Madison,WI
+ZIONSVILLE-IN.GOV,State/Local Govt,Non-Federal Agency,Zionsville,IN


### PR DESCRIPTION
This is an update to the .gov second-level domain list, as provided by GSA's Office of Government-wide Policy, exported on November 3, 2015.