### PR TITLE
Updated domain data for 2016-06-30

### DIFF
--- a/dotgov-domains/2016-06-30-city.csv
+++ b/dotgov-domains/2016-06-30-city.csv
@@ -1,0 +1,2387 @@
+Domain Name,Domain Type,Agency,City,State,Status
+SANFRANCISCO.GOV,City,General Services Administration,San Francisco,CA,ACTIVE
+SF.GOV,City,General Services Administration,San Francisco,CA,ACTIVE
+ABERDEENMD.GOV,City,Non-Federal Agency,Aberdeen,MD,ACTIVE
+ABERDEENWA.GOV,City,Non-Federal Agency,Aberdeen,WA,ACTIVE
+ABINGDON-VA.GOV,City,Non-Federal Agency,Abingdon,VA,ACTIVE
+ABINGTONMA.GOV,City,Non-Federal Agency,Abington,MA,ACTIVE
+ABSECONNJ.GOV,City,Non-Federal Agency,Absecon,NJ,ACTIVE
+ACCESSPRINCETONNJ.GOV,City,Non-Federal Agency,Princeton,NJ,ACTIVE
+ACTON-MA.GOV,City,Non-Federal Agency,Acton,MA,ACTIVE
+ACTONMA.GOV,City,Non-Federal Agency,Acton,MA,ACTIVE
+ADAK-AK.GOV,City,Non-Federal Agency,Adak,AK,ACTIVE
+ADAMN.GOV,City,Non-Federal Agency,Ada,MN,ACTIVE
+ADDISONTX.GOV,City,Non-Federal Agency,Addison,TX,ACTIVE
+ADRIANMI.GOV,City,Non-Federal Agency,Adrian,MI,ACTIVE
+AFTONWYOMING.GOV,City,Non-Federal Agency,AFTON,WY,ACTIVE
+AKRONOHIO.GOV,City,Non-Federal Agency,Akron,OH,ACTIVE
+ALAMEDACA.GOV,City,Non-Federal Agency,Alameda,CA,ACTIVE
+ALAMOHEIGHTSTX.GOV,City,Non-Federal Agency,Alamo Heights,TX,ACTIVE
+ALBANYNY.GOV,City,Non-Federal Agency,Albany,NY,ACTIVE
+ALBEMARLENC.GOV,City,Non-Federal Agency,Albemarle,NC,ACTIVE
+ALBUQUERQUE-NM.GOV,City,Non-Federal Agency,Albuquerque,NM,ACTIVE
+ALEKNAGIKAK.GOV,City,Non-Federal Agency,Aleknagik,AK,ACTIVE
+ALEXANDERCITYAL.GOV,City,Non-Federal Agency,Alexander City,AL,ACTIVE
+ALEXANDRIANJ.GOV,City,Non-Federal Agency,Milford,NJ,ACTIVE
+ALEXANDRIAVA.GOV,City,Non-Federal Agency,Alexandria,VA,ACTIVE
+ALFREDME.GOV,City,Non-Federal Agency,Alfred,ME,ACTIVE
+ALGONAC-MI.GOV,City,Non-Federal Agency,Algonac,MI,ACTIVE
+ALGONAWA.GOV,City,Non-Federal Agency,Algona,WA,ACTIVE
+ALGOODTN.GOV,City,Non-Federal Agency,Algood,TN,ACTIVE
+ALIQUIPPAPA.GOV,City,Non-Federal Agency,Aliquippa,PA,ACTIVE
+ALLENDALENJ.GOV,City,Non-Federal Agency,Allendale,NJ,ACTIVE
+ALLENSTOWNNH.GOV,City,Non-Federal Agency,Allenstown,NH,ACTIVE
+ALLENTOWNPA.GOV,City,Non-Federal Agency,Allentown,PA,ACTIVE
+ALLIANCEOH.GOV,City,Non-Federal Agency,Alliance,OH,ACTIVE
+ALMONTMICHIGAN.GOV,City,Non-Federal Agency,Almont,MI,ACTIVE
+ALSTEADNH.GOV,City,Non-Federal Agency,Alstead,NH,ACTIVE
+ALTAVISTAVA.GOV,City,Non-Federal Agency,Altavista,VA,ACTIVE
+ALTON-TX.GOV,City,Non-Federal Agency,Alton,TX,ACTIVE
+ALTOONAPA.GOV,City,Non-Federal Agency,Altoona,PA,ACTIVE
+ALTUSOK.GOV,City,Non-Federal Agency,Altus,OK,ACTIVE
+ALVIN-TX.GOV,City,Non-Federal Agency,Alvin,TX,ACTIVE
+AMARILLO.GOV,City,Non-Federal Agency,Amarillo,TX,ACTIVE
+AMENIANY.GOV,City,Non-Federal Agency,Amenia,NY,ACTIVE
+AMERICUSGA.GOV,City,Non-Federal Agency,Americus,GA,ACTIVE
+AMERYWI.GOV,City,Non-Federal Agency,Amery,WI,ACTIVE
+AMHERSTMA.GOV,City,Non-Federal Agency,Amherst,MA,ACTIVE
+AMHERSTNH.GOV,City,Non-Federal Agency,Amherst,NH,ACTIVE
+AMHERSTVA.GOV,City,Non-Federal Agency,Amherst,VA,ACTIVE
+AMITYARKANSAS.GOV,City,Non-Federal Agency,Amity,AR,ACTIVE
+AMSTERDAMNY.GOV,City,Non-Federal Agency,Amsterdam,NY,ACTIVE
+ANCHORAGEAK.GOV,City,Non-Federal Agency,Anchorage,AK,ACTIVE
+ANDOVER-NH.GOV,City,Non-Federal Agency,Andover,NH,ACTIVE
+ANDOVERMA.GOV,City,Non-Federal Agency,Andover,MA,ACTIVE
+ANDOVERMN.GOV,City,Non-Federal Agency,Andover,MN,ACTIVE
+ANGELFIRENM.GOV,City,Non-Federal Agency,Angel Fire,NM,ACTIVE
+ANGELSCAMP.GOV,City,Non-Federal Agency,City of Angels Camp,CA,ACTIVE
+ANKENYIOWA.GOV,City,Non-Federal Agency,Ankeny,IA,ACTIVE
+ANNATEXAS.GOV,City,Non-Federal Agency,Anna,TX,ACTIVE
+ANNETTATX.GOV,City,Non-Federal Agency,Aledo,TX,ACTIVE
+ANNISTONAL.GOV,City,Non-Federal Agency,Anniston,AL,ACTIVE
+ANTIOCHTOWNSHIPIL.GOV,City,Non-Federal Agency,Lake Villa,IL,ACTIVE
+APPLEVALLEYCA.GOV,City,Non-Federal Agency,Apple Valley,CA,ACTIVE
+APPLEVALLEYUT.GOV,City,Non-Federal Agency,Apple Valley,UT,ACTIVE
+APPOMATTOXVA.GOV,City,Non-Federal Agency,Appomattox,VA,ACTIVE
+AQUINNAH-MA.GOV,City,Non-Federal Agency,Aquinnah,MA,ACTIVE
+ARANSASPASSTX.GOV,City,Non-Federal Agency,Aransas Pass,TX,ACTIVE
+ARCADIA-FL.GOV,City,Non-Federal Agency,Arcadia,FL,ACTIVE
+ARCADIACA.GOV,City,Non-Federal Agency,Arcadia,CA,ACTIVE
+ARCHBALDBOROUGHPA.GOV,City,Non-Federal Agency,Archbald,PA,ACTIVE
+ARCHDALE-NC.GOV,City,Non-Federal Agency,ARCHDALE,NC,ACTIVE
+ARKANSASCITYKS.GOV,City,Non-Federal Agency,Arkansas City,KS,ACTIVE
+ARLINGTON-TX.GOV,City,Non-Federal Agency,Arlington,TX,ACTIVE
+ARLINGTONMA.GOV,City,Non-Federal Agency,Arlington,MA,ACTIVE
+ARLINGTONTX.GOV,City,Non-Federal Agency,Arlington,TX,ACTIVE
+ARLINGTONWA.GOV,City,Non-Federal Agency,Arlington,WA,ACTIVE
+ARTESIANM.GOV,City,Non-Federal Agency,Artesia,NM,ACTIVE
+ARTHUR-IL.GOV,City,Non-Federal Agency,Arthur,IL,ACTIVE
+ASHBURNHAM-MA.GOV,City,Non-Federal Agency,Ashburnham,MA,ACTIVE
+ASHBYMA.GOV,City,Non-Federal Agency,Ashby,MA,ACTIVE
+ASHEBORONC.GOV,City,Non-Federal Agency,Asheboro,NC,ACTIVE
+ASHEVILLENC.GOV,City,Non-Federal Agency,Asheville,NC,ACTIVE
+ASHGROVEMO.GOV,City,Non-Federal Agency,Ash Grove,MO,ACTIVE
+ASHLANDCITYTN.GOV,City,Non-Federal Agency,Ashland City,TN,ACTIVE
+ASHLANDKY.GOV,City,Non-Federal Agency,Ashland,KY,ACTIVE
+ASHVILLEOHIO.GOV,City,Non-Federal Agency,Ashville,OH,ACTIVE
+ATHENSTX.GOV,City,Non-Federal Agency,Athens,TX,ACTIVE
+ATHOL-MA.GOV,City,Non-Federal Agency,Athol,MA,ACTIVE
+ATKINSON-NH.GOV,City,Non-Federal Agency,Atkinson,NH,ACTIVE
+ATLANTAGA.GOV,City,Non-Federal Agency,Atlanta,GA,ACTIVE
+ATLANTISFL.GOV,City,Non-Federal Agency,Atlantis,FL,ACTIVE
+ATRISCO-NM.GOV,City,Non-Federal Agency,Atrisco,NM,ACTIVE
+ATTICA-IN.GOV,City,Non-Federal Agency,Attica,IN,ACTIVE
+AUBREYTX.GOV,City,Non-Federal Agency,Aubrey,TX,ACTIVE
+AUBURNMAINE.GOV,City,Non-Federal Agency,Auburn,ME,ACTIVE
+AUBURNNY.GOV,City,Non-Federal Agency,Auburn,NY,ACTIVE
+AUBURNWA.GOV,City,Non-Federal Agency,Auburn,WA,ACTIVE
+AUGUSTAMAINE.GOV,City,Non-Federal Agency,Augusta,ME,ACTIVE
+AUGUSTAME.GOV,City,Non-Federal Agency,Augusta,ME,ACTIVE
+AURORATEXAS.GOV,City,Non-Federal Agency,Rhome,TX,ACTIVE
+AUSTELLGA.GOV,City,Non-Federal Agency,Austell,GA,ACTIVE
+AUSTINTEXAS.GOV,City,Non-Federal Agency,Austin,TX,ACTIVE
+AUSTINTX.GOV,City,Non-Federal Agency,Austin,TX,ACTIVE
+AVONCT.GOV,City,Non-Federal Agency,Avon,CT,ACTIVE
+AVONDALEAZ.GOV,City,Non-Federal Agency,Avondale,AZ,ACTIVE
+AZTECNM.GOV,City,Non-Federal Agency,Aztec,NM,ACTIVE
+BADENPA.GOV,City,Non-Federal Agency,Baden,PA,ACTIVE
+BAINBRIDGEWA.GOV,City,Non-Federal Agency,Bainbridge Island,WA,ACTIVE
+BAKERSFIELD-CA.GOV,City,Non-Federal Agency,Bakersfield,CA,ACTIVE
+BALHARBOURFL.GOV,City,Non-Federal Agency,Bal Harbour,FL,ACTIVE
+BALTIMORECITY.GOV,City,Non-Federal Agency,Baltimore,MD,ACTIVE
+BANGORMAINE.GOV,City,Non-Federal Agency,Bangor,ME,ACTIVE
+BARLINGAR.GOV,City,Non-Federal Agency,Barling,AR,ACTIVE
+BARRINGTON-IL.GOV,City,Non-Federal Agency,Barrington,IL,ACTIVE
+BARRINGTONHILLS-IL.GOV,City,Non-Federal Agency,Barrington Hills,IL,ACTIVE
+BASSLAKEWI.GOV,City,Non-Federal Agency,Hayward,WI,ACTIVE
+BASTROPTX.GOV,City,Non-Federal Agency,Bastrop,TX,ACTIVE
+BATTLECREEK-MI.GOV,City,Non-Federal Agency,Battle Creek,MI,ACTIVE
+BATTLECREEKMI.GOV,City,Non-Federal Agency,Battle Creek,MI,ACTIVE
+BATTLEFIELDMO.GOV,City,Non-Federal Agency,Battlefield,MO,ACTIVE
+BAXTERMN.GOV,City,Non-Federal Agency,Baxter,MN,ACTIVE
+BAYCOUNTY-MI.GOV,City,Non-Federal Agency,Bay City,MI,ACTIVE
+BAYSIDE-WI.GOV,City,Non-Federal Agency,Bayside,WI,ACTIVE
+BAYSTLOUIS-MS.GOV,City,Non-Federal Agency,Bay St. Louis,MS,ACTIVE
+BAYVILLENY.GOV,City,Non-Federal Agency,Bayville,NY,ACTIVE
+BEACHHAVEN-NJ.GOV,City,Non-Federal Agency,Beach Haven,NJ,ACTIVE
+BEAUMONT-CA.GOV,City,Non-Federal Agency,Beaumont,CA,ACTIVE
+BEAUMONTTEXAS.GOV,City,Non-Federal Agency,Beaumont,TX,ACTIVE
+BEAUXARTS-WA.GOV,City,Non-Federal Agency,Beaux Arts,WA,ACTIVE
+BEAVERCREEKOHIO.GOV,City,Non-Federal Agency,Beavercreek,OH,ACTIVE
+BEAVERPA.GOV,City,Non-Federal Agency,Beaver,PA,ACTIVE
+BEAVERTONOREGON.GOV,City,Non-Federal Agency,Beaverton,OR,ACTIVE
+BEAVERTWP-OH.GOV,City,Non-Federal Agency,North Lima,OH,ACTIVE
+BECKEMEYERIL.GOV,City,Non-Federal Agency,Beckemeyer,IL,ACTIVE
+BEDFORDHEIGHTS.GOV,City,Non-Federal Agency,Bedford Heights,OH,ACTIVE
+BEDFORDMA.GOV,City,Non-Federal Agency,Bedford,MA,ACTIVE
+BEDFORDNY.GOV,City,Non-Federal Agency,Bedford Hills,NY,ACTIVE
+BEDFORDOH.GOV,City,Non-Federal Agency,Bedford,OH,ACTIVE
+BEDFORDTX.GOV,City,Non-Federal Agency,Bedford,TX,ACTIVE
+BEDFORDVA.GOV,City,Non-Federal Agency,Bedford,VA,ACTIVE
+BEECAVETEXAS.GOV,City,Non-Federal Agency,Bee Cave,TX,ACTIVE
+BELAIREKS.GOV,City,Non-Federal Agency,Bel Aire,KS,ACTIVE
+BELEN-NM.GOV,City,Non-Federal Agency,Belen,NM,ACTIVE
+BELLAIRETX.GOV,City,Non-Federal Agency,Bellaire,TX,ACTIVE
+BELLAVISTAAR.GOV,City,Non-Federal Agency,Bella Vista,AR,ACTIVE
+BELLEAIRBLUFFS-FL.GOV,City,Non-Federal Agency,Belleair Bluffs,FL,ACTIVE
+BELLEFONTEPA.GOV,City,Non-Federal Agency,Bellefonte,PA,ACTIVE
+BELLEMEADE-KY.GOV,City,Non-Federal Agency,Louisville,KY,ACTIVE
+BELLERIVEACRESMO.GOV,City,Non-Federal Agency,Normandy,MO,ACTIVE
+BELLEVUEIA.GOV,City,Non-Federal Agency,Bellevue,IA,ACTIVE
+BELLEVUEWA.GOV,City,Non-Federal Agency,Bellevue,WA,ACTIVE
+BELMONT-MA.GOV,City,Non-Federal Agency,Belmont,MA,ACTIVE
+BELMONT.GOV,City,Non-Federal Agency,Belmont,CA,ACTIVE
+BELOITWI.GOV,City,Non-Federal Agency,Beloit,WI,ACTIVE
+BELTONPARKSMO.GOV,City,Non-Federal Agency,Belton,MO,ACTIVE
+BELTONTEXAS.GOV,City,Non-Federal Agency,Belton,TX,ACTIVE
+BENBROOK-TX.GOV,City,Non-Federal Agency,Benbrook,TX,ACTIVE
+BENDOREGON.GOV,City,Non-Federal Agency,Bend,OR,ACTIVE
+BENSALEMPA.GOV,City,Non-Federal Agency,Bensalem,PA,ACTIVE
+BENSONAZ.GOV,City,Non-Federal Agency,Benson,AZ,ACTIVE
+BENTONCHARTERTOWNSHIP-MI.GOV,City,Non-Federal Agency,Benton Harbor,MI,ACTIVE
+BENTONIL.GOV,City,Non-Federal Agency,Benton,IL,ACTIVE
+BEREAKY.GOV,City,Non-Federal Agency,Berea,KY,ACTIVE
+BERKELEYHEIGHTSTWPNJ.GOV,City,Non-Federal Agency,Berkeley Heights,NJ,ACTIVE
+BERLINMD.GOV,City,Non-Federal Agency,Berlin,MD,ACTIVE
+BERLINNH.GOV,City,Non-Federal Agency,Berlin,NH,ACTIVE
+BERNCO.GOV,City,Non-Federal Agency,Albuquerque,NM,ACTIVE
+BERRYVILLEVA.GOV,City,Non-Federal Agency,Berryville,VA,ACTIVE
+BERTHOLD-ND.GOV,City,Non-Federal Agency,Berthold,ND,ACTIVE
+BERWYN-IL.GOV,City,Non-Federal Agency,Berwyn,IL,ACTIVE
+BERWYNHEIGHTSMD.GOV,City,Non-Federal Agency,Berwyn Heights,MD,ACTIVE
+BETHANYBEACH-DE.GOV,City,Non-Federal Agency,Bethany Beach,DE,ACTIVE
+BETHEL-CT.GOV,City,Non-Federal Agency,Bethel,CT,ACTIVE
+BETHEL-OH.GOV,City,Non-Federal Agency,Bethel,OH,ACTIVE
+BETHLEHEM-PA.GOV,City,Non-Federal Agency,Bethlehem,PA,ACTIVE
+BEVERLYHILLS-CA.GOV,City,Non-Federal Agency,Beverly Hills,CA,ACTIVE
+BEVERLYHILLSCA.GOV,City,Non-Federal Agency,Beverly Hills,CA,ACTIVE
+BEVERLYMA.GOV,City,Non-Federal Agency,Beverly,MA,ACTIVE
+BHTX.GOV,City,Non-Federal Agency,Balcones Heights,TX,ACTIVE
+BIGFLATSNY.GOV,City,Non-Federal Agency,Big Flats,NY,ACTIVE
+BIGGS-CA.GOV,City,Non-Federal Agency,Biggs,CA,ACTIVE
+BIGSANDYTX.GOV,City,Non-Federal Agency,Big Sandy,TX,ACTIVE
+BINGHAMTON-NY.GOV,City,Non-Federal Agency,Binghamton,NY,ACTIVE
+BIRMINGHAMAL.GOV,City,Non-Federal Agency,Birmingham,AL,ACTIVE
+BISBEEAZ.GOV,City,Non-Federal Agency,Bisbee,AZ,ACTIVE
+BISCAYNEPARKFL.GOV,City,Non-Federal Agency,Biscayne Park,FL,ACTIVE
+BISMARCKND.GOV,City,Non-Federal Agency,Bismarck,ND,ACTIVE
+BIXBYOK.GOV,City,Non-Federal Agency,Bixby,OK,ACTIVE
+BLACKSBURG.GOV,City,Non-Federal Agency,Blacksburg,VA,ACTIVE
+BLAINEMN.GOV,City,Non-Federal Agency,Blaine,MN,ACTIVE
+BLAIRSVILLE-GA.GOV,City,Non-Federal Agency,Blairsville,GA,ACTIVE
+BLANDING-UT.GOV,City,Non-Federal Agency,Blanding,UT,ACTIVE
+BLENDONTOWNSHIP-MI.GOV,City,Non-Federal Agency,Hudsonville,MI,ACTIVE
+BLISSFIELDMICHIGAN.GOV,City,Non-Federal Agency,Blissfield,MI,ACTIVE
+BLOOMINGDALE-GA.GOV,City,Non-Federal Agency,Bloomingdale,GA,ACTIVE
+BLOOMINGTON-MN.GOV,City,Non-Federal Agency,Bloomington,MN,ACTIVE
+BLOOMINGTONMN.GOV,City,Non-Federal Agency,Bloomington,MN,ACTIVE
+BLUEASH-OH.GOV,City,Non-Federal Agency,Blue Ash,OH,ACTIVE
+BOCARATON-FL.GOV,City,Non-Federal Agency,Boca Raton,FL,ACTIVE
+BOERNE-TX.GOV,City,Non-Federal Agency,BOERNE,TX,ACTIVE
+BOISEIDAHO.GOV,City,Non-Federal Agency,Boise,ID,ACTIVE
+BOLTON-MA.GOV,City,Non-Federal Agency,Bolton,MA,ACTIVE
+BONNEYTEXAS.GOV,City,Non-Federal Agency,Bonney,TX,ACTIVE
+BOONEVILLE-MS.GOV,City,Non-Federal Agency,Booneville,MS,ACTIVE
+BORGERTX.GOV,City,Non-Federal Agency,Borger,TX,ACTIVE
+BOSQUEFARMSNM.GOV,City,Non-Federal Agency,Bosque Farms,NM,ACTIVE
+BOSTON.GOV,City,Non-Federal Agency,Boston,MA,ACTIVE
+BOTHELLWA.GOV,City,Non-Federal Agency,Bothell,WA,ACTIVE
+BOULDER-CO.GOV,City,Non-Federal Agency,Boulder,CO,ACTIVE
+BOULDERCITY-NV.GOV,City,Non-Federal Agency,Boulder City,NV,ACTIVE
+BOULDERCITYNV.GOV,City,Non-Federal Agency,Boulder City,NV,ACTIVE
+BOULDERCOLORADO.GOV,City,Non-Federal Agency,Boulder,CO,ACTIVE
+BOUNTIFULUTAH.GOV,City,Non-Federal Agency,Bountiful,UT,ACTIVE
+BOURBON-IN.GOV,City,Non-Federal Agency,Bremen,IN,ACTIVE
+BOW-NH.GOV,City,Non-Federal Agency,Bow,NH,ACTIVE
+BOWERSDE.GOV,City,Non-Federal Agency,"Frederica,",DE,ACTIVE
+BOWLINGGREEN-MO.GOV,City,Non-Federal Agency,Bowling Green,MO,ACTIVE
+BOWLINGGREENKY.GOV,City,Non-Federal Agency,Bowling Green,KY,ACTIVE
+BOWMAR.GOV,City,Non-Federal Agency,Bow Mar,CO,ACTIVE
+BOXBOROUGH-MA.GOV,City,Non-Federal Agency,Boxborough,MA,ACTIVE
+BOYCEVA.GOV,City,Non-Federal Agency,Boyce,VA,ACTIVE
+BOYLSTON-MA.GOV,City,Non-Federal Agency,Boylston,MA,ACTIVE
+BOZEMAN-MT.GOV,City,Non-Federal Agency,Bozeman,MT,ACTIVE
+BRADLEYBEACHNJ.GOV,City,Non-Federal Agency,Bradley Beach,NJ,ACTIVE
+BRANFORD-CT.GOV,City,Non-Federal Agency,Branford,CT,ACTIVE
+BRANSONMO.GOV,City,Non-Federal Agency,Branson,MO,ACTIVE
+BRASWELLGA.GOV,City,Non-Federal Agency,Rockmart,GA,ACTIVE
+BRAWLEY-CA.GOV,City,Non-Federal Agency,Brawley,CA,ACTIVE
+BRECKENRIDGETX.GOV,City,Non-Federal Agency,Breckenridge,TX,ACTIVE
+BREMENGA.GOV,City,Non-Federal Agency,Bremen,GA,ACTIVE
+BREMERTONWA.GOV,City,Non-Federal Agency,Bremerton,WA,ACTIVE
+BRENTWOOD-TN.GOV,City,Non-Federal Agency,Brentwood,TN,ACTIVE
+BRENTWOODCA.GOV,City,Non-Federal Agency,Brentwood,CA,ACTIVE
+BRENTWOODMD.GOV,City,Non-Federal Agency,Brentwood,MD,ACTIVE
+BRENTWOODNH.GOV,City,Non-Federal Agency,Brentwood,NH,ACTIVE
+BRENTWOODTN.GOV,City,Non-Federal Agency,Brentwood,TN,ACTIVE
+BREWSTER-MA.GOV,City,Non-Federal Agency,Brewster,MA,ACTIVE
+BREWSTERVILLAGE-NY.GOV,City,Non-Federal Agency,Brewster,NY,ACTIVE
+BRICKTOWNSHIP-NJ.GOV,City,Non-Federal Agency,Brick,NJ,ACTIVE
+BRIDGEPORTCT.GOV,City,Non-Federal Agency,Bridgeport,CT,ACTIVE
+BRIDGEPORTWV.GOV,City,Non-Federal Agency,Bridgeport,WV,ACTIVE
+BRIDGEVIEW-IL.GOV,City,Non-Federal Agency,Bridgeview,IL,ACTIVE
+BRIDGEWATERNJ.GOV,City,Non-Federal Agency,Bridgewater,NJ,ACTIVE
+BRIGHTONCO.GOV,City,Non-Federal Agency,Brighton,CO,ACTIVE
+BRIMFIELDOHIO.GOV,City,Non-Federal Agency,Kent,OH,ACTIVE
+BRISTOLCT.GOV,City,Non-Federal Agency,Bristol,CT,ACTIVE
+BRLA.GOV,City,Non-Federal Agency,Baton Rouge,LA,ACTIVE
+BROADVIEW-IL.GOV,City,Non-Federal Agency,Broadview,IL,ACTIVE
+BROKENARROWOK.GOV,City,Non-Federal Agency,Broken Arrow,OK,ACTIVE
+BROOKFIELD-WI.GOV,City,Non-Federal Agency,Brookfield,WI,ACTIVE
+BROOKFIELDCT.GOV,City,Non-Federal Agency,Brookfield,CT,ACTIVE
+BROOKFIELDIL.GOV,City,Non-Federal Agency,Brookfield ,IL,ACTIVE
+BROOKHAVENGA.GOV,City,Non-Federal Agency,Dunwoody,GA,ACTIVE
+BROOKLINEMA.GOV,City,Non-Federal Agency,Brookline,MA,ACTIVE
+BROOKLYNOHIO.GOV,City,Non-Federal Agency,Brooklyn,OH,ACTIVE
+BROOKLYNWI.GOV,City,Non-Federal Agency,Brooklyn,WI,ACTIVE
+BROOMFIELDCO.GOV,City,Non-Federal Agency,Broomfield,CO,ACTIVE
+BROWNSVILLETN.GOV,City,Non-Federal Agency,Brownsville,TN,ACTIVE
+BROWNWOODTEXAS.GOV,City,Non-Federal Agency,Brownwood,TX,ACTIVE
+BRYANTX.GOV,City,Non-Federal Agency,Bryan,TX,ACTIVE
+BRYCECANYONCITYUT.GOV,City,Non-Federal Agency,Bryce Canyon City,UT,ACTIVE
+BRYSONCITYNC.GOV,City,Non-Federal Agency,Bryson City,NC,ACTIVE
+BUCHANAN-VA.GOV,City,Non-Federal Agency,BUCHANAN,VA,ACTIVE
+BUCKEYEAZ.GOV,City,Non-Federal Agency,Buckeye,AZ,ACTIVE
+BUCKSPORTMAINE.GOV,City,Non-Federal Agency,Bucksport,ME,ACTIVE
+BUENAVISTACO.GOV,City,Non-Federal Agency,Buena Vista,CO,ACTIVE
+BULLHEADCITYAZ.GOV,City,Non-Federal Agency,Bullhead City,AZ,ACTIVE
+BULVERDETX.GOV,City,Non-Federal Agency,Bulverde,TX,ACTIVE
+BUNKERHILLTX.GOV,City,Non-Federal Agency,HOUSTON,TX,ACTIVE
+BURBANKCA.GOV,City,Non-Federal Agency,Burbank,CA,ACTIVE
+BURBANKIL.GOV,City,Non-Federal Agency,Burbank,IL,ACTIVE
+BURIENWA.GOV,City,Non-Federal Agency,Burien,WA,ACTIVE
+BURKITTSVILLE-MD.GOV,City,Non-Federal Agency,Burkittsville,MD,ACTIVE
+BURLINGTON-WI.GOV,City,Non-Federal Agency,Burlington,WI,ACTIVE
+BURLINGTONKANSAS.GOV,City,Non-Federal Agency,Burlington,KS,ACTIVE
+BURLINGTONNC.GOV,City,Non-Federal Agency,Burlington,NC,ACTIVE
+BURLINGTONND.GOV,City,Non-Federal Agency,Burlington,ND,ACTIVE
+BURLINGTONVT.GOV,City,Non-Federal Agency,Burlington,VT,ACTIVE
+BURLINGTONWA.GOV,City,Non-Federal Agency,Burlington,WA,ACTIVE
+BURNSHARBOR-IN.GOV,City,Non-Federal Agency,Burns Harbor,IN,ACTIVE
+BURNSVILLEMN.GOV,City,Non-Federal Agency,Burnsville,MN,ACTIVE
+BURR-RIDGE.GOV,City,Non-Federal Agency,Burr Ridge,IL,ACTIVE
+BURRILLVILLE-RI.GOV,City,Non-Federal Agency,Harrisville,RI,ACTIVE
+BURTONMI.GOV,City,Non-Federal Agency,Burton,MI,ACTIVE
+BUTLERWI.GOV,City,Non-Federal Agency,Butler,WI,ACTIVE
+BYESVILLEOH.GOV,City,Non-Federal Agency,Byesville,OH,ACTIVE
+CABOTAR.GOV,City,Non-Federal Agency,Cabot,AR,ACTIVE
+CABQ.GOV,City,Non-Federal Agency,Albuquerque,NM,ACTIVE
+CALAISVERMONT.GOV,City,Non-Federal Agency,East Calais,VT,ACTIVE
+CALDWELLTX.GOV,City,Non-Federal Agency,Caldwell,TX,ACTIVE
+CALEDONIAMN.GOV,City,Non-Federal Agency,Caledonia,MN,ACTIVE
+CALIFORNIACITY-CA.GOV,City,Non-Federal Agency,California City,CA,ACTIVE
+CALUMETTWP-IN.GOV,City,Non-Federal Agency,Gary,IN,ACTIVE
+CAMBRIDGEMA.GOV,City,Non-Federal Agency,Cambridge,MA,ACTIVE
+CAMBRIDGENY.GOV,City,Non-Federal Agency,Cambridge,NY,ACTIVE
+CAMDENMAINE.GOV,City,Non-Federal Agency,Camden,ME,ACTIVE
+CAMDENTN.GOV,City,Non-Federal Agency,Camden,TN,ACTIVE
+CAMPBELLCA.GOV,City,Non-Federal Agency,Campbell,CA,ACTIVE
+CAMPBELLOHIO.GOV,City,Non-Federal Agency,Campbell,OH,ACTIVE
+CANALWINCHESTEROHIO.GOV,City,Non-Federal Agency,Canal Winchester,OH,ACTIVE
+CANANDAIGUANEWYORK.GOV,City,Non-Federal Agency,Canandaigua,NY,ACTIVE
+CANNONFALLSMN.GOV,City,Non-Federal Agency,Cannon Falls,MN,ACTIVE
+CANTONOHIO.GOV,City,Non-Federal Agency,Canton,OH,ACTIVE
+CANTONTWP-OH.GOV,City,Non-Federal Agency,Canton,OH,ACTIVE
+CANTONTX.GOV,City,Non-Federal Agency,Canton,TX,ACTIVE
+CAPECORALFL.GOV,City,Non-Federal Agency,Cape Coral,FL,ACTIVE
+CARBONDALE-PA.GOV,City,Non-Federal Agency,Carbondale,PA,ACTIVE
+CARLISLE-IA.GOV,City,Non-Federal Agency,Carlisle,IA,ACTIVE
+CARLISLEMA.GOV,City,Non-Federal Agency,Carlisle,MA,ACTIVE
+CARLSBADCA.GOV,City,Non-Federal Agency,Carlsbad,CA,ACTIVE
+CARNATIONWA.GOV,City,Non-Federal Agency,Carnation,WA,ACTIVE
+CARNEGIEOK.GOV,City,Non-Federal Agency,Carnegie,OK,ACTIVE
+CARNEYSPOINTNJ.GOV,City,Non-Federal Agency,Carneys Point,NJ,ACTIVE
+CARRBORONC.GOV,City,Non-Federal Agency,Carrboro,NC,ACTIVE
+CARROLLTON-GA.GOV,City,Non-Federal Agency,Carrollton,GA,ACTIVE
+CARTERLAKE-IA.GOV,City,Non-Federal Agency,Carter Lake,IA,ACTIVE
+CARTERSVILLEGA.GOV,City,Non-Federal Agency,Cartersville,GA,ACTIVE
+CARTHAGEMO.GOV,City,Non-Federal Agency,Carthage,MO,ACTIVE
+CARVERMA.GOV,City,Non-Federal Agency,Carver,MA,ACTIVE
+CARYNC.GOV,City,Non-Federal Agency,Cary,NC,ACTIVE
+CASAGRANDEAZ.GOV,City,Non-Federal Agency,Casa Grande,AZ,ACTIVE
+CASPERWY.GOV,City,Non-Federal Agency,Casper,WY,ACTIVE
+CASTROVILLETX.GOV,City,Non-Federal Agency,Castroville,TX,ACTIVE
+CATHEDRALCITY.GOV,City,Non-Federal Agency,Cathedral City,CA,ACTIVE
+CAVESPRINGSAR.GOV,City,Non-Federal Agency,Cave Springs,AR,ACTIVE
+CECILTONMD.GOV,City,Non-Federal Agency,Cecilton ,MD,ACTIVE
+CECILTOWNSHIP-PA.GOV,City,Non-Federal Agency,Cecil,PA,ACTIVE
+CEDARHURST.GOV,City,Non-Federal Agency,cedarhurst,NY,ACTIVE
+CEDARPARKTEXAS.GOV,City,Non-Federal Agency,Cedar Park,TX,ACTIVE
+CEDARRAPIDS-IA.GOV,City,Non-Federal Agency,Cedar Rapids,IA,ACTIVE
+CEDARTOWNGEORGIA.GOV,City,Non-Federal Agency,Cedartown,GA,ACTIVE
+CELINA-TX.GOV,City,Non-Federal Agency,Celina,TX,ACTIVE
+CENTENNIALCO.GOV,City,Non-Federal Agency,Centennial,CO,ACTIVE
+CENTERCO.GOV,City,Non-Federal Agency,Center,CO,ACTIVE
+CENTERLINE.GOV,City,Non-Federal Agency,Center Line,MI,ACTIVE
+CENTERVILLEOHIO.GOV,City,Non-Federal Agency,Centerville,OH,ACTIVE
+CENTERVILLETX.GOV,City,Non-Federal Agency,College Station,TX,ACTIVE
+CENTRAL-LA.GOV,City,Non-Federal Agency,Central,LA,ACTIVE
+CENTRALPOINTOREGON.GOV,City,Non-Federal Agency,Central Point,OR,ACTIVE
+CENTREVILLE-MD.GOV,City,Non-Federal Agency,Centreville,MD,ACTIVE
+CGAZ.GOV,City,Non-Federal Agency,Casa Grande,AZ,ACTIVE
+CHADDSFORDPA.GOV,City,Non-Federal Agency,Chadds Ford,PA,ACTIVE
+CHAMBERSBURGPA.GOV,City,Non-Federal Agency,Chambersburg,PA,ACTIVE
+CHAMBLEEGA.GOV,City,Non-Federal Agency,Chamblee,GA,ACTIVE
+CHAMPAIGN-IL.GOV,City,Non-Federal Agency,Champaign,IL,ACTIVE
+CHAMPAIGNIL.GOV,City,Non-Federal Agency,Champaign,IL,ACTIVE
+CHANDLERAZ.GOV,City,Non-Federal Agency,Chandler,AZ,ACTIVE
+CHARLESTON-SC.GOV,City,Non-Federal Agency,Charleston,SC,ACTIVE
+CHARLESTONWV.GOV,City,Non-Federal Agency,Charleston,WV,ACTIVE
+CHARLESTOWN-NH.GOV,City,Non-Federal Agency,Charlestown,NH,ACTIVE
+CHARLOTTENC.GOV,City,Non-Federal Agency,Charlotte,NC,ACTIVE
+CHARLOTTESVILLEVA.GOV,City,Non-Federal Agency,Charlottesville,VA,ACTIVE
+CHATHAM-MA.GOV,City,Non-Federal Agency,Chatham,MA,ACTIVE
+CHATHAM-VA.GOV,City,Non-Federal Agency,Chatham,VA,ACTIVE
+CHATHAMTOWNSHIP-NJ.GOV,City,Non-Federal Agency,Chatham,NJ,ACTIVE
+CHATSWORTHGA.GOV,City,Non-Federal Agency,Chatsworth,GA,ACTIVE
+CHATTANOOGA.GOV,City,Non-Federal Agency,Chattanooga,TN,ACTIVE
+CHELSEAMA.GOV,City,Non-Federal Agency,Chelsea,MA,ACTIVE
+CHESAPEAKEBEACHMD.GOV,City,Non-Federal Agency,Chesapeake Beach,MD,ACTIVE
+CHESAPEAKECITY-MD.GOV,City,Non-Federal Agency,Chesapeake City,MD,ACTIVE
+CHESHIRE-MA.GOV,City,Non-Federal Agency,Cheshire,MA,ACTIVE
+CHESTER-NY.GOV,City,Non-Federal Agency,Chester,NY,ACTIVE
+CHESTERFIELD.GOV,City,Non-Federal Agency,Chesterfield,VA,ACTIVE
+CHESTERVT.GOV,City,Non-Federal Agency,Chester,VT,ACTIVE
+CHESTNUTHILLTWP-PA.GOV,City,Non-Federal Agency,Brodheadsville,PA,ACTIVE
+CHEVERLY-MD.GOV,City,Non-Federal Agency,Cheverly,MD,ACTIVE
+CHEVYCHASEVILLAGEMD.GOV,City,Non-Federal Agency,Chevy Chase,MD,ACTIVE
+CHICAGO-IL.GOV,City,Non-Federal Agency,Chicago,IL,ACTIVE
+CHICOCA.GOV,City,Non-Federal Agency,Chico,CA,ACTIVE
+CHICOPEEMA.GOV,City,Non-Federal Agency,Chicopee,MA,ACTIVE
+CHILLICOTHEOH.GOV,City,Non-Federal Agency,Chillicothe,OH,ACTIVE
+CHILMARKMA.GOV,City,Non-Federal Agency,Chilmark,MA,ACTIVE
+CHINAGROVENC.GOV,City,Non-Federal Agency,China Grove,NC,ACTIVE
+CHINCOTEAGUE-VA.GOV,City,Non-Federal Agency,Chincoteague,VA,ACTIVE
+CHIPPEWAFALLS-WI.GOV,City,Non-Federal Agency,Chippewa Falls,WI,ACTIVE
+CHOWANCOUNTY-NC.GOV,City,Non-Federal Agency,Edenton,NC,ACTIVE
+CHULAVISTACA.GOV,City,Non-Federal Agency,Chula Vista,CA,ACTIVE
+CHURCHHILLTN.GOV,City,Non-Federal Agency,Church Hill,TN,ACTIVE
+CIBOLOTX.GOV,City,Non-Federal Agency,Cibolo,TX,ACTIVE
+CINCINNATI-OH.GOV,City,Non-Federal Agency,Cincinnati,OH,ACTIVE
+CINCINNATIOHIO.GOV,City,Non-Federal Agency,Cincinnati,OH,ACTIVE
+CITYKANKAKEE-IL.GOV,City,Non-Federal Agency,KANKAKEE,IL,ACTIVE
+CITYOFADAMS-WI.GOV,City,Non-Federal Agency,Adams,WI,ACTIVE
+CITYOFAIKENSC.GOV,City,Non-Federal Agency,Aiken,SC,ACTIVE
+CITYOFALAMEDACA.GOV,City,Non-Federal Agency,Alameda,CA,ACTIVE
+CITYOFALBIONMI.GOV,City,Non-Federal Agency,albion,MI,ACTIVE
+CITYOFALCOA-TN.GOV,City,Non-Federal Agency,Alcoa,TN,ACTIVE
+CITYOFALGOODTN.GOV,City,Non-Federal Agency,Algood,TN,ACTIVE
+CITYOFALMAGA.GOV,City,Non-Federal Agency,Alma,GA,ACTIVE
+CITYOFAUBURNWA.GOV,City,Non-Federal Agency,Auburn,WA,ACTIVE
+CITYOFBAKERLA.GOV,City,Non-Federal Agency,Baker ,LA,ACTIVE
+CITYOFBELOITWI.GOV,City,Non-Federal Agency,Beloit,WI,ACTIVE
+CITYOFBENTONHARBORMI.GOV,City,Non-Federal Agency,Benton Harbor,MI,ACTIVE
+CITYOFBLUERIDGEGA.GOV,City,Non-Federal Agency,Blue Ridge,GA,ACTIVE
+CITYOFBOWIEMD.GOV,City,Non-Federal Agency,Bowie,MD,ACTIVE
+CITYOFBOWMANGA.GOV,City,Non-Federal Agency,Bowman,GA,ACTIVE
+CITYOFBRUNSWICK-GA.GOV,City,Non-Federal Agency,Brunswick,GA,ACTIVE
+CITYOFBURTON-TX.GOV,City,Non-Federal Agency,Burton,TX,ACTIVE
+CITYOFCANALFULTON-OH.GOV,City,Non-Federal Agency,Canal Fulton,OH,ACTIVE
+CITYOFCAYCE-SC.GOV,City,Non-Federal Agency,Cayce,SC,ACTIVE
+CITYOFCHAMPAIGN-IL.GOV,City,Non-Federal Agency,Champaign,IL,ACTIVE
+CITYOFCHAMPAIGNIL.GOV,City,Non-Federal Agency,Champaign,IL,ACTIVE
+CITYOFCHETEK-WI.GOV,City,Non-Federal Agency,Chetek,WI,ACTIVE
+CITYOFCHOTEAU-MT.GOV,City,Non-Federal Agency,Choteau,MT,ACTIVE
+CITYOFCLAYTONGA.GOV,City,Non-Federal Agency,Clayton,GA,ACTIVE
+CITYOFCODY-WY.GOV,City,Non-Federal Agency,Cody,WY,ACTIVE
+CITYOFCONWAY-AR.GOV,City,Non-Federal Agency,Conway,AR,ACTIVE
+CITYOFCOWETA-OK.GOV,City,Non-Federal Agency,Coweta,OK,ACTIVE
+CITYOFCRISFIELD-MD.GOV,City,Non-Federal Agency,Crisfield,MD,ACTIVE
+CITYOFCUDAHYCA.GOV,City,Non-Federal Agency,Cudahy,CA,ACTIVE
+CITYOFDALTON-GA.GOV,City,Non-Federal Agency,Dalton,GA,ACTIVE
+CITYOFDOUGLASGA.GOV,City,Non-Federal Agency,Douglas,GA,ACTIVE
+CITYOFDUNBARWV.GOV,City,Non-Federal Agency,Dunbar,WV,ACTIVE
+CITYOFDUPONTWA.GOV,City,Non-Federal Agency,DuPont,WA,ACTIVE
+CITYOFENGLEWOOD-NJ.GOV,City,Non-Federal Agency,Englewood,NJ,ACTIVE
+CITYOFEUDORAKS.GOV,City,Non-Federal Agency,Eudora,KS,ACTIVE
+CITYOFFAIRFAX-MN.GOV,City,Non-Federal Agency,Fairfax,MN,ACTIVE
+CITYOFFARGO-ND.GOV,City,Non-Federal Agency,Fargo,ND,ACTIVE
+CITYOFFARMERSVILLE-CA.GOV,City,Non-Federal Agency,Farmersville,CA,ACTIVE
+CITYOFFARMINGTON-AR.GOV,City,Non-Federal Agency,Farmington,AR,ACTIVE
+CITYOFFOLKSTON-GA.GOV,City,Non-Federal Agency,Folkston,GA,ACTIVE
+CITYOFFORTOGLETHORPEGA.GOV,City,Non-Federal Agency,FORT OGLETHORPE,GA,ACTIVE
+CITYOFGAFFNEY-SC.GOV,City,Non-Federal Agency,Gaffney,SC,ACTIVE
+CITYOFGALENAPARK-TX.GOV,City,Non-Federal Agency,Galena Park,TX,ACTIVE
+CITYOFGRAVETTE-AR.GOV,City,Non-Federal Agency,Gravette,AR,ACTIVE
+CITYOFGROTON-CT.GOV,City,Non-Federal Agency,Groton,CT,ACTIVE
+CITYOFGROVEOK.GOV,City,Non-Federal Agency,Grove,OK,ACTIVE
+CITYOFGUNNISON-CO.GOV,City,Non-Federal Agency,Gunnison,CO,ACTIVE
+CITYOFHAMPTON-GA.GOV,City,Non-Federal Agency,Hampton,GA,ACTIVE
+CITYOFHARRISON-MI.GOV,City,Non-Federal Agency,Harrison,MI,ACTIVE
+CITYOFHAYWARD-CA.GOV,City,Non-Federal Agency,Hayward,CA,ACTIVE
+CITYOFHAYWARDWI.GOV,City,Non-Federal Agency,Hayward,WI,ACTIVE
+CITYOFHIRAMGA.GOV,City,Non-Federal Agency,HIRAM,GA,ACTIVE
+CITYOFHOKAH-MN.GOV,City,Non-Federal Agency,Hokah,MN,ACTIVE
+CITYOFHOLYOKE-CO.GOV,City,Non-Federal Agency,Holyoke,CO,ACTIVE
+CITYOFHOMER-AK.GOV,City,Non-Federal Agency,Homer,AK,ACTIVE
+CITYOFHONDO-TX.GOV,City,Non-Federal Agency,Hondo,TX,ACTIVE
+CITYOFHOUSTON.GOV,City,Non-Federal Agency,Houston,TX,ACTIVE
+CITYOFHUMBLE-TX.GOV,City,Non-Federal Agency,Humble,TX,ACTIVE
+CITYOFHUMBLETX.GOV,City,Non-Federal Agency,Humble,TX,ACTIVE
+CITYOFHUNTSVILLETX.GOV,City,Non-Federal Agency,Huntsville,TX,ACTIVE
+CITYOFIRONDALEAL.GOV,City,Non-Federal Agency,Irondale,AL,ACTIVE
+CITYOFKEYWEST-FL.GOV,City,Non-Federal Agency,Key West,FL,ACTIVE
+CITYOFKINGMAN.GOV,City,Non-Federal Agency,Kingman,AZ,ACTIVE
+CITYOFKINGSBURG-CA.GOV,City,Non-Federal Agency,Kingsburg,CA,ACTIVE
+CITYOFLACRESCENT-MN.GOV,City,Non-Federal Agency,La Crescent,MN,ACTIVE
+CITYOFLADUE-MO.GOV,City,Non-Federal Agency,Ladue,MO,ACTIVE
+CITYOFLAGRANGEMO.GOV,City,Non-Federal Agency,LaGrange,MO,ACTIVE
+CITYOFLAHABRA-CA.GOV,City,Non-Federal Agency,LA HABRA,CA,ACTIVE
+CITYOFLENEXA-KS.GOV,City,Non-Federal Agency,Lenexa,KS,ACTIVE
+CITYOFLENEXAKS.GOV,City,Non-Federal Agency,Lenexa,KS,ACTIVE
+CITYOFLINDALETX.GOV,City,Non-Federal Agency,LINDALE,TX,ACTIVE
+CITYOFLISBON-IA.GOV,City,Non-Federal Agency,Lisbon,IA,ACTIVE
+CITYOFLUBBOCKTX.GOV,City,Non-Federal Agency,Lubbock,TX,ACTIVE
+CITYOFMACON-MO.GOV,City,Non-Federal Agency,Macon,MO,ACTIVE
+CITYOFMARIONIL.GOV,City,Non-Federal Agency,Marion,IL,ACTIVE
+CITYOFMARIONWI.GOV,City,Non-Federal Agency,MARION,WI,ACTIVE
+CITYOFMCCAYSVILLEGA.GOV,City,Non-Federal Agency,McCaysville,GA,ACTIVE
+CITYOFMENASHA-WI.GOV,City,Non-Federal Agency,Menasha,WI,ACTIVE
+CITYOFMIDLANDMI.GOV,City,Non-Federal Agency,Midland,MI,ACTIVE
+CITYOFMILLBROOK-AL.GOV,City,Non-Federal Agency,Millbrook,AL,ACTIVE
+CITYOFMILLENGA.GOV,City,Non-Federal Agency,Millen,GA,ACTIVE
+CITYOFMONONGAHELA-PA.GOV,City,Non-Federal Agency,Monongahela,PA,ACTIVE
+CITYOFMORROWGA.GOV,City,Non-Federal Agency,Morrow,GA,ACTIVE
+CITYOFMTVERNON-IA.GOV,City,Non-Federal Agency,Mount Vernon,IA,ACTIVE
+CITYOFNANTICOKE-PA.GOV,City,Non-Federal Agency,Nanticoke,PA,ACTIVE
+CITYOFNEWBURGH-NY.GOV,City,Non-Federal Agency,Newburgh,NY,ACTIVE
+CITYOFNEWULM-MN.GOV,City,Non-Federal Agency,New Ulm,MN,ACTIVE
+CITYOFNORMANDY.GOV,City,Non-Federal Agency,St. Louis,MO,ACTIVE
+CITYOFNOVI-MI.GOV,City,Non-Federal Agency,Novi,MI,ACTIVE
+CITYOFOLYMPIA-WA.GOV,City,Non-Federal Agency,Olympia,WA,ACTIVE
+CITYOFOLYMPIAWA.GOV,City,Non-Federal Agency,Olympia,WA,ACTIVE
+CITYOFOMAHA-NE.GOV,City,Non-Federal Agency,Omaha,NE,ACTIVE
+CITYOFPACIFICWA.GOV,City,Non-Federal Agency,Pacific,WA,ACTIVE
+CITYOFPALMVALLEY-TX.GOV,City,Non-Federal Agency,Harlingen,TX,ACTIVE
+CITYOFPARISTN.GOV,City,Non-Federal Agency,Paris,TN,ACTIVE
+CITYOFPARMA-OH.GOV,City,Non-Federal Agency,Parma,OH,ACTIVE
+CITYOFPASSAICNJ.GOV,City,Non-Federal Agency,Passaic,NJ,ACTIVE
+CITYOFPATASKALAOHIO.GOV,City,Non-Federal Agency,Pataskala,OH,ACTIVE
+CITYOFPATTERSONLA.GOV,City,Non-Federal Agency,Patterson,LA,ACTIVE
+CITYOFPEARLANDTX.GOV,City,Non-Federal Agency,Pearland,TX,ACTIVE
+CITYOFPHOENIX.GOV,City,Non-Federal Agency,Phoenix,AZ,ACTIVE
+CITYOFPIGEONFORGETN.GOV,City,Non-Federal Agency,Pigeon Forge,TN,ACTIVE
+CITYOFPLAINVILLE-KS.GOV,City,Non-Federal Agency,Plainville,KS,ACTIVE
+CITYOFPLATTSBURGH-NY.GOV,City,Non-Federal Agency,Plattsburgh,NY,ACTIVE
+CITYOFPLEASANTONCA.GOV,City,Non-Federal Agency,Pleasanton,CA,ACTIVE
+CITYOFPOCOMOKEMD.GOV,City,Non-Federal Agency,Pocomoke City,MD,ACTIVE
+CITYOFPORTLANDTN.GOV,City,Non-Federal Agency,Portland,TN,ACTIVE
+CITYOFREDMOND.GOV,City,Non-Federal Agency,Redmond,WA,ACTIVE
+CITYOFRENONV.GOV,City,Non-Federal Agency,Reno,NV,ACTIVE
+CITYOFROCHESTER.GOV,City,Non-Federal Agency,Rochester,NY,ACTIVE
+CITYOFROCKHILLSC.GOV,City,Non-Federal Agency,Rock Hill,SC,ACTIVE
+CITYOFROCKPORT-IN.GOV,City,Non-Federal Agency,Rockport,IN,ACTIVE
+CITYOFSAFFORD-AZ.GOV,City,Non-Federal Agency,Safford,AZ,ACTIVE
+CITYOFSAFFORDAZ.GOV,City,Non-Federal Agency,Safford,AZ,ACTIVE
+CITYOFSALEMNJ.GOV,City,Non-Federal Agency,Salem,NJ,ACTIVE
+CITYOFSANTAANA-CA.GOV,City,Non-Federal Agency,Santa Ana,CA,ACTIVE
+CITYOFSANTEECA.GOV,City,Non-Federal Agency,Santee,CA,ACTIVE
+CITYOFSEATTLE.GOV,City,Non-Federal Agency,Seattle,WA,ACTIVE
+CITYOFSPARTANBURG-SC.GOV,City,Non-Federal Agency,Spartanburg,SC,ACTIVE
+CITYOFSTMARYSPA.GOV,City,Non-Federal Agency,St. Marys,PA,ACTIVE
+CITYOFSTOCKBRIDGE-GA.GOV,City,Non-Federal Agency,Stockbridge,GA,ACTIVE
+CITYOFSUGAR-LANDTX.GOV,City,Non-Federal Agency,Sugar Land,TX,ACTIVE
+CITYOFSUGARLAND-TX.GOV,City,Non-Federal Agency,Sugar Land,TX,ACTIVE
+CITYOFSUGARLANDTX.GOV,City,Non-Federal Agency,Sugar Land,TX,ACTIVE
+CITYOFSUNRISEFL.GOV,City,Non-Federal Agency,Sunrise,FL,ACTIVE
+CITYOFSUNRISEFLORIDA.GOV,City,Non-Federal Agency,Sunrise,FL,ACTIVE
+CITYOFTITUSVILLEPA.GOV,City,Non-Federal Agency,Titusville,PA,ACTIVE
+CITYOFTORRANCECA.GOV,City,Non-Federal Agency,Torrance,CA,ACTIVE
+CITYOFTUKWILA-WA.GOV,City,Non-Federal Agency,Tukwila,WA,ACTIVE
+CITYOFTYLER-TX.GOV,City,Non-Federal Agency,Tyler,TX,ACTIVE
+CITYOFTYLERTX.GOV,City,Non-Federal Agency,Tyler,TX,ACTIVE
+CITYOFWARRENPA.GOV,City,Non-Federal Agency,Warren,PA,ACTIVE
+CITYOFWASHINGTONGA.GOV,City,Non-Federal Agency,Washington,GA,ACTIVE
+CITYOFWEATHERBYLAKE-MO.GOV,City,Non-Federal Agency,Weatherby Lake,MO,ACTIVE
+CITYOFWESTONLAKES-TX.GOV,City,Non-Federal Agency,Fulshear,TX,ACTIVE
+CITYOFWESTPALMBEACH-FL.GOV,City,Non-Federal Agency,West Palm Beach,FL,ACTIVE
+CITYOFWEYAUWEGA-WI.GOV,City,Non-Federal Agency,Weyauwega,WI,ACTIVE
+CITYOFWHEATON-IL.GOV,City,Non-Federal Agency,Wheaton,IL,ACTIVE
+CITYOFWOODBURYGA.GOV,City,Non-Federal Agency,Woodbury,GA,ACTIVE
+CITYOFWORLANDWY.GOV,City,Non-Federal Agency,Worland,WY,ACTIVE
+CITYOFYUKONOK.GOV,City,Non-Federal Agency,Yukon,OK,ACTIVE
+CITYOLYMPIA-WA.GOV,City,Non-Federal Agency,Olympia,WA,ACTIVE
+CITYOLYMPIAWA.GOV,City,Non-Federal Agency,Olympia,WA,ACTIVE
+CLAIRTON-PA.GOV,City,Non-Federal Agency,Clairton,PA,ACTIVE
+CLARKSTONGA.GOV,City,Non-Federal Agency,Clarkston,GA,ACTIVE
+CLARKSVILLEAR.GOV,City,Non-Federal Agency,Clarksville,AR,ACTIVE
+CLAYTONMO.GOV,City,Non-Federal Agency,Clayton,MO,ACTIVE
+CLEARLAKE-WI.GOV,City,Non-Federal Agency,Clear Lake,WI,ACTIVE
+CLEARLAKESHORES-TX.GOV,City,Non-Federal Agency,Clear Lake Shores,TX,ACTIVE
+CLERMONTFL.GOV,City,Non-Federal Agency,Clermont,FM,ACTIVE
+CLEVELAND-OH.GOV,City,Non-Federal Agency,Cleveland,OH,ACTIVE
+CLEVELANDOHIO.GOV,City,Non-Federal Agency,Cleveland,OH,ACTIVE
+CLEVELANDTN.GOV,City,Non-Federal Agency,Cleveland,TN,ACTIVE
+CLEVELANDWI.GOV,City,Non-Federal Agency,Cleveland,WI,ACTIVE
+CLEWISTON-FL.GOV,City,Non-Federal Agency,Clewiston,FL,ACTIVE
+CLIFFSIDEPARKNJ.GOV,City,Non-Federal Agency,Cliffside Park,NJ,ACTIVE
+CLIFTONAZ.GOV,City,Non-Federal Agency,Clifton,AZ,ACTIVE
+CLIFTONFORGEVA.GOV,City,Non-Federal Agency,Clifton Forge,VA,ACTIVE
+CLINTONMA.GOV,City,Non-Federal Agency,Clinton,MA,ACTIVE
+CLINTONNJ.GOV,City,Non-Federal Agency,New Jersey,NJ,ACTIVE
+CLINTONOK.GOV,City,Non-Federal Agency,Clinton,OK,ACTIVE
+CLINTONTOWNSHIP-MI.GOV,City,Non-Federal Agency,Clinton Township,MI,ACTIVE
+CMSDCA.GOV,City,Non-Federal Agency,Costa Mesa,CA,ACTIVE
+COALCITY-IL.GOV,City,Non-Federal Agency,Coal City,IL,ACTIVE
+COALRUNKY.GOV,City,Non-Federal Agency,Pikeville,KY,ACTIVE
+COHOES-NY.GOV,City,Non-Federal Agency,Cohoes,NY,ACTIVE
+COLCHESTERCT.GOV,City,Non-Federal Agency,Colchester,CT,ACTIVE
+COLCHESTERVT.GOV,City,Non-Federal Agency,Colchester,VT,ACTIVE
+COLDSPRINGKY.GOV,City,Non-Federal Agency,COLD SPRING,KY,ACTIVE
+COLDSPRINGNY.GOV,City,Non-Federal Agency,Cold Spring ,NY,ACTIVE
+COLFAX-CA.GOV,City,Non-Federal Agency,Colfax,CA,ACTIVE
+COLLEGEDALETN.GOV,City,Non-Federal Agency,Collegedale,TN,ACTIVE
+COLLEGEPARKMD.GOV,City,Non-Federal Agency,College Park,MD,ACTIVE
+COLLEGEVILLE-PA.GOV,City,Non-Federal Agency,Collegeville,PA,ACTIVE
+COLLIERVILLETN.GOV,City,Non-Federal Agency,Collierville,TN,ACTIVE
+COLLINCOUNTYTEXAS.GOV,City,Non-Federal Agency,Mckinney,TX,ACTIVE
+COLLINCOUNTYTX.GOV,City,Non-Federal Agency,McKinney,TX,ACTIVE
+COLONIALHEIGHTSVA.GOV,City,Non-Federal Agency,Colonial Heights,VA,ACTIVE
+COLONIE-NY.GOV,City,Non-Federal Agency,Newtonville,NY,ACTIVE
+COLORADOSPRINGS.GOV,City,Non-Federal Agency,Colorado Springs,CO,ACTIVE
+COLRAIN-MA.GOV,City,Non-Federal Agency,Colrain,MA,ACTIVE
+COLTONCA.GOV,City,Non-Federal Agency,Colton,CA,ACTIVE
+COLUMBIAHEIGHTSMN.GOV,City,Non-Federal Agency,Columbia Heights,MN,ACTIVE
+COLUMBIANAOHIO.GOV,City,Non-Federal Agency,Columbiana,OH,ACTIVE
+COLUMBIASC.GOV,City,Non-Federal Agency,Columbia,SC,ACTIVE
+COLUMBIATN.GOV,City,Non-Federal Agency,Columbia,TN,ACTIVE
+COLUMBIATWP-OH.GOV,City,Non-Federal Agency,Columbia Station,OH,ACTIVE
+COLUMBUS.GOV,City,Non-Federal Agency,Columbus,OH,ACTIVE
+COLUMBUSOH.GOV,City,Non-Federal Agency,Columbus,OH,ACTIVE
+COLUMBUSOHIO.GOV,City,Non-Federal Agency,Columbus,OH,ACTIVE
+COMMERCIALPOINTOHIO.GOV,City,Non-Federal Agency,Commercial Point,OH,ACTIVE
+COMO.GOV,City,Non-Federal Agency,Columbia,MO,ACTIVE
+COMSTOCKMI.GOV,City,Non-Federal Agency,Kalamazoo,MI,ACTIVE
+CONCORDMA.GOV,City,Non-Federal Agency,Concord,MA,ACTIVE
+CONCORDNC.GOV,City,Non-Federal Agency,Concord,NC,ACTIVE
+CONCORDNH.GOV,City,Non-Federal Agency,Concord,NH,ACTIVE
+CONCRETEWA.GOV,City,Non-Federal Agency,Concrete,WA,ACTIVE
+CONNEAUTOHIO.GOV,City,Non-Federal Agency,Conneaut,OH,ACTIVE
+CONNERSVILLEIN.GOV,City,Non-Federal Agency,Connersville,IN,ACTIVE
+CONOVERNC.GOV,City,Non-Federal Agency,Conover,NC,ACTIVE
+CONYERSGA.GOV,City,Non-Federal Agency,Conyers,GA,ACTIVE
+COOKEVILLE-TN.GOV,City,Non-Federal Agency,Cookeville,TN,ACTIVE
+COONRAPIDSMN.GOV,City,Non-Federal Agency,Coon Rapids,MN,ACTIVE
+COPPELLTX.GOV,City,Non-Federal Agency,Coppell,TX,ACTIVE
+COPPERASCOVETX.GOV,City,Non-Federal Agency,Copperas Cove,TX,ACTIVE
+COR.GOV,City,Non-Federal Agency,Richardson,TX,ACTIVE
+CORALGABLES-FL.GOV,City,Non-Federal Agency,Coral Gables,FL,ACTIVE
+CORALGABLESFL.GOV,City,Non-Federal Agency,Coral Gables,FL,ACTIVE
+CORBIN-KY.GOV,City,Non-Federal Agency,Corbin,KY,ACTIVE
+CORNINGAR.GOV,City,Non-Federal Agency,Corning,AR,ACTIVE
+CORNWALLNY.GOV,City,Non-Federal Agency,Cornwall,NY,ACTIVE
+CORPUSCHRISTI-TX.GOV,City,Non-Federal Agency,Corpus Christi,TX,ACTIVE
+CORRALESNM.GOV,City,Non-Federal Agency,Corales,NM,ACTIVE
+CORRYPA.GOV,City,Non-Federal Agency,Corry,PA,ACTIVE
+CORUNNA-MI.GOV,City,Non-Federal Agency,Corunna,MI,ACTIVE
+CORVALLISOREGON.GOV,City,Non-Federal Agency,Corvallis,OR,ACTIVE
+CORYDON-IN.GOV,City,Non-Federal Agency,Corydon,IN,ACTIVE
+COSMOPOLISWA.GOV,City,Non-Federal Agency,Cosmopolis,WA,ACTIVE
+COSPRINGS.GOV,City,Non-Federal Agency,Colorado Springs,CO,ACTIVE
+COSTAMESACA.GOV,City,Non-Federal Agency,Costa Mesa,CA,ACTIVE
+COTTAGECITYMD.GOV,City,Non-Federal Agency,Cottage City,MD,ACTIVE
+COTTONWOODAZ.GOV,City,Non-Federal Agency,Cottonwood,AZ,ACTIVE
+COUNTRYSIDE-IL.GOV,City,Non-Federal Agency,Countryside,IL,ACTIVE
+COVINACA.GOV,City,Non-Federal Agency,Covina,CA,ACTIVE
+COVINGTON-OH.GOV,City,Non-Federal Agency,COVINGTON ,OH,ACTIVE
+COVINGTONKY.GOV,City,Non-Federal Agency,Covington,KY,ACTIVE
+COVINGTONWA.GOV,City,Non-Federal Agency,Covington,WA,ACTIVE
+CRANBERRYISLES-ME.GOV,City,Non-Federal Agency,Islesford,ME,ACTIVE
+CRAWFORDSVILLE-IN.GOV,City,Non-Federal Agency,Crawfordsville,IN,ACTIVE
+CREDITRIVER-MN.GOV,City,Non-Federal Agency,Prior Lake,MN,ACTIVE
+CRESTONIOWA.GOV,City,Non-Federal Agency,Creston,IA,ACTIVE
+CRETE-NE.GOV,City,Non-Federal Agency,Crete,NE,ACTIVE
+CREVECOEURMO.GOV,City,Non-Federal Agency,Creve Coeur,MO,ACTIVE
+CROSSROADSTX.GOV,City,Non-Federal Agency,Crossroads,TX,ACTIVE
+CROSSVILLETN.GOV,City,Non-Federal Agency,Crossville,TN,ACTIVE
+CROTONONHUDSON-NY.GOV,City,Non-Federal Agency,Croton-On-Hudson,NY,ACTIVE
+CRYSTALMN.GOV,City,Non-Federal Agency,Crystal,MN,ACTIVE
+CUBAASSESSORIL.GOV,City,Non-Federal Agency,Barrington,IL,ACTIVE
+CUBATWPIL.GOV,City,Non-Federal Agency,Barrington,IL,ACTIVE
+CUDAHY-WI.GOV,City,Non-Federal Agency,Cudahy,WI,ACTIVE
+CULPEPERVA.GOV,City,Non-Federal Agency,Culpeper,VA,ACTIVE
+CUMBERLANDMD.GOV,City,Non-Federal Agency,Cumberland,MD,ACTIVE
+CUMMINGTON-MA.GOV,City,Non-Federal Agency,Cummington,MA,ACTIVE
+CUTLERBAY-FL.GOV,City,Non-Federal Agency,Cutler Bay,FL,ACTIVE
+DACULAGA.GOV,City,Non-Federal Agency,Dacula,GA,ACTIVE
+DAHLONEGA-GA.GOV,City,Non-Federal Agency,Dahlonega,GA,ACTIVE
+DALHARTTX.GOV,City,Non-Federal Agency,Dalhart,TX,ACTIVE
+DALLAS-GA.GOV,City,Non-Federal Agency,Dallas,GA,ACTIVE
+DALLASOR.GOV,City,Non-Federal Agency,Dallas,OR,ACTIVE
+DALLASOREGON.GOV,City,Non-Federal Agency,Dallas,OR,ACTIVE
+DALTON-MA.GOV,City,Non-Federal Agency,Dalton,MA,ACTIVE
+DAMASCUSOREGON.GOV,City,Non-Federal Agency,Damascus,OR,ACTIVE
+DANBURY-CT.GOV,City,Non-Federal Agency,Danbury,CT,ACTIVE
+DANDRIDGETN.GOV,City,Non-Federal Agency,Dandridge,TN,ACTIVE
+DANIABEACHFL.GOV,City,Non-Federal Agency,DANIA BEACH,FL,ACTIVE
+DANVERSMA.GOV,City,Non-Federal Agency,Danvers,MA,ACTIVE
+DANVILLE-VA.GOV,City,Non-Federal Agency,Danville,VA,ACTIVE
+DANVILLEVA.GOV,City,Non-Federal Agency,Danville,VA,ACTIVE
+DARIENCT.GOV,City,Non-Federal Agency,Darien,CT,ACTIVE
+DARIENIL.GOV,City,Non-Federal Agency,Darien,IL,ACTIVE
+DAUGHERTYTOWNSHIP-PA.GOV,City,Non-Federal Agency,New Brighton,PA,ACTIVE
+DAVIE-FL.GOV,City,Non-Federal Agency,Davie,FL,ACTIVE
+DAWSONVILLE-GA.GOV,City,Non-Federal Agency,Dawsonville,GA,ACTIVE
+DAYTON-ME.GOV,City,Non-Federal Agency,Dayton,ME,ACTIVE
+DAYTONOHIO.GOV,City,Non-Federal Agency,Dayton,OH,ACTIVE
+DECATUR-AL.GOV,City,Non-Federal Agency,Decatur,AL,ACTIVE
+DECATURIL.GOV,City,Non-Federal Agency,Decatur,IL,ACTIVE
+DECATURILLINOIS.GOV,City,Non-Federal Agency,Decatur,IL,ACTIVE
+DECATURTX.GOV,City,Non-Federal Agency,Decatur,TX,ACTIVE
+DEDHAM-MA.GOV,City,Non-Federal Agency,Dedham,MA,ACTIVE
+DEERFIELDMICHIGAN.GOV,City,Non-Federal Agency,Deerfield,MI,ACTIVE
+DEERPARK-OH.GOV,City,Non-Federal Agency,Deer Park,OH,ACTIVE
+DEERPARKTX.GOV,City,Non-Federal Agency,Deer Park,TX,ACTIVE
+DEKORRA-WI.GOV,City,Non-Federal Agency,Poynette,WI,ACTIVE
+DELAWARETOWNSHIPPA.GOV,City,Non-Federal Agency,Dingmans Ferry,PA,ACTIVE
+DELRAYBEACHFL.GOV,City,Non-Federal Agency,Delray Beach,FL,ACTIVE
+DELTA-CO.GOV,City,Non-Federal Agency,Delta,CO,ACTIVE
+DELTAMI.GOV,City,Non-Federal Agency,Lansing,MI,ACTIVE
+DELTONAFL.GOV,City,Non-Federal Agency,Deltona,FL,ACTIVE
+DEMOPOLISAL.GOV,City,Non-Federal Agency,Demopolis,AL,ACTIVE
+DENVERCO.GOV,City,Non-Federal Agency,Denver,CO,ACTIVE
+DERBYCT.GOV,City,Non-Federal Agency,Derby,CT,ACTIVE
+DESMOINESWA.GOV,City,Non-Federal Agency,Des Moines,WA,ACTIVE
+DESOTOTEXAS.GOV,City,Non-Federal Agency,DeSoto,TX,ACTIVE
+DETROITMI.GOV,City,Non-Federal Agency,Detroit,MI,ACTIVE
+DEXTERMI.GOV,City,Non-Federal Agency,Dexter,MI,ACTIVE
+DHAZ.GOV,City,Non-Federal Agency,Humboldt,AZ,ACTIVE
+DIAMONDBARCA.GOV,City,Non-Federal Agency,Diamond Bar,CA,ACTIVE
+DICKINSON-TX.GOV,City,Non-Federal Agency,Dickinson,TX,ACTIVE
+DICKINSONTEXAS.GOV,City,Non-Federal Agency,Dickinson,TX,ACTIVE
+DICKSONCITY-PA.GOV,City,Non-Federal Agency,Dickson City,PA,ACTIVE
+DIGHTON-MA.GOV,City,Non-Federal Agency,Dighton,MA,ACTIVE
+DISCOVERWAUKESHA-WI.GOV,City,Non-Federal Agency,Waukesha,WI,ACTIVE
+DONALDOREGON.GOV,City,Non-Federal Agency,Donald,OR,ACTIVE
+DONALDSONVILLE-LA.GOV,City,Non-Federal Agency,Donaldsonville,LA,ACTIVE
+DORAL-FL.GOV,City,Non-Federal Agency,Doral,FL,ACTIVE
+DORALPD-FL.GOV,City,Non-Federal Agency,Doral,FL,ACTIVE
+DOUGLASAZ.GOV,City,Non-Federal Agency,Douglas,AZ,ACTIVE
+DOUGLASVILLEGA.GOV,City,Non-Federal Agency,Douglasville,GA,ACTIVE
+DREW-MS.GOV,City,Non-Federal Agency,Drew,MS,ACTIVE
+DRUIDHILLSKY.GOV,City,Non-Federal Agency,Louisville,KY,ACTIVE
+DUBLIN-CA.GOV,City,Non-Federal Agency,Dublin,CA,ACTIVE
+DUBLINCA.GOV,City,Non-Federal Agency,Dublin,CA,ACTIVE
+DUBLINOHIOUSA.GOV,City,Non-Federal Agency,Dublin,OH,ACTIVE
+DUBOISPA.GOV,City,Non-Federal Agency,DuBois,PA,ACTIVE
+DULUTHMN.GOV,City,Non-Federal Agency,Duluth,MN,ACTIVE
+DUMASTX.GOV,City,Non-Federal Agency,Dumas,TX,ACTIVE
+DUMFRIESVA.GOV,City,Non-Federal Agency,Dumfries,VA,ACTIVE
+DUMONTNJ.GOV,City,Non-Federal Agency,Dumont,NJ,ACTIVE
+DUNCANOK.GOV,City,Non-Federal Agency,Duncan,OK,ACTIVE
+DUNCANVILLETX.GOV,City,Non-Federal Agency,Duncanville,TX,ACTIVE
+DUNDEEVILLAGEMI.GOV,City,Non-Federal Agency,Dundee,MI,ACTIVE
+DUNELLEN-NJ.GOV,City,Non-Federal Agency,Dunellen,NJ,ACTIVE
+DUNMOREPA.GOV,City,Non-Federal Agency,Dunmore,PA,ACTIVE
+DUNSTABLE-MA.GOV,City,Non-Federal Agency,Dunstable,MA,ACTIVE
+DUNWOODYGA.GOV,City,Non-Federal Agency,Dunwoody,GA,ACTIVE
+DUNWOODYGEORGIA.GOV,City,Non-Federal Agency,Dunwoody,GA,ACTIVE
+DUPONTWA.GOV,City,Non-Federal Agency,DuPont,WA,ACTIVE
+DURHAMNC.GOV,City,Non-Federal Agency,Durham,NC,ACTIVE
+DUSHOREPA.GOV,City,Non-Federal Agency,Dushore,PA,ACTIVE
+DUTCHESSNY.GOV,City,Non-Federal Agency,Poughkeepsie,NY,ACTIVE
+DUVALLWA.GOV,City,Non-Federal Agency,Duvall,WA,ACTIVE
+DYERSBURGTN.GOV,City,Non-Federal Agency,Dyersburg,TN,ACTIVE
+EAGARAZ.GOV,City,Non-Federal Agency,Eagar,AZ,ACTIVE
+EAGLE-WI.GOV,City,Non-Federal Agency,Eagle,WI,ACTIVE
+EAGLELAKE-TX.GOV,City,Non-Federal Agency,Eagle Lake,TX,ACTIVE
+EASTBOROUGH-KS.GOV,City,Non-Federal Agency,Eastborough,KS,ACTIVE
+EASTCOVENTRY-PA.GOV,City,Non-Federal Agency,Pottstown,PA,ACTIVE
+EASTHAMPTONCT.GOV,City,Non-Federal Agency,East Hampton,CT,ACTIVE
+EASTHAMPTONNY.GOV,City,Non-Federal Agency,Amagansett,NY,ACTIVE
+EASTHAMPTONVILLAGENY.GOV,City,Non-Federal Agency,East Hampton,NY,ACTIVE
+EASTHARTFORDCT.GOV,City,Non-Federal Agency,East Hartford,CT,ACTIVE
+EASTKINGSTONNH.GOV,City,Non-Federal Agency,East Kingston,NH,ACTIVE
+EASTLONGMEADOWMA.GOV,City,Non-Federal Agency,East Longmeadow,MA,ACTIVE
+EASTMOUNTAINTX.GOV,City,Non-Federal Agency,East Mountain,TX,ACTIVE
+EASTON-PA.GOV,City,Non-Federal Agency,Easton,PA,ACTIVE
+EASTONCT.GOV,City,Non-Federal Agency,Easton,CT,ACTIVE
+EASTONMD.GOV,City,Non-Federal Agency,Easton,MD,ACTIVE
+EASTORANGE-NJ.GOV,City,Non-Federal Agency,East ORange,NJ,ACTIVE
+EASTPALESTINE-OH.GOV,City,Non-Federal Agency,East Palestine,OH,ACTIVE
+EASTPORT-ME.GOV,City,Non-Federal Agency,Eastport,ME,ACTIVE
+EASTRIDGETN.GOV,City,Non-Federal Agency,East Ridge,TN,ACTIVE
+EASTTROYWI.GOV,City,Non-Federal Agency,East Troy,WI,ACTIVE
+EASTVALECA.GOV,City,Non-Federal Agency,Eastvale,CA,ACTIVE
+EASTWINDSOR-CT.GOV,City,Non-Federal Agency,Broad Brook,CT,ACTIVE
+EATONVILLE-WA.GOV,City,Non-Federal Agency,Eatonville,WA,ACTIVE
+EAUCLAIREVILLAGE-MI.GOV,City,Non-Federal Agency,Eau Claire,MI,ACTIVE
+EAUCLAIREWI.GOV,City,Non-Federal Agency,Eau Claire,WI,ACTIVE
+ECORSEMI.GOV,City,Non-Federal Agency,ECORSE,MI,ACTIVE
+EDDINGTONMAINE.GOV,City,Non-Federal Agency,Eddington,ME,ACTIVE
+EDENNY.GOV,City,Non-Federal Agency,Eden,NY,ACTIVE
+EDGEWATERFL.GOV,City,Non-Federal Agency,Edgewater,FL,ACTIVE
+EDGEWOOD-FL.GOV,City,Non-Federal Agency,Edgewood,FL,ACTIVE
+EDGEWOOD-NM.GOV,City,Non-Federal Agency,Edgewood,NM,ACTIVE
+EDINAMN.GOV,City,Non-Federal Agency,Edina,MN,ACTIVE
+EDMONDS-WA.GOV,City,Non-Federal Agency,Edmonds,WA,ACTIVE
+EDMONDSWA.GOV,City,Non-Federal Agency,Edmonds,WA,ACTIVE
+EDMONSTONMD.GOV,City,Non-Federal Agency,Edmonston,MD,ACTIVE
+EHALERTCT.GOV,City,Non-Federal Agency,East Hartford,CT,ACTIVE
+EHAMPTONNY.GOV,City,Non-Federal Agency,East Hampton,NY,ACTIVE
+ELKHARTLAKEWI.GOV,City,Non-Federal Agency,Elkhart Lake,WI,ACTIVE
+ELKOCITYNV.GOV,City,Non-Federal Agency,Elko,NV,ACTIVE
+ELKRIVERMN.GOV,City,Non-Federal Agency,Elk River,MN,ACTIVE
+ELKTONVA.GOV,City,Non-Federal Agency,Elkton,VA,ACTIVE
+ELKTOWNSHIPNJ.GOV,City,Non-Federal Agency,Monroeville,NJ,ACTIVE
+ELLAGO-TX.GOV,City,Non-Federal Agency,El Lago,TX,ACTIVE
+ELLIJAY-GA.GOV,City,Non-Federal Agency,Ellijay,GA,ACTIVE
+ELLINGTON-CT.GOV,City,Non-Federal Agency,Ellington,CT,ACTIVE
+ELLSWORTHMAINE.GOV,City,Non-Federal Agency,Ellsworth,ME,ACTIVE
+ELMIRAGE-AZ.GOV,City,Non-Federal Agency,El Mirage,AZ,ACTIVE
+ELMONTECA.GOV,City,Non-Federal Agency,El Monte,CA,ACTIVE
+ELOYAZ.GOV,City,Non-Federal Agency,Eloy,AZ,ACTIVE
+ELPASOTEXAS.GOV,City,Non-Federal Agency,El Paso,TX,ACTIVE
+EMERALDBAY-TX.GOV,City,Non-Federal Agency,Bullard,TX,ACTIVE
+EMMITSBURGMD.GOV,City,Non-Federal Agency,Emmitsburg,MD,ACTIVE
+EMPORIA-KANSAS.GOV,City,Non-Federal Agency,Emporia,KS,ACTIVE
+ENCINITASCA.GOV,City,Non-Federal Agency,Encinitas,CA,ACTIVE
+ENCINITASCALIFORNIA.GOV,City,Non-Federal Agency,Encinitas,CA,ACTIVE
+ENFIELD-CT.GOV,City,Non-Federal Agency,Enfield,CT,ACTIVE
+ENNISTX.GOV,City,Non-Federal Agency,Ennis,TX,ACTIVE
+ENON-OH.GOV,City,Non-Federal Agency,Enon,OH,ACTIVE
+ENTERPRISEAL.GOV,City,Non-Federal Agency,Enterprise,AL,ACTIVE
+ERIECO.GOV,City,Non-Federal Agency,Erie,CO,ACTIVE
+ESPANOLANM.GOV,City,Non-Federal Agency,Espanola,NM,ACTIVE
+ESSEXCT.GOV,City,Non-Federal Agency,Essex,CT,ACTIVE
+ESTERO-FL.GOV,City,Non-Federal Agency,Estero,FL,ACTIVE
+ETON-GA.GOV,City,Non-Federal Agency,Eton,GA,ACTIVE
+EUGENE-OR.GOV,City,Non-Federal Agency,Eugene,OR,ACTIVE
+EULESSTX.GOV,City,Non-Federal Agency,Euless,TX,ACTIVE
+EUREKA-MT.GOV,City,Non-Federal Agency,Eureka,MT,ACTIVE
+EUREKASPRINGSAR.GOV,City,Non-Federal Agency,Eureka Springs,AR,ACTIVE
+EVANSCOLORADO.GOV,City,Non-Federal Agency,Evans,CO,ACTIVE
+EVERETTWA.GOV,City,Non-Federal Agency,Everett,WA,ACTIVE
+EVESHAM-NJ.GOV,City,Non-Federal Agency,Marlton,NJ,ACTIVE
+EXETERNH.GOV,City,Non-Federal Agency,Exeter,NH,ACTIVE
+FABIUS-NY.GOV,City,Non-Federal Agency,Fabius,NY,ACTIVE
+FAIRFAX-VT.GOV,City,Non-Federal Agency,Fairfax,VT,ACTIVE
+FAIRFAXVA.GOV,City,Non-Federal Agency,Fairfax,VA,ACTIVE
+FAIRFIELDOH.GOV,City,Non-Federal Agency,Fairfield,OH,ACTIVE
+FAIRHOPE-AL.GOV,City,Non-Federal Agency,Fairhope,AL,ACTIVE
+FAIRMONTWV.GOV,City,Non-Federal Agency,Fairmont,WV,ACTIVE
+FAIRMOUNTHEIGHTSMD.GOV,City,Non-Federal Agency,Fairmount Heights,MD,ACTIVE
+FAIRVIEWNC.GOV,City,Non-Federal Agency,Monroe,NC,ACTIVE
+FAIRVIEWOREGON.GOV,City,Non-Federal Agency,Fairview,OR,ACTIVE
+FALLCREEKWI.GOV,City,Non-Federal Agency,Fall Creek,WI,ACTIVE
+FALLONNEVADA.GOV,City,Non-Federal Agency,Fallon,NV,ACTIVE
+FALLSCHURCHCITYVA.GOV,City,Non-Federal Agency,Falls Church,VA,ACTIVE
+FALLSCHURCHVA.GOV,City,Non-Federal Agency,Falls Church,VA,ACTIVE
+FALLSCITYOREGON.GOV,City,Non-Federal Agency,Falls City,OR,ACTIVE
+FARGO-ND.GOV,City,Non-Federal Agency,Fargo,ND,ACTIVE
+FARGOND.GOV,City,Non-Federal Agency,Fargo,ND,ACTIVE
+FARMERSBRANCHTX.GOV,City,Non-Federal Agency,Farmers Branch,TX,ACTIVE
+FARMINGTON-MO.GOV,City,Non-Federal Agency,Farmington,MO,ACTIVE
+FARMVILLENC.GOV,City,Non-Federal Agency,Farmville,NC,ACTIVE
+FARRAGUT-TN.GOV,City,Non-Federal Agency,Farragut,TN,ACTIVE
+FAYETTEVILLE-AR.GOV,City,Non-Federal Agency,Fayetteville,AR,ACTIVE
+FAYETTEVILLEFIRST-AR.GOV,City,Non-Federal Agency,Fayetteville,AR,ACTIVE
+FAYETTEVILLENC.GOV,City,Non-Federal Agency,Fayetteville,NC,ACTIVE
+FAYETTEVILLENY.GOV,City,Non-Federal Agency,Fayetteville,NY,ACTIVE
+FEDERALWAYWA.GOV,City,Non-Federal Agency,Federal Way ,WA,ACTIVE
+FERNDALEMI.GOV,City,Non-Federal Agency,Ferndale,MI,ACTIVE
+FERRISTEXAS.GOV,City,Non-Federal Agency,Ferris,TX,ACTIVE
+FIRESTONECO.GOV,City,Non-Federal Agency,Firestone,CO,ACTIVE
+FISHKILL-NY.GOV,City,Non-Federal Agency,Fishkill,NY,ACTIVE
+FITCHBURGMA.GOV,City,Non-Federal Agency,Fitchburg,MA,ACTIVE
+FITCHBURGWI.GOV,City,Non-Federal Agency,Fitchburg,WI,ACTIVE
+FITZWILLIAM-NH.GOV,City,Non-Federal Agency,Fitzwilliam,NH,ACTIVE
+FLAGSTAFFAZ.GOV,City,Non-Federal Agency,Flagstaff,AZ,ACTIVE
+FLATONIATX.GOV,City,Non-Federal Agency,Flatonia,TX,ACTIVE
+FLORENCE-KY.GOV,City,Non-Federal Agency,Florence,KY,ACTIVE
+FLORENCE-NJ.GOV,City,Non-Federal Agency,Florence,NJ,ACTIVE
+FLORENCEAZ.GOV,City,Non-Federal Agency,Florence,AZ,ACTIVE
+FLORESVILLETX.GOV,City,Non-Federal Agency,Floresville,TX,ACTIVE
+FLORIDACITYFL.GOV,City,Non-Federal Agency,Florida City,FL,ACTIVE
+FORESTGROVE-OR.GOV,City,Non-Federal Agency,FOREST GROVE,OR,ACTIVE
+FORESTHEIGHTSMD.GOV,City,Non-Federal Agency,Forest Heights,MD,ACTIVE
+FORESTPARKOK.GOV,City,Non-Federal Agency,Forest Park,OK,ACTIVE
+FORSYTH-IL.GOV,City,Non-Federal Agency,Forsyth,IL,ACTIVE
+FORTCOLLINS-CO.GOV,City,Non-Federal Agency,Fort Collins,CO,ACTIVE
+FORTLUPTON-CO.GOV,City,Non-Federal Agency,Fort Lupton,CO,ACTIVE
+FORTLUPTONCO.GOV,City,Non-Federal Agency,Fort Lupton,CO,ACTIVE
+FORTMADISON-IA.GOV,City,Non-Federal Agency,Fort Madison,IA,ACTIVE
+FORTMILLSC.GOV,City,Non-Federal Agency,Fort Mill,SC,ACTIVE
+FORTMYERSBEACHFL.GOV,City,Non-Federal Agency,Fort Myers Beach,FL,ACTIVE
+FORTSMITHAR.GOV,City,Non-Federal Agency,Fort Smith,AR,ACTIVE
+FORTWORTH-TEXAS.GOV,City,Non-Federal Agency,Fort Worth,TX,ACTIVE
+FORTWORTH-TX.GOV,City,Non-Federal Agency,Fort Worth,TX,ACTIVE
+FORTWORTHTEXAS.GOV,City,Non-Federal Agency,Fort Worth,TX,ACTIVE
+FOSTORIAOHIO.GOV,City,Non-Federal Agency,Fostoria,OH,ACTIVE
+FOXBOROUGHMA.GOV,City,Non-Federal Agency,Foxborough,MA,ACTIVE
+FRAMINGHAMMA.GOV,City,Non-Federal Agency,Framingham,MA,ACTIVE
+FRANCESTOWN-NH.GOV,City,Non-Federal Agency,Francestown,NH,ACTIVE
+FRANKFORT-IN.GOV,City,Non-Federal Agency,Frankfort,IN,ACTIVE
+FRANKFORT-KY.GOV,City,Non-Federal Agency,Frankfort,KY,ACTIVE
+FRANKLIN-IN.GOV,City,Non-Federal Agency,FRANKLIN,IN,ACTIVE
+FRANKLIN-NJ.GOV,City,Non-Federal Agency,Someret,NJ,ACTIVE
+FRANKLIN-TN.GOV,City,Non-Federal Agency,Franklin,TN,ACTIVE
+FRANKLINNJ.GOV,City,Non-Federal Agency,Somerset,NJ,ACTIVE
+FRANKLINPA.GOV,City,Non-Federal Agency,Franklin,PA,ACTIVE
+FRANKLINTN.GOV,City,Non-Federal Agency,Franklin,TN,ACTIVE
+FRANKLINWI.GOV,City,Non-Federal Agency,Franklin,WI,ACTIVE
+FREDENBERGTWP-MN.GOV,City,Non-Federal Agency,Duluth,MN,ACTIVE
+FREDERICKCO.GOV,City,Non-Federal Agency,Frederick,CO,ACTIVE
+FREDERICKOK.GOV,City,Non-Federal Agency,Frederick,OK,ACTIVE
+FREDERICKSBURGVA.GOV,City,Non-Federal Agency,Fredericksburg,VA,ACTIVE
+FREEHOLDBOROUGHNJ.GOV,City,Non-Federal Agency,Freehold,NJ,ACTIVE
+FREEPORTNY.GOV,City,Non-Federal Agency,Freeport,NY,ACTIVE
+FREETOWNMA.GOV,City,Non-Federal Agency,Assonet,MA,ACTIVE
+FREMONT.GOV,City,Non-Federal Agency,Fremont,CA,ACTIVE
+FREMONTNC.GOV,City,Non-Federal Agency,Fremont,NC,ACTIVE
+FREMONTNE.GOV,City,Non-Federal Agency,Fremont,NE,ACTIVE
+FRENCHSETTLEMENT-LA.GOV,City,Non-Federal Agency,French Settlement,LA,ACTIVE
+FRESNO.GOV,City,Non-Federal Agency,Fresno,CA,ACTIVE
+FRIDLEYMN.GOV,City,Non-Federal Agency,Fridley,MN,ACTIVE
+FRIENDSHIPHEIGHTSMD.GOV,City,Non-Federal Agency,Chevy Chase,MD,ACTIVE
+FRISCOTEXAS.GOV,City,Non-Federal Agency,Frisco,TX,ACTIVE
+FRISCOTX.GOV,City,Non-Federal Agency,Frisco,TX,ACTIVE
+FROMBERG-MT.GOV,City,Non-Federal Agency,Fromberg,MT,ACTIVE
+FRONTROYAL-VA.GOV,City,Non-Federal Agency,Front Royal,VA,ACTIVE
+FRONTROYALVA.GOV,City,Non-Federal Agency,Front Royal,VA,ACTIVE
+FRUITPORTTOWNSHIP-MI.GOV,City,Non-Federal Agency,Fruitport,MI,ACTIVE
+FULSHEARTEXAS.GOV,City,Non-Federal Agency,Fulshear,TX,ACTIVE
+GAHANNA.GOV,City,Non-Federal Agency,Gahanna,OH,ACTIVE
+GALENAKS.GOV,City,Non-Federal Agency,GALENA,KS,ACTIVE
+GALENAOHIO.GOV,City,Non-Federal Agency,Galena,OH,ACTIVE
+GALESBURG-IL.GOV,City,Non-Federal Agency,Galesburg,IL,ACTIVE
+GALLATIN-TN.GOV,City,Non-Federal Agency,Gallatin,TN,ACTIVE
+GALLAWAYTN.GOV,City,Non-Federal Agency,Gallaway,TN,ACTIVE
+GALLOWAYTWP-NJ.GOV,City,Non-Federal Agency,Galloway,NJ,ACTIVE
+GALLUPNM.GOV,City,Non-Federal Agency,GALLUP,NM,ACTIVE
+GALVAIL.GOV,City,Non-Federal Agency,Galva,IL,ACTIVE
+GALVESTONTX.GOV,City,Non-Federal Agency,Galveston,TX,ACTIVE
+GARDENCITY-GA.GOV,City,Non-Federal Agency,Garden City,GA,ACTIVE
+GARDNERKANSAS.GOV,City,Non-Federal Agency,Gardner,KS,ACTIVE
+GARDNERVILLE-NV.GOV,City,Non-Federal Agency,Gardnerville,NV,ACTIVE
+GARLANDTX.GOV,City,Non-Federal Agency,Garland,TX,ACTIVE
+GARNERNC.GOV,City,Non-Federal Agency,Garner,NC,ACTIVE
+GARRETTPARK-MD.GOV,City,Non-Federal Agency,Garrett Park,MD,ACTIVE
+GARRETTPARKMD.GOV,City,Non-Federal Agency,Garrett Park,MD,ACTIVE
+GATLINBURGTN.GOV,City,Non-Federal Agency,Gatlinburg,TN,ACTIVE
+GAUTIER-MS.GOV,City,Non-Federal Agency,Gautier,MS,ACTIVE
+GENEVAOHIO.GOV,City,Non-Federal Agency,Geneva,OH,ACTIVE
+GEORGETOWN-MI.GOV,City,Non-Federal Agency,Jenison,MI,ACTIVE
+GEORGETOWNKY.GOV,City,Non-Federal Agency,Georgetown,KY,ACTIVE
+GEORGETOWNTX.GOV,City,Non-Federal Agency,Georgetown,TX,ACTIVE
+GERMANTOWN-TN.GOV,City,Non-Federal Agency,Germantown,TN,ACTIVE
+GETTYSBURG-PA.GOV,City,Non-Federal Agency,Gettysburg,PA,ACTIVE
+GILBERTAZ.GOV,City,Non-Federal Agency,Gilbert,AZ,ACTIVE
+GILLETTEWY.GOV,City,Non-Federal Agency,Gillette,WY,ACTIVE
+GIRARDKANSAS.GOV,City,Non-Federal Agency,Girard,KS,ACTIVE
+GLASTONBURY-CT.GOV,City,Non-Federal Agency,Glastonbury,CT,ACTIVE
+GLENDALE-WI.GOV,City,Non-Federal Agency,Glendale,WI,ACTIVE
+GLENDALEAZ.GOV,City,Non-Federal Agency,Glendale,AZ,ACTIVE
+GLENDALECA.GOV,City,Non-Federal Agency,Glendale,CA,ACTIVE
+GLENNHEIGHTSTX.GOV,City,Non-Federal Agency,Glenn Heights,TX,ACTIVE
+GLENVIEWKY.GOV,City,Non-Federal Agency,Glenview,KY,ACTIVE
+GLENWILLOW-OH.GOV,City,Non-Federal Agency,Glenwillow,OH,ACTIVE
+GLENWOODSPRINGSCO.GOV,City,Non-Federal Agency,Glenwood Springs,CO,ACTIVE
+GLOBEAZ.GOV,City,Non-Federal Agency,GLOBE,AZ,ACTIVE
+GLOUCESTER-MA.GOV,City,Non-Federal Agency,Gloucester,MA,ACTIVE
+GODDARDKS.GOV,City,Non-Federal Agency,Goddard,KS,ACTIVE
+GODLEYTX.GOV,City,Non-Federal Agency,Godley,TX,ACTIVE
+GOFFSTOWNNH.GOV,City,Non-Federal Agency,Goffstown,NH,ACTIVE
+GOLDBEACHOREGON.GOV,City,Non-Federal Agency,GoldBeach,OR,ACTIVE
+GOLDENVALLEYMN.GOV,City,Non-Federal Agency,Golden Valley,MN,ACTIVE
+GOLDSBORONC.GOV,City,Non-Federal Agency,Goldsboro,NC,ACTIVE
+GOODHOPEAL.GOV,City,Non-Federal Agency,Cullman,AL,ACTIVE
+GOODLETTSVILLE-TN.GOV,City,Non-Federal Agency,Goodlettsville,TN,ACTIVE
+GOODYEARAZ.GOV,City,Non-Federal Agency,Goodyear,AZ,ACTIVE
+GOSHEN-OH.GOV,City,Non-Federal Agency,Goshen,OH,ACTIVE
+GOSHEN-OHIO.GOV,City,Non-Federal Agency,Goshen,OH,ACTIVE
+GOSHENCT.GOV,City,Non-Federal Agency,Goshen,CT,ACTIVE
+GPSHORESMI.GOV,City,Non-Federal Agency,Grosse Pointe Shores,MI,ACTIVE
+GRAFTON-MA.GOV,City,Non-Federal Agency,Grafton,MA,ACTIVE
+GRANBY-CT.GOV,City,Non-Federal Agency,Granby,CT,ACTIVE
+GRANBY-MA.GOV,City,Non-Federal Agency,Granby,MA,ACTIVE
+GRANDTERRACE-CA.GOV,City,Non-Federal Agency,Grand Terrace,CA,ACTIVE
+GRANDVIEW-IN.GOV,City,Non-Federal Agency,Grandview,IN,ACTIVE
+GRANGERIOWA.GOV,City,Non-Federal Agency,Granger,IA,ACTIVE
+GRANITEFALLSWA.GOV,City,Non-Federal Agency,Granite Falls,WA,ACTIVE
+GRANITEQUARRYNC.GOV,City,Non-Federal Agency,Granite Quarry ,NC,ACTIVE
+GRANTFORKIL.GOV,City,Non-Federal Agency,Highland,IL,ACTIVE
+GRANTSPASSOREGON.GOV,City,Non-Federal Agency,Grants Pass,OR,ACTIVE
+GRANTSVILLEUT.GOV,City,Non-Federal Agency,Grantsville,UT,ACTIVE
+GRAPEVINETEXAS.GOV,City,Non-Federal Agency,Grapevine,TX,ACTIVE
+GRAPEVINETX.GOV,City,Non-Federal Agency,Grapevine,TX,ACTIVE
+GREECENY.GOV,City,Non-Federal Agency,Rochester,NY,ACTIVE
+GREENBAYWI.GOV,City,Non-Federal Agency,Green Bay,WI,ACTIVE
+GREENBELTMD.GOV,City,Non-Federal Agency,Greenbelt,MD,ACTIVE
+GREENCASTLEPA.GOV,City,Non-Federal Agency,Greencastle,PA,ACTIVE
+GREENEVILLETN.GOV,City,Non-Federal Agency,Greeneville,TN,ACTIVE
+GREENFIELD-MA.GOV,City,Non-Federal Agency,Greenfield,MA,ACTIVE
+GREENFIELD-NH.GOV,City,Non-Federal Agency,Greenfield,NH,ACTIVE
+GREENHOUSTONTX.GOV,City,Non-Federal Agency,Houston,TX,ACTIVE
+GREENISLANDNY.GOV,City,Non-Federal Agency,Green Island,NY,ACTIVE
+GREENMOUNTAINFALLSCO.GOV,City,Non-Federal Agency,Green Mountain Falls,CO,ACTIVE
+GREENSBORO-GA.GOV,City,Non-Federal Agency,Greensboro,GA,ACTIVE
+GREENSBORO-NC.GOV,City,Non-Federal Agency,Greensboro,NC,ACTIVE
+GREENSBOROGA.GOV,City,Non-Federal Agency,Greensboro,GA,ACTIVE
+GREENVILLENC.GOV,City,Non-Federal Agency,Greenville,NC,ACTIVE
+GREENVILLESC.GOV,City,Non-Federal Agency,Greenville,SC,ACTIVE
+GRESHAMOREGON.GOV,City,Non-Federal Agency,Gresham,OR,ACTIVE
+GREYFOREST-TX.GOV,City,Non-Federal Agency,Grey Forest,TX,ACTIVE
+GRIMESIOWA.GOV,City,Non-Federal Agency,Grimes,IA,ACTIVE
+GROTON-CT.GOV,City,Non-Federal Agency,Groton,CT,ACTIVE
+GROTONMA.GOV,City,Non-Federal Agency,Groton,MA,ACTIVE
+GROTONSD.GOV,City,Non-Federal Agency,Groton,SD,ACTIVE
+GROVECITYOHIO.GOV,City,Non-Federal Agency,Grove City,OH,ACTIVE
+GROVELAND-FL.GOV,City,Non-Federal Agency,Groveland,FL,ACTIVE
+GULFBREEZEFL.GOV,City,Non-Federal Agency,Gulf Breeze,FL,ACTIVE
+GULFPORT-MS.GOV,City,Non-Federal Agency,Gulfport,MS,ACTIVE
+GULFSHORESAL.GOV,City,Non-Federal Agency,Gulf Shores,AL,ACTIVE
+GUNNISONCO.GOV,City,Non-Federal Agency,Gunnison,CO,ACTIVE
+GUNTERSVILLEAL.GOV,City,Non-Federal Agency,Guntersville,AL,ACTIVE
+GUNTERTX.GOV,City,Non-Federal Agency,Gunter,TX,ACTIVE
+GUSTAVUS-AK.GOV,City,Non-Federal Agency,Gustavus,AK,ACTIVE
+GWSCO.GOV,City,Non-Federal Agency,Glenwood Springs,CO,ACTIVE
+HADDONFIELD-NJ.GOV,City,Non-Federal Agency,Haddonfield,NJ,ACTIVE
+HADLEYMA.GOV,City,Non-Federal Agency,Hadley,MA,ACTIVE
+HAHIRAGA.GOV,City,Non-Federal Agency,Hahira,GA,ACTIVE
+HALLANDALEBEACHFL.GOV,City,Non-Federal Agency,hallandale beach,FL,ACTIVE
+HAMILTON-NY.GOV,City,Non-Federal Agency,HAMILTON,NY,ACTIVE
+HAMILTON-OH.GOV,City,Non-Federal Agency,Hamilton,OH,ACTIVE
+HAMPDENMAINE.GOV,City,Non-Federal Agency,Hampden,ME,ACTIVE
+HAMPSTEADMD.GOV,City,Non-Federal Agency,Hampstead,MD,ACTIVE
+HAMPTON.GOV,City,Non-Federal Agency,Hampton,VA,ACTIVE
+HAMPTONGA.GOV,City,Non-Federal Agency,Hampton,GA,ACTIVE
+HAMPTONNH.GOV,City,Non-Federal Agency,Hampton,NH,ACTIVE
+HAMPTONSC.GOV,City,Non-Federal Agency,Hampton,SC,ACTIVE
+HAMPTONVA.GOV,City,Non-Federal Agency,Hampton,VA,ACTIVE
+HANKSVILLEUTAH.GOV,City,Non-Federal Agency,Hanksville,UT,ACTIVE
+HANNIBAL-MO.GOV,City,Non-Federal Agency,Hannibal,MO,ACTIVE
+HANOVER-MA.GOV,City,Non-Federal Agency,Hanover,MA,ACTIVE
+HANOVERVA.GOV,City,Non-Federal Agency,Hanover,VA,ACTIVE
+HANSON-MA.GOV,City,Non-Federal Agency,Hanson,MA,ACTIVE
+HAPPYVALLEYOR.GOV,City,Non-Federal Agency,Happy Valley,OR,ACTIVE
+HARMARTOWNSHIP-PA.GOV,City,Non-Federal Agency,Freeport,PA,ACTIVE
+HARMONYTWP-NJ.GOV,City,Non-Federal Agency,Phillipsburg,NJ,ACTIVE
+HARPERCOUNTYKS.GOV,City,Non-Federal Agency,Anthony,KS,ACTIVE
+HARRAH-OK.GOV,City,Non-Federal Agency,Harrah,OK,ACTIVE
+HARRINGTONPARKNJ.GOV,City,Non-Federal Agency,HARRINGTON PARK,NJ,ACTIVE
+HARRISBURGPA.GOV,City,Non-Federal Agency,Harrisburg,PA,ACTIVE
+HARRISBURGSD.GOV,City,Non-Federal Agency,Harrisburg,SD,ACTIVE
+HARRISON-NY.GOV,City,Non-Federal Agency,Harrison,NY,ACTIVE
+HARRISONBURGVA.GOV,City,Non-Federal Agency,Harrisonburg,VA,ACTIVE
+HARRISONOH.GOV,City,Non-Federal Agency,Harrison,OH,ACTIVE
+HARRISONOHIO.GOV,City,Non-Federal Agency,Harrison,OH,ACTIVE
+HARRISONTWP-PA.GOV,City,Non-Federal Agency,Natrona Heights,PA,ACTIVE
+HARTFORD.GOV,City,Non-Federal Agency,Hartford,CT,ACTIVE
+HARTSVILLESC.GOV,City,Non-Federal Agency,Hartsville,SC,ACTIVE
+HARWICH-MA.GOV,City,Non-Federal Agency,Harwich,MA,ACTIVE
+HASTINGSMN.GOV,City,Non-Federal Agency,Hastings,MN,ACTIVE
+HAVERHILLMA.GOV,City,Non-Federal Agency,Haverhill,MA,ACTIVE
+HAVREDEGRACEMD.GOV,City,Non-Federal Agency,Havre de Grace,MD,ACTIVE
+HAWTHORNECA.GOV,City,Non-Federal Agency,Hawthorne,CA,ACTIVE
+HAYDEN-CO.GOV,City,Non-Federal Agency,Hayden,CO,ACTIVE
+HAYESTOWNSHIPMI.GOV,City,Non-Federal Agency,Charlevoix,MI,ACTIVE
+HAYSIVIRGINIA.GOV,City,Non-Federal Agency,Haysi,VA,ACTIVE
+HAYWARD-CA.GOV,City,Non-Federal Agency,Hayward,CA,ACTIVE
+HAZARDKY.GOV,City,Non-Federal Agency,Hazard,KY,ACTIVE
+HAZLEHURSTGA.GOV,City,Non-Federal Agency,Hazlehurst,GA,ACTIVE
+HEADOFTHEHARBORNY.GOV,City,Non-Federal Agency,Saint James,NY,ACTIVE
+HEATHOHIO.GOV,City,Non-Federal Agency,Heath,OH,ACTIVE
+HEDWIGTX.GOV,City,Non-Federal Agency,Houston,TX,ACTIVE
+HELENAMT.GOV,City,Non-Federal Agency,Helena,MT,ACTIVE
+HELOTES-TX.GOV,City,Non-Federal Agency,Helotes,TX,ACTIVE
+HENDERSONNEVADA.GOV,City,Non-Federal Agency,Henderson,NV,ACTIVE
+HENDERSONNV.GOV,City,Non-Federal Agency,Henderson,NV,ACTIVE
+HENDERSONTN.GOV,City,Non-Federal Agency,Henderson,TN,ACTIVE
+HENDERSONVILLENC.GOV,City,Non-Federal Agency,Hendersonville,NC,ACTIVE
+HEREFORD-TX.GOV,City,Non-Federal Agency,Hereford,TX,ACTIVE
+HERNDON-VA.GOV,City,Non-Federal Agency,Herndon,VA,ACTIVE
+HEYWORTH-IL.GOV,City,Non-Federal Agency,Heyworth,IL,ACTIVE
+HIALEAHFL.GOV,City,Non-Federal Agency,Hialeah,FL,ACTIVE
+HIAWASSEEGA.GOV,City,Non-Federal Agency,Hiawassee,GA,ACTIVE
+HICKORYCREEK-TX.GOV,City,Non-Federal Agency,Hickory Creek,TX,ACTIVE
+HICKORYNC.GOV,City,Non-Federal Agency,Hickory,NC,ACTIVE
+HIDEOUTUTAH.GOV,City,Non-Federal Agency,Hideout,UT,ACTIVE
+HIGHLANDHEIGHTS-KY.GOV,City,Non-Federal Agency,Highland Heights,KY,ACTIVE
+HIGHLANDIL.GOV,City,Non-Federal Agency,Highland,IL,ACTIVE
+HIGHLANDS-NY.GOV,City,Non-Federal Agency,Highland Falls,NY,ACTIVE
+HIGHPOINT-NC.GOV,City,Non-Federal Agency,High Point,NC,ACTIVE
+HIGHPOINTNC.GOV,City,Non-Federal Agency,High Point,NC,ACTIVE
+HILLIARDOHIO.GOV,City,Non-Federal Agency,Hilliard,OH,ACTIVE
+HILLSBORO-OREGON.GOV,City,Non-Federal Agency,HILLSBORO,OR,ACTIVE
+HILLSBOROUGHNC.GOV,City,Non-Federal Agency,Hillsborough,NC,ACTIVE
+HILTONHEADISLANDSC.GOV,City,Non-Federal Agency,Hilton Head Island,SC,ACTIVE
+HINGHAM-MA.GOV,City,Non-Federal Agency,Hingham,MA,ACTIVE
+HIRAM-GA.GOV,City,Non-Federal Agency,Hiram,GA,ACTIVE
+HOBOKENNJ.GOV,City,Non-Federal Agency,Hoboken,NJ,ACTIVE
+HOLBROOKMA.GOV,City,Non-Federal Agency,Holbrook,MA,ACTIVE
+HOLDEN-MA.GOV,City,Non-Federal Agency,Holden,MA,ACTIVE
+HOLDENMA.GOV,City,Non-Federal Agency,HOLDEN,MA,ACTIVE
+HOLDERNESS-NH.GOV,City,Non-Federal Agency,Holderness,NH,ACTIVE
+HOLLANDTOWNSHIPNJ.GOV,City,Non-Federal Agency,Milford,NJ,ACTIVE
+HOLLYWOODPARK-TX.GOV,City,Non-Federal Agency,Hollywood Park,TX,ACTIVE
+HOMERGLENIL.GOV,City,Non-Federal Agency,Homer Glen,IL,ACTIVE
+HOMEWOODIL.GOV,City,Non-Federal Agency,Homewood,IL,ACTIVE
+HONDO-TX.GOV,City,Non-Federal Agency,Hondo,TX,ACTIVE
+HOOPESTON-IL.GOV,City,Non-Federal Agency,Hoopeston,IL,ACTIVE
+HOOVERAL.GOV,City,Non-Federal Agency,Hoover,AL,ACTIVE
+HOOVERALABAMA.GOV,City,Non-Federal Agency,Hoover,AL,ACTIVE
+HOPEDALE-MA.GOV,City,Non-Federal Agency,Hopedale,MA,ACTIVE
+HOPEWELLVA.GOV,City,Non-Federal Agency,HOPEWELL,VA,ACTIVE
+HOPKINSPARK-IL.GOV,City,Non-Federal Agency,Hopkins Park,IL,ACTIVE
+HOPKINSVILLE-KY.GOV,City,Non-Federal Agency,Hopkinsville,KY,ACTIVE
+HOPKINTON-NH.GOV,City,Non-Federal Agency,Hopkinton,NH,ACTIVE
+HOPKINTONMA.GOV,City,Non-Federal Agency,Hopkinton,MA,ACTIVE
+HORICONNY.GOV,City,Non-Federal Agency,Brant Lake,NY,ACTIVE
+HORIZONCITY-TX.GOV,City,Non-Federal Agency,Horizon City,TX,ACTIVE
+HORSESHOE-BAY-TX.GOV,City,Non-Federal Agency,Horseshoe Bay,TX,ACTIVE
+HOUSTON-AK.GOV,City,Non-Federal Agency,Houston,AK,ACTIVE
+HOUSTONTX.GOV,City,Non-Federal Agency,Houston,TX,ACTIVE
+HPCA.GOV,City,Non-Federal Agency,Huntington Park,CA,ACTIVE
+HRPDCVA.GOV,City,Non-Federal Agency,Chesapeake,VA,ACTIVE
+HUACHUCACITYAZ.GOV,City,Non-Federal Agency,Huachuca City,AZ,ACTIVE
+HUDSONNH.GOV,City,Non-Federal Agency,Hudson,NH,ACTIVE
+HUETTER-ID.GOV,City,Non-Federal Agency,POST FALLS,ID,ACTIVE
+HULMEVILLE-PA.GOV,City,Non-Federal Agency,Hulmeville,PA,ACTIVE
+HUMBLETX.GOV,City,Non-Federal Agency,Humble,TX,ACTIVE
+HUNTINGBURG-IN.GOV,City,Non-Federal Agency,Huntingburg,IN,ACTIVE
+HUNTINGTONBEACHCA.GOV,City,Non-Federal Agency,Huntington Beach,CA,ACTIVE
+HUNTINGTONNY.GOV,City,Non-Federal Agency,Huntington,NY,ACTIVE
+HUNTSPOINT-WA.GOV,City,Non-Federal Agency,Hunts Point,WA,ACTIVE
+HUNTSVILLEAL.GOV,City,Non-Federal Agency,Huntsville,AL,ACTIVE
+HUNTSVILLETX.GOV,City,Non-Federal Agency,Huntsville,TX,ACTIVE
+HURLOCK-MD.GOV,City,Non-Federal Agency,Hurlock,MD,ACTIVE
+HURONTOWNSHIP-MI.GOV,City,Non-Federal Agency,New Boston,MI,ACTIVE
+HURST-TEXAS.GOV,City,Non-Federal Agency,Hurst,TX,ACTIVE
+HURSTTX.GOV,City,Non-Federal Agency,Hurst,TX,ACTIVE
+HUTTOTX.GOV,City,Non-Federal Agency,Hutto,TX,ACTIVE
+HVLNC.GOV,City,Non-Federal Agency,Hendersonville,NC,ACTIVE
+IDABEL-OK.GOV,City,Non-Federal Agency,Idabel,OK,ACTIVE
+IDAHOFALLSIDAHO.GOV,City,Non-Federal Agency,Idaho Falls,ID,ACTIVE
+ILWACO-WA.GOV,City,Non-Federal Agency,Ilwaco,WA,ACTIVE
+IMPERIALBEACHCA.GOV,City,Non-Federal Agency,Imperial Beach,CA,ACTIVE
+INCLINEVILLAGE-NV.GOV,City,Non-Federal Agency,INCLINE VILLAGE,NV,ACTIVE
+INDEPENDENCEKS.GOV,City,Non-Federal Agency,INDEPENDENCE,KS,ACTIVE
+INDEPENDENCEMO.GOV,City,Non-Federal Agency,Independence,MO,ACTIVE
+INDEPENDENCEOHIO.GOV,City,Non-Federal Agency,Independence,OH,ACTIVE
+INDIANAPOLIS-IN.GOV,City,Non-Federal Agency,Indianapolis,IN,ACTIVE
+INDIANHEADPARK-IL.GOV,City,Non-Federal Agency,Indian Head Park,IL,ACTIVE
+INDIANOLAIOWA.GOV,City,Non-Federal Agency,Indianola,IA,ACTIVE
+INDIANOLAMS.GOV,City,Non-Federal Agency,Indianola,MS,ACTIVE
+INDIANPOINT-MO.GOV,City,Non-Federal Agency,Branson,MO,ACTIVE
+INDY.GOV,City,Non-Federal Agency,Indianapolis,IN,ACTIVE
+INGLESIDETX.GOV,City,Non-Federal Agency,Ingleside,TX,ACTIVE
+INTERLACHEN-FL.GOV,City,Non-Federal Agency,Interlachen,FL,ACTIVE
+INVERNESS-FL.GOV,City,Non-Federal Agency,Inverness,FL,ACTIVE
+INVERNESS-IL.GOV,City,Non-Federal Agency,Inverness,IL,ACTIVE
+IPSWICH-MA.GOV,City,Non-Federal Agency,Ipswich,MA,ACTIVE
+IPSWICHMA.GOV,City,Non-Federal Agency,Ipswich,MA,ACTIVE
+IRONTONMO.GOV,City,Non-Federal Agency,Ironton,MO,ACTIVE
+IRVINGTONNY.GOV,City,Non-Federal Agency,Irvington,NY,ACTIVE
+IRWINDALECA.GOV,City,Non-Federal Agency,Irwindale,CA,ACTIVE
+ISLIP-NY.GOV,City,Non-Federal Agency,Islip,NY,ACTIVE
+ISLIPNY.GOV,City,Non-Federal Agency,Islip,NY,ACTIVE
+ISLIPTOWN-NY.GOV,City,Non-Federal Agency,Islip,NY,ACTIVE
+ISSAQUAHWA.GOV,City,Non-Federal Agency,Issaquah,WA,ACTIVE
+JACINTOCITY-TX.GOV,City,Non-Federal Agency,Jacinto City,TX,ACTIVE
+JACKSON-SC.GOV,City,Non-Federal Agency,Jackson,SC,ACTIVE
+JACKSONMS.GOV,City,Non-Federal Agency,Jackson,MS,ACTIVE
+JACKSONTOWNSHIP-PA.GOV,City,Non-Federal Agency,Myerstown,PA,ACTIVE
+JACKSONTOWNSHIPPA.GOV,City,Non-Federal Agency,Jackson Township,PA,ACTIVE
+JACKSONTWP-PA.GOV,City,Non-Federal Agency,Reeders,PA,ACTIVE
+JACKSONVILLENC.GOV,City,Non-Federal Agency,Jacksonville,NC,ACTIVE
+JAMESTOWN-NC.GOV,City,Non-Federal Agency,Jamestown,NC,ACTIVE
+JAMESTOWNRI.GOV,City,Non-Federal Agency,Jamestown,RI,ACTIVE
+JAMESTOWNTN.GOV,City,Non-Federal Agency,Jamestown,TN,ACTIVE
+JANESVILLEMN.GOV,City,Non-Federal Agency,Janesville,MN,ACTIVE
+JEFFERSONCITYMO.GOV,City,Non-Federal Agency,Jefferson City,MO,ACTIVE
+JEFFERSONTOWNKY.GOV,City,Non-Federal Agency,Jeffersontown,KY,ACTIVE
+JEMEZSPRINGS-NM.GOV,City,Non-Federal Agency,Jemez Springs,NM,ACTIVE
+JERICHOVT.GOV,City,Non-Federal Agency,Jericho,VT,ACTIVE
+JEROME-OH.GOV,City,Non-Federal Agency,Plain City,OH,ACTIVE
+JERSEYCITYNJ.GOV,City,Non-Federal Agency,Jersey City,NJ,ACTIVE
+JESUPGA.GOV,City,Non-Federal Agency,Jesup,GA,ACTIVE
+JOHNSCREEKGA.GOV,City,Non-Federal Agency,Johns Creek,GA,ACTIVE
+JOHNSONCITYTN.GOV,City,Non-Federal Agency,Johnson City,TN,ACTIVE
+JONESVILLENC.GOV,City,Non-Federal Agency,Jonesville,NC,ACTIVE
+JORDANMN.GOV,City,Non-Federal Agency,Jordan,MN,ACTIVE
+JUNCTIONCITY-KS.GOV,City,Non-Federal Agency,Junction City,KS,ACTIVE
+JUNCTIONCITYOREGON.GOV,City,Non-Federal Agency,Junction City,OR,ACTIVE
+JUPITERFL.GOV,City,Non-Federal Agency,Jupiter,FL,ACTIVE
+KANNAPOLISNC.GOV,City,Non-Federal Agency,Concord,NC,ACTIVE
+KANSASCITYMO.GOV,City,Non-Federal Agency,Kansas City,MO,ACTIVE
+KCMO.GOV,City,Non-Federal Agency,Kansas City,MO,ACTIVE
+KEANSBURGNJ.GOV,City,Non-Federal Agency,Keansburg,NJ,ACTIVE
+KELSO.GOV,City,Non-Federal Agency,Kelso,WA,ACTIVE
+KEMAH-TX.GOV,City,Non-Federal Agency,Kemah,TX,ACTIVE
+KENMOREWA.GOV,City,Non-Federal Agency,Kenmore,WA,ACTIVE
+KENNEBUNKPORTME.GOV,City,Non-Federal Agency,Kennebunkport,ME,ACTIVE
+KENNESAW-GA.GOV,City,Non-Federal Agency,Kennesaw,GA,ACTIVE
+KENTWA.GOV,City,Non-Federal Agency,Kent,WA,ACTIVE
+KERRVILLETX.GOV,City,Non-Federal Agency,Kerrville,TX,ACTIVE
+KILLEENTEXAS.GOV,City,Non-Federal Agency,Killeen,TX,ACTIVE
+KILLINGLYCT.GOV,City,Non-Federal Agency,Danielson,CT,ACTIVE
+KINDERHOOK-NY.GOV,City,Non-Federal Agency,Niverville,NY,ACTIVE
+KINGSLANDGA.GOV,City,Non-Federal Agency,Kingsland,GA,ACTIVE
+KINGSPORTTN.GOV,City,Non-Federal Agency,Kingsport,TN,ACTIVE
+KINGSTON-NY.GOV,City,Non-Federal Agency,Kingston,NY,ACTIVE
+KINGSTONSPRINGS-TN.GOV,City,Non-Federal Agency,Kingston Springs,TN,ACTIVE
+KINROSSTOWNSHIP-MI.GOV,City,Non-Federal Agency,Kincheloe,MI,ACTIVE
+KINSTONNC.GOV,City,Non-Federal Agency,Kinston,NC,ACTIVE
+KIRKLANDWA.GOV,City,Non-Federal Agency,Kirkland,WA,ACTIVE
+KISSIMMEE-FL.GOV,City,Non-Federal Agency,Kissimmee,FL,ACTIVE
+KISSIMMEEFL.GOV,City,Non-Federal Agency,Kissimmee,FL,ACTIVE
+KITTERYME.GOV,City,Non-Federal Agency,Kittery,ME,ACTIVE
+KITTYHAWKNC.GOV,City,Non-Federal Agency,Kitty Hawk,NC,ACTIVE
+KNIGHTDALENC.GOV,City,Non-Federal Agency,Knightdale,NC,ACTIVE
+KNOXVILLEIA.GOV,City,Non-Federal Agency,Knoxville,IA,ACTIVE
+KNOXVILLEIOWA.GOV,City,Non-Federal Agency,Knoxville,IA,ACTIVE
+KNOXVILLETN.GOV,City,Non-Federal Agency,Knoxville,TN,ACTIVE
+KUNAID.GOV,City,Non-Federal Agency,Kuna,ID,ACTIVE
+LACKAWANNANY.GOV,City,Non-Federal Agency,Lackawanna,NY,ACTIVE
+LACKAWAXENTOWNSHIPPA.GOV,City,Non-Federal Agency,Hawley,PA,ACTIVE
+LAFOLLETTETN.GOV,City,Non-Federal Agency,LaFollette,TN,ACTIVE
+LAGRANGEGA.GOV,City,Non-Federal Agency,LaGrange,GA,ACTIVE
+LAGRANGENY.GOV,City,Non-Federal Agency,Lagrangeville,NY,ACTIVE
+LAGUNAHILLSCA.GOV,City,Non-Federal Agency,Laguna Hills,CA,ACTIVE
+LAHABRACA.GOV,City,Non-Federal Agency,LA HABRA,CA,ACTIVE
+LAKEFORESTCA.GOV,City,Non-Federal Agency,Lake Forest,CA,ACTIVE
+LAKEGROVENY.GOV,City,Non-Federal Agency,Lake Grove,NY,ACTIVE
+LAKEJACKSON-TX.GOV,City,Non-Federal Agency,Lake Jackson,TX,ACTIVE
+LAKEJACKSONTX.GOV,City,Non-Federal Agency,Lake Jackson,TX,ACTIVE
+LAKELANDGA.GOV,City,Non-Federal Agency,Lakeland,GA,ACTIVE
+LAKELANDTN.GOV,City,Non-Federal Agency,Lakeland,TN,ACTIVE
+LAKEPARKNC.GOV,City,Non-Federal Agency,Indian Trail,NC,ACTIVE
+LAKEPROVIDENCELA.GOV,City,Non-Federal Agency,Lake Providence,LA,ACTIVE
+LAKESITETN.GOV,City,Non-Federal Agency,Lakesite,TN,ACTIVE
+LAKESTATION-IN.GOV,City,Non-Federal Agency,Lake Station,IN,ACTIVE
+LAKESTEVENSWA.GOV,City,Non-Federal Agency,Lake Stevens,WA,ACTIVE
+LAKEVILLE-MN.GOV,City,Non-Federal Agency,Lakeville,MN,ACTIVE
+LAKEVILLEMN.GOV,City,Non-Federal Agency,Lakeville,MN,ACTIVE
+LAKEVILLEMNFIRE.GOV,City,Non-Federal Agency,Lakeville,MN,ACTIVE
+LAKEWAY-TX.GOV,City,Non-Federal Agency,Lakeway,TX,ACTIVE
+LAKEWOODNJ.GOV,City,Non-Federal Agency,Lakewood,NJ,ACTIVE
+LANCASTERCITYSC.GOV,City,Non-Federal Agency,Lancaster,SC,ACTIVE
+LANCASTERNY.GOV,City,Non-Federal Agency,Lancaster,NY,ACTIVE
+LANESBORO-MN.GOV,City,Non-Federal Agency,Lanesboro,MN,ACTIVE
+LANESBOROUGH-MA.GOV,City,Non-Federal Agency,LANESBOROUGH,MA,ACTIVE
+LANSINGMI.GOV,City,Non-Federal Agency,Lansing,MI,ACTIVE
+LANTABUS-PA.GOV,City,Non-Federal Agency,Allentown,PA,ACTIVE
+LAPORTETX.GOV,City,Non-Federal Agency,La Porte,TX,ACTIVE
+LAREDOTEXAS.GOV,City,Non-Federal Agency,Laredo,TX,ACTIVE
+LASALLE-IL.GOV,City,Non-Federal Agency,LaSalle,IL,ACTIVE
+LASVEGASNEVADA.GOV,City,Non-Federal Agency,Las Vegas,NV,ACTIVE
+LASVEGASNM.GOV,City,Non-Federal Agency,Las Vegas,NM,ACTIVE
+LAUDERDALEBYTHESEA-FL.GOV,City,Non-Federal Agency,Lauderdale By The Sea,FL,ACTIVE
+LAUDERHILL-FL.GOV,City,Non-Federal Agency,Lauderhill,FL,ACTIVE
+LAUDERHILLFL.GOV,City,Non-Federal Agency,Lauderhill,FL,ACTIVE
+LAVERGNETN.GOV,City,Non-Federal Agency,La Vergne,TN,ACTIVE
+LAVERNIA-TX.GOV,City,Non-Federal Agency,La Vernia,TX,ACTIVE
+LAWRENCEBURGTN.GOV,City,Non-Federal Agency,Lawrenceburg,TN,ACTIVE
+LAWTONMI.GOV,City,Non-Federal Agency,Lawton,MI,ACTIVE
+LAWTONOK.GOV,City,Non-Federal Agency,Lawton,OK,ACTIVE
+LBTS-FL.GOV,City,Non-Federal Agency,Lauderdale-By-The-Sea,FL,ACTIVE
+LEADVILLE-CO.GOV,City,Non-Federal Agency,Leadville,CO,ACTIVE
+LEAGUECITY-TX.GOV,City,Non-Federal Agency,League City,TX,ACTIVE
+LEAGUECITYTX.GOV,City,Non-Federal Agency,League City,TX,ACTIVE
+LEANDERTX.GOV,City,Non-Federal Agency,Leander,TX,ACTIVE
+LEBANONCT.GOV,City,Non-Federal Agency,Lebanon,CT,ACTIVE
+LEBANONNH.GOV,City,Non-Federal Agency,Lebanon,NH,ACTIVE
+LEBANONOHIO.GOV,City,Non-Federal Agency,Lebanon,OH,ACTIVE
+LECLAIREIOWA.GOV,City,Non-Federal Agency,LECLAIRE,IA,ACTIVE
+LEEDSALABAMA.GOV,City,Non-Federal Agency,Leeds,AL,ACTIVE
+LEESBURGFLORIDA.GOV,City,Non-Federal Agency,Leesburg,FL,ACTIVE
+LEESBURGVA.GOV,City,Non-Federal Agency,Leesburg,VA,ACTIVE
+LEESVILLELA.GOV,City,Non-Federal Agency,LEESVILLE,LA,ACTIVE
+LEHI-UT.GOV,City,Non-Federal Agency,Lehi,UT,ACTIVE
+LENEXA-KS.GOV,City,Non-Federal Agency,Lenexa,KS,ACTIVE
+LENOIR-NC.GOV,City,Non-Federal Agency,Lenoir,NC,ACTIVE
+LENOIRCITYTN.GOV,City,Non-Federal Agency,Lenoir City,TN,ACTIVE
+LEOMINSTER-MA.GOV,City,Non-Federal Agency,Leominster,MA,ACTIVE
+LEONIANJ.GOV,City,Non-Federal Agency,Leonia,NJ,ACTIVE
+LEONVALLEYTEXAS.GOV,City,Non-Federal Agency,Leon Valley,TX,ACTIVE
+LEROYTOWNSHIP-MI.GOV,City,Non-Federal Agency,Webberville,MI,ACTIVE
+LETSMOVEBRIDGEPORTCT.GOV,City,Non-Federal Agency,Bridgeport,CT,ACTIVE
+LEWISBURGTN.GOV,City,Non-Federal Agency,Lewisburg,TN,ACTIVE
+LEWISTONMAINE.GOV,City,Non-Federal Agency,Lewiston,ME,ACTIVE
+LEXINGTONKY.GOV,City,Non-Federal Agency,lexington,KY,ACTIVE
+LEXINGTONNC.GOV,City,Non-Federal Agency,Lexington,NC,ACTIVE
+LEXINGTONTN.GOV,City,Non-Federal Agency,Lexington,TN,ACTIVE
+LEXINGTONVA.GOV,City,Non-Federal Agency,Lexington,VA,ACTIVE
+LHCAZ.GOV,City,Non-Federal Agency,Lake Havasu City,AZ,ACTIVE
+LIBERTYHILLTX.GOV,City,Non-Federal Agency,Liberty Hill,TX,ACTIVE
+LIBERTYIN.GOV,City,Non-Federal Agency,Liberty,IN,ACTIVE
+LIBERTYLAKEWA.GOV,City,Non-Federal Agency,Liberty Lake,WA,ACTIVE
+LIBERTYMISSOURI.GOV,City,Non-Federal Agency,Liberty,MO,ACTIVE
+LIBERTYMO.GOV,City,Non-Federal Agency,Liberty,MO,ACTIVE
+LIMERICK-ME.GOV,City,Non-Federal Agency,Limerick,ME,ACTIVE
+LINCOLNCA.GOV,City,Non-Federal Agency,Lincoln,CA,ACTIVE
+LINCOLNIL.GOV,City,Non-Federal Agency,Lincoln,IL,ACTIVE
+LINCOLNSHIREIL.GOV,City,Non-Federal Agency,Lincolnshire,IL,ACTIVE
+LINDALE-TX.GOV,City,Non-Federal Agency,Lindale,TX,ACTIVE
+LINDALETX.GOV,City,Non-Federal Agency,Lindale,TX,ACTIVE
+LINDENWOLDNJ.GOV,City,Non-Federal Agency,Lindenwold,NJ,ACTIVE
+LINNDALEVILLAGE-OH.GOV,City,Non-Federal Agency,Linndale,OH,ACTIVE
+LINTON-IN.GOV,City,Non-Federal Agency,Linton,IN,ACTIVE
+LITCHFIELD-NH.GOV,City,Non-Federal Agency,Litchfield,NH,ACTIVE
+LITCHFIELDNH.GOV,City,Non-Federal Agency,Litchfield,NH,ACTIVE
+LITTLEROCKAR.GOV,City,Non-Federal Agency,Little Rock,AR,ACTIVE
+LOCKHAVENPA.GOV,City,Non-Federal Agency,Lock Haven,PA,ACTIVE
+LOCKPORTNY.GOV,City,Non-Federal Agency,Lockport,NY,ACTIVE
+LOCUSTGROVE-GA.GOV,City,Non-Federal Agency,Locust Grove,GA,ACTIVE
+LODI.GOV,City,Non-Federal Agency,Lodi,CA,ACTIVE
+LODICA.GOV,City,Non-Federal Agency,Lodi,CA,ACTIVE
+LOGANCO.GOV,City,Non-Federal Agency,Sterling,CO,ACTIVE
+LOGANTOWNSHIP-PA.GOV,City,Non-Federal Agency,Altoona,PA,ACTIVE
+LOGANVILLE-GA.GOV,City,Non-Federal Agency,Loganville,GA,ACTIVE
+LOMALINDA-CA.GOV,City,Non-Federal Agency,Loma Linda,CA,ACTIVE
+LONDONBRITAINTOWNSHIP-PA.GOV,City,Non-Federal Agency,Landenberg,PA,ACTIVE
+LONDONKY.GOV,City,Non-Federal Agency,London,KY,ACTIVE
+LONEOAKTX.GOV,City,Non-Federal Agency,LONE OAK,TX,ACTIVE
+LONGBEACH.GOV,City,Non-Federal Agency,Long Beach,CA,ACTIVE
+LONGBEACHNY.GOV,City,Non-Federal Agency,Long Beach,NY,ACTIVE
+LONGBEACHWA.GOV,City,Non-Federal Agency,Long Beach,WA,ACTIVE
+LONGHILLNJ.GOV,City,Non-Federal Agency,Long Hill,NJ,ACTIVE
+LONGLAKEMN.GOV,City,Non-Federal Agency,Long Lake,MN,ACTIVE
+LONGMONTCOLORADO.GOV,City,Non-Federal Agency,Longmont,CO,ACTIVE
+LONGPORTNJ.GOV,City,Non-Federal Agency,Longport,NJ,ACTIVE
+LONGVIEW-WA.GOV,City,Non-Federal Agency,Longview,WA,ACTIVE
+LONGVIEWTEXAS.GOV,City,Non-Federal Agency,Longview,TX,ACTIVE
+LONGVIEWTX.GOV,City,Non-Federal Agency,Longview,TX,ACTIVE
+LONGVIEWWA.GOV,City,Non-Federal Agency,Longview,WA,ACTIVE
+LORENATX.GOV,City,Non-Federal Agency,Lorena,TX,ACTIVE
+LOSALTOSCA.GOV,City,Non-Federal Agency,Los Altos,CA,ACTIVE
+LOSANGELES-CA.GOV,City,Non-Federal Agency,Los Angeles,CA,ACTIVE
+LOSGATOSCA.GOV,City,Non-Federal Agency,Los Gatos,CA,ACTIVE
+LOSLUNASNM.GOV,City,Non-Federal Agency,Los Lunas,NM,ACTIVE
+LOSRANCHOSNM.GOV,City,Non-Federal Agency,Los Ranchos de Albuquerque,NM,ACTIVE
+LOTT-TX.GOV,City,Non-Federal Agency,Lott,TX,ACTIVE
+LOUISBURGKANSAS.GOV,City,Non-Federal Agency,Louisburg,KS,ACTIVE
+LOUISVILLECO.GOV,City,Non-Federal Agency,Louisville,CO,ACTIVE
+LOUISVILLEKY.GOV,City,Non-Federal Agency,Louisville,KY,ACTIVE
+LOUISVILLETN.GOV,City,Non-Federal Agency,Louisville,TN,ACTIVE
+LOVEJOY-GA.GOV,City,Non-Federal Agency,Lovejoy,GA,ACTIVE
+LOVETTSVILLEVA.GOV,City,Non-Federal Agency,Lovettsville,VA,ACTIVE
+LOVINGTON-IL.GOV,City,Non-Federal Agency,Lovington,IL,ACTIVE
+LOWELL-OR.GOV,City,Non-Federal Agency,Lowell,OR,ACTIVE
+LOWELLARKANSAS.GOV,City,Non-Federal Agency,Lowell,AR,ACTIVE
+LOWERALLOWAYSCREEK-NJ.GOV,City,Non-Federal Agency,Hancocks Bridge,NJ,ACTIVE
+LOWERPAXTON-PA.GOV,City,Non-Federal Agency,Harrisburg,PA,ACTIVE
+LUBBOCKTX.GOV,City,Non-Federal Agency,Lubbock,TX,ACTIVE
+LUDINGTON-MI.GOV,City,Non-Federal Agency,Ludington,MI,ACTIVE
+LUNENBURGMA.GOV,City,Non-Federal Agency,Lunenburg,MA,ACTIVE
+LYMAN-ME.GOV,City,Non-Federal Agency,Lyman,ME,ACTIVE
+LYMANSC.GOV,City,Non-Federal Agency,Lyman,SC,ACTIVE
+LYMECT.GOV,City,Non-Federal Agency,Lyme,CT,ACTIVE
+LYMENH.GOV,City,Non-Federal Agency,Lyme,NH,ACTIVE
+LYNCHBURGVA.GOV,City,Non-Federal Agency,Lynchburg,VA,ACTIVE
+LYNDEBOROUGHNH.GOV,City,Non-Federal Agency,Lyndeborough,NH,ACTIVE
+LYNDONKS.GOV,City,Non-Federal Agency,Lyndon,KS,ACTIVE
+LYNNMA.GOV,City,Non-Federal Agency,Lynn,MA,ACTIVE
+LYNNWOODWA.GOV,City,Non-Federal Agency,Lynnwood,WA,ACTIVE
+LYONSTOWNSHIPIL.GOV,City,Non-Federal Agency,Countryside,IL,ACTIVE
+MACOMB-MI.GOV,City,Non-Federal Agency,Macomb,MI,ACTIVE
+MACONGA.GOV,City,Non-Federal Agency,Macon,GA,ACTIVE
+MADEIRABEACHFL.GOV,City,Non-Federal Agency,Madeira Beach,FL,ACTIVE
+MADERA-CA.GOV,City,Non-Federal Agency,Madera,CA,ACTIVE
+MADISON-AL.GOV,City,Non-Federal Agency,Madison,AL,ACTIVE
+MADISON-IN.GOV,City,Non-Federal Agency,Madison,IN,ACTIVE
+MADISONAL.GOV,City,Non-Federal Agency,Madison,AL,ACTIVE
+MADISONLAKEMN.GOV,City,Non-Federal Agency,Madison LAke,MN,ACTIVE
+MAHARISHIVEDICCITY-IOWA.GOV,City,Non-Federal Agency,Maharishi Vedic City,IA,ACTIVE
+MAHOMET-IL.GOV,City,Non-Federal Agency,Mahomet,IL,ACTIVE
+MAHWAH-NJ.GOV,City,Non-Federal Agency,Mahwah,NJ,ACTIVE
+MAIDENNC.GOV,City,Non-Federal Agency,Maiden,NC,ACTIVE
+MALIBU-CA.GOV,City,Non-Federal Agency,Malibu,CA,ACTIVE
+MALVERNAR.GOV,City,Non-Federal Agency,Malvern,AR,ACTIVE
+MAMARONECK-NY.GOV,City,Non-Federal Agency,Mamaroneck,NY,ACTIVE
+MAMARONECKVILLAGENY.GOV,City,Non-Federal Agency,Mamaroneck,NY,ACTIVE
+MANASQUAN-NJ.GOV,City,Non-Federal Agency,MANASQUAN,NJ,ACTIVE
+MANASSASPARKVA.GOV,City,Non-Federal Agency,Manassas Park,VA,ACTIVE
+MANASSASVA.GOV,City,Non-Federal Agency,Manassas,VA,ACTIVE
+MANCHESTER-GA.GOV,City,Non-Federal Agency,Manchester,GA,ACTIVE
+MANCHESTER-VT.GOV,City,Non-Federal Agency,Manchester Center,VT,ACTIVE
+MANCHESTERCT.GOV,City,Non-Federal Agency,Manchester,CT,ACTIVE
+MANCHESTERMD.GOV,City,Non-Federal Agency,MANCHESTER,MD,ACTIVE
+MANCHESTERMO.GOV,City,Non-Federal Agency,Manchester,MO,ACTIVE
+MANCHESTERNH.GOV,City,Non-Federal Agency,Manchester,NH,ACTIVE
+MANISTEEMI.GOV,City,Non-Federal Agency,Traverse City,MI,ACTIVE
+MANITOUSPRINGS-CO.GOV,City,Non-Federal Agency,Colorado Springs,CO,ACTIVE
+MANKATO-MN.GOV,City,Non-Federal Agency,Mankato,MN,ACTIVE
+MANKATOMN.GOV,City,Non-Federal Agency,Mankato,MN,ACTIVE
+MANSFIELD-TX.GOV,City,Non-Federal Agency,Mansfield,TX,ACTIVE
+MANSFIELDCT.GOV,City,Non-Federal Agency,Mansfield,CT,ACTIVE
+MANSFIELDGA.GOV,City,Non-Federal Agency,Mans,GA,ACTIVE
+MANSFIELDTEXAS.GOV,City,Non-Federal Agency,Mansfield,TX,ACTIVE
+MANSFIELDTOWNSHIP-NJ.GOV,City,Non-Federal Agency,Port Murray,NJ,ACTIVE
+MANTUATOWNSHIPOHIO.GOV,City,Non-Federal Agency,Mantua,OH,ACTIVE
+MAPLEGROVEMN.GOV,City,Non-Federal Agency,Maple Grove,MN,ACTIVE
+MAPLEVALLEYWA.GOV,City,Non-Federal Agency,Maple Valley,WA,ACTIVE
+MAPLEWOODMN.GOV,City,Non-Federal Agency,Maplewood,MN,ACTIVE
+MARANAAZ.GOV,City,Non-Federal Agency,Marana,AZ,ACTIVE
+MARBLEFALLSTX.GOV,City,Non-Federal Agency,Marble Falls,TX,ACTIVE
+MARICOPA-AZ.GOV,City,Non-Federal Agency,Maricopa,AZ,ACTIVE
+MARIONKY.GOV,City,Non-Federal Agency,Marion,KY,ACTIVE
+MARIONMA.GOV,City,Non-Federal Agency,Marion,MA,ACTIVE
+MARIONSC.GOV,City,Non-Federal Agency,Marion,SC,ACTIVE
+MARKESANWI.GOV,City,Non-Federal Agency,Markesan,WI,ACTIVE
+MARLBORO-NJ.GOV,City,Non-Federal Agency,Marlboro,NJ,ACTIVE
+MARLBOROUGH-MA.GOV,City,Non-Federal Agency,Marlborough,MA,ACTIVE
+MARLOWNH.GOV,City,Non-Federal Agency,Marlow,NH,ACTIVE
+MAROAILLINOIS.GOV,City,Non-Federal Agency,Maroa,IL,ACTIVE
+MARSHALL-IL.GOV,City,Non-Federal Agency,Marshall,IL,ACTIVE
+MARSHFIELDMO.GOV,City,Non-Federal Agency,Marshfield,MO,ACTIVE
+MARTINSVILLE-VA.GOV,City,Non-Federal Agency,Martinsville,VA,ACTIVE
+MARYSVILLEWA.GOV,City,Non-Federal Agency,Marysville,WA,ACTIVE
+MARYVILLE-TN.GOV,City,Non-Federal Agency,maryville,TN,ACTIVE
+MASHPEEMA.GOV,City,Non-Federal Agency,Mashpee,MA,ACTIVE
+MASTICBEACHVILLAGENY.GOV,City,Non-Federal Agency,Mastic Beach,NY,ACTIVE
+MATTHEWSNC.GOV,City,Non-Federal Agency,Matthews,NC,ACTIVE
+MAYAGUEZPR.GOV,City,Non-Federal Agency,Mayaguez,PR,ACTIVE
+MAYFIELDKY.GOV,City,Non-Federal Agency,Mayfield,KY,ACTIVE
+MCCOMB-MS.GOV,City,Non-Federal Agency,McComb,MS,ACTIVE
+MCDONOUGH-GA.GOV,City,Non-Federal Agency,McDonough,GA,ACTIVE
+MCKEESPORT-PA.GOV,City,Non-Federal Agency,McKeesport,PA,ACTIVE
+MCKENZIETN.GOV,City,Non-Federal Agency,McKenzie,TN,ACTIVE
+MCMINNVILLEOREGON.GOV,City,Non-Federal Agency,McMinnville,OR,ACTIVE
+MCTX.GOV,City,Non-Federal Agency,Missouri City,TX,ACTIVE
+MEADOWSPLACETX.GOV,City,Non-Federal Agency,Meadows Place,TX,ACTIVE
+MECHANICVILLENY.GOV,City,Non-Federal Agency,Mechanicville,NY,ACTIVE
+MEDFORD-MA.GOV,City,Non-Federal Agency,Medford,MA,ACTIVE
+MEDINA-WA.GOV,City,Non-Federal Agency,Medina,WA,ACTIVE
+MEDINAMN.GOV,City,Non-Federal Agency,Medina,MN,ACTIVE
+MELVILLELA.GOV,City,Non-Federal Agency,Melville,LA,ACTIVE
+MEMPHISTN.GOV,City,Non-Federal Agency,Memphis,TN,ACTIVE
+MENDONMA.GOV,City,Non-Federal Agency,Mendon,MA,ACTIVE
+MENOMONIE-WI.GOV,City,Non-Federal Agency,Menomonie,WI,ACTIVE
+MENTONEALABAMA.GOV,City,Non-Federal Agency,Mentone,AL,ACTIVE
+MERCERISLANDWA.GOV,City,Non-Federal Agency,Mercer Island,WA,ACTIVE
+MERCHANTVILLENJ.GOV,City,Non-Federal Agency,Merchantville,NJ,ACTIVE
+MERIDENCT.GOV,City,Non-Federal Agency,Meriden,CT,ACTIVE
+MERRIMACKNH.GOV,City,Non-Federal Agency,Merrimack,NH,ACTIVE
+MESAAZ.GOV,City,Non-Federal Agency,Mesa,AZ,ACTIVE
+MESILLANM.GOV,City,Non-Federal Agency,Mesilla,NM,ACTIVE
+MESQUITENV.GOV,City,Non-Federal Agency,Mesquite,NV,ACTIVE
+MESQUITETX.GOV,City,Non-Federal Agency,Mesquite,TX,ACTIVE
+MIAMIAZ.GOV,City,Non-Federal Agency,Miami,AZ,ACTIVE
+MIAMIBEACHFL.GOV,City,Non-Federal Agency,Miami Beach,FL,ACTIVE
+MIAMIGARDENS-FL.GOV,City,Non-Federal Agency,Miami Gardens,FL,ACTIVE
+MIAMILAKES-FL.GOV,City,Non-Federal Agency,Miami Lakes,FL,ACTIVE
+MIAMISPRINGS-FL.GOV,City,Non-Federal Agency,Miami Springs,FL,ACTIVE
+MIAMITOWNSHIPOH.GOV,City,Non-Federal Agency,Milford,OH,ACTIVE
+MIAMITWPOH.GOV,City,Non-Federal Agency,Milford,OH,ACTIVE
+MIDDLEBURGVA.GOV,City,Non-Federal Agency,Middleburg,VA,ACTIVE
+MIDDLESEXBORO-NJ.GOV,City,Non-Federal Agency,Middlesex,NJ,ACTIVE
+MIDDLETONMA.GOV,City,Non-Federal Agency,Middleton,MA,ACTIVE
+MIDDLETONNH.GOV,City,Non-Federal Agency,Middleton,NH,ACTIVE
+MIDDLETOWN-CT.GOV,City,Non-Federal Agency,Middletown,CT,ACTIVE
+MIDDLETOWNCT.GOV,City,Non-Federal Agency,Middletown,CT,ACTIVE
+MIDDLETOWNVA.GOV,City,Non-Federal Agency,Middletown,VA,ACTIVE
+MIDLANDTEXAS.GOV,City,Non-Federal Agency,Midland,TX,ACTIVE
+MIDLOTHIANTX.GOV,City,Non-Federal Agency,Midlothian,TX,ACTIVE
+MIDWAY-NC.GOV,City,Non-Federal Agency,Winston-Salem,NC,ACTIVE
+MIFFLIN-OH.GOV,City,Non-Federal Agency,Gahanna,OH,ACTIVE
+MILAN-NY.GOV,City,Non-Federal Agency,Milan,NY,ACTIVE
+MILANMO.GOV,City,Non-Federal Agency,Milan,MO,ACTIVE
+MILANOHIO.GOV,City,Non-Federal Agency,Milan,OH,ACTIVE
+MILFORD-CT.GOV,City,Non-Federal Agency,Milford,CT,ACTIVE
+MILFORD-DE.GOV,City,Non-Federal Agency,Milford,DE,ACTIVE
+MILFORDNE.GOV,City,Non-Federal Agency,Milford,NE,ACTIVE
+MILLIKENCO.GOV,City,Non-Federal Agency,Milliken,CO,ACTIVE
+MILLIKENCOLORADO.GOV,City,Non-Federal Agency,Milliken,CO,ACTIVE
+MILLINGTONTN.GOV,City,Non-Federal Agency,Millington,TN,ACTIVE
+MILLSTONENJ.GOV,City,Non-Federal Agency,Millstone,NJ,ACTIVE
+MILLSWY.GOV,City,Non-Federal Agency,Mills,WY,ACTIVE
+MILLVILLENJ.GOV,City,Non-Federal Agency,Millville,NJ,ACTIVE
+MILTON-WI.GOV,City,Non-Federal Agency,Milton,WI,ACTIVE
+MILWAUKEE.GOV,City,Non-Federal Agency,Milwaukee,WI,ACTIVE
+MILWAUKIEOREGON.GOV,City,Non-Federal Agency,Milwaukie,OR,ACTIVE
+MINEOLA-NY.GOV,City,Non-Federal Agency,Mineola,NY,ACTIVE
+MINERALWELLSTX.GOV,City,Non-Federal Agency,Mineral Wells,TX,ACTIVE
+MINNEAPOLIS-MN.GOV,City,Non-Federal Agency,Minneapolis,MN,ACTIVE
+MINNEAPOLISMN.GOV,City,Non-Federal Agency,Minneapolis,MN,ACTIVE
+MINNETONKA-MN.GOV,City,Non-Federal Agency,Minnetonka,MN,ACTIVE
+MIRAMARFL.GOV,City,Non-Federal Agency,Miramar,FL,ACTIVE
+MISSIONHILLSKS.GOV,City,Non-Federal Agency,Mission Hills,KS,ACTIVE
+MISSOULA-MT.GOV,City,Non-Federal Agency,Missoula,MT,ACTIVE
+MISSOURICITYTEXAS.GOV,City,Non-Federal Agency,Missouri City,TX,ACTIVE
+MISSOURICITYTX.GOV,City,Non-Federal Agency,Missouri City,TX,ACTIVE
+MITCHELL-IN.GOV,City,Non-Federal Agency,Mitchell,IN,ACTIVE
+MOBILE-AL.GOV,City,Non-Federal Agency,Mobile,AL,ACTIVE
+MOCKSVILLENC.GOV,City,Non-Federal Agency,Mocksville,NC,ACTIVE
+MONROEGA.GOV,City,Non-Federal Agency,Monroe,GA,ACTIVE
+MONROEMI.GOV,City,Non-Federal Agency,Monroe,MI,ACTIVE
+MONROETWP-OH.GOV,City,Non-Federal Agency,Bethel,OH,ACTIVE
+MONROEWA.GOV,City,Non-Federal Agency,Monroe,WA,ACTIVE
+MONTAGUE-MA.GOV,City,Non-Federal Agency,Turners Falls,MA,ACTIVE
+MONTCLAIRCA.GOV,City,Non-Federal Agency,Montclair,CA,ACTIVE
+MONTEREYMA.GOV,City,Non-Federal Agency,Monterey,MA,ACTIVE
+MONTGOMERYAL.GOV,City,Non-Federal Agency,Montgomery,AL,ACTIVE
+MONTGOMERYMA.GOV,City,Non-Federal Agency,Montgomery,MA,ACTIVE
+MONTGOMERYOHIO.GOV,City,Non-Federal Agency,Montgomery,OH,ACTIVE
+MONTGOMERYTEXAS.GOV,City,Non-Federal Agency,Montgomery,TX,ACTIVE
+MONTICELLOIN.GOV,City,Non-Federal Agency,Monticello,IN,ACTIVE
+MOODYALABAMA.GOV,City,Non-Federal Agency,Moody,AL,ACTIVE
+MOORESVILLE-NC.GOV,City,Non-Federal Agency,Mooresville,NC,ACTIVE
+MOORPARKCA.GOV,City,Non-Federal Agency,Moorpark,CA,ACTIVE
+MOREHEAD-KY.GOV,City,Non-Federal Agency,Morehead,KY,ACTIVE
+MORGANTONNC.GOV,City,Non-Federal Agency,Morganton,NC,ACTIVE
+MORGANTOWNWV.GOV,City,Non-Federal Agency,Morgantown,WV,ACTIVE
+MORIARTYNM.GOV,City,Non-Federal Agency,Moriarty,NM,ACTIVE
+MORROBAYCA.GOV,City,Non-Federal Agency,Morro Bay,CA,ACTIVE
+MORTON-IL.GOV,City,Non-Federal Agency,Morton,IL,ACTIVE
+MOULTONBOROUGHNH.GOV,City,Non-Federal Agency,Moultonborough,NH,ACTIVE
+MOUNTAINAIRNM.GOV,City,Non-Federal Agency,Mountainair,NM,ACTIVE
+MOUNTAINHOUSECA.GOV,City,Non-Federal Agency,Mountain House,CA,ACTIVE
+MOUNTAINPARK-GA.GOV,City,Non-Federal Agency,Mountain Park,GA,ACTIVE
+MOUNTAINVIEW.GOV,City,Non-Federal Agency,Mountain View,CA,ACTIVE
+MOUNTCARMELTN.GOV,City,Non-Federal Agency,Mount Carmel,TN,ACTIVE
+MOUNTKISCONY.GOV,City,Non-Federal Agency,Mount Kisco,NY,ACTIVE
+MOUNTPLEASANTTN.GOV,City,Non-Federal Agency,Mount Pleasant,TN,ACTIVE
+MOUNTPOCONO-PA.GOV,City,Non-Federal Agency,Mount Pocono,PA,ACTIVE
+MOUNTPROSPECT-IL.GOV,City,Non-Federal Agency,Mount Prospect,IL,ACTIVE
+MOUNTPROSPECTIL.GOV,City,Non-Federal Agency,Mount Prospect,IL,ACTIVE
+MOUNTVERNONWA.GOV,City,Non-Federal Agency,Mount Vernon,WA,ACTIVE
+MQUEBRADILLASPR.GOV,City,Non-Federal Agency,Quebradillas,PR,ACTIVE
+MSVFL.GOV,City,Non-Federal Agency,Miami Shores,FL,ACTIVE
+MTCRESTEDBUTTE-CO.GOV,City,Non-Federal Agency,Mt. Crested Butte,CO,ACTIVE
+MTJULIET-TN.GOV,City,Non-Federal Agency,Mt Juliet,TN,ACTIVE
+MTPLEASANTWI.GOV,City,Non-Federal Agency,Mount Pleasant,WI,ACTIVE
+MTSHASTACA.GOV,City,Non-Federal Agency,Mt. Shasta,CA,ACTIVE
+MUKILTEOWA.GOV,City,Non-Federal Agency,Mukilteo,WA,ACTIVE
+MUNDELEIN-IL.GOV,City,Non-Federal Agency,Mundelein,IL,ACTIVE
+MUNDYTWP-MI.GOV,City,Non-Federal Agency,Swartz Creek,MI,ACTIVE
+MURFREESBOROTN.GOV,City,Non-Federal Agency,Murfreesboro,TN,ACTIVE
+MURPHYSBORO-IL.GOV,City,Non-Federal Agency,Murphysboro,IL,ACTIVE
+MURPHYTX.GOV,City,Non-Federal Agency,Murphy,TX,ACTIVE
+MURRAYKY.GOV,City,Non-Federal Agency,Murray,KY,ACTIVE
+MURRIETACA.GOV,City,Non-Federal Agency,Murrieta,CA,ACTIVE
+MUSCATINEIOWA.GOV,City,Non-Federal Agency,Muscatine,IA,ACTIVE
+MUSKEGON-MI.GOV,City,Non-Federal Agency,Muskegon,MI,ACTIVE
+MVPD.GOV,City,Non-Federal Agency,Mountain View,CA,ACTIVE
+MYARLINGTONTX.GOV,City,Non-Federal Agency,Arlington,TX,ACTIVE
+MYCOLUMBUS.GOV,City,Non-Federal Agency,Columbus,OH,ACTIVE
+MYDELRAYBEACHFL.GOV,City,Non-Federal Agency,Delray Beach,FL,ACTIVE
+NAGSHEADNC.GOV,City,Non-Federal Agency,Nags Head,NC,ACTIVE
+NANTICOKECITY-PA.GOV,City,Non-Federal Agency,NANTICOKE,PA,ACTIVE
+NANTUCKET-MA.GOV,City,Non-Federal Agency,Nantucket,MA,ACTIVE
+NAPA-CA.GOV,City,Non-Federal Agency,Napa,CA,ACTIVE
+NAPLESCITYUT.GOV,City,Non-Federal Agency,Naples,UT,ACTIVE
+NARBERTHPA.GOV,City,Non-Federal Agency,Narberth,PA,ACTIVE
+NARRAGANSETTRI.GOV,City,Non-Federal Agency,Narragansett,RI,ACTIVE
+NASHOTAH-WI.GOV,City,Non-Federal Agency,Nashotah,WI,ACTIVE
+NASHUANH.GOV,City,Non-Federal Agency,Nashua,NH,ACTIVE
+NASHVILLE.GOV,City,Non-Federal Agency,Nashville,TN,ACTIVE
+NATCHITOCHESLA.GOV,City,Non-Federal Agency,Natchitoches,LA,ACTIVE
+NATIONALCITYCA.GOV,City,Non-Federal Agency,National City,CA,ACTIVE
+NAUGATUCK-CT.GOV,City,Non-Federal Agency,Naugatuck,CT,ACTIVE
+NAVASOTATX.GOV,City,Non-Federal Agency,Navasota,TX,ACTIVE
+NAZARETHBOROUGHPA.GOV,City,Non-Federal Agency,Nazareth,PA,ACTIVE
+NBCA.GOV,City,Non-Federal Agency,Newport Beach,CA,ACTIVE
+NEBRASKACITYNE.GOV,City,Non-Federal Agency,Nebraska City,NE,ACTIVE
+NEEDHAMMA.GOV,City,Non-Federal Agency,NEEDHAM,MA,ACTIVE
+NEVADACITYCA.GOV,City,Non-Federal Agency,Nevada City,CA,ACTIVE
+NEVADAMO.GOV,City,Non-Federal Agency,Nevada,MO,ACTIVE
+NEVILLEISLAND-PA.GOV,City,Non-Federal Agency,Pittsburgh,PA,ACTIVE
+NEWARKDE.GOV,City,Non-Federal Agency,Newark,DE,ACTIVE
+NEWAUBURNMN.GOV,City,Non-Federal Agency,New Auburn,MN,ACTIVE
+NEWBEDFORD-MA.GOV,City,Non-Federal Agency,New Bedford,MA,ACTIVE
+NEWBERGOREGON.GOV,City,Non-Federal Agency,Newberg,OR,ACTIVE
+NEWBOSTONNH.GOV,City,Non-Federal Agency,New Boston,NH,ACTIVE
+NEWBRIGHTONMN.GOV,City,Non-Federal Agency,New Brighton,MN,ACTIVE
+NEWBRITAINCT.GOV,City,Non-Federal Agency,New Britain,CT,ACTIVE
+NEWBURGH-IN.GOV,City,Non-Federal Agency,Newburgh,IN,ACTIVE
+NEWBURGHHTSOH.GOV,City,Non-Federal Agency,Newburgh Heights,OH,ACTIVE
+NEWCANAANCT.GOV,City,Non-Federal Agency,New Canaan,CT,ACTIVE
+NEWCARROLLTONMD.GOV,City,Non-Federal Agency,New Carrollton,MD,ACTIVE
+NEWCASTLEPA.GOV,City,Non-Federal Agency,New Castle,PA,ACTIVE
+NEWCONCORD-OH.GOV,City,Non-Federal Agency,New Concord,OH,ACTIVE
+NEWFIELDSNH.GOV,City,Non-Federal Agency,Newfields,NH,ACTIVE
+NEWHARMONY-IN.GOV,City,Non-Federal Agency,New Harmony,IN,ACTIVE
+NEWHAVENCT.GOV,City,Non-Federal Agency,New Haven,CT,ACTIVE
+NEWHOPEMN.GOV,City,Non-Federal Agency,New Hope,MN,ACTIVE
+NEWINGTONCT.GOV,City,Non-Federal Agency,Newington,CT,ACTIVE
+NEWMARKETNH.GOV,City,Non-Federal Agency,Newmarket,NH,ACTIVE
+NEWMARLBOROUGHMA.GOV,City,Non-Federal Agency,Mill River,MA,ACTIVE
+NEWNANGA.GOV,City,Non-Federal Agency,Newnan,GA,ACTIVE
+NEWORLEANS-LA.GOV,City,Non-Federal Agency,New Orleans,LA,ACTIVE
+NEWORLEANSLA.GOV,City,Non-Federal Agency,New Orleans,LA,ACTIVE
+NEWPORT-RI.GOV,City,Non-Federal Agency,Newport,RI,ACTIVE
+NEWPORTBEACH-CA.GOV,City,Non-Federal Agency,Newport Beach,CA,ACTIVE
+NEWPORTBEACHCA.GOV,City,Non-Federal Agency,Newport Beach,CA,ACTIVE
+NEWPORTKY.GOV,City,Non-Federal Agency,Newport,KY,ACTIVE
+NEWPORTNEWSVA.GOV,City,Non-Federal Agency,Newport News,VA,ACTIVE
+NEWPORTOREGON.GOV,City,Non-Federal Agency,Newport,OR,ACTIVE
+NEWRICHMONDWI.GOV,City,Non-Federal Agency,New Richmond ,WI,ACTIVE
+NEWRUSSIATOWNSHIP-OH.GOV,City,Non-Federal Agency,Oberlin,OH,ACTIVE
+NEWTON-NH.GOV,City,Non-Federal Agency,Newton,NH,ACTIVE
+NEWTONNC.GOV,City,Non-Federal Agency,Newton,NC,ACTIVE
+NEWTOWN-CT.GOV,City,Non-Federal Agency,Newtown,CT,ACTIVE
+NEWTOWNOHIO.GOV,City,Non-Federal Agency,Newtown,OH,ACTIVE
+NEWTOWNPA.GOV,City,Non-Federal Agency,Newtown,PA,ACTIVE
+NEWWINDSOR-NY.GOV,City,Non-Federal Agency,New Windsor,NY,ACTIVE
+NEWWINDSORMD.GOV,City,Non-Federal Agency,New Windsor,MD,ACTIVE
+NIAGARAFALLSNY.GOV,City,Non-Federal Agency,Niagara Falls,NY,ACTIVE
+NIAGARAFALLSNYCARTS.GOV,City,Non-Federal Agency,Niagara Falls,NY,ACTIVE
+NICHOLSHILLS-OK.GOV,City,Non-Federal Agency,Nichols Hills,OK,ACTIVE
+NILES-IL.GOV,City,Non-Federal Agency,Niles,IL,ACTIVE
+NILESTWPMI.GOV,City,Non-Federal Agency,Niles,MI,ACTIVE
+NINNEKAHOK.GOV,City,Non-Federal Agency,NINNEKAH,OK,ACTIVE
+NISSEQUOGUENY.GOV,City,Non-Federal Agency,St. James,NY,ACTIVE
+NIXAMO.GOV,City,Non-Federal Agency,Nixa,MO,ACTIVE
+NNVA.GOV,City,Non-Federal Agency,Newport News,VA,ACTIVE
+NOGALESAZ.GOV,City,Non-Federal Agency,Nogales,AZ,ACTIVE
+NOLA.GOV,City,Non-Federal Agency,New Orleans,LA,ACTIVE
+NOLAERB.GOV,City,Non-Federal Agency,New Orleans,LA,ACTIVE
+NOLAIPM.GOV,City,Non-Federal Agency,New Orleans,LA,ACTIVE
+NOLAOIG.GOV,City,Non-Federal Agency,New Orleans,LA,ACTIVE
+NOLENSVILLETN.GOV,City,Non-Federal Agency,Nolensville,TN,ACTIVE
+NORFOLK.GOV,City,Non-Federal Agency,Norfolk,VA,ACTIVE
+NORFOLKNE.GOV,City,Non-Federal Agency,Norfolk,NE,ACTIVE
+NORFOLKVA.GOV,City,Non-Federal Agency,Norfolk,VA,ACTIVE
+NORMANDYPARKWA.GOV,City,Non-Federal Agency,Normandy Park,WA,ACTIVE
+NORMANOK.GOV,City,Non-Federal Agency,Norman,OK,ACTIVE
+NORMANPARKGA.GOV,City,Non-Federal Agency,Norman Park,GA,ACTIVE
+NORRIDGE-IL.GOV,City,Non-Federal Agency,Norridge,IL,ACTIVE
+NORTHADAMS-MA.GOV,City,Non-Federal Agency,North Adams,MA,ACTIVE
+NORTHAMPTONMA.GOV,City,Non-Federal Agency,Northampton,MA,ACTIVE
+NORTHANDOVERMA.GOV,City,Non-Federal Agency,North Andover,MA,ACTIVE
+NORTHBENDWA.GOV,City,Non-Federal Agency,North Bend,WA,ACTIVE
+NORTHBOROUGH-MA.GOV,City,Non-Federal Agency,Northborough,MA,ACTIVE
+NORTHBROOKIL.GOV,City,Non-Federal Agency,Northbrook,IL,ACTIVE
+NORTHBRUNSWICKNJ.GOV,City,Non-Federal Agency,North Brunswick,NJ,ACTIVE
+NORTHCANTONOHIO.GOV,City,Non-Federal Agency,North Canton,OH,ACTIVE
+NORTHFIELD-VT.GOV,City,Non-Federal Agency,Northfield,VT,ACTIVE
+NORTHFIELDMA.GOV,City,Non-Federal Agency,Northfield,MA,ACTIVE
+NORTHFIELDMI.GOV,City,Non-Federal Agency,Whitmore Lake,MI,ACTIVE
+NORTHFIELDVILLAGE-OH.GOV,City,Non-Federal Agency,NORTHFIELD,OH,ACTIVE
+NORTHHAMPTON-NH.GOV,City,Non-Federal Agency,North Hampton,NH,ACTIVE
+NORTHHAVEN-CT.GOV,City,Non-Federal Agency,North Haven,CT,ACTIVE
+NORTHHEMPSTEADNY.GOV,City,Non-Federal Agency,MANHASSET,NY,ACTIVE
+NORTHLEBANONTWPPA.GOV,City,Non-Federal Agency,Lebanon,PA,ACTIVE
+NORTHPORTNY.GOV,City,Non-Federal Agency,Northport,NY,ACTIVE
+NORTHPROVIDENCERI.GOV,City,Non-Federal Agency,North Providence,RI,ACTIVE
+NORTHREADINGMA.GOV,City,Non-Federal Agency,North Reading,MA,ACTIVE
+NORTHSIOUXCITY-SD.GOV,City,Non-Federal Agency,N. Sioux City,SD,ACTIVE
+NORTHSTONINGTONCT.GOV,City,Non-Federal Agency,North Stonington,CT,ACTIVE
+NORTHUNIONTOWNSHIP-PA.GOV,City,Non-Federal Agency,Lemont Furnace,PA,ACTIVE
+NORTHVERNON-IN.GOV,City,Non-Federal Agency,North Vernon,IN,ACTIVE
+NORTONVA.GOV,City,Non-Federal Agency,Norton,VA,ACTIVE
+NORWALKCA.GOV,City,Non-Federal Agency,Norwalk,CA,ACTIVE
+NORWAYMI.GOV,City,Non-Federal Agency,Norway,MI,ACTIVE
+NORWOOD-MA.GOV,City,Non-Federal Agency,Norwood,MA,ACTIVE
+NORWOODMA.GOV,City,Non-Federal Agency,Norwood,MA,ACTIVE
+NOTTINGHAM-NH.GOV,City,Non-Federal Agency,Nottingham,NH,ACTIVE
+NOWATAOK.GOV,City,Non-Federal Agency,Nowata,OK,ACTIVE
+NSIDFL.GOV,City,Non-Federal Agency,Coral Springs,FL,ACTIVE
+NYACK-NY.GOV,City,Non-Federal Agency,Nyack,NY,ACTIVE
+NYC-NY.GOV,City,Non-Federal Agency,Brooklyn,NY,ACTIVE
+NYC.GOV,City,Non-Federal Agency,Brooklyn,NY,ACTIVE
+OAK-BROOK-IL.GOV,City,Non-Federal Agency,OAK BROOK,IL,ACTIVE
+OAKBLUFFSMA.GOV,City,Non-Federal Agency,Oak Bluffs,MA,ACTIVE
+OAKHAM-MA.GOV,City,Non-Federal Agency,Oakham,MA,ACTIVE
+OAKLAND-ME.GOV,City,Non-Federal Agency,Oakland,ME,ACTIVE
+OAKLANDCA.GOV,City,Non-Federal Agency,Oakland,CA,ACTIVE
+OAKLANDPARKFL.GOV,City,Non-Federal Agency,Oakland Park,FL,ACTIVE
+OAKLAWN-IL.GOV,City,Non-Federal Agency,OAK LAWN,IL,ACTIVE
+OAKPARKMI.GOV,City,Non-Federal Agency,Oak Park,MI,ACTIVE
+OAKRIDGETN.GOV,City,Non-Federal Agency,"Oak Ridge, TN 37830 United States",TN,ACTIVE
+OAKWOODOHIO.GOV,City,Non-Federal Agency,Oakwood,OH,ACTIVE
+OBERLINKANSAS.GOV,City,Non-Federal Agency,Oberlin,KS,ACTIVE
+OCCOQUANVA.GOV,City,Non-Federal Agency,Occoquan,VA,ACTIVE
+OCEANAWV.GOV,City,Non-Federal Agency,Oceana,WV,ACTIVE
+OCEANCITYMD.GOV,City,Non-Federal Agency,Ocean City ,MD,ACTIVE
+OCEANGATE-NJ.GOV,City,Non-Federal Agency,Ocean Gate,NJ,ACTIVE
+OCEANSPRINGS-MS.GOV,City,Non-Federal Agency,Ocean Springs,MS,ACTIVE
+OCONOMOWOC-WI.GOV,City,Non-Federal Agency,Oconomowoc,WI,ACTIVE
+ODESSA-TX.GOV,City,Non-Federal Agency,Odessa,TX,ACTIVE
+OGALLALA-NE.GOV,City,Non-Federal Agency,Ogallala,NE,ACTIVE
+OGDEN-KS.GOV,City,Non-Federal Agency,Ogden ,KS,ACTIVE
+OLDLYME-CT.GOV,City,Non-Federal Agency,Old Lyme,CT,ACTIVE
+OLDSAYBROOKCT.GOV,City,Non-Federal Agency,Old Saybrook,CT,ACTIVE
+OLIVERSPRINGS-TN.GOV,City,Non-Federal Agency,Oliver Springs,TN,ACTIVE
+OLYMPIA-WA.GOV,City,Non-Federal Agency,Olympia,WA,ACTIVE
+OLYMPIAWA.GOV,City,Non-Federal Agency,Olympia,WA,ACTIVE
+OMAHA-NE.GOV,City,Non-Federal Agency,Omaha,NE,ACTIVE
+ONTARIOCA.GOV,City,Non-Federal Agency,Ontario,CA,ACTIVE
+OPALOCKAFL.GOV,City,Non-Federal Agency,OPALOCKA,FL,ACTIVE
+OPELIKA-AL.GOV,City,Non-Federal Agency,Opelika,AL,ACTIVE
+ORANGE-CT.GOV,City,Non-Federal Agency,Orange,CT,ACTIVE
+ORLANDOFL.GOV,City,Non-Federal Agency,Orlando,FL,ACTIVE
+ORMONDBEACH-FL.GOV,City,Non-Federal Agency,Ormond Beach,FL,ACTIVE
+ORONOCOTOWNSHIP-MN.GOV,City,Non-Federal Agency,Oronoco,MN,ACTIVE
+OROVALLEYAZ.GOV,City,Non-Federal Agency,Oro Valley,AZ,ACTIVE
+OSAGEBEACH-MO.GOV,City,Non-Federal Agency,OSAGE BEACH,MO,ACTIVE
+OSCODATOWNSHIPMI.GOV,City,Non-Federal Agency,Oscoda,MI,ACTIVE
+OTAYWATER.GOV,City,Non-Federal Agency,Spring Valley,CA,ACTIVE
+OTHELLOWA.GOV,City,Non-Federal Agency,Othello,WA,ACTIVE
+OTISFIELDME.GOV,City,Non-Federal Agency,OTISFIELD,ME,ACTIVE
+OTTAWAKS.GOV,City,Non-Federal Agency,Ottawa,KS,ACTIVE
+OXFORD-CT.GOV,City,Non-Federal Agency,Oxford,CT,ACTIVE
+OYSTERBAY-NY.GOV,City,Non-Federal Agency,Oyster Bay,NY,ACTIVE
+PACIFICWA.GOV,City,Non-Federal Agency,Pacific,WA,ACTIVE
+PADUCAHKY.GOV,City,Non-Federal Agency,Paducah,KY,ACTIVE
+PAGEAZ.GOV,City,Non-Federal Agency,Page,AZ,ACTIVE
+PALATKA-FL.GOV,City,Non-Federal Agency,Palatka,FL,ACTIVE
+PALMETTOBAY-FL.GOV,City,Non-Federal Agency,Palmetto Bay,FL,ACTIVE
+PALMSPRINGS-CA.GOV,City,Non-Federal Agency,Palm Springs,CA,ACTIVE
+PALMSPRINGSCA.GOV,City,Non-Federal Agency,Palm Springs,CA,ACTIVE
+PALOALTO-CA.GOV,City,Non-Federal Agency,Palo Alto,CA,ACTIVE
+PALOSHILLS-IL.GOV,City,Non-Federal Agency,Palos Hills,IL,ACTIVE
+PANORAMAVILLAGETX.GOV,City,Non-Federal Agency,Panorama Village,TX,ACTIVE
+PARADISEVALLEYAZ.GOV,City,Non-Federal Agency,Paradise Valley,AZ,ACTIVE
+PARISTEXAS.GOV,City,Non-Federal Agency,Paris,TX,ACTIVE
+PARISTN.GOV,City,Non-Federal Agency,Paris,TN,ACTIVE
+PARKERSBURGWV.GOV,City,Non-Federal Agency,Parkersburg,WV,ACTIVE
+PARKVILLEMO.GOV,City,Non-Federal Agency,Parkville,MO,ACTIVE
+PARMAHEIGHTSOH.GOV,City,Non-Federal Agency,Parma Heights,OH,ACTIVE
+PASADENACA.GOV,City,Non-Federal Agency,Pasadena,CA,ACTIVE
+PASADENATX.GOV,City,Non-Federal Agency,Pasadena,TX,ACTIVE
+PASCO-WA.GOV,City,Non-Federal Agency,Pasco,WA,ACTIVE
+PATAGONIA-AZ.GOV,City,Non-Federal Agency,Patagonia,AZ,ACTIVE
+PATERSONNJ.GOV,City,Non-Federal Agency,Paterson,NJ,ACTIVE
+PAWLING-NY.GOV,City,Non-Federal Agency,Pawling,NY,ACTIVE
+PAWNEEROCK-KS.GOV,City,Non-Federal Agency,Pawnee Rock,KS,ACTIVE
+PAXTONFL.GOV,City,Non-Federal Agency,Laurel Hill,FL,ACTIVE
+PAYSONAZ.GOV,City,Non-Federal Agency,Payson,AZ,ACTIVE
+PEABODY-MA.GOV,City,Non-Federal Agency,Peabody,MA,ACTIVE
+PEABODYMA.GOV,City,Non-Federal Agency,PEABODY,MA,ACTIVE
+PEARLANDTX.GOV,City,Non-Federal Agency,Pearland,TX,ACTIVE
+PECOSTX.GOV,City,Non-Federal Agency,Pecos,TX,ACTIVE
+PEMBROKE-MA.GOV,City,Non-Federal Agency,Pembroke,MA,ACTIVE
+PEORIAAZ.GOV,City,Non-Federal Agency,Peoria,AZ,ACTIVE
+PEORIAHEIGHTS-IL.GOV,City,Non-Federal Agency,Peoria Heights,IL,ACTIVE
+PEQUOTLAKES-MN.GOV,City,Non-Federal Agency,Pequot Lakes,MN,ACTIVE
+PERMITTINGROGERSAR.GOV,City,Non-Federal Agency,Rogers,AR,ACTIVE
+PERRY-WI.GOV,City,Non-Federal Agency,Mount Horeb,WI,ACTIVE
+PERRYTOWNSHIP-IN.GOV,City,Non-Federal Agency,Indianapolis,IN,ACTIVE
+PETERBOROUGHNH.GOV,City,Non-Federal Agency,Peterborough,NH,ACTIVE
+PETERSBURGAK.GOV,City,Non-Federal Agency,Petersburg,AK,ACTIVE
+PETERSBURGVA.GOV,City,Non-Federal Agency,Petersburg,VA,ACTIVE
+PFLUGERVILLETX.GOV,City,Non-Federal Agency,Pflugerville,TX,ACTIVE
+PHARR-TX.GOV,City,Non-Federal Agency,Pharr,TX,ACTIVE
+PHILA.GOV,City,Non-Federal Agency,Philadelphia,PA,ACTIVE
+PHILIPSBURGMT.GOV,City,Non-Federal Agency,Philipsburg,MT,ACTIVE
+PHILLIPSTON-MA.GOV,City,Non-Federal Agency,Phillipston,MA,ACTIVE
+PHOENIX.GOV,City,Non-Federal Agency,Phoenix,AZ,ACTIVE
+PHOENIXOREGON.GOV,City,Non-Federal Agency,Phoenix,OR,ACTIVE
+PIEDMONT-OK.GOV,City,Non-Federal Agency,PIEDMONT,OK,ACTIVE
+PIERMONT-NY.GOV,City,Non-Federal Agency,Piermont,NY,ACTIVE
+PIKEVILLEKY.GOV,City,Non-Federal Agency,Pikeville,KY,ACTIVE
+PILOTPOINTAK.GOV,City,Non-Federal Agency,Pilot Point,AK,ACTIVE
+PINEBLUFFSWY.GOV,City,Non-Federal Agency,Pine Bluffs,WY,ACTIVE
+PINEHURSTNC.GOV,City,Non-Federal Agency,Pinehurst,NC,ACTIVE
+PINEPLAINS-NY.GOV,City,Non-Federal Agency,Pine Plains,NY,ACTIVE
+PINETOPLAKESIDEAZ.GOV,City,Non-Federal Agency,LAKESIDE,AZ,ACTIVE
+PINEVILLENC.GOV,City,Non-Federal Agency,Pineville,NC,ACTIVE
+PITTSBORONC.GOV,City,Non-Federal Agency,Pittsboro,NC,ACTIVE
+PITTSBURGCA.GOV,City,Non-Federal Agency,PITTSBURG,CA,ACTIVE
+PITTSBURGHPA.GOV,City,Non-Federal Agency,Pittsburgh,PA,ACTIVE
+PITTSFIELD-MI.GOV,City,Non-Federal Agency,Ann Arbor,MI,ACTIVE
+PITTSFIELDNH.GOV,City,Non-Federal Agency,Pittsfield,NH,ACTIVE
+PLAINFIELDNJ.GOV,City,Non-Federal Agency,Plainfield,NJ,ACTIVE
+PLANDOMEHEIGHTS-NY.GOV,City,Non-Federal Agency,Manhasset,NY,ACTIVE
+PLANO.GOV,City,Non-Federal Agency,Plano,TX,ACTIVE
+PLATTSBURG-MO.GOV,City,Non-Federal Agency,Plattsburg,MO,ACTIVE
+PLEASANTONCA.GOV,City,Non-Federal Agency,Pleasanton,CA,ACTIVE
+PLEASANTONTX.GOV,City,Non-Federal Agency,Pleasanton,TX,ACTIVE
+PLEASANTPRAIRIE-WI.GOV,City,Non-Federal Agency,Pleasant Prairie,WI,ACTIVE
+PLEASANTPRAIRIEWI.GOV,City,Non-Federal Agency,Pleasant Prairie,WI,ACTIVE
+PLEASANTVALLEY-NY.GOV,City,Non-Federal Agency,Pleasant Valley,NY,ACTIVE
+PLEASANTVILLE-NY.GOV,City,Non-Federal Agency,Pleasantville,NY,ACTIVE
+PLOVERWI.GOV,City,Non-Federal Agency,Plover,WI,ACTIVE
+PLUMSTEAD.GOV,City,Non-Federal Agency,Plumsteadville,PA,ACTIVE
+PLYMOUTH-MA.GOV,City,Non-Federal Agency,Plymouth,MA,ACTIVE
+PLYMOUTHMN.GOV,City,Non-Federal Agency,Plymouth,MN,ACTIVE
+POCOMOKEMD.GOV,City,Non-Federal Agency,Pocomoke City,MD,ACTIVE
+POCONOPA.GOV,City,Non-Federal Agency,Tannersville,PA,ACTIVE
+POLKCITYIA.GOV,City,Non-Federal Agency,Polk City,IA,ACTIVE
+POMFRETCT.GOV,City,Non-Federal Agency,Pomfret Center,CT,ACTIVE
+POMPANOBEACHFL.GOV,City,Non-Federal Agency,Pompano Beach,FL,ACTIVE
+POMPEY-NY.GOV,City,Non-Federal Agency,MANLIUS,NY,ACTIVE
+PONCACITYOK.GOV,City,Non-Federal Agency,Ponca City,OK,ACTIVE
+POOLER-GA.GOV,City,Non-Federal Agency,Pooler,GA,ACTIVE
+POOLESVILLEMD.GOV,City,Non-Federal Agency,Poolesville,MD,ACTIVE
+POPLARBLUFF-MO.GOV,City,Non-Federal Agency,Poplar Bluff,MO,ACTIVE
+POPLARVILLEMS.GOV,City,Non-Federal Agency,Poplarvile,MS,ACTIVE
+POQUOSON-VA.GOV,City,Non-Federal Agency,Poquioson,VA,ACTIVE
+PORTAGE-MI.GOV,City,Non-Federal Agency,Portage,MI,ACTIVE
+PORTAGEMI.GOV,City,Non-Federal Agency,Portage,MI,ACTIVE
+PORTAGEWI.GOV,City,Non-Federal Agency,Portage,WI,ACTIVE
+PORTALESNM.GOV,City,Non-Federal Agency,Portales,NM,ACTIVE
+PORTARTHURTX.GOV,City,Non-Federal Agency,Port Arthur,TX,ACTIVE
+PORTCLINTON-OH.GOV,City,Non-Federal Agency,Port Clinton,OH,ACTIVE
+PORTERVILLE-CA.GOV,City,Non-Federal Agency,Porterville,CA,ACTIVE
+PORTERVILLECA.GOV,City,Non-Federal Agency,Porterville,CA,ACTIVE
+PORTLANDMAINE.GOV,City,Non-Federal Agency,Portland,ME,ACTIVE
+PORTLANDOREGON.GOV,City,Non-Federal Agency,Portland,OR,ACTIVE
+PORTLANDTX.GOV,City,Non-Federal Agency,Portland,TX,ACTIVE
+PORTSMOUTHVA.GOV,City,Non-Federal Agency,Portsmouth,VA,ACTIVE
+PORTSMOUTHVIRGINIA.GOV,City,Non-Federal Agency,Portsmouth,VA,ACTIVE
+POTTERTWP-PA.GOV,City,Non-Federal Agency,Monaca,PA,ACTIVE
+POWHATANVA.GOV,City,Non-Federal Agency,Powhatan,VA,ACTIVE
+POYNETTE-WI.GOV,City,Non-Federal Agency,Poynette,WI,ACTIVE
+PRAIRIEDUCHIEN-WI.GOV,City,Non-Federal Agency,Prairie du Chien,WI,ACTIVE
+PRAIRIEVIEWTEXAS.GOV,City,Non-Federal Agency,Prairie View,TX,ACTIVE
+PRATTVILLE-AL.GOV,City,Non-Federal Agency,Prattville,AL,ACTIVE
+PRATTVILLEAL.GOV,City,Non-Federal Agency,Prattville,AL,ACTIVE
+PRESCOTT-AZ.GOV,City,Non-Federal Agency,Prescott,AZ,ACTIVE
+PRESCOTTVALLEY-AZ.GOV,City,Non-Federal Agency,Prescott Valley,AZ,ACTIVE
+PRESQUEISLEMAINE.GOV,City,Non-Federal Agency,Presque Isle,ME,ACTIVE
+PRIESTRIVER-ID.GOV,City,Non-Federal Agency,Priest River,ID,ACTIVE
+PRINCETONNJ.GOV,City,Non-Federal Agency,Princeton,NJ,ACTIVE
+PRINCETONTX.GOV,City,Non-Federal Agency,Princeton,TX,ACTIVE
+PRINCETONWV.GOV,City,Non-Federal Agency,Princeton,WV,ACTIVE
+PROCTORMN.GOV,City,Non-Federal Agency,Proctor,MN,ACTIVE
+PROSPERTX.GOV,City,Non-Federal Agency,Prosper,TX,ACTIVE
+PROVIDENCERI.GOV,City,Non-Federal Agency,Providence,RI,ACTIVE
+PULLMAN-WA.GOV,City,Non-Federal Agency,Pullman,WA,ACTIVE
+PURCELLVILLEVA.GOV,City,Non-Federal Agency,Purcellville,VA,ACTIVE
+QUAKERTOWN-PA.GOV,City,Non-Federal Agency,Quakertown,PA,ACTIVE
+QUINCYIL.GOV,City,Non-Federal Agency,Quincy,IL,ACTIVE
+QUINCYMA.GOV,City,Non-Federal Agency,Quincy,MA,ACTIVE
+RADFORDVA.GOV,City,Non-Federal Agency,Radford,VA,ACTIVE
+RALEIGHNC.GOV,City,Non-Federal Agency,Raleigh,NC,ACTIVE
+RAMAPO-NY.GOV,City,Non-Federal Agency,Suffern,NY,ACTIVE
+RANCHOMIRAGECA.GOV,City,Non-Federal Agency,Rancho Mirage,CA,ACTIVE
+RANDOLPH-MA.GOV,City,Non-Federal Agency,Randolph,MA,ACTIVE
+RANDOLPHTOWNSHIPOHIO.GOV,City,Non-Federal Agency,Randolph,OH,ACTIVE
+RANGELY-CO.GOV,City,Non-Federal Agency,Rangely,CO,ACTIVE
+RANGELYCO.GOV,City,Non-Federal Agency,Rangely,CO,ACTIVE
+RATONNM.GOV,City,Non-Federal Agency,Raton,NM,ACTIVE
+RAYCITYGA.GOV,City,Non-Federal Agency,Ray City,GA,ACTIVE
+RAYMONDNH.GOV,City,Non-Federal Agency,Raymond,NH,ACTIVE
+READINGMA.GOV,City,Non-Federal Agency,READING,MA,ACTIVE
+READINGPA.GOV,City,Non-Federal Agency,Reading,PA,ACTIVE
+READYHOUSTONTX.GOV,City,Non-Federal Agency,Houston,TX,ACTIVE
+READYSOUTHTEXAS.GOV,City,Non-Federal Agency,San Antonio,TX,ACTIVE
+READYWESTLINNOR.GOV,City,Non-Federal Agency,West Linn,OR,ACTIVE
+REDBANKTN.GOV,City,Non-Federal Agency,Red Bank,TN,ACTIVE
+REDBAY-AL.GOV,City,Non-Federal Agency,Red Bay,AL,ACTIVE
+REDDING-CA.GOV,City,Non-Federal Agency,Redding,CA,ACTIVE
+REDMOND.GOV,City,Non-Federal Agency,Redmond,WA,ACTIVE
+REEDSBURGWI.GOV,City,Non-Federal Agency,Reedsburg,WI,ACTIVE
+REIDSVILLENC.GOV,City,Non-Federal Agency,Reidsville,NC,ACTIVE
+REMINGTON-VA.GOV,City,Non-Federal Agency,Remington,VA,ACTIVE
+RENO.GOV,City,Non-Federal Agency,Reno,NV,ACTIVE
+RENONV.GOV,City,Non-Federal Agency,Reno,NV,ACTIVE
+RENSSELAERNY.GOV,City,Non-Federal Agency,Rensselaer,NY,ACTIVE
+RENTONWA.GOV,City,Non-Federal Agency,Renton,WA,ACTIVE
+RHEACOUNTYTN.GOV,City,Non-Federal Agency,Dayton,TN,ACTIVE
+RHINEBECK-NY.GOV,City,Non-Federal Agency,Rhinebeck,NY,ACTIVE
+RHINEBECKNY.GOV,City,Non-Federal Agency,Rhinebeck,NY,ACTIVE
+RIALTOCA.GOV,City,Non-Federal Agency,Rialto,CA,ACTIVE
+RICETX.GOV,City,Non-Federal Agency,Rice,TX,ACTIVE
+RICHFIELDWI.GOV,City,Non-Federal Agency,Hubertus,WI,ACTIVE
+RICHLANDMS.GOV,City,Non-Federal Agency,Richland,MS,ACTIVE
+RICHLANDS-VA.GOV,City,Non-Federal Agency,Richlands,VA,ACTIVE
+RICHLANDSNC.GOV,City,Non-Federal Agency,Richlands,NC,ACTIVE
+RICHMOND-VA.GOV,City,Non-Federal Agency,Richmond,VA,ACTIVE
+RICHMONDHILL-GA.GOV,City,Non-Federal Agency,Richmond Hill ,GA,ACTIVE
+RICHMONDINDIANA.GOV,City,Non-Federal Agency,Richmond,IN,ACTIVE
+RICHMONDTX.GOV,City,Non-Federal Agency,RICHMOND,TX,ACTIVE
+RICHMONDVA.GOV,City,Non-Federal Agency,Richmond,VA,ACTIVE
+RICHMONDVT.GOV,City,Non-Federal Agency,Richmond,VT,ACTIVE
+RICHWOODTX.GOV,City,Non-Federal Agency,Richwood,TX,ACTIVE
+RICHWOODWV.GOV,City,Non-Federal Agency,Richwood,WV,ACTIVE
+RIDGECREST-CA.GOV,City,Non-Federal Agency,Ridgecrest,CA,ACTIVE
+RIDGEFIELDNJ.GOV,City,Non-Federal Agency,Ridgefield,NJ,ACTIVE
+RIDGELANDSC.GOV,City,Non-Federal Agency,Ridgeland,SC,ACTIVE
+RIORANCHONM.GOV,City,Non-Federal Agency,Rio Rancho,NM,ACTIVE
+RITZVILLE-WA.GOV,City,Non-Federal Agency,Ritzville,WA,ACTIVE
+RIVERDALEGA.GOV,City,Non-Federal Agency,Riverdale,GA,ACTIVE
+RIVERDALENJ.GOV,City,Non-Federal Agency,Riverdale,NJ,ACTIVE
+RIVERDALEPARKMD.GOV,City,Non-Federal Agency,Riverdale,MD,ACTIVE
+RIVERSIDECA.GOV,City,Non-Federal Agency,Riverside,CA,ACTIVE
+RIVERTONWY.GOV,City,Non-Federal Agency,Riverton,WY,ACTIVE
+ROAMINGSHORESOH.GOV,City,Non-Federal Agency,Roaming Shores,OH,ACTIVE
+ROANOKEVA.GOV,City,Non-Federal Agency,Roanoke,VA,ACTIVE
+ROBINSONPA.GOV,City,Non-Federal Agency,McDonald,PA,ACTIVE
+ROCHELLEPARKNJ.GOV,City,Non-Federal Agency,Rochelle Park,NJ,ACTIVE
+ROCHESTERMN.GOV,City,Non-Federal Agency,Rochester,MN,ACTIVE
+ROCKFORD-IL.GOV,City,Non-Federal Agency,Rockford,IL,ACTIVE
+ROCKFORDIL.GOV,City,Non-Federal Agency,Rockford,IL,ACTIVE
+ROCKHALLMD.GOV,City,Non-Federal Agency,Rock Hall,MD,ACTIVE
+ROCKLAND-MA.GOV,City,Non-Federal Agency,Rockland,MA,ACTIVE
+ROCKLANDMAINE.GOV,City,Non-Federal Agency,Rockland,ME,ACTIVE
+ROCKMART-GA.GOV,City,Non-Federal Agency,Rockmart,GA,ACTIVE
+ROCKPORTMA.GOV,City,Non-Federal Agency,Rockport,MA,ACTIVE
+ROCKPORTMAINE.GOV,City,Non-Federal Agency,Rockport,ME,ACTIVE
+ROCKVILLE-IN.GOV,City,Non-Federal Agency,Rockville,IN,ACTIVE
+ROCKVILLEMD.GOV,City,Non-Federal Agency,Rockville,MD,ACTIVE
+ROCKWELLNC.GOV,City,Non-Federal Agency,Rockwell,NC,ACTIVE
+ROCKYHILL-NJ.GOV,City,Non-Federal Agency,Rocky Hill,NJ,ACTIVE
+ROCKYHILLCT.GOV,City,Non-Federal Agency,Rocky Hill,CT,ACTIVE
+ROCKYMOUNTNC.GOV,City,Non-Federal Agency,Rocky Mount,NC,ACTIVE
+ROGERSAR.GOV,City,Non-Federal Agency,Rogers,AR,ACTIVE
+ROGERSMN.GOV,City,Non-Federal Agency,Rogers,MN,ACTIVE
+ROLESVILLENC.GOV,City,Non-Federal Agency,Rolesville,NC,ACTIVE
+ROLLINGHILLSESTATES-CA.GOV,City,Non-Federal Agency,Rolling Hills Estates,CA,ACTIVE
+ROLLINGHILLSESTATESCA.GOV,City,Non-Federal Agency,Rolling Hills Estates,CA,ACTIVE
+ROME-NY.GOV,City,Non-Federal Agency,Rome,NY,ACTIVE
+ROMI.GOV,City,Non-Federal Agency,Royal Oak,MI,ACTIVE
+ROMULUS-MI.GOV,City,Non-Federal Agency,Romulus,MI,ACTIVE
+ROSENBERGTX.GOV,City,Non-Federal Agency,Rosenberg,TX,ACTIVE
+ROSEVILLE-MI.GOV,City,Non-Federal Agency,Roseville,MI,ACTIVE
+ROSLYNNY.GOV,City,Non-Federal Agency,Roslyn,NY,ACTIVE
+ROSWELL-NM.GOV,City,Non-Federal Agency,Roswell,NM,ACTIVE
+ROUNDROCKTEXAS.GOV,City,Non-Federal Agency,Round Rock,TX,ACTIVE
+ROWE-MA.GOV,City,Non-Federal Agency,Rowe,MA,ACTIVE
+ROWLETTTX.GOV,City,Non-Federal Agency,Rowlett,TX,ACTIVE
+ROXBURY-CT.GOV,City,Non-Federal Agency,Roxbury,CT,ACTIVE
+ROYALOAKMI.GOV,City,Non-Federal Agency,Royal Oak,MI,ACTIVE
+ROYALSTON-MA.GOV,City,Non-Federal Agency,Royalston,MA,ACTIVE
+RPVCA.GOV,City,Non-Federal Agency,Rancho Palos Verdes,CA,ACTIVE
+RRNM.GOV,City,Non-Federal Agency,Rio Rancho,NM,ACTIVE
+RUIDOSO-NM.GOV,City,Non-Federal Agency,Ruidoso,NM,ACTIVE
+RUMSONNJ.GOV,City,Non-Federal Agency,Rumson,NJ,ACTIVE
+RUSSELLSPOINT-OH.GOV,City,Non-Federal Agency,Russells Point,OH,ACTIVE
+RYENY.GOV,City,Non-Federal Agency,Rye,NY,ACTIVE
+SACKETSHARBOR-NY.GOV,City,Non-Federal Agency,Sackets Harbor,NY,ACTIVE
+SADDLEBROOKNJ.GOV,City,Non-Federal Agency,Saddlebrook,NJ,ACTIVE
+SADDLEROCKNY.GOV,City,Non-Federal Agency,SADDLE ROCK,NY,ACTIVE
+SAFFORD-AZ.GOV,City,Non-Federal Agency,Safford,AZ,ACTIVE
+SAFFORDAZ.GOV,City,Non-Federal Agency,Safford,AZ,ACTIVE
+SAGHARBORNY.GOV,City,Non-Federal Agency,Sag Harbor,NY,ACTIVE
+SAHUARITAAZ.GOV,City,Non-Federal Agency,Sahuarita,AZ,ACTIVE
+SAINTPETERMN.GOV,City,Non-Federal Agency,Saint Peter,MN,ACTIVE
+SALADOTX.GOV,City,Non-Federal Agency,Salado,TX,ACTIVE
+SALEMCT.GOV,City,Non-Federal Agency,Salem,CT,ACTIVE
+SALEMVA.GOV,City,Non-Federal Agency,Salem,VA,ACTIVE
+SALISBURYMA.GOV,City,Non-Federal Agency,Salisbury,MA,ACTIVE
+SALISBURYNC.GOV,City,Non-Federal Agency,Salisbury,NC,ACTIVE
+SALTLAKECITY-UT.GOV,City,Non-Federal Agency,Salt Lake City,UT,ACTIVE
+SAMMAMISHWA.GOV,City,Non-Federal Agency,Sammamish,WA,ACTIVE
+SANANTONIO.GOV,City,Non-Federal Agency,San Antonio,TX,ACTIVE
+SANDIEGO.GOV,City,Non-Federal Agency,San Diego,CA,ACTIVE
+SANDYSPRINGSGA.GOV,City,Non-Federal Agency,Sandy Springs,GA,ACTIVE
+SANFORDFL.GOV,City,Non-Federal Agency,Sanford,FL,ACTIVE
+SANFRANCISCO-CA.GOV,City,Non-Federal Agency,San Francisco,CA,ACTIVE
+SANJOSECA.GOV,City,Non-Federal Agency,San Jose,CA,ACTIVE
+SANMARCOSTEXAS.GOV,City,Non-Federal Agency,San Marcos,TX,ACTIVE
+SANMARCOSTX.GOV,City,Non-Federal Agency,San Marcos,TX,ACTIVE
+SANMARINOCA.GOV,City,Non-Federal Agency,San Marino,CA,ACTIVE
+SANNET.GOV,City,Non-Federal Agency,San Diego,CA,ACTIVE
+SANPABLOCA.GOV,City,Non-Federal Agency,San Pablo,CA,ACTIVE
+SANTAANA-CA.GOV,City,Non-Federal Agency,Santa Ana,CA,ACTIVE
+SANTABARBARACA.GOV,City,Non-Federal Agency,Santa Barbara,CA,ACTIVE
+SANTACLARACA.GOV,City,Non-Federal Agency,Santa Clara,CA,ACTIVE
+SANTACLARITACA.GOV,City,Non-Federal Agency,Santa Clarita,CA,ACTIVE
+SANTAFENM.GOV,City,Non-Federal Agency,Santa Fe,NM,ACTIVE
+SANTAMONICACA.GOV,City,Non-Federal Agency,Santa Monica,CA,ACTIVE
+SARANACLAKENY.GOV,City,Non-Federal Agency,Saranac Lake,NY,ACTIVE
+SARDISCITYAL.GOV,City,Non-Federal Agency,SARDIS CITY,AL,ACTIVE
+SAUGUS-MA.GOV,City,Non-Federal Agency,Saugus,MA,ACTIVE
+SAULTSTEMARIE-MI.GOV,City,Non-Federal Agency,Sault Ste Marie,MI,ACTIVE
+SAVANNA-IL.GOV,City,Non-Federal Agency,Savanna,IL,ACTIVE
+SAVANNAHGA.GOV,City,Non-Federal Agency,Savannah,GA,ACTIVE
+SBMTD.GOV,City,Non-Federal Agency,Santa Barbara,CA,ACTIVE
+SCHENECTADYNY.GOV,City,Non-Federal Agency,Schenectady,NY,ACTIVE
+SCHERTZ-TX.GOV,City,Non-Federal Agency,Schertz,TX,ACTIVE
+SCIENCEHILL-KY.GOV,City,Non-Federal Agency,Science Hill,KY,ACTIVE
+SCITUATEMA.GOV,City,Non-Federal Agency,Scituate,MA,ACTIVE
+SCOTCHPLAINSNJ.GOV,City,Non-Federal Agency,SCOTCH PLAINS,NJ,ACTIVE
+SCOTTSDALEAZ.GOV,City,Non-Federal Agency,Scottsdale,AZ,ACTIVE
+SCRANTONPA.GOV,City,Non-Federal Agency,Scranton,PA,ACTIVE
+SEABROOKTX.GOV,City,Non-Federal Agency,Seabrook,TX,ACTIVE
+SEACLIFF-NY.GOV,City,Non-Federal Agency,Sea Cliff,NY,ACTIVE
+SEALBEACHCA.GOV,City,Non-Federal Agency,Seal Beach,CA,ACTIVE
+SEARANCHLAKESFLORIDA.GOV,City,Non-Federal Agency,Sea Ranch Lakes,FL,ACTIVE
+SEATPLEASANTMD.GOV,City,Non-Federal Agency,Seat Pleasant,MD,ACTIVE
+SEATTLE.GOV,City,Non-Federal Agency,Seattle,WA,ACTIVE
+SEBEWAINGMI.GOV,City,Non-Federal Agency,Sebewaing,MI,ACTIVE
+SECAUCUSNJ.GOV,City,Non-Federal Agency,Secaucus,NJ,ACTIVE
+SEDONAAZ.GOV,City,Non-Federal Agency,Sedona,AZ,ACTIVE
+SEEKONK-MA.GOV,City,Non-Federal Agency,Seekonk,MA,ACTIVE
+SEGUINTEXAS.GOV,City,Non-Federal Agency,Seguin,TX,ACTIVE
+SELAHWA.GOV,City,Non-Federal Agency,Selah,WA,ACTIVE
+SELLERSBURG-IN.GOV,City,Non-Federal Agency,Sellersburg,IN,ACTIVE
+SELMA-AL.GOV,City,Non-Federal Agency,Selma,AL,ACTIVE
+SENECASC.GOV,City,Non-Federal Agency,Seneca,SC,ACTIVE
+SEQUIMWA.GOV,City,Non-Federal Agency,SEQUIM,WA,ACTIVE
+SHAFTSBURYVT.GOV,City,Non-Federal Agency,Shaftsbury,VT,ACTIVE
+SHAKOPEEMN.GOV,City,Non-Federal Agency,Shakopee,MN,ACTIVE
+SHEBOYGANFALLS-WI.GOV,City,Non-Federal Agency,Sheboygan Falls,WI,ACTIVE
+SHEBOYGANWI.GOV,City,Non-Federal Agency,Sheboygan,WI,ACTIVE
+SHEFFIELDMA.GOV,City,Non-Federal Agency,Sheffield,MA,ACTIVE
+SHELTERCOVE-CA.GOV,City,Non-Federal Agency,Whitethorn,CA,ACTIVE
+SHERWOODOREGON.GOV,City,Non-Federal Agency,Sherwood,OR,ACTIVE
+SHIRLEY-MA.GOV,City,Non-Federal Agency,Shirley,MA,ACTIVE
+SHIVELYKY.GOV,City,Non-Federal Agency,Shively,KY,ACTIVE
+SHORELINE-WA.GOV,City,Non-Federal Agency,Shoreline,WA,ACTIVE
+SHORELINEWA.GOV,City,Non-Federal Agency,Shoreline,WA,ACTIVE
+SHOREVIEWMN.GOV,City,Non-Federal Agency,Shoreview,MN,ACTIVE
+SHOWLOWAZ.GOV,City,Non-Federal Agency,Show Low,AZ,ACTIVE
+SHREVEPORTLA.GOV,City,Non-Federal Agency,Shreveport,LA,ACTIVE
+SHREWSBURYMA.GOV,City,Non-Federal Agency,Shrewsbury,MA,ACTIVE
+SIERRAVISTAAZ.GOV,City,Non-Federal Agency,Sierra Vista,AZ,ACTIVE
+SIGNALMOUNTAINTN.GOV,City,Non-Federal Agency,Signal Mountain,TN,ACTIVE
+SILVERCITYNM.GOV,City,Non-Federal Agency,Silver City,NM,ACTIVE
+SILVERSPRINGTWP-PA.GOV,City,Non-Federal Agency,Mechanicsburg,PA,ACTIVE
+SIMONTONTEXAS.GOV,City,Non-Federal Agency,simonton,TX,ACTIVE
+SIMSBURY-CT.GOV,City,Non-Federal Agency,Simsbury,CT,ACTIVE
+SIOUXFALLSSD.GOV,City,Non-Federal Agency,Sioux Falls,SD,ACTIVE
+SISTERBAYWI.GOV,City,Non-Federal Agency,Sister Bay,WI,ACTIVE
+SLEEPYHOLLOWNY.GOV,City,Non-Federal Agency,Sleepy Hollow,NY,ACTIVE
+SLIPPERYROCKBOROUGHPA.GOV,City,Non-Federal Agency,Slippery Rock,PA,ACTIVE
+SMITHFIELDRI.GOV,City,Non-Federal Agency,Smithfield,RI,ACTIVE
+SMITHFIELDVA.GOV,City,Non-Federal Agency,Smithfield,VA,ACTIVE
+SMITHTOWNNY.GOV,City,Non-Federal Agency,Smithtown,NY,ACTIVE
+SMYRNAGA.GOV,City,Non-Federal Agency,Smyrna,GA,ACTIVE
+SNOHOMISHWA.GOV,City,Non-Federal Agency,Snohomish,WA,ACTIVE
+SNOWFLAKE-AZ.GOV,City,Non-Federal Agency,Snowflake,AZ,ACTIVE
+SOCORRONM.GOV,City,Non-Federal Agency,Socorro,NM,ACTIVE
+SODDY-DAISY-TN.GOV,City,Non-Federal Agency,Soddy-Daisy,TN,ACTIVE
+SODDY-DAISYTN.GOV,City,Non-Federal Agency,Soddy-Daisy,TN,ACTIVE
+SODDYDAISY-TN.GOV,City,Non-Federal Agency,Soddy-Daisy,TN,ACTIVE
+SODDYDAISYTN.GOV,City,Non-Federal Agency,Soddy-daisy,TN,ACTIVE
+SOLWAYTOWNSHIP-MN.GOV,City,Non-Federal Agency,Cloquet,MN,ACTIVE
+SOMERSCT.GOV,City,Non-Federal Agency,Somers,CT,ACTIVE
+SOMERSETTX.GOV,City,Non-Federal Agency,Somerset,TX,ACTIVE
+SOMERTONAZ.GOV,City,Non-Federal Agency,Somerton,AZ,ACTIVE
+SOMERVILLEMA.GOV,City,Non-Federal Agency,Somerville,MA,ACTIVE
+SOMERVILLETN.GOV,City,Non-Federal Agency,Town of Somerville,TN,ACTIVE
+SORRENTOLA.GOV,City,Non-Federal Agency,Sorrento,LA,ACTIVE
+SOUTHABINGTONPA.GOV,City,Non-Federal Agency,Chinchilla,PA,ACTIVE
+SOUTHAMBOYNJ.GOV,City,Non-Federal Agency,South Amboy,NJ,ACTIVE
+SOUTHAMPTONTOWNNY.GOV,City,Non-Federal Agency,Southampton,NY,ACTIVE
+SOUTHBEND-WA.GOV,City,Non-Federal Agency,South Bend,WA,ACTIVE
+SOUTHBENDIN.GOV,City,Non-Federal Agency,South Bend,IN,ACTIVE
+SOUTHBRUNSWICKNJ.GOV,City,Non-Federal Agency,South Brunswick,NJ,ACTIVE
+SOUTHBURLINGTONVT.GOV,City,Non-Federal Agency,South Burlington,VT,ACTIVE
+SOUTHBURY-CT.GOV,City,Non-Federal Agency,Southbury,CT,ACTIVE
+SOUTHEAST-NY.GOV,City,Non-Federal Agency,BREWSTER,NY,ACTIVE
+SOUTHHADLEYMA.GOV,City,Non-Federal Agency,South Hadley,MA,ACTIVE
+SOUTHJORDANUTAH.GOV,City,Non-Federal Agency,South Jordan,UT,ACTIVE
+SOUTHMIAMIFL.GOV,City,Non-Federal Agency,South Miami,FL,ACTIVE
+SOUTHOLDTOWNNY.GOV,City,Non-Federal Agency,Southold,NY,ACTIVE
+SOUTHPADRETEXAS.GOV,City,Non-Federal Agency,South Padre Island,TX,ACTIVE
+SOUTHPASADENACA.GOV,City,Non-Federal Agency,South Pasadena,CA,ACTIVE
+SOUTHPITTSBURG-TN.GOV,City,Non-Federal Agency,South Pittsburg,TN,ACTIVE
+SOUTHWILLIAMSPORT-PA.GOV,City,Non-Federal Agency,South Williamsport,PA,ACTIVE
+SPEEDWAYIN.GOV,City,Non-Federal Agency,Speedway,IN,ACTIVE
+SPENCERMA.GOV,City,Non-Federal Agency,Spencer,MA,ACTIVE
+SPERRYOK.GOV,City,Non-Federal Agency,Sperry,OK,ACTIVE
+SPIRITLAKEID.GOV,City,Non-Federal Agency,Spirit Lake,ID,ACTIVE
+SPRINGCITYPA.GOV,City,Non-Federal Agency,Spring City,PA,ACTIVE
+SPRINGDALEAR.GOV,City,Non-Federal Agency,Springdale,AR,ACTIVE
+SPRINGERVILLEAZ.GOV,City,Non-Federal Agency,Springerville,AZ,ACTIVE
+SPRINGFIELD-MA.GOV,City,Non-Federal Agency,Springfield,MA,ACTIVE
+SPRINGFIELD-OR.GOV,City,Non-Federal Agency,Springfield,OR,ACTIVE
+SPRINGFIELDMA.GOV,City,Non-Federal Agency,Springfield,MA,ACTIVE
+SPRINGFIELDMO.GOV,City,Non-Federal Agency,Springfield,MO,ACTIVE
+SPRINGFIELDOHIO.GOV,City,Non-Federal Agency,Springfield,OH,ACTIVE
+SPRINGHILLKS.GOV,City,Non-Federal Agency,Spring Hill,KS,ACTIVE
+SPRINGHILLLOUISIANA.GOV,City,Non-Federal Agency,Springhill,LA,ACTIVE
+SPRUCEPINE-NC.GOV,City,Non-Federal Agency,Spruce Pine,NC,ACTIVE
+STAFFORDNJ.GOV,City,Non-Federal Agency,Manawhakin,NJ,ACTIVE
+STAFFORDTX.GOV,City,Non-Federal Agency,stafford,TX,ACTIVE
+STAMFORDCT.GOV,City,Non-Federal Agency,Stamford,CT,ACTIVE
+STANHOPENJ.GOV,City,Non-Federal Agency,Stanhope,NJ,ACTIVE
+STARNC.GOV,City,Non-Federal Agency,Star,NC,ACTIVE
+STATECOLLEGEPA.GOV,City,Non-Federal Agency,State College,PA,ACTIVE
+STATESBOROGA.GOV,City,Non-Federal Agency,Statesboro,GA,ACTIVE
+STAYTONOREGON.GOV,City,Non-Federal Agency,Stayton,OR,ACTIVE
+STCHARLESCITYMO.GOV,City,Non-Federal Agency,Saint Charles,MO,ACTIVE
+STCHARLESIL.GOV,City,Non-Federal Agency,St. Charles,IL,ACTIVE
+STCROIXFALLSWI.GOV,City,Non-Federal Agency,City of St. Croix Falls,WI,ACTIVE
+STEPHENVILLETX.GOV,City,Non-Federal Agency,Stephenville,TX,ACTIVE
+STERLING-IL.GOV,City,Non-Federal Agency,Sterling,IL,ACTIVE
+STERLING-MA.GOV,City,Non-Federal Agency,Sterling,MA,ACTIVE
+STERLINGHEIGHTSMI.GOV,City,Non-Federal Agency,Sterling Heights,MI,ACTIVE
+STJOHNSAZ.GOV,City,Non-Federal Agency,St. Johns,AZ,ACTIVE
+STLOUIS-MO.GOV,City,Non-Federal Agency,St. Louis,MO,ACTIVE
+STLUCIECO.GOV,City,Non-Federal Agency,Ft. Pierce,FL,ACTIVE
+STMARYSGA.GOV,City,Non-Federal Agency,ST. MARYS,GA,ACTIVE
+STMARYSPA.GOV,City,Non-Federal Agency,St. Marys,PA,ACTIVE
+STMATTHEWSKY.GOV,City,Non-Federal Agency,Louisville,KY,ACTIVE
+STOCKTONCA.GOV,City,Non-Federal Agency,Stockton,CA,ACTIVE
+STONEHAM-MA.GOV,City,Non-Federal Agency,Stoneham,MA,ACTIVE
+STONINGTON-CT.GOV,City,Non-Federal Agency,Stonington,CT,ACTIVE
+STPAUL.GOV,City,Non-Federal Agency,Saint Paul,MN,ACTIVE
+STPETE-FL.GOV,City,Non-Federal Agency,St. Petersburg,FL,ACTIVE
+STRATHAMNH.GOV,City,Non-Federal Agency,Stratham,NH,ACTIVE
+STURGIS-SD.GOV,City,Non-Federal Agency,Sturgis,SD,ACTIVE
+STURGISMI.GOV,City,Non-Federal Agency,Sturgis,MI,ACTIVE
+STURTEVANT-WI.GOV,City,Non-Federal Agency,Sturtevant,WI,ACTIVE
+SUDBURY-MA.GOV,City,Non-Federal Agency,Sudbury,MA,ACTIVE
+SUFFOLK-VA.GOV,City,Non-Federal Agency,Suffolk,VA,ACTIVE
+SUGAR-LANDCITYTX.GOV,City,Non-Federal Agency,Sugar Land,TX,ACTIVE
+SUGAR-LANDTX.GOV,City,Non-Federal Agency,Sugar Land,TX,ACTIVE
+SUGARCITYIDAHO.GOV,City,Non-Federal Agency,Sugar City,ID,ACTIVE
+SUGARGROVEIL.GOV,City,Non-Federal Agency,Sugar Grove,IL,ACTIVE
+SUGARLAND-CITYTX.GOV,City,Non-Federal Agency,Sugar Land,TX,ACTIVE
+SUGARLAND-TX.GOV,City,Non-Federal Agency,Sugar Land,TX,ACTIVE
+SUGARLANDCITY-TX.GOV,City,Non-Federal Agency,Sugar Land,TX,ACTIVE
+SUGARLANDCITYTX.GOV,City,Non-Federal Agency,Sugar Land,TX,ACTIVE
+SUGARLANDTX.GOV,City,Non-Federal Agency,Sugar Land,TX,ACTIVE
+SULLIVANOHIO.GOV,City,Non-Federal Agency,Sullivan,OH,ACTIVE
+SUMMERVILLESC.GOV,City,Non-Federal Agency,Summerville,SC,ACTIVE
+SUMNERWA.GOV,City,Non-Federal Agency,Sumner,WA,ACTIVE
+SUMTERSC.GOV,City,Non-Federal Agency,Sumter,SC,ACTIVE
+SUNLANDPARK-NM.GOV,City,Non-Federal Agency,Sunland Park,NM,ACTIVE
+SUNNYSIDE-WA.GOV,City,Non-Federal Agency,Sunnyside,WA,ACTIVE
+SUNRISEBEACH-MO.GOV,City,Non-Federal Agency,Sunrise Beach,MO,ACTIVE
+SUNSETBEACHNC.GOV,City,Non-Federal Agency,Sunset Beach,NC,ACTIVE
+SUPERIORAZ.GOV,City,Non-Federal Agency,Superior,AZ,ACTIVE
+SUPERIORCOLORADO.GOV,City,Non-Federal Agency,Superior,CO,ACTIVE
+SURGOINSVILLETN.GOV,City,Non-Federal Agency,Surgoinsville,TN,ACTIVE
+SURPRISEAZ.GOV,City,Non-Federal Agency,Surprise,AZ,ACTIVE
+SUTTON-NH.GOV,City,Non-Federal Agency,Sutton,NH,ACTIVE
+SYLACAUGAAL.GOV,City,Non-Federal Agency,Sylacauga,AL,ACTIVE
+SYRACUSEKS.GOV,City,Non-Federal Agency,Syracuse,KS,ACTIVE
+TABERNACLENJ.GOV,City,Non-Federal Agency,Tabernacle,NJ,ACTIVE
+TACOMAWA.GOV,City,Non-Federal Agency,Tacoma,WA,ACTIVE
+TAFTTX.GOV,City,Non-Federal Agency,TAFT,TX,ACTIVE
+TALLAPOOSAGA.GOV,City,Non-Federal Agency,Tallapoosa,GA,ACTIVE
+TALLASSEE-AL.GOV,City,Non-Federal Agency,Millbrook,AL,ACTIVE
+TALLULAH-LA.GOV,City,Non-Federal Agency,Tallulah,LA,ACTIVE
+TALLULAHFALLSGA.GOV,City,Non-Federal Agency,Tallulah Falls,GA,ACTIVE
+TAMPAFL.GOV,City,Non-Federal Agency,Tampa,FL,ACTIVE
+TAPPAHANNOCK-VA.GOV,City,Non-Federal Agency,Tappahannock,VA,ACTIVE
+TAUNTON-MA.GOV,City,Non-Federal Agency,Taunton,MA,ACTIVE
+TAYLORMILLKY.GOV,City,Non-Federal Agency,Taylor Mill,KY,ACTIVE
+TAYLORSVILLEUT.GOV,City,Non-Federal Agency,Taylorsville ,UT,ACTIVE
+TAYLORTX.GOV,City,Non-Federal Agency,Taylor,TX,ACTIVE
+TEANECKNJ.GOV,City,Non-Federal Agency,Teaneck,NJ,ACTIVE
+TEGACAYSC.GOV,City,Non-Federal Agency,Tega Cay,SC,ACTIVE
+TELLURIDE-CO.GOV,City,Non-Federal Agency,Telluride,CO,ACTIVE
+TEMECULACA.GOV,City,Non-Federal Agency,Temecula,CA,ACTIVE
+TEMPE.GOV,City,Non-Federal Agency,Tempe,AZ,ACTIVE
+TEMPLETX.GOV,City,Non-Federal Agency,Temple,TX,ACTIVE
+TENNILLE-GA.GOV,City,Non-Federal Agency,Tennille,GA,ACTIVE
+THECOLONYTX.GOV,City,Non-Federal Agency,The Colony,TX,ACTIVE
+THEWOODLANDS-TX.GOV,City,Non-Federal Agency,The Woodlands,TX,ACTIVE
+THEWOODLANDSTOWNSHIP-TX.GOV,City,Non-Federal Agency,The Woodlands,TX,ACTIVE
+THOMASVILLE-NC.GOV,City,Non-Federal Agency,Thomasville,NC,ACTIVE
+THORNEBAY-AK.GOV,City,Non-Federal Agency,Thorne Bay,AK,ACTIVE
+TIFFINOHIO.GOV,City,Non-Federal Agency,Tiffin,OH,ACTIVE
+TIGARD-OR.GOV,City,Non-Federal Agency,Tigard,OR,ACTIVE
+TILLAMOOKOR.GOV,City,Non-Federal Agency,Tillamook,OR,ACTIVE
+TIMNATH-CO.GOV,City,Non-Federal Agency,Timnath,CO,ACTIVE
+TINLEYPARK-IL.GOV,City,Non-Federal Agency,Tinley Park,IL,ACTIVE
+TINLEYPARKIL.GOV,City,Non-Federal Agency,Tinley Park,IL,ACTIVE
+TIOGATX.GOV,City,Non-Federal Agency,Tioga,TX,ACTIVE
+TIPPCITYOHIO.GOV,City,Non-Federal Agency,Tipp City,OH,ACTIVE
+TISBURYMA.GOV,City,Non-Federal Agency,Tisbury,MA,ACTIVE
+TOBYHANNATWPPA.GOV,City,Non-Federal Agency,Pocono Pines,PA,ACTIVE
+TOLLAND-MA.GOV,City,Non-Federal Agency,Tolland,MA,ACTIVE
+TOMBALLTX.GOV,City,Non-Federal Agency,Tomball,TX,ACTIVE
+TOMPKINSVILLEKY.GOV,City,Non-Federal Agency,Tompkinsville,KY,ACTIVE
+TONTITOWNAR.GOV,City,Non-Federal Agency,Tontitown,AR,ACTIVE
+TOPSFIELD-MA.GOV,City,Non-Federal Agency,Topsfield,MA,ACTIVE
+TORRANCECA.GOV,City,Non-Federal Agency,Torrance,CA,ACTIVE
+TORREYUTAH.GOV,City,Non-Federal Agency,Torrey,UT,ACTIVE
+TORRINGTON-CT.GOV,City,Non-Federal Agency,Torrington,CT,ACTIVE
+TORRINGTONWY.GOV,City,Non-Federal Agency,Torrington,WY,ACTIVE
+TOWERLAKES-IL.GOV,City,Non-Federal Agency,Tower Lakes,IL,ACTIVE
+TOWNOFBETHLEHEM-NY.GOV,City,Non-Federal Agency,Delmar,NY,ACTIVE
+TOWNOFBLOWINGROCKNC.GOV,City,Non-Federal Agency,Blowing Rock,NC,ACTIVE
+TOWNOFBLYTHEWOODSC.GOV,City,Non-Federal Agency,Blythewood,SC,ACTIVE
+TOWNOFCALLAHAN-FL.GOV,City,Non-Federal Agency,Callahan,FL,ACTIVE
+TOWNOFCARRBORONC.GOV,City,Non-Federal Agency,Carrboro,NC,ACTIVE
+TOWNOFCARYNC.GOV,City,Non-Federal Agency,Cary,NC,ACTIVE
+TOWNOFCATSKILLNY.GOV,City,Non-Federal Agency,Catskill,NY,ACTIVE
+TOWNOFCHADBOURNNC.GOV,City,Non-Federal Agency,Chadbourn,NC,ACTIVE
+TOWNOFCLAYTONNC.GOV,City,Non-Federal Agency,Clayton,NC,ACTIVE
+TOWNOFDUNNWI.GOV,City,Non-Federal Agency,McFarland,WI,ACTIVE
+TOWNOFEASTHAVEN-CT.GOV,City,Non-Federal Agency,East Haven,CT,ACTIVE
+TOWNOFHALFMOON-NY.GOV,City,Non-Federal Agency,Halfmoon,NY,ACTIVE
+TOWNOFHAVERHILL-FL.GOV,City,Non-Federal Agency,Haverhill,FL,ACTIVE
+TOWNOFHAYDENAZ.GOV,City,Non-Federal Agency,Hayden,AZ,ACTIVE
+TOWNOFHOMECROFTIN.GOV,City,Non-Federal Agency,Indianapolis,IN,ACTIVE
+TOWNOFHOUNSFIELD-NY.GOV,City,Non-Federal Agency,Watertown,NY,ACTIVE
+TOWNOFISLIP-NY.GOV,City,Non-Federal Agency,Islip,NY,ACTIVE
+TOWNOFKEENENY.GOV,City,Non-Federal Agency,Keene,NY,ACTIVE
+TOWNOFKENTNY.GOV,City,Non-Federal Agency,Kent Lakes,NY,ACTIVE
+TOWNOFLAPOINTEWI.GOV,City,Non-Federal Agency,La Pointe,WI,ACTIVE
+TOWNOFLAVETA-CO.GOV,City,Non-Federal Agency,La Veta,CO,ACTIVE
+TOWNOFMAYNARD-MA.GOV,City,Non-Federal Agency,Maynard,MA,ACTIVE
+TOWNOFMONTEAGLE-TN.GOV,City,Non-Federal Agency,Monteagle,TN,ACTIVE
+TOWNOFNASHVILLENC.GOV,City,Non-Federal Agency,Nashville,NC,ACTIVE
+TOWNOFNORTH-SC.GOV,City,Non-Federal Agency,North,SC,ACTIVE
+TOWNOFNORTHEASTNY.GOV,City,Non-Federal Agency,Millerton,NY,ACTIVE
+TOWNOFORANGEVA.GOV,City,Non-Federal Agency,Orange,VA,ACTIVE
+TOWNOFOYSTERBAY-NY.GOV,City,Non-Federal Agency,Oyster Bay,NY,ACTIVE
+TOWNOFPALERMONY.GOV,City,Non-Federal Agency,FULTON,NY,ACTIVE
+TOWNOFPENNINGTONVA.GOV,City,Non-Federal Agency,Pennington Gap,VA,ACTIVE
+TOWNOFPOUGHKEEPSIE-NY.GOV,City,Non-Federal Agency,POUGHKEEPSIE,NY,ACTIVE
+TOWNOFRAMAPO-NY.GOV,City,Non-Federal Agency,Suffern,NY,ACTIVE
+TOWNOFRIVERHEADNY.GOV,City,Non-Federal Agency,Riverhead,NY,ACTIVE
+TOWNOFROBERSONVILLE-NC.GOV,City,Non-Federal Agency,Robersonville,NC,ACTIVE
+TOWNOFSHIELDS-WI.GOV,City,Non-Federal Agency,Montello,WI,ACTIVE
+TOWNOFSHIRLEY-MA.GOV,City,Non-Federal Agency,Shirley,MA,ACTIVE
+TOWNOFSMYRNA-TN.GOV,City,Non-Federal Agency,Smyrna,TN,ACTIVE
+TOWNOFSTLEO-FL.GOV,City,Non-Federal Agency,Saint Leo,FL,ACTIVE
+TOWNOFSURFSIDEFL.GOV,City,Non-Federal Agency,Surfside,FL,ACTIVE
+TOWNOFTROPICUT.GOV,City,Non-Federal Agency,Tropic,UT,ACTIVE
+TOWNOFTROUTVILLE-VA.GOV,City,Non-Federal Agency,Troutville,VA,ACTIVE
+TOWNOFVASSNC.GOV,City,Non-Federal Agency,Vass,NC,ACTIVE
+TOWNOFWALLINGFORD-CT.GOV,City,Non-Federal Agency,Wallingford,CT,ACTIVE
+TOWNOFWALWORTHNY.GOV,City,Non-Federal Agency,Walworth,NY,ACTIVE
+TOWNOFWARREN-RI.GOV,City,Non-Federal Agency,Warren,RI,ACTIVE
+TOWNOFWASHINGTONVA.GOV,City,Non-Federal Agency,Washington,VA,ACTIVE
+TOWNOFWILLSBORONY.GOV,City,Non-Federal Agency,Willsboro,NY,ACTIVE
+TOWNOFWOODSTOCKVA.GOV,City,Non-Federal Agency,Woodstock,VA,ACTIVE
+TOWNSHIPOFTABERNACLE-NJ.GOV,City,Non-Federal Agency,Tabernacle,NJ,ACTIVE
+TRAVERSECITYMI.GOV,City,Non-Federal Agency,Traverse City,MI,ACTIVE
+TRENTONGA.GOV,City,Non-Federal Agency,trenton,GA,ACTIVE
+TRICOUNTYCONSERVANCY-IN.GOV,City,Non-Federal Agency,Plainfield,IN,ACTIVE
+TRINITY-NC.GOV,City,Non-Federal Agency,Trinity,NC,ACTIVE
+TRINITYAL.GOV,City,Non-Federal Agency,Trinity,AL,ACTIVE
+TROPHYCLUBTX.GOV,City,Non-Federal Agency,Trophy Club,TX,ACTIVE
+TROUTDALEOREGON.GOV,City,Non-Federal Agency,Troutdale,OR,ACTIVE
+TROUTMANNC.GOV,City,Non-Federal Agency,Troutman,NC,ACTIVE
+TROYAL.GOV,City,Non-Federal Agency,Troy,AL,ACTIVE
+TROYMI.GOV,City,Non-Federal Agency,Troy,MI,ACTIVE
+TROYNY.GOV,City,Non-Federal Agency,Troy,NY,ACTIVE
+TROYOHIO.GOV,City,Non-Federal Agency,Troy,OH,ACTIVE
+TRUMANSBURG-NY.GOV,City,Non-Federal Agency,Trumansburg,NY,ACTIVE
+TRUMBULL-CT.GOV,City,Non-Federal Agency,Trumbull,CT,ACTIVE
+TRURO-MA.GOV,City,Non-Federal Agency,Truro,MA,ACTIVE
+TUALATINOREGON.GOV,City,Non-Federal Agency,TUALATIN,OR,ACTIVE
+TUCKERGA.GOV,City,Non-Federal Agency,Tucker,GA,ACTIVE
+TUCSONAZ.GOV,City,Non-Federal Agency,Tucson,AZ,ACTIVE
+TUKWILA-WA.GOV,City,Non-Federal Agency,Tukwila,WA,ACTIVE
+TUKWILAWA.GOV,City,Non-Federal Agency,Tukwila,WA,ACTIVE
+TULIA-TX.GOV,City,Non-Federal Agency,Tulia,TX,ACTIVE
+TULLAHOMATN.GOV,City,Non-Federal Agency,Tullahoma,TN,ACTIVE
+TUMWATERWA.GOV,City,Non-Federal Agency,Tumwater,WA,ACTIVE
+TUPELOMS.GOV,City,Non-Federal Agency,Tupelo,MS,ACTIVE
+TUPPERLAKENY.GOV,City,Non-Federal Agency,Tupper Lake,NY,ACTIVE
+TUSAYAN-AZ.GOV,City,Non-Federal Agency,Tusayan,AZ,ACTIVE
+TUSAYANAZ.GOV,City,Non-Federal Agency,Grand Canyon,AZ,ACTIVE
+TUSCALOOSA-AL.GOV,City,Non-Federal Agency,Tuscaloosa,AL,ACTIVE
+TUSKEGEEALABAMA.GOV,City,Non-Federal Agency,Tuskegee,AL,ACTIVE
+TUXEDOPARK-NY.GOV,City,Non-Federal Agency,Sloatsburg,NY,ACTIVE
+TWPOCEANNJ.GOV,City,Non-Federal Agency,Waretown,NJ,ACTIVE
+TYNGSBOROUGHMA.GOV,City,Non-Federal Agency,Tyngsborough,MA,ACTIVE
+TYRINGHAM-MA.GOV,City,Non-Federal Agency,Tyringham,MA,ACTIVE
+UCTX.GOV,City,Non-Federal Agency,Universal City,TX,ACTIVE
+UNDERHILLVT.GOV,City,Non-Federal Agency,"Underhill, Ctr",VT,ACTIVE
+UNIONBEACHNJ.GOV,City,Non-Federal Agency,Union Beach,NJ,ACTIVE
+UNIONCITY-IN.GOV,City,Non-Federal Agency,Union City,IN,ACTIVE
+UNIONCITYNJ.GOV,City,Non-Federal Agency,Union City,NJ,ACTIVE
+UNIONCITYTN.GOV,City,Non-Federal Agency,UNION CITY,TN,ACTIVE
+UNIONGAPWA.GOV,City,Non-Federal Agency,Union Gap,WA,ACTIVE
+UNIONSPRINGSAL.GOV,City,Non-Federal Agency,Union Springs,AL,ACTIVE
+UNIONTWP-HCNJ.GOV,City,Non-Federal Agency,HAMPTON,NJ,ACTIVE
+UNITYNH.GOV,City,Non-Federal Agency,Charlestown,NH,ACTIVE
+UNIVERSALCITYTEXAS.GOV,City,Non-Federal Agency,Universal City,TX,ACTIVE
+UPLANDCA.GOV,City,Non-Federal Agency,UPLAND,CA,ACTIVE
+UPPERMARLBOROMD.GOV,City,Non-Federal Agency,Upper Marlboro,MD,ACTIVE
+UPPERUWCHLAN-PA.GOV,City,Non-Federal Agency,Chester Springs,PA,ACTIVE
+UPTONMA.GOV,City,Non-Federal Agency,Upton,MA,ACTIVE
+URBANNAVA.GOV,City,Non-Federal Agency,Urbanna,VA,ACTIVE
+UTICA-IL.GOV,City,Non-Federal Agency,Utica,IL,ACTIVE
+UVALDETX.GOV,City,Non-Federal Agency,Uvalde,TX,ACTIVE
+UXBRIDGE-MA.GOV,City,Non-Federal Agency,Uxbridge,MA,ACTIVE
+VANMETERIA.GOV,City,Non-Federal Agency,Van Meter,IA,ACTIVE
+VBHIL.GOV,City,Non-Federal Agency,Barrington Hills,IL,ACTIVE
+VENETAOREGON.GOV,City,Non-Federal Agency,Veneta,OR,ACTIVE
+VERMONTVILLE-MI.GOV,City,Non-Federal Agency,Vermontville,MI,ACTIVE
+VERNON-CT.GOV,City,Non-Federal Agency,Vernon,CT,ACTIVE
+VERNONIA-OR.GOV,City,Non-Federal Agency,Vernonia,OR,ACTIVE
+VERNONTWP-PA.GOV,City,Non-Federal Agency,Meadville,PA,ACTIVE
+VERNONTX.GOV,City,Non-Federal Agency,Vernon,TX,ACTIVE
+VERONAWI.GOV,City,Non-Federal Agency,Verona,WI,ACTIVE
+VICKSBURGMS.GOV,City,Non-Federal Agency,Vicksburg,MS,ACTIVE
+VICTORVILLECA.GOV,City,Non-Federal Agency,Victorville,CA,ACTIVE
+VICTORYGARDENSNJ.GOV,City,Non-Federal Agency,Victory Gardens,NJ,ACTIVE
+VIDALIAGA.GOV,City,Non-Federal Agency,VIDALIA,GA,ACTIVE
+VIENNAVA.GOV,City,Non-Federal Agency,VIENNA,VA,ACTIVE
+VILLAGEOFBABYLONNY.GOV,City,Non-Federal Agency,Babylon,NY,ACTIVE
+VILLAGEOFCAMILLUS-NY.GOV,City,Non-Federal Agency,CAMILLUS,NY,ACTIVE
+VILLAGEOFCRESTWOODIL.GOV,City,Non-Federal Agency,Crestwood,IL,ACTIVE
+VILLAGEOFDUNLAP-IL.GOV,City,Non-Federal Agency,Dunlap,IL,ACTIVE
+VILLAGEOFGOSHEN-NY.GOV,City,Non-Federal Agency,Goshen,NY,ACTIVE
+VILLAGEOFGOUVERNEURNY.GOV,City,Non-Federal Agency,Gouverneur,NY,ACTIVE
+VILLAGEOFHEMPSTEADNY.GOV,City,Non-Federal Agency,Hemsptead,NY,ACTIVE
+VILLAGEOFKENSINGTONNY.GOV,City,Non-Federal Agency,Great Neck,NY,ACTIVE
+VILLAGEOFLINDENHURSTNY.GOV,City,Non-Federal Agency,Lindenhurst,NY,ACTIVE
+VILLAGEOFMAMARONECKNY.GOV,City,Non-Federal Agency,Mamaroneck,NY,ACTIVE
+VILLAGEOFMAZOMANIEWI.GOV,City,Non-Federal Agency,Mazomanie,WI,ACTIVE
+VILLAGEOFMCCOMBOH.GOV,City,Non-Federal Agency,McComb,OH,ACTIVE
+VILLAGEOFMISENHEIMERNC.GOV,City,Non-Federal Agency,Misenheimer,NC,ACTIVE
+VILLAGEOFNEWHAVEN-MI.GOV,City,Non-Federal Agency,New Haven,MI,ACTIVE
+VILLAGEOFNEWHOLLAND-OH.GOV,City,Non-Federal Agency,New Holland,OH,ACTIVE
+VILLAGEOFNEWTOWNOHIO.GOV,City,Non-Federal Agency,Newtown,OH,ACTIVE
+VILLAGEOFPHOENIX-NY.GOV,City,Non-Federal Agency,Phoenix,NY,ACTIVE
+VILLAGEOFPINEHURSTNC.GOV,City,Non-Federal Agency,Pinehurst,NC,ACTIVE
+VILLAGEOFQUOGUENY.GOV,City,Non-Federal Agency,Quogue,NY,ACTIVE
+VILLAGEOFRHINEBECKNY.GOV,City,Non-Federal Agency,Rhinebeck,NY,ACTIVE
+VILLAGEOFSCOTIANY.GOV,City,Non-Federal Agency,Scotia,NY,ACTIVE
+VILLAGEOFVOLENTE-TX.GOV,City,Non-Federal Agency,Volente,TX,ACTIVE
+VILLAGEOFWAUCONDA-IL.GOV,City,Non-Federal Agency,Wauconda,IL,ACTIVE
+VINTONVA.GOV,City,Non-Federal Agency,Vinton,VA,ACTIVE
+VIRGINIAGARDENS-FL.GOV,City,Non-Federal Agency,Virginia Gardens,FL,ACTIVE
+VOLENTETEXAS.GOV,City,Non-Federal Agency,Volente,TX,ACTIVE
+VOLUNTOWN.GOV,City,Non-Federal Agency,Voluntown,CT,ACTIVE
+VONORMYTX.GOV,City,Non-Federal Agency,Von Ormy,TX,ACTIVE
+WACOTX.GOV,City,Non-Federal Agency,Waco,TX,ACTIVE
+WAITEHILLOH.GOV,City,Non-Federal Agency,Waite Hill,OH,ACTIVE
+WAKEFORESTNC.GOV,City,Non-Federal Agency,WAKE FOREST,NC,ACTIVE
+WALDENTN.GOV,City,Non-Federal Agency,Signal Mountain,TN,ACTIVE
+WALKER-LA.GOV,City,Non-Federal Agency,Walker,LA,ACTIVE
+WALKERSVILLEMD.GOV,City,Non-Federal Agency,Walkersville,MD,ACTIVE
+WALLAWALLAWA.GOV,City,Non-Federal Agency,Walla Walla,WA,ACTIVE
+WALLINGFORDCT.GOV,City,Non-Federal Agency,Wallingford,CT,ACTIVE
+WALNUTGROVEMS.GOV,City,Non-Federal Agency,Walnut Grove,MS,ACTIVE
+WALTONHILLSOHIO.GOV,City,Non-Federal Agency,Walton Hills,OH,ACTIVE
+WANATAH-IN.GOV,City,Non-Federal Agency,Wanatah,IN,ACTIVE
+WAPPINGERSFALLSNY.GOV,City,Non-Federal Agency,Wappingers Falls,NY,ACTIVE
+WARNERROBINSGA.GOV,City,Non-Federal Agency,Warner Robins,GA,ACTIVE
+WARRACRES-OK.GOV,City,Non-Federal Agency,Warr Acres,OK,ACTIVE
+WARREN-MA.GOV,City,Non-Federal Agency,Warren,MA,ACTIVE
+WARRENPA.GOV,City,Non-Federal Agency,Warren,PA,ACTIVE
+WARRENTONVA.GOV,City,Non-Federal Agency,Warrenton,VA,ACTIVE
+WARWICKRI.GOV,City,Non-Federal Agency,Warwick,RI,ACTIVE
+WASHINGTON-WARRENAIRPORT-NC.GOV,City,Non-Federal Agency,WASHINGTON,NC,ACTIVE
+WASHINGTONBORO-NJ.GOV,City,Non-Federal Agency,Washington,NJ,ACTIVE
+WASHINGTONISLAND-WI.GOV,City,Non-Federal Agency,Washington Island,WI,ACTIVE
+WASHINGTONPA.GOV,City,Non-Federal Agency,Washington,PA,ACTIVE
+WASHINGTONVA.GOV,City,Non-Federal Agency,Washington,VA,ACTIVE
+WASHINGTONVILLE-NY.GOV,City,Non-Federal Agency,Washingtonville,NY,ACTIVE
+WASHINGTONVIRGINIA.GOV,City,Non-Federal Agency,Washington,VA,ACTIVE
+WATCHUNGNJ.GOV,City,Non-Federal Agency,Watchung,NJ,ACTIVE
+WATERBORO-ME.GOV,City,Non-Federal Agency,East Waterboro,ME,ACTIVE
+WATERFORDMI.GOV,City,Non-Federal Agency,Waterford,MI,ACTIVE
+WATERTOWN-MA.GOV,City,Non-Federal Agency,Watertown,MA,ACTIVE
+WATERTOWN-NY.GOV,City,Non-Federal Agency,Watertown,NY,ACTIVE
+WATERVILLE-ME.GOV,City,Non-Federal Agency,Waterville,ME,ACTIVE
+WAUCONDA-IL.GOV,City,Non-Federal Agency,Wauconda,IL,ACTIVE
+WAUKEGANIL.GOV,City,Non-Federal Agency,Waukegan,IL,ACTIVE
+WAUKESHA-WI.GOV,City,Non-Federal Agency,Waukesha,WI,ACTIVE
+WAVELAND-MS.GOV,City,Non-Federal Agency,Waveland,MS,ACTIVE
+WAYNESBURGPA.GOV,City,Non-Federal Agency,Waynesburg,PA,ACTIVE
+WAYNESVILLENC.GOV,City,Non-Federal Agency,Waynesville,NC,ACTIVE
+WEATHERFORDTX.GOV,City,Non-Federal Agency,Weatherford,TX,ACTIVE
+WEATHERLYPA.GOV,City,Non-Federal Agency,Weatherly,PA,ACTIVE
+WEBSTER-MA.GOV,City,Non-Federal Agency,Webster,MA,ACTIVE
+WEBSTER-NH.GOV,City,Non-Federal Agency,Webster,NH,ACTIVE
+WEBSTERFL.GOV,City,Non-Federal Agency,Webster,FL,ACTIVE
+WEEHAWKENNJ.GOV,City,Non-Federal Agency,Weehawken,NJ,ACTIVE
+WELAKA-FL.GOV,City,Non-Federal Agency,Welaka,FL,ACTIVE
+WELLESLEYMA.GOV,City,Non-Federal Agency,Wellesley,MA,ACTIVE
+WELLFLEET-MA.GOV,City,Non-Federal Agency,Wellfleet,MA,ACTIVE
+WELLINGTONCOLORADO.GOV,City,Non-Federal Agency,Wellington,CO,ACTIVE
+WELLINGTONFL.GOV,City,Non-Federal Agency,Wellington,FL,ACTIVE
+WELLSBURGWV.GOV,City,Non-Federal Agency,WELLSBURG,WV,ACTIVE
+WENATCHEEWA.GOV,City,Non-Federal Agency,Wenatchee,WA,ACTIVE
+WESLACOTX.GOV,City,Non-Federal Agency,Weslaco,TX,ACTIVE
+WESSONMS.GOV,City,Non-Federal Agency,Wesson,MS,ACTIVE
+WESTALLISWI.GOV,City,Non-Federal Agency,West Allis,WI,ACTIVE
+WESTAMPTONNJ.GOV,City,Non-Federal Agency,Westampton,NJ,ACTIVE
+WESTBENDWI.GOV,City,Non-Federal Agency,West Bend,WI,ACTIVE
+WESTBOYLSTON-MA.GOV,City,Non-Federal Agency,West Boylston,MA,ACTIVE
+WESTBUECHELKY.GOV,City,Non-Federal Agency,WEST BUECHEL,KY,ACTIVE
+WESTCOLUMBIASC.GOV,City,Non-Federal Agency,West Columbia,SC,ACTIVE
+WESTFARGOND.GOV,City,Non-Federal Agency,Bismarck,ND,ACTIVE
+WESTFIELDNJ.GOV,City,Non-Federal Agency,Westfield,NJ,ACTIVE
+WESTFORD-MA.GOV,City,Non-Federal Agency,Westford,MA,ACTIVE
+WESTFORDMA.GOV,City,Non-Federal Agency,Westford,MA,ACTIVE
+WESTFORKAR.GOV,City,Non-Federal Agency,West Fork,AR,ACTIVE
+WESTFRANKFORT-IL.GOV,City,Non-Federal Agency,West Frankfort,IL,ACTIVE
+WESTHARTFORDCT.GOV,City,Non-Federal Agency,West Hartford,CT,ACTIVE
+WESTHAVEN-CT.GOV,City,Non-Federal Agency,West Haven,CT,ACTIVE
+WESTJEFFERSONOHIO.GOV,City,Non-Federal Agency,West Jefferson,OH,ACTIVE
+WESTLINNOREGON.GOV,City,Non-Federal Agency,West Linn,OR,ACTIVE
+WESTMILTONOHIO.GOV,City,Non-Federal Agency,West Milton,OH,ACTIVE
+WESTMINSTER-CA.GOV,City,Non-Federal Agency,Westminster,CA,ACTIVE
+WESTMINSTER-MA.GOV,City,Non-Federal Agency,Westminster,MA,ACTIVE
+WESTMINSTERMD.GOV,City,Non-Federal Agency,Westminster,MD,ACTIVE
+WESTMORELANDTN.GOV,City,Non-Federal Agency,Westmoreland,TN,ACTIVE
+WESTONCT.GOV,City,Non-Federal Agency,Weston,CT,ACTIVE
+WESTONFL.GOV,City,Non-Federal Agency,Weston,FL,ACTIVE
+WESTONWI.GOV,City,Non-Federal Agency,Weston,WI,ACTIVE
+WESTPALMBEACH-FL.GOV,City,Non-Federal Agency,West Palm Beach,FL,ACTIVE
+WESTPORT-MA.GOV,City,Non-Federal Agency,Westport,MA,ACTIVE
+WESTPORTCT.GOV,City,Non-Federal Agency,Westport,CT,ACTIVE
+WESTSTOCKBRIDGE-MA.GOV,City,Non-Federal Agency,West Stockbridge,MA,ACTIVE
+WESTTISBURY-MA.GOV,City,Non-Federal Agency,West Tisbury,MA,ACTIVE
+WESTUTX.GOV,City,Non-Federal Agency,West University Place ,TX,ACTIVE
+WESTVALLEYCITY-UT.GOV,City,Non-Federal Agency,West Valley City,UT,ACTIVE
+WESTWOOD-MA.GOV,City,Non-Federal Agency,Westwood,MA,ACTIVE
+WESTWOODMA.GOV,City,Non-Federal Agency,Westwood,MA,ACTIVE
+WESTWOODNJ.GOV,City,Non-Federal Agency,Westwood,NJ,ACTIVE
+WETHERSFIELDCT.GOV,City,Non-Federal Agency,Wethersfield,CT,ACTIVE
+WHEELINGIL.GOV,City,Non-Federal Agency,Wheeling,IL,ACTIVE
+WHEELINGWV.GOV,City,Non-Federal Agency,Wheeling,WV,ACTIVE
+WHITECOUNTY-IL.GOV,City,Non-Federal Agency,Carmi,IL,ACTIVE
+WHITEHOUSEOH.GOV,City,Non-Federal Agency,Whitehouse,OH,ACTIVE
+WHITEPLAINSNY.GOV,City,Non-Federal Agency,White Plains,NY,ACTIVE
+WHITEWATER-WI.GOV,City,Non-Federal Agency,Whitewater,WI,ACTIVE
+WHITINGWI.GOV,City,Non-Federal Agency,Stevens Point,WI,ACTIVE
+WHITTIERALASKA.GOV,City,Non-Federal Agency,Whittier,AK,ACTIVE
+WICHITA.GOV,City,Non-Federal Agency,Wichita,KS,ACTIVE
+WICHITAFALLSTX.GOV,City,Non-Federal Agency,Wichita Falls,TX,ACTIVE
+WILBRAHAM-MA.GOV,City,Non-Federal Agency,Wilbraham,MA,ACTIVE
+WILDWOOD-FL.GOV,City,Non-Federal Agency,Wildwood,FL,ACTIVE
+WILKINSBURGPA.GOV,City,Non-Federal Agency,Wilkinsburg,PA,ACTIVE
+WILLAMINAOREGON.GOV,City,Non-Federal Agency,Willamina,OR,ACTIVE
+WILLARDNM.GOV,City,Non-Federal Agency,Willard,NM,ACTIVE
+WILLIAMSAZ.GOV,City,Non-Federal Agency,Williams,AZ,ACTIVE
+WILLIAMSBURGVA.GOV,City,Non-Federal Agency,Williamsburg,VA,ACTIVE
+WILLIAMSPORTMD.GOV,City,Non-Federal Agency,WILLIAMSPORT,MD,ACTIVE
+WILLIAMSTOWNMA.GOV,City,Non-Federal Agency,Williamstown,MA,ACTIVE
+WILLINGBORONJ.GOV,City,Non-Federal Agency,Willingboro,NJ,ACTIVE
+WILLINGTONCT.GOV,City,Non-Federal Agency,Willington,CT,ACTIVE
+WILLISTONFL.GOV,City,Non-Federal Agency,Williston,FL,ACTIVE
+WILLMARMN.GOV,City,Non-Federal Agency,Willmar,MN,ACTIVE
+WILLOUGHBYHILLS-OH.GOV,City,Non-Federal Agency,Willoughby Hills,OH,ACTIVE
+WILLOWSPRINGS-IL.GOV,City,Non-Federal Agency,Willow Springs,IL,ACTIVE
+WILMINGTONDE.GOV,City,Non-Federal Agency,Wilmington,DE,ACTIVE
+WILMINGTONMA.GOV,City,Non-Federal Agency,wilmington,MA,ACTIVE
+WILTONNH.GOV,City,Non-Federal Agency,Wilton,NH,ACTIVE
+WINCHESTER-IN.GOV,City,Non-Federal Agency,Winchester,IN,ACTIVE
+WINCHESTER-NH.GOV,City,Non-Federal Agency,Winchester,NH,ACTIVE
+WINCHESTERVA.GOV,City,Non-Federal Agency,Winchester,VA,ACTIVE
+WINDCREST-TX.GOV,City,Non-Federal Agency,Windcrest,TX,ACTIVE
+WINDGAP-PA.GOV,City,Non-Federal Agency,Wind Gap,PA,ACTIVE
+WINDHAMNH.GOV,City,Non-Federal Agency,Windham,NH,ACTIVE
+WINDSOR-VA.GOV,City,Non-Federal Agency,Windsor,VA,ACTIVE
+WINDSORWI.GOV,City,Non-Federal Agency,DeForest,WI,ACTIVE
+WINNECONNEWI.GOV,City,Non-Federal Agency,Winneconne,WI,ACTIVE
+WINSLOW-ME.GOV,City,Non-Federal Agency,Winslow,ME,ACTIVE
+WINSLOWAZ.GOV,City,Non-Federal Agency,Winslow,AZ,ACTIVE
+WOBURNMA.GOV,City,Non-Federal Agency,Woburn,MA,ACTIVE
+WOODBURN-OR.GOV,City,Non-Federal Agency,Woodburn,OR,ACTIVE
+WOODBURYMN.GOV,City,Non-Federal Agency,Woodbury,MN,ACTIVE
+WOODFIN-NC.GOV,City,Non-Federal Agency,Woodfin,NC,ACTIVE
+WOODHEIGHTS-MO.GOV,City,Non-Federal Agency,Wood Heights,MO,ACTIVE
+WOODSTOCKCT.GOV,City,Non-Federal Agency,Woodstock,CT,ACTIVE
+WOODSTOCKGA.GOV,City,Non-Federal Agency,Woodstock,GA,ACTIVE
+WOODSTOCKIL.GOV,City,Non-Federal Agency,Woodstock,IL,ACTIVE
+WOODVILLE-TX.GOV,City,Non-Federal Agency,Woodville,TX,ACTIVE
+WORCESTERMA.GOV,City,Non-Federal Agency,Worcester,MA,ACTIVE
+WRGA.GOV,City,Non-Federal Agency,Warner Robins,GA,ACTIVE
+WSPMN.GOV,City,Non-Federal Agency,West Saint Paul,MN,ACTIVE
+WVC-UT.GOV,City,Non-Federal Agency,West Valley,UT,ACTIVE
+WYLIETEXAS.GOV,City,Non-Federal Agency,Wylie,TX,ACTIVE
+WYOMINGMI.GOV,City,Non-Federal Agency,Wyoming,MI,ACTIVE
+WYOMINGOHIO.GOV,City,Non-Federal Agency,Wyoming,OH,ACTIVE
+XENIA-OH.GOV,City,Non-Federal Agency,Xenia,OH,ACTIVE
+YAKIMAWA.GOV,City,Non-Federal Agency,Yakima,WA,ACTIVE
+YAMHILLCOUNTY-OR.GOV,City,Non-Federal Agency,McMinnville,OR,ACTIVE
+YONKERSNY.GOV,City,Non-Federal Agency,Yonkers,NY,ACTIVE
+YORKTOWNTX.GOV,City,Non-Federal Agency,Yorktown,TX,ACTIVE
+YOUNGSTOWNOHIO.GOV,City,Non-Federal Agency,Youngstown,OH,ACTIVE
+YOUNGSVILLELA.GOV,City,Non-Federal Agency,Youngsville,LA,ACTIVE
+YUCAIPA-CA.GOV,City,Non-Federal Agency,Yucaipa,CA,ACTIVE
+YUMAAZ.GOV,City,Non-Federal Agency,Yuma,AZ,ACTIVE
+ZILWAUKEEMICHIGAN.GOV,City,Non-Federal Agency,Zilwaukee,MI,ACTIVE

--- a/dotgov-domains/2016-06-30-counties.csv
+++ b/dotgov-domains/2016-06-30-counties.csv
@@ -1,0 +1,572 @@
+Domain Name,Domain Type,Agency,City,State,Status
+ADAMSCOUNTYMS.GOV,County,Non-Federal Agency,Natchez,MS,ACTIVE
+ADAMSCOUNTYOH.GOV,County,Non-Federal Agency,West Union,OH,ACTIVE
+AIKENCOUNTYSC.GOV,County,Non-Federal Agency,Aiken,SC,ACTIVE
+ALBANYCOUNTYNY.GOV,County,Non-Federal Agency,Albany,NY,ACTIVE
+ALEXANDERCOUNTY-NC.GOV,County,Non-Federal Agency,Taylorsville,NC,ACTIVE
+ALEXANDERCOUNTYNC.GOV,County,Non-Federal Agency,Taylorsville,NC,ACTIVE
+ALLEGHANYCOUNTY-NC.GOV,County,Non-Federal Agency,Sparta,NC,ACTIVE
+ALLEGHENYCOUNTYPA.GOV,County,Non-Federal Agency,Pittsburgh,PA,ACTIVE
+ALPINECOUNTYCA.GOV,County,Non-Federal Agency,Markleeville,CA,ACTIVE
+AMITECOUNTYMS.GOV,County,Non-Federal Agency,Liberty,MS,ACTIVE
+ANDROSCOGGINCOUNTYMAINE.GOV,County,Non-Federal Agency,Auburn,ME,ACTIVE
+ANOKACOUNTYMN.GOV,County,Non-Federal Agency,Anoka,MN,ACTIVE
+APPOMATTOXCOUNTYVA.GOV,County,Non-Federal Agency,Appomattox,VA,ACTIVE
+ARANSASCOUNTYTX.GOV,County,Non-Federal Agency,Rockport,TX,ACTIVE
+AUGUSTACOUNTY-VA.GOV,County,Non-Federal Agency,Verona,VA,ACTIVE
+AUGUSTACOUNTYVA.GOV,County,Non-Federal Agency,Verona,VA,ACTIVE
+AVERYCOUNTYNC.GOV,County,Non-Federal Agency,Newland,NC,ACTIVE
+BACACOUNTYCO.GOV,County,Non-Federal Agency,Springfield,CO,ACTIVE
+BALDWINCOUNTYAL.GOV,County,Non-Federal Agency,Bay Minette,AL,ACTIVE
+BALTIMORECOUNTYMD.GOV,County,Non-Federal Agency,Towson,MD,ACTIVE
+BAMBERGCOUNTYSC.GOV,County,Non-Federal Agency,Bamberg,SC,ACTIVE
+BARNSTABLECOUNTY-MA.GOV,County,Non-Federal Agency,Barnstable,MA,ACTIVE
+BARRONCOUNTYWI.GOV,County,Non-Federal Agency,Barron,WI,ACTIVE
+BASTROPCOUNTYTEXAS.GOV,County,Non-Federal Agency,Bastrop,TX,ACTIVE
+BAYCOUNTY911-MI.GOV,County,Non-Federal Agency,Bay City,MI,ACTIVE
+BAYCOUNTYFL.GOV,County,Non-Federal Agency,Panama City,FL,ACTIVE
+BCCIRCLK.GOV,County,Non-Federal Agency,Princeton,IL,ACTIVE
+BEAVERCOUNTYPA.GOV,County,Non-Federal Agency,Beaver,PA,ACTIVE
+BEDFORDCOUNTYVA.GOV,County,Non-Federal Agency,Bedford,VA,ACTIVE
+BENTONCOUNTYAR.GOV,County,Non-Federal Agency,Bentonville,AR,ACTIVE
+BENTONCOUNTYMS.GOV,County,Non-Federal Agency,Ashland,MS,ACTIVE
+BENTONCOUNTYTN.GOV,County,Non-Federal Agency,Camden,TN,ACTIVE
+BERKELEYCOUNTYSC.GOV,County,Non-Federal Agency,Moncks Corner,SC,ACTIVE
+BERRIENCOUNTY-MI.GOV,County,Non-Federal Agency,St. Joseph,MI,ACTIVE
+BIGHORNCOUNTYMT.GOV,County,Non-Federal Agency,Hardin,MT,ACTIVE
+BIGHORNCOUNTYWY.GOV,County,Non-Federal Agency,Basin,WY,ACTIVE
+BILLINGSCOUNTYND.GOV,County,Non-Federal Agency,Medora,ND,ACTIVE
+BLAINECOUNTY-MT.GOV,County,Non-Federal Agency,CHINOOK,MT,ACTIVE
+BLANDCOUNTYVA.GOV,County,Non-Federal Agency,Bland,VA,ACTIVE
+BLUEEARTHCOUNTYMN.GOV,County,Non-Federal Agency,Mankato,MN,ACTIVE
+BONNERCOUNTYID.GOV,County,Non-Federal Agency,Sandpoint,ID,ACTIVE
+BOONECOUNTY-AR.GOV,County,Non-Federal Agency,Harrison,AR,ACTIVE
+BOSSIERPARISHLA.GOV,County,Non-Federal Agency,Benton ,LA,ACTIVE
+BOTETOURTVA.GOV,County,Non-Federal Agency,Fincastle,VA,ACTIVE
+BOULDERCOUNTYCOLORADO.GOV,County,Non-Federal Agency,Boulder,CO,ACTIVE
+BOWMANCOUNTYND.GOV,County,Non-Federal Agency,Bismarck,ND,ACTIVE
+BOYDCOUNTYKY.GOV,County,Non-Federal Agency,Catlettsburg,KY,ACTIVE
+BRADFORDCOUNTYFL.GOV,County,Non-Federal Agency,Starke,FL,ACTIVE
+BRADLEYCOUNTYTN.GOV,County,Non-Federal Agency,Cleveland,TN,ACTIVE
+BRANCHCOUNTYMI.GOV,County,Non-Federal Agency,Coldwater,MI,ACTIVE
+BRAZORIACOUNTY-TX.GOV,County,Non-Federal Agency,Angleton,TX,ACTIVE
+BRAZORIACOUNTY.GOV,County,Non-Federal Agency,Angleton,TX,ACTIVE
+BRAZORIACOUNTYTX.GOV,County,Non-Federal Agency,Angleton,TX,ACTIVE
+BRAZOSCOUNTYTX.GOV,County,Non-Federal Agency,Bryan,TX,ACTIVE
+BRECKINRIDGECOUNTYKY.GOV,County,Non-Federal Agency,Hardinsburg,KY,ACTIVE
+BREVARDFL.GOV,County,Non-Federal Agency,Viera,FL,ACTIVE
+BROOKINGSCOUNTYSD.GOV,County,Non-Federal Agency,Brookings,SD,ACTIVE
+BROOMECOUNTYNY.GOV,County,Non-Federal Agency,Binghamton,NY,ACTIVE
+BROWNCOUNTY-IN.GOV,County,Non-Federal Agency,Nashville,IN,ACTIVE
+BROWNCOUNTYOHIO.GOV,County,Non-Federal Agency,Georgetown,OH,ACTIVE
+BROWNCOUNTYWI.GOV,County,Non-Federal Agency,Green Bay,WI,ACTIVE
+BRUNSWICKCOUNTYNC.GOV,County,Non-Federal Agency,Bolivia,NC,ACTIVE
+BUCHANANCOUNTY-VA.GOV,County,Non-Federal Agency,Grundy,VA,ACTIVE
+BUNCOMBECOUNTYNC.GOV,County,Non-Federal Agency,Asheville,NC,ACTIVE
+BUREAUCOUNTY-IL.GOV,County,Non-Federal Agency,Princeton,IL,ACTIVE
+CABARRUSCOUNTYNC.GOV,County,Non-Federal Agency,Concord,NC,ACTIVE
+CALHOUNCOUNTYAL.GOV,County,Non-Federal Agency,Anniston,AL,ACTIVE
+CALHOUNCOUNTYMI.GOV,County,Non-Federal Agency,Marshall,MI,ACTIVE
+CALLOWAYCOUNTY-KY.GOV,County,Non-Federal Agency,Murray,KY,ACTIVE
+CAMBRIACOUNTYPA.GOV,County,Non-Federal Agency,Ebensburg,PA,ACTIVE
+CAMDENCOUNTYNC.GOV,County,Non-Federal Agency,Camden,NC,ACTIVE
+CAMPBELLCOUNTYKY.GOV,County,Non-Federal Agency,Newport,KY,ACTIVE
+CAMPBELLCOUNTYTN.GOV,County,Non-Federal Agency,Jacksboro,TN,ACTIVE
+CAMPBELLCOUNTYVA.GOV,County,Non-Federal Agency,Rustburg,VA,ACTIVE
+CANDLERCO-GA.GOV,County,Non-Federal Agency,Metter,GA,ACTIVE
+CAPECOD-MA.GOV,County,Non-Federal Agency,Barnstable,MA,ACTIVE
+CAPEMAYCOUNTYNJ.GOV,County,Non-Federal Agency,Cape May Court House,NJ,ACTIVE
+CAPITALALERT.GOV,County,Non-Federal Agency,Fairfax,VA,ACTIVE
+CAPITALERT.GOV,County,Non-Federal Agency,Fairfax,VA,ACTIVE
+CAPITALREGION.GOV,County,Non-Federal Agency,Fairfax,VA,ACTIVE
+CAROLINECOUNTYVA.GOV,County,Non-Federal Agency,Bowling Green,VA,ACTIVE
+CARROLLCOUNTYIN.GOV,County,Non-Federal Agency,Delphi,IN,ACTIVE
+CARTERCOUNTYTN.GOV,County,Non-Federal Agency,Elizabethton,TN,ACTIVE
+CARTERETCOUNTYNC.GOV,County,Non-Federal Agency,Beaufort,NC,ACTIVE
+CASCADECOUNTYMT.GOV,County,Non-Federal Agency,Great Falls,MT,ACTIVE
+CASSCOUNTYND.GOV,County,Non-Federal Agency,Bismarck,ND,ACTIVE
+CASWELLCOUNTYNC.GOV,County,Non-Federal Agency,Yanceyville,NC,ACTIVE
+CATAWBACOUNTYNC.GOV,County,Non-Federal Agency,Newton,NC,ACTIVE
+CATRONCOUNTYNM.GOV,County,Non-Federal Agency,Reserve,NM,ACTIVE
+CECILCOUNTYMD.GOV,County,Non-Federal Agency,Elkton,MD,ACTIVE
+CEDARCOUNTYMO.GOV,County,Non-Federal Agency,Stockton,MO,ACTIVE
+CENTRECOUNTYPA.GOV,County,Non-Federal Agency,Bellefonte,PA,ACTIVE
+CHAMBERSCOUNTYAL.GOV,County,Non-Federal Agency,Lafayette,AL,ACTIVE
+CHAMBERSTX.GOV,County,Non-Federal Agency,Anahuac,TX,ACTIVE
+CHARLESCOUNTYMD.GOV,County,Non-Federal Agency,La Plata,MD,ACTIVE
+CHARLOTTECOUNTYFL.GOV,County,Non-Federal Agency,Port Charlotte,FL,ACTIVE
+CHARLTONCOUNTYGA.GOV,County,Non-Federal Agency,Folkston,GA,ACTIVE
+CHATHAMCOUNTYGA.GOV,County,Non-Federal Agency,Savannah,GA,ACTIVE
+CHEATHAMCOUNTYTN.GOV,County,Non-Federal Agency,Ashland City,TN,ACTIVE
+CHELANCOUNTYWA.GOV,County,Non-Federal Agency,Wenatchee,WA,ACTIVE
+CHEROKEECOUNTY-AL.GOV,County,Non-Federal Agency,Centre,AL,ACTIVE
+CHEROKEECOUNTY-KS.GOV,County,Non-Federal Agency,Columbus,KS,ACTIVE
+CHEROKEECOUNTY-NC.GOV,County,Non-Federal Agency,Murphy,NC,ACTIVE
+CHEROKEECOUNTYKS.GOV,County,Non-Federal Agency,Columbus,KS,ACTIVE
+CHEROKEECOUNTYSC.GOV,County,Non-Federal Agency,Gaffney,SC,ACTIVE
+CHESTERFIELDCOUNTY.GOV,County,Non-Federal Agency,Chesterfield,VA,ACTIVE
+CHEYENNECOUNTY-CO.GOV,County,Non-Federal Agency,CHEYENNE WELLS,CO,ACTIVE
+CHIPPEWACOUNTYMI.GOV,County,Non-Federal Agency,Sault Ste Marie,MI,ACTIVE
+CHRISTIANCOUNTYKY.GOV,County,Non-Federal Agency,Hopkinsville,KY,ACTIVE
+CHRISTIANCOUNTYMO.GOV,County,Non-Federal Agency,Ozark,MO,ACTIVE
+CLARKCOUNTYNV.GOV,County,Non-Federal Agency,Las Vegas,NV,ACTIVE
+CLARKCOUNTYOHIO.GOV,County,Non-Federal Agency,Springfield,OH,ACTIVE
+CLARKECOUNTY.GOV,County,Non-Federal Agency,Berryville,VA,ACTIVE
+CLARKECOUNTYMS.GOV,County,Non-Federal Agency,Quitman,MS,ACTIVE
+CLATSOPCOUNTYOR.GOV,County,Non-Federal Agency,Astoria,OR,ACTIVE
+CLAYCOUNTYMN.GOV,County,Non-Federal Agency,Moorhead,MN,ACTIVE
+CLAYCOUNTYMO.GOV,County,Non-Federal Agency,Liberty,MO,ACTIVE
+CLAYTONCOUNTYGA.GOV,County,Non-Federal Agency,Jonesboro,GA,ACTIVE
+CLAYTONCOUNTYIA.GOV,County,Non-Federal Agency,Elkader,IA,ACTIVE
+CLERMONTCOUNTYOHIO.GOV,County,Non-Federal Agency,Batavia,OH,ACTIVE
+CLINTONCOUNTY-IA.GOV,County,Non-Federal Agency,Clinton,IA,ACTIVE
+COLUMBIACOUNTYGA.GOV,County,Non-Federal Agency,Evans,GA,ACTIVE
+COLUMBIACOUNTYNY.GOV,County,Non-Federal Agency,Hudson,NY,ACTIVE
+CONVERSECOUNTYWY.GOV,County,Non-Federal Agency,Douglas,WY,ACTIVE
+COOKCOUNTYIL.GOV,County,Non-Federal Agency,Chicago,IL,ACTIVE
+COOPERCOUNTYMO.GOV,County,Non-Federal Agency,Boonville,MO,ACTIVE
+COPIAHCOUNTYMS.GOV,County,Non-Federal Agency,Hazlehurst,MS,ACTIVE
+CORONADOCA.GOV,County,Non-Federal Agency,Coronado,CA,ACTIVE
+COSCPINALCOUNTYAZ.GOV,County,Non-Federal Agency,Florence,AZ,ACTIVE
+COSTILLACOUNTY-CO.GOV,County,Non-Federal Agency,San Luis,CO,ACTIVE
+COUNTYOFVENTURACA.GOV,County,Non-Federal Agency,VENTURA,CA,ACTIVE
+COVINGTONCOUNTYMS.GOV,County,Non-Federal Agency,Collins,MS,ACTIVE
+CRAIGCOUNTYVA.GOV,County,Non-Federal Agency,New Castle,VA,ACTIVE
+CRAVENCOUNTYNC.GOV,County,Non-Federal Agency,New Bern,NC,ACTIVE
+CRAWFORDCOUNTYKANSAS.GOV,County,Non-Federal Agency,Girard,KS,ACTIVE
+CRAWFORDCOUNTYMO.GOV,County,Non-Federal Agency,Steelville,MO,ACTIVE
+CULPEPERCOUNTY.GOV,County,Non-Federal Agency,Culpeper,VA,ACTIVE
+CUMBERLANDCOUNTYTN.GOV,County,Non-Federal Agency,Crossville,TN,ACTIVE
+CURRITUCKCOUNTYNC.GOV,County,Non-Federal Agency,Currituck,NC,ACTIVE
+DADECOUNTY-GA.GOV,County,Non-Federal Agency,Trenton,GA,ACTIVE
+DAKOTACOUNTYMN.GOV,County,Non-Federal Agency,Hastings,MN,ACTIVE
+DALLASCOUNTY-TX.GOV,County,Non-Federal Agency,Dallas,TX,ACTIVE
+DALLASCOUNTYIOWA.GOV,County,Non-Federal Agency,Adel,IA,ACTIVE
+DARECOUNTYNC.GOV,County,Non-Federal Agency,Manteo,NC,ACTIVE
+DAVIDSONCOUNTYNC.GOV,County,Non-Federal Agency,Lexington,NC,ACTIVE
+DAVIECOUNTYNC.GOV,County,Non-Federal Agency,Mocksville,NC,ACTIVE
+DAVISCOUNTYUT4HEALTH.GOV,County,Non-Federal Agency,Farmington,UT,ACTIVE
+DAVISCOUNTYUTAH.GOV,County,Non-Federal Agency,Farmington,UT,ACTIVE
+DAVISUT4HEALTH.GOV,County,Non-Federal Agency,Farmington,UT,ACTIVE
+DAWSONCOUNTYNE.GOV,County,Non-Federal Agency,Lexington,NE,ACTIVE
+DCONC.GOV,County,Non-Federal Agency,Durham,NC,ACTIVE
+DECATURCOUNTYGA.GOV,County,Non-Federal Agency,Bainbridge,GA,ACTIVE
+DEKALBCOUNTYGA.GOV,County,Non-Federal Agency,Decatur,GA,ACTIVE
+DEKALBCOUNTYIL.GOV,County,Non-Federal Agency,Sycamore,IL,ACTIVE
+DESOTOCOUNTYMS.GOV,County,Non-Federal Agency,HERNANDO,MS,ACTIVE
+DICKINSONCOUNTYMI.GOV,County,Non-Federal Agency,Iron Mountain,MI,ACTIVE
+DICKSONCOUNTYTN.GOV,County,Non-Federal Agency,Charlotte,TN,ACTIVE
+DOUGLASCOUNTY-NE.GOV,County,Non-Federal Agency,Omaha,NE,ACTIVE
+DOUGLASCOUNTYNV.GOV,County,Non-Federal Agency,Minden,NV,ACTIVE
+DUNNCOUNTYWI.GOV,County,Non-Federal Agency,Menomonie,WI,ACTIVE
+DURHAMCOUNTYNC.GOV,County,Non-Federal Agency,Durham,NC,ACTIVE
+ECTORCOUNTYTX.GOV,County,Non-Federal Agency,Odessa,TX,ACTIVE
+EDGECOMBECOUNTYNC.GOV,County,Non-Federal Agency,Tarboro,NC,ACTIVE
+ELBERTCOUNTY-CO.GOV,County,Non-Federal Agency,Kiowa,CO,ACTIVE
+EMANUELCO-GA.GOV,County,Non-Federal Agency,Swainsboro,GA,ACTIVE
+ERIE.GOV,County,Non-Federal Agency,Buffalo,NY,ACTIVE
+ERIECOUNTYPA.GOV,County,Non-Federal Agency,Erie,PA,ACTIVE
+EUREKACOUNTYNV.GOV,County,Non-Federal Agency,Eureka,NV,ACTIVE
+FAIRFAXCOUNTY.GOV,County,Non-Federal Agency,Fairfax,VA,ACTIVE
+FAIRFAXCOUNTYVA.GOV,County,Non-Federal Agency,Fairfax,VA,ACTIVE
+FAIRFAXCOUNTYVIRGINIA.GOV,County,Non-Federal Agency,Fairfax,VA,ACTIVE
+FAIRFIELDCOUNTYOHIO.GOV,County,Non-Federal Agency,Lancaster,OH,ACTIVE
+FAUQUIERCOUNTY.GOV,County,Non-Federal Agency,Warrenton,VA,ACTIVE
+FENTRESSCOUNTYTN.GOV,County,Non-Federal Agency,Jamestown,TN,ACTIVE
+FORTBENDCOUNTYTX.GOV,County,Non-Federal Agency,Richmond,TX,ACTIVE
+FRANKLINCOUNTYGA.GOV,County,Non-Federal Agency,Carnesville,GA,ACTIVE
+FRANKLINCOUNTYIL.GOV,County,Non-Federal Agency,Benton,IL,ACTIVE
+FRANKLINCOUNTYMAINE.GOV,County,Non-Federal Agency,Farmington,ME,ACTIVE
+FRANKLINCOUNTYOHIO.GOV,County,Non-Federal Agency,Columbus,OH,ACTIVE
+FRANKLINCOUNTYPA.GOV,County,Non-Federal Agency,Chambersburg,PA,ACTIVE
+FRANKLINCOUNTYVA.GOV,County,Non-Federal Agency,Rocky Mount,VA,ACTIVE
+FREDERICKCOUNTYMD.GOV,County,Non-Federal Agency,Frederick,MD,ACTIVE
+FREDERICKCOUNTYVA.GOV,County,Non-Federal Agency,Winchester,VA,ACTIVE
+FREMONTCOUNTYWY.GOV,County,Non-Federal Agency,Lander,WY,ACTIVE
+FRIOCOUNTY-TX.GOV,County,Non-Federal Agency,Pearsall,TX,ACTIVE
+FULTONCOUNTYGA.GOV,County,Non-Federal Agency,Atlanta,GA,ACTIVE
+FULTONCOUNTYNY.GOV,County,Non-Federal Agency,Johnstown,NY,ACTIVE
+GADSDENCOUNTYFL.GOV,County,Non-Federal Agency,Quincy,FL,ACTIVE
+GALVESTONCOUNTYTX.GOV,County,Non-Federal Agency,Galveston,TX,ACTIVE
+GARFIELDCOUNTY-CO.GOV,County,Non-Federal Agency,Glenwood Springs,CO,ACTIVE
+GATESCOUNTYNC.GOV,County,Non-Federal Agency,Gatesville,NC,ACTIVE
+GEORGECOUNTYMS.GOV,County,Non-Federal Agency,Lucedale,MS,ACTIVE
+GGSC.GOV,County,Non-Federal Agency,Greenville,SC,ACTIVE
+GIBSONCOUNTY-IN.GOV,County,Non-Federal Agency,Princeton,IN,ACTIVE
+GILACOUNTYAZ.GOV,County,Non-Federal Agency,Globe,AZ,ACTIVE
+GILMERCOUNTY-GA.GOV,County,Non-Federal Agency,Ellijay,GA,ACTIVE
+GILMERCOUNTYWV.GOV,County,Non-Federal Agency,GLENVILLE,WV,ACTIVE
+GLOUCESTERCOUNTYNJ.GOV,County,Non-Federal Agency,Woodbury,NJ,ACTIVE
+GOGEBICCOUNTYMI.GOV,County,Non-Federal Agency,Bessemer,MI,ACTIVE
+GOLIADCOUNTYTX.GOV,County,Non-Federal Agency,Goliad,TX,ACTIVE
+GRADYCOUNTYGA.GOV,County,Non-Federal Agency,Cairo,GA,ACTIVE
+GRAINGERCOUNTYTN.GOV,County,Non-Federal Agency,Rutledge,TN,ACTIVE
+GRANTCOUNTY-OR.GOV,County,Non-Federal Agency,Canyon City,OR,ACTIVE
+GRANTCOUNTYWA.GOV,County,Non-Federal Agency,Ephrata,WA,ACTIVE
+GRAYSONCOUNTYVA.GOV,County,Non-Federal Agency,Independence,VA,ACTIVE
+GREENECOUNTYGA.GOV,County,Non-Federal Agency,Greensboro,GA,ACTIVE
+GREENECOUNTYMO.GOV,County,Non-Federal Agency,Springfield,MO,ACTIVE
+GREENECOUNTYMS.GOV,County,Non-Federal Agency,Leaksville,MS,ACTIVE
+GREENECOUNTYNC.GOV,County,Non-Federal Agency,Snow Hill,NC,ACTIVE
+GREENECOUNTYVA.GOV,County,Non-Federal Agency,Stanardsville,VA,ACTIVE
+GREENHARRISCOUNTYTX.GOV,County,Non-Federal Agency,Houston,TX,ACTIVE
+GREENMCHENRYCOUNTYIL.GOV,County,Non-Federal Agency,Woodstock,IL,ACTIVE
+GREENMCHENRYCOUNTYILLINOIS.GOV,County,Non-Federal Agency,Woodstock,IL,ACTIVE
+GREENSVILLECOUNTYVA.GOV,County,Non-Federal Agency,Emporia,VA,ACTIVE
+GREENVILLECOUNTYSC.GOV,County,Non-Federal Agency,Greenville,SC,ACTIVE
+GREENWOODSC.GOV,County,Non-Federal Agency,Greenwood,SC,ACTIVE
+GRIGGSCOUNTYND.GOV,County,Non-Federal Agency,Bismarck,ND,ACTIVE
+GULFCOUNTY-FL.GOV,County,Non-Federal Agency,Port St. Joe,FL,ACTIVE
+GWINNETTCOUNTYGA.GOV,County,Non-Federal Agency,Lawrenceville,GA,ACTIVE
+HABERSHAMCOUNTY-GA.GOV,County,Non-Federal Agency,Clarkesville,GA,ACTIVE
+HAINESALASKA.GOV,County,Non-Federal Agency,Haines,AK,ACTIVE
+HALIFAXCOUNTYVA.GOV,County,Non-Federal Agency,Halifax,VA,ACTIVE
+HALLCOUNTYGA.GOV,County,Non-Federal Agency,Gainesville,GA,ACTIVE
+HALLCOUNTYNE.GOV,County,Non-Federal Agency,Grand Island,NE,ACTIVE
+HAMBLENCOUNTYTN.GOV,County,Non-Federal Agency,Morristown,TN,ACTIVE
+HAMILTONCOUNTYFLORIDA.GOV,County,Non-Federal Agency,Jasper,FL,ACTIVE
+HAMILTONCOUNTYNY.GOV,County,Non-Federal Agency,Lake Pleasent,NY,ACTIVE
+HAMILTONCOUNTYOHIO.GOV,County,Non-Federal Agency,Cincinnati,OH,ACTIVE
+HAMILTONTN.GOV,County,Non-Federal Agency,Chattanooga,TN,ACTIVE
+HANCOCKCOUNTY-IL.GOV,County,Non-Federal Agency,Carthage,IL,ACTIVE
+HANCOCKCOUNTYGA.GOV,County,Non-Federal Agency,Sparta,GA,ACTIVE
+HANCOCKCOUNTYMS.GOV,County,Non-Federal Agency,Bay St. Louis,MS,ACTIVE
+HANOVER.GOV,County,Non-Federal Agency,Hanover,VA,ACTIVE
+HANOVERCOUNTY.GOV,County,Non-Federal Agency,Hanover,VA,ACTIVE
+HANOVERCOUNTYVA.GOV,County,Non-Federal Agency,Hanover,VA,ACTIVE
+HARALSONCOUNTYGA.GOV,County,Non-Federal Agency,Buchanan,GA,ACTIVE
+HARDINCOUNTYIA.GOV,County,Non-Federal Agency,Eldora,IA,ACTIVE
+HARRISCOUNTYGA.GOV,County,Non-Federal Agency,Hamilton,GA,ACTIVE
+HARRISCOUNTYTX.GOV,County,Non-Federal Agency,Houston,TX,ACTIVE
+HARRISONCOUNTY-MS.GOV,County,Non-Federal Agency,Gulfport,MS,ACTIVE
+HARRISONCOUNTYWV.GOV,County,Non-Federal Agency,Clarksburg,WV,ACTIVE
+HARTCOUNTYGA.GOV,County,Non-Federal Agency,Hartwell,GA,ACTIVE
+HAWAIICOUNTY.GOV,County,Non-Federal Agency,Hilo,HI,ACTIVE
+HAWKINSCOUNTYTN.GOV,County,Non-Federal Agency,Rogersville,TN,ACTIVE
+HAYWOODCOUNTYNC.GOV,County,Non-Federal Agency,Waynesville,NC,ACTIVE
+HCSHERIFF.GOV,County,Non-Federal Agency,Chattanooga,TN,ACTIVE
+HENDERSONCOUNTYTN.GOV,County,Non-Federal Agency,Lexington,TN,ACTIVE
+HENRYCOUNTYVA.GOV,County,Non-Federal Agency,Martinsville,VA,ACTIVE
+HERTFORDCOUNTYNC.GOV,County,Non-Federal Agency,Winton,NC,ACTIVE
+HINSDALECOUNTY-CO.GOV,County,Non-Federal Agency,Lake City,CO,ACTIVE
+HOWARDCOUNTYIN.GOV,County,Non-Federal Agency,Kokomo,IN,ACTIVE
+HOWARDCOUNTYMARYLAND.GOV,County,Non-Federal Agency,Ellicott City,MD,ACTIVE
+HOWARDCOUNTYMD.GOV,County,Non-Federal Agency,Ellicott City,MD,ACTIVE
+HURONCOUNTY-OH.GOV,County,Non-Federal Agency,Norwalk,OH,ACTIVE
+HYDECOUNTYNC.GOV,County,Non-Federal Agency,Swanquarter,NC,ACTIVE
+ICATCO.GOV,County,Non-Federal Agency,Newton,NC,ACTIVE
+ISLANDCOUNTYWA.GOV,County,Non-Federal Agency,Coupeville,WA,ACTIVE
+ISSAQUENACOUNTYMS.GOV,County,Non-Federal Agency,Mayersville,MS,ACTIVE
+JACKSONCOGA.GOV,County,Non-Federal Agency,Jefferson,GA,ACTIVE
+JACKSONCOUNTY-IL.GOV,County,Non-Federal Agency,Murphysboro,IL,ACTIVE
+JAMESCITYCOUNTYVA.GOV,County,Non-Federal Agency,Williamsburg,VA,ACTIVE
+JASPERCOUNTYIN.GOV,County,Non-Federal Agency,Rensselaer,IN,ACTIVE
+JASPERCOUNTYSC.GOV,County,Non-Federal Agency,Ridgeland,SC,ACTIVE
+JEFFERSONCOUNTY-MT.GOV,County,Non-Federal Agency,Boulder,MT,ACTIVE
+JEFFERSONCOUNTYFL.GOV,County,Non-Federal Agency,Monticello,FL,ACTIVE
+JEFFERSONCOUNTYGA.GOV,County,Non-Federal Agency,LOUISVILLE,GA,ACTIVE
+JEFFERSONCOUNTYMS.GOV,County,Non-Federal Agency,Fayette,MS,ACTIVE
+JEFFERSONCOUNTYTN.GOV,County,Non-Federal Agency,Dandridge,TN,ACTIVE
+JEFFERSONCOUNTYWI.GOV,County,Non-Federal Agency,Jefferson,WI,ACTIVE
+JENNINGSCOUNTY-IN.GOV,County,Non-Federal Agency,Vernon,IN,ACTIVE
+JIMWELLSCOUNTY-TX.GOV,County,Non-Federal Agency,Alice,TX,ACTIVE
+JONESCOUNTYNC.GOV,County,Non-Federal Agency,Trenton,NC,ACTIVE
+KANAWHACOUNTYWV.GOV,County,Non-Federal Agency,Charleston,WV,ACTIVE
+KAUAI.GOV,County,Non-Federal Agency,Lihue,HI,ACTIVE
+KEITHCOUNTYNE.GOV,County,Non-Federal Agency,Ogallala,NE,ACTIVE
+KENNEBECCOUNTY-ME.GOV,County,Non-Federal Agency,Augusta,ME,ACTIVE
+KENTCOUNTYMI.GOV,County,Non-Federal Agency,Grand Rapids,MI,ACTIVE
+KERNCOG-CA.GOV,County,Non-Federal Agency,Bakersfield,CA,ACTIVE
+KINGCOUNTY.GOV,County,Non-Federal Agency,Seattle,WA,ACTIVE
+KINGGEORGECOUNTYVA.GOV,County,Non-Federal Agency,King George,VA,ACTIVE
+KINGSBURYNY.GOV,County,Non-Federal Agency,Hudson Falls,NY,ACTIVE
+KNOXCOUNTYMAINE.GOV,County,Non-Federal Agency,Rockland,ME,ACTIVE
+KNOXCOUNTYTEXAS.GOV,County,Non-Federal Agency,Benjamin,TX,ACTIVE
+LACOUNTY.GOV,County,Non-Federal Agency,Downey,CA,ACTIVE
+LAKECOUNTYCA.GOV,County,Non-Federal Agency,Lakeport,CA,ACTIVE
+LAKECOUNTYIL.GOV,County,Non-Federal Agency,Waukegan,IL,ACTIVE
+LAKECOUNTYOHIO.GOV,County,Non-Federal Agency,Painesville,OH,ACTIVE
+LAKEMT.GOV,County,Non-Federal Agency,Polson,MT,ACTIVE
+LAMARCOUNTYMS.GOV,County,Non-Federal Agency,Purvis,MS,ACTIVE
+LANCASTERCOUNTYPA.GOV,County,Non-Federal Agency,Lancaster,PA,ACTIVE
+LAPAZCOUNTYAZ.GOV,County,Non-Federal Agency,Parker,AZ,ACTIVE
+LAUDERDALECOUNTYAL.GOV,County,Non-Federal Agency,Florence,AL,ACTIVE
+LAWRENCECOUNTYTN.GOV,County,Non-Federal Agency,Lawrenceburg,TN,ACTIVE
+LCCOUNTYMT.GOV,County,Non-Federal Agency,Helena,MT,ACTIVE
+LEE-COUNTY-FL.GOV,County,Non-Federal Agency,Fort Myers,FL,ACTIVE
+LEECOUNTYNC.GOV,County,Non-Federal Agency,Sanford,NC,ACTIVE
+LEONCOUNTYFL.GOV,County,Non-Federal Agency,Tallahassee,FL,ACTIVE
+LEWISCOUNTYWA.GOV,County,Non-Federal Agency,Chehalis,WA,ACTIVE
+LIBERTYCOUNTY-GA.GOV,County,Non-Federal Agency,Hinesville,GA,ACTIVE
+LIMESTONECOUNTY-AL.GOV,County,Non-Federal Agency,Athens,AL,ACTIVE
+LIMESTONECOUNTYEMA-AL.GOV,County,Non-Federal Agency,Athens,AL,ACTIVE
+LINCOLNCOUNTYNM.GOV,County,Non-Federal Agency,Carrizozo,NM,ACTIVE
+LIVINGSTONCOUNTYIL.GOV,County,Non-Federal Agency,Pontiac,IL,ACTIVE
+LIVINGSTONPARISHLA.GOV,County,Non-Federal Agency,Livingston,LA,ACTIVE
+LOGANCOUNTYCO.GOV,County,Non-Federal Agency,Sterling,CO,ACTIVE
+LOGANCOUNTYIL.GOV,County,Non-Federal Agency,Lincoln,IL,ACTIVE
+LOUDONCOUNTY-TN.GOV,County,Non-Federal Agency,Loudon,TN,ACTIVE
+LOUDOUN.GOV,County,Non-Federal Agency,Leesburg,VA,ACTIVE
+LOUDOUNCOUNTYVA.GOV,County,Non-Federal Agency,Leesburg,VA,ACTIVE
+LOWNDESCOUNTYGA.GOV,County,Non-Federal Agency,Valdosta,GA,ACTIVE
+LUCASCOUNTYOH.GOV,County,Non-Federal Agency,Toledo,OH,ACTIVE
+LUMPKINCOUNTY.GOV,County,Non-Federal Agency,Dahlonega,GA,ACTIVE
+MACOMBCOUNTYMI.GOV,County,Non-Federal Agency,Mount Clemens,MI,ACTIVE
+MACONBIBBCOUNTYGA.GOV,County,Non-Federal Agency,Macon,GA,ACTIVE
+MACONCOUNTYGA.GOV,County,Non-Federal Agency,Oglethorpe,GA,ACTIVE
+MACONCOUNTYTN.GOV,County,Non-Federal Agency,Lafayette,TN,ACTIVE
+MACOUPINCOUNTYIL.GOV,County,Non-Federal Agency,Carlinville,IL,ACTIVE
+MADISONCOUNTYAL.GOV,County,Non-Federal Agency,Huntsville,AL,ACTIVE
+MADISONCOUNTYMT.GOV,County,Non-Federal Agency,Virginia City,MT,ACTIVE
+MADISONCOUNTYNC.GOV,County,Non-Federal Agency,Marshall,NC,ACTIVE
+MADISONCOUNTYTN.GOV,County,Non-Federal Agency,Jackson,TN,ACTIVE
+MAHONINGCOUNTYOH.GOV,County,Non-Federal Agency,Youngstown,OH,ACTIVE
+MANISTEECOUNTYMI.GOV,County,Non-Federal Agency,Manistee,MI,ACTIVE
+MARICOPA.GOV,County,Non-Federal Agency,Phoenix,AZ,ACTIVE
+MARIONCOUNTY-MO.GOV,County,Non-Federal Agency,Hannibal,MO,ACTIVE
+MARSHALLCOUNTYIA.GOV,County,Non-Federal Agency,Marshalltown,IA,ACTIVE
+MARSHALLCOUNTYKY.GOV,County,Non-Federal Agency,Benton,KY,ACTIVE
+MATHEWSCOUNTYVA.GOV,County,Non-Federal Agency,Mathews,VA,ACTIVE
+MAUICOUNTY-HI.GOV,County,Non-Federal Agency,Wailuku,HI,ACTIVE
+MAUICOUNTY.GOV,County,Non-Federal Agency,Wailuku,HI,ACTIVE
+MAURYCOUNTY-TN.GOV,County,Non-Federal Agency,Columbia,TN,ACTIVE
+MCCRACKENCOUNTYKY.GOV,County,Non-Federal Agency,Paducah,KY,ACTIVE
+MCDONALDCOUNTYMO.GOV,County,Non-Federal Agency,Pineville,MO,ACTIVE
+MCHENRYCOUNTYIL.GOV,County,Non-Federal Agency,Woodstock,IL,ACTIVE
+MCHENRYCOUNTYILLINOIS.GOV,County,Non-Federal Agency,Woodstock,IL,ACTIVE
+MCINTOSHCOUNTY-GA.GOV,County,Non-Federal Agency,Darien,GA,ACTIVE
+MCLEANCOUNTYIL.GOV,County,Non-Federal Agency,Bloomington,IL,ACTIVE
+MCLEANCOUNTYND.GOV,County,Non-Federal Agency,Washburn,ND,ACTIVE
+MCMINNCOUNTYTN.GOV,County,Non-Federal Agency,Athens,TN,ACTIVE
+MEADEKY.GOV,County,Non-Federal Agency,Brandenburg,KY,ACTIVE
+MECKLENBURGCOUNTYNC.GOV,County,Non-Federal Agency,Charlotte,NC,ACTIVE
+MEETEETSECD-WY.GOV,County,Non-Federal Agency,Meeteetse,WY,ACTIVE
+MERCEDCOUNTYCA.GOV,County,Non-Federal Agency,Merced,CA,ACTIVE
+MERIWETHERCOUNTYGA.GOV,County,Non-Federal Agency,Greenville,GA,ACTIVE
+MIAMI-DADE.GOV,County,Non-Federal Agency,Miami,FL,ACTIVE
+MIAMICOUNTYIN.GOV,County,Non-Federal Agency,Peru,IN,ACTIVE
+MIAMICOUNTYOHIO.GOV,County,Non-Federal Agency,Troy,OH,ACTIVE
+MIAMIDADE.GOV,County,Non-Federal Agency,Miami,FL,ACTIVE
+MIAMIDADECOUNTY-FL.GOV,County,Non-Federal Agency,Miami,FL,ACTIVE
+MIAMIDADECOUNTYFL.GOV,County,Non-Federal Agency,Miami,FL,ACTIVE
+MIDDLESEXCOUNTYNJ.GOV,County,Non-Federal Agency,New Brunswick,NJ,ACTIVE
+MILWAUKEECOUNTYWI.GOV,County,Non-Federal Agency,Milwaukee,WI,ACTIVE
+MOBILECOUNTYAL.GOV,County,Non-Federal Agency,Mobile,AL,ACTIVE
+MONROECOUNTY-FL.GOV,County,Non-Federal Agency,Key West,FL,ACTIVE
+MONROECOUNTY.GOV,County,Non-Federal Agency,Rochester,NY,ACTIVE
+MONROECOUNTYAL.GOV,County,Non-Federal Agency,Monroeville,AL,ACTIVE
+MONROECOUNTYPA.GOV,County,Non-Federal Agency,Stroudsburg,PA,ACTIVE
+MONTGOMERYCOUNTYGA.GOV,County,Non-Federal Agency,mt. vernon,GA,ACTIVE
+MONTGOMERYCOUNTYMD.GOV,County,Non-Federal Agency,Rockville,MD,ACTIVE
+MONTGOMERYCOUNTYVA.GOV,County,Non-Federal Agency,Christiansburg,VA,ACTIVE
+MOORECOUNTYNC.GOV,County,Non-Federal Agency,Carthage,NC,ACTIVE
+MORGANCOUNTY-OH.GOV,County,Non-Federal Agency,McConnelsville,OH,ACTIVE
+MORGANCOUNTYTN.GOV,County,Non-Federal Agency,wartburg,TN,ACTIVE
+MORGANCOUNTYWV.GOV,County,Non-Federal Agency,Berkeley Springs,WV,ACTIVE
+MORRILLCOUNTYNE.GOV,County,Non-Federal Agency,Bridgeport,NE,ACTIVE
+MORRISCOUNTYNJ.GOV,County,Non-Federal Agency,Morristown,NJ,ACTIVE
+MORROWCOUNTYOHIO.GOV,County,Non-Federal Agency,Mount Gilead,OH,ACTIVE
+NASHCOUNTYNC.GOV,County,Non-Federal Agency,Nashville,NC,ACTIVE
+NASSAUCOUNTYNY.GOV,County,Non-Federal Agency,Mineola,NY,ACTIVE
+NATRONACOUNTY-WY.GOV,County,Non-Federal Agency,Casper,WY,ACTIVE
+NAVAJOCOUNTYAZ.GOV,County,Non-Federal Agency,Holbrook,AZ,ACTIVE
+NELSONCOUNTY-VA.GOV,County,Non-Federal Agency,Lovingston,VA,ACTIVE
+NIAGARACOUNTY-NY.GOV,County,Non-Federal Agency,LOCKPORT,NY,ACTIVE
+NOBLECOUNTYOHIO.GOV,County,Non-Federal Agency,Caldwell,OH,ACTIVE
+NORTONCOUNTYKS.GOV,County,Non-Federal Agency,Norton,KS,ACTIVE
+NWCLEANAIRWA.GOV,County,Non-Federal Agency,Mount Vernon,WA,ACTIVE
+OAKLANDCOUNTYMI.GOV,County,Non-Federal Agency,Pontiac,MI,ACTIVE
+OGEMAWCOUNTYMI.GOV,County,Non-Federal Agency,West Branch,MI,ACTIVE
+OGLETHORPECOUNTYGA.GOV,County,Non-Federal Agency,Lexington,GA,ACTIVE
+OHIOCOUNTYKY.GOV,County,Non-Federal Agency,Hartford,KY,ACTIVE
+OHIOCOUNTYWV.GOV,County,Non-Federal Agency,Wheeling,WV,ACTIVE
+OLDHAMCOUNTYKY.GOV,County,Non-Federal Agency,La Grange,KY,ACTIVE
+ORANGECOUNTY-VA.GOV,County,Non-Federal Agency,ORANGE,VA,ACTIVE
+ORANGECOUNTYNC.GOV,County,Non-Federal Agency,Hillsborough,NC,ACTIVE
+ORANGECOUNTYVA.GOV,County,Non-Federal Agency,Orange,VA,ACTIVE
+ORANGECOUNTYVT.GOV,County,Non-Federal Agency,Chelsea,VT,ACTIVE
+ORLEANSCOUNTYNY.GOV,County,Non-Federal Agency,Albion,NY,ACTIVE
+OSWEGOCOUNTYNY.GOV,County,Non-Federal Agency,Oswego,NY,ACTIVE
+OTSEGOCOUNTYMI.GOV,County,Non-Federal Agency,Gaylord,MI,ACTIVE
+OURAYCOUNTYCO.GOV,County,Non-Federal Agency,Ouray,CO,ACTIVE
+PARKECOUNTY-IN.GOV,County,Non-Federal Agency,Rockville,IN,ACTIVE
+PAYNECOUNTYOK.GOV,County,Non-Federal Agency,Stillwater,OK,ACTIVE
+PEMBINACOUNTYND.GOV,County,Non-Federal Agency,Cavalier,ND,ACTIVE
+PENDERCOUNTYNC.GOV,County,Non-Federal Agency,Burgaw,NC,ACTIVE
+PERQUIMANSCOUNTYNC.GOV,County,Non-Federal Agency,Hertford,NC,ACTIVE
+PICKENSCOUNTYGA.GOV,County,Non-Federal Agency,Jasper,GA,ACTIVE
+PIERCECOUNTYGA.GOV,County,Non-Federal Agency,Blackshear,GA,ACTIVE
+PIERCECOUNTYND.GOV,County,Non-Federal Agency,Rugby,ND,ACTIVE
+PIERCECOUNTYWA.GOV,County,Non-Federal Agency,Tacoma,WA,ACTIVE
+PIKECOUNTY-MO.GOV,County,Non-Federal Agency,Bowling Green,MO,ACTIVE
+PIKECOUNTYKY.GOV,County,Non-Federal Agency,Pikeville,KY,ACTIVE
+PIMA.GOV,County,Non-Federal Agency,Tucson,AZ,ACTIVE
+PINALCOUNTYAZ.GOV,County,Non-Federal Agency,Florence,AZ,ACTIVE
+PINELLAS.GOV,County,Non-Federal Agency,Clearwater,FL,ACTIVE
+PITTCOUNTYNC.GOV,County,Non-Federal Agency,Greenville,NC,ACTIVE
+PITTSYLVANIACOUNTYVA.GOV,County,Non-Federal Agency,Chatham,VA,ACTIVE
+PLYMOUTHCOUNTY-MA.GOV,County,Non-Federal Agency,Plymouth,MA,ACTIVE
+POLKCOUNTYGA.GOV,County,Non-Federal Agency,Cedartown,GA,ACTIVE
+POLKCOUNTYIOWA.GOV,County,Non-Federal Agency,Des Moines,IA,ACTIVE
+PORTAGECOUNTYWI.GOV,County,Non-Federal Agency,Stevens Point,WI,ACTIVE
+POSEYCOUNTYIN.GOV,County,Non-Federal Agency,Mount Vernon,IN,ACTIVE
+POTTAWATTAMIECOUNTY-IA.GOV,County,Non-Federal Agency,COUNCIL BLUFFS,IA,ACTIVE
+POTTCOUNTY-IA.GOV,County,Non-Federal Agency,COUNCIL BLUFFS,IA,ACTIVE
+POWELLCOUNTYMT.GOV,County,Non-Federal Agency,Deer Lodge,MT,ACTIVE
+PRESTONCOUNTYWV.GOV,County,Non-Federal Agency,Kingwood,WV,ACTIVE
+PRINCEGEORGECOUNTYVA.GOV,County,Non-Federal Agency,Prince George,VA,ACTIVE
+PRINCEGEORGESCOUNTYMD.GOV,County,Non-Federal Agency,Largo,MD,ACTIVE
+PUEBLOCOUNTYCO.GOV,County,Non-Federal Agency,Pueblo,CO,ACTIVE
+PULASKICOUNTYIL.GOV,County,Non-Federal Agency,Ullin,IL,ACTIVE
+PULASKICOUNTYVA.GOV,County,Non-Federal Agency,Pulaski,VA,ACTIVE
+PUTNAMCOUNTYNY.GOV,County,Non-Federal Agency,Carmel,NY,ACTIVE
+PUTNAMCOUNTYOHIO.GOV,County,Non-Federal Agency,Ottawa,OH,ACTIVE
+PUTNAMCOUNTYTN.GOV,County,Non-Federal Agency,Cookeville,TN,ACTIVE
+QUAYCOUNTY-NM.GOV,County,Non-Federal Agency,Tucumcari,NM,ACTIVE
+RANDOLPHCOUNTY-MO.GOV,County,Non-Federal Agency,Huntsville,MO,ACTIVE
+RANDOLPHCOUNTYALABAMA.GOV,County,Non-Federal Agency,Wedowee,AL,ACTIVE
+RANDOLPHCOUNTYNC.GOV,County,Non-Federal Agency,Asheboro,NC,ACTIVE
+RAPPAHANNOCKCOUNTYVA.GOV,County,Non-Federal Agency,Washington,VA,ACTIVE
+READYALBANYCOUNTY-NY.GOV,County,Non-Federal Agency,Albany,NY,ACTIVE
+READYHARRISCOUNTYTX.GOV,County,Non-Federal Agency,Houston,TX,ACTIVE
+READYMCHENRYCOUNTYIL.GOV,County,Non-Federal Agency,Woodstock,IL,ACTIVE
+READYMCHENRYCOUNTYILLINOIS.GOV,County,Non-Federal Agency,Woodstock,IL,ACTIVE
+REYNOLDSCOUNTY-MO.GOV,County,Non-Federal Agency,Centerville,MO,ACTIVE
+RILEYCOUNTYKS.GOV,County,Non-Federal Agency,Manhattan,KS,ACTIVE
+ROANECOUNTYTN.GOV,County,Non-Federal Agency,Kingston,TN,ACTIVE
+ROANOKECOUNTY-VA.GOV,County,Non-Federal Agency,Roanoke,VA,ACTIVE
+ROANOKECOUNTYVA.GOV,County,Non-Federal Agency,Roanoke,VA,ACTIVE
+ROANOKECOUNTYVIRGINIA.GOV,County,Non-Federal Agency,Roanoke,VA,ACTIVE
+ROCKBRIDGECOUNTYVA.GOV,County,Non-Federal Agency,Lexington,VA,ACTIVE
+ROCKCOUNTY-WI.GOV,County,Non-Federal Agency,Janesville,WI,ACTIVE
+ROCKDALECOUNTYGA.GOV,County,Non-Federal Agency,Conyers,GA,ACTIVE
+ROCKINGHAMCOUNTYVA.GOV,County,Non-Federal Agency,Harrisonburg,VA,ACTIVE
+ROSEBUDCOUNTYMT.GOV,County,Non-Federal Agency,Forsyth,MT,ACTIVE
+ROSSCOUNTYOHIO.GOV,County,Non-Federal Agency,Chillicothe,OH,ACTIVE
+RUTHERFORDCOUNTYNC.GOV,County,Non-Federal Agency,Rutherfordton,NC,ACTIVE
+RUTHERFORDCOUNTYTN.GOV,County,Non-Federal Agency,Murfreesboro,TN,ACTIVE
+SAGUACHECOUNTY-CO.GOV,County,Non-Federal Agency,Saguache,CO,ACTIVE
+SALEMCOUNTYNJ.GOV,County,Non-Federal Agency,Salem,NJ,ACTIVE
+SANDIEGOCOUNTY.GOV,County,Non-Federal Agency,San Diego,CA,ACTIVE
+SANDOVALCOUNTYNM.GOV,County,Non-Federal Agency,Bernalillo,NM,ACTIVE
+SANMIGUELCOUNTYCO.GOV,County,Non-Federal Agency,TELLURIDE,CO,ACTIVE
+SANPETECOUNTY-UT.GOV,County,Non-Federal Agency,Manti,UT,ACTIVE
+SANTACLARACOUNTYCA.GOV,County,Non-Federal Agency,San Jose,CA,ACTIVE
+SANTACRUZCOUNTYAZ.GOV,County,Non-Federal Agency,Nogales,AZ,ACTIVE
+SANTAFECOUNTYNM.GOV,County,Non-Federal Agency,Santa Fe,NM,ACTIVE
+SARATOGACOUNTYNY.GOV,County,Non-Federal Agency,Ballston Spa,NY,ACTIVE
+SAUKCOUNTYWI.GOV,County,Non-Federal Agency,Baraboo,WI,ACTIVE
+SBCOUNTY.GOV,County,Non-Federal Agency,San Bernardino,CA,ACTIVE
+SCHOHARIECOUNTY-NY.GOV,County,Non-Federal Agency,Schoharie,NY,ACTIVE
+SCOTTCOUNTY-TN.GOV,County,Non-Federal Agency,Huntsville,TN,ACTIVE
+SCOTTCOUNTYMN.GOV,County,Non-Federal Agency,Shakopee,MN,ACTIVE
+SCOTTCOUNTYMS.GOV,County,Non-Federal Agency,Forest,MS,ACTIVE
+SEBASTIANCOUNTYAR.GOV,County,Non-Federal Agency,Fort Smith,AR,ACTIVE
+SENECACOUNTYOHIO.GOV,County,Non-Federal Agency,Tiffin,OH,ACTIVE
+SEQUATCHIECOUNTY-TN.GOV,County,Non-Federal Agency,Dunlap,TN,ACTIVE
+SEVIERCOUNTYTN.GOV,County,Non-Federal Agency,Sevierville,TN,ACTIVE
+SHARKEYCOUNTYMS.GOV,County,Non-Federal Agency,Rolling Fork,MS,ACTIVE
+SHELBYCOUNTYTN.GOV,County,Non-Federal Agency,Memphis,TN,ACTIVE
+SIERRACOUNTYNM.GOV,County,Non-Federal Agency,Truth or Consequences,NM,ACTIVE
+SNOHOMISHCOUNTYWA.GOV,County,Non-Federal Agency,Everett,WA,ACTIVE
+SONOMACOUNTYCA.GOV,County,Non-Federal Agency,Santa Rosa,CA,ACTIVE
+SPENCERCOUNTYKY.GOV,County,Non-Federal Agency,Taylorsville,KY,ACTIVE
+SPOTSYLVANIACOUNTY-VA.GOV,County,Non-Federal Agency,Spotsylvania,VA,ACTIVE
+SPOTSYLVANIACOUNTYVA.GOV,County,Non-Federal Agency,Spotsylvania,VA,ACTIVE
+STAFFORDCOUNTYVA.GOV,County,Non-Federal Agency,Stafford,VA,ACTIVE
+STANLYCOUNTYNC.GOV,County,Non-Federal Agency,Albemarle,NC,ACTIVE
+STARKCOUNTYND.GOV,County,Non-Federal Agency,Bismarck,ND,ACTIVE
+STARKCOUNTYOHIO.GOV,County,Non-Federal Agency,Canton,OH,ACTIVE
+STCHARLESPARISH-LA.GOV,County,Non-Federal Agency,Hahnville,LA,ACTIVE
+STCLAIRCOUNTYIL.GOV,County,Non-Federal Agency,Belleville,IL,ACTIVE
+STEARNSCOUNTYMN.GOV,County,Non-Federal Agency,Saint Cloud,MN,ACTIVE
+STEPHENSCOUNTYTX.GOV,County,Non-Federal Agency,Breckenridge,TX,ACTIVE
+STEWARTCOUNTYGA.GOV,County,Non-Federal Agency,Lumpkin,GA,ACTIVE
+STJOHN-LA.GOV,County,Non-Federal Agency,LaPlace,LA,ACTIVE
+STJOHNBAPTISTPARISHLA.GOV,County,Non-Federal Agency,LaPlace,LA,ACTIVE
+STLOUISCOUNTYMN.GOV,County,Non-Federal Agency,Duluth,MN,ACTIVE
+STMARYPARISHLA.GOV,County,Non-Federal Agency,FRANKLIN,LA,ACTIVE
+STOKESCOUNTYNC.GOV,County,Non-Federal Agency,Danbury,NC,ACTIVE
+STONECOUNTYMS.GOV,County,Non-Federal Agency,Wiggins,MS,ACTIVE
+STORYCOUNTYIOWA.GOV,County,Non-Federal Agency,Nevada,IA,ACTIVE
+SUFFOLKCOUNTYNY.GOV,County,Non-Federal Agency,Hauppauge,NY,ACTIVE
+SULLIVANCOUNTYNH.GOV,County,Non-Federal Agency,Newport,NH,ACTIVE
+SULLIVANCOUNTYTN.GOV,County,Non-Federal Agency,Blountville,TN,ACTIVE
+SUMMERSCOUNTYWV.GOV,County,Non-Federal Agency,Hinton,WV,ACTIVE
+SUMMITCOUNTYCO.GOV,County,Non-Federal Agency,Breckenridge,CO,ACTIVE
+SUMTERCOUNTYFL.GOV,County,Non-Federal Agency,Bushnell,FL,ACTIVE
+SURRYCOUNTYVA.GOV,County,Non-Federal Agency,Surry,VA,ACTIVE
+SUSSEXCOUNTYDE.GOV,County,Non-Federal Agency,Georgetown,DE,ACTIVE
+SUSSEXCOUNTYVA.GOV,County,Non-Federal Agency,Sussex,VA,ACTIVE
+SWAINCOUNTYNC.GOV,County,Non-Federal Agency,Bryson City,NC,ACTIVE
+TALBOTCOUNTYMD.GOV,County,Non-Federal Agency,Easton,MD,ACTIVE
+TAMACOUNTYIOWA.GOV,County,Non-Federal Agency,Toledo,IA,ACTIVE
+TARRANTCOUNTYTX.GOV,County,Non-Federal Agency,Fort Worth,TX,ACTIVE
+TETONCOUNTYIDAHO.GOV,County,Non-Federal Agency,Driggs,ID,ACTIVE
+TEXASCOUNTYMISSOURI.GOV,County,Non-Federal Agency,Houston,MO,ACTIVE
+THAYERCOUNTYNE.GOV,County,Non-Federal Agency,Hebron,NE,ACTIVE
+THOMASCOUNTYGA.GOV,County,Non-Federal Agency,Thomasville,GA,ACTIVE
+THOMASCOUNTYKS.GOV,County,Non-Federal Agency,Colby,KS,ACTIVE
+THURSTONCOUNTYWA.GOV,County,Non-Federal Agency,Olympia,WA,ACTIVE
+TOMGREENCOUNTYTX.GOV,County,Non-Federal Agency,San Angelo,TX,ACTIVE
+TOMPKINSCOUNTYNY.GOV,County,Non-Federal Agency,Ithaca,NY,ACTIVE
+TOOELECOUNTYUT.GOV,County,Non-Federal Agency,Tooele,UT,ACTIVE
+TOOLECOUNTYMT.GOV,County,Non-Federal Agency,Shelby,MT,ACTIVE
+TOOMBSCOUNTYGA.GOV,County,Non-Federal Agency,Lyons,GA,ACTIVE
+TRAVISCOUNTYTX.GOV,County,Non-Federal Agency,Austin,TX,ACTIVE
+TROUSDALECOUNTYTN.GOV,County,Non-Federal Agency,Hartsville,TN,ACTIVE
+ULSTERCOUNTYNY.GOV,County,Non-Federal Agency,Kingston,NY,ACTIVE
+UNICOICOUNTYTN.GOV,County,Non-Federal Agency,Erwin,TN,ACTIVE
+UNIONCOUNTY-FL.GOV,County,Non-Federal Agency,Lake Butler,FL,ACTIVE
+UNIONCOUNTYGA.GOV,County,Non-Federal Agency,Blairsveille,GA,ACTIVE
+UNIONCOUNTYIL.GOV,County,Non-Federal Agency,Jonesboro,IL,ACTIVE
+UNIONCOUNTYIN.GOV,County,Non-Federal Agency,Liberty,IN,ACTIVE
+UNIONCOUNTYNC.GOV,County,Non-Federal Agency,Monroe,NC,ACTIVE
+UTAHCOUNTY.GOV,County,Non-Federal Agency,Provo,UT,ACTIVE
+VALLEYCOUNTYMT.GOV,County,Non-Federal Agency,Glasgow,MT,ACTIVE
+VANBURENCOUNTYIA.GOV,County,Non-Federal Agency,Keosauqua,IA,ACTIVE
+VILASCOUNTYWI.GOV,County,Non-Federal Agency,Eagle River,WI,ACTIVE
+VINTONCOUNTYOHIO.GOV,County,Non-Federal Agency,McArthur,OH,ACTIVE
+WARRENCOUNTYKY.GOV,County,Non-Federal Agency,Bowling Green,KY,ACTIVE
+WARRENCOUNTYNC.GOV,County,Non-Federal Agency,Warrenton,NC,ACTIVE
+WARRENCOUNTYNY.GOV,County,Non-Federal Agency,Lake George,NY,ACTIVE
+WARRENCOUNTYTN.GOV,County,Non-Federal Agency,McMinnville,TN,ACTIVE
+WARRICKCOUNTY.GOV,County,Non-Federal Agency,Boonville,IN,ACTIVE
+WASHAKIECOUNTYWY.GOV,County,Non-Federal Agency,Worland,WY,ACTIVE
+WASHINGTONCOUNTYGA.GOV,County,Non-Federal Agency,Sandersville,GA,ACTIVE
+WASHINGTONCOUNTYKS.GOV,County,Non-Federal Agency,Washington,KS,ACTIVE
+WASHINGTONCOUNTYNY.GOV,County,Non-Federal Agency,Fort Edward,NY,ACTIVE
+WASHTENAWCOUNTY-MI.GOV,County,Non-Federal Agency,Ann Arbor,MI,ACTIVE
+WAUKESHACOUNTY-WI.GOV,County,Non-Federal Agency,Waukesha,WI,ACTIVE
+WAUKESHACOUNTY.GOV,County,Non-Federal Agency,Waukesha,WI,ACTIVE
+WAYNECOUNTY-GA.GOV,County,Non-Federal Agency,JESUP,GA,ACTIVE
+WAYNECOUNTYMS.GOV,County,Non-Federal Agency,Waynesboro,MS,ACTIVE
+WAYNECOUNTYPA.GOV,County,Non-Federal Agency,Honesdale,PA,ACTIVE
+WEAKLEYCOUNTYTN.GOV,County,Non-Federal Agency,Dresden,TN,ACTIVE
+WEBBCOUNTYTX.GOV,County,Non-Federal Agency,Laredo,TX,ACTIVE
+WEBERCOUNTYUTAH.GOV,County,Non-Federal Agency,Ogden,UT,ACTIVE
+WEBSTERCOUNTYMO.GOV,County,Non-Federal Agency,Marshfield,MO,ACTIVE
+WESTCHESTERCOUNTYNY.GOV,County,Non-Federal Agency,White Plains,NY,ACTIVE
+WESTFELICIANAPARISH-LA.GOV,County,Non-Federal Agency,St. Francisville,LA,ACTIVE
+WHITECOUNTYGA.GOV,County,Non-Federal Agency,Cleveland,GA,ACTIVE
+WHITECOUNTYTN.GOV,County,Non-Federal Agency,Sparta,TN,ACTIVE
+WHITEPINECOUNTYNV.GOV,County,Non-Federal Agency,Ely,NV,ACTIVE
+WILLCOUNTY-IL.GOV,County,Non-Federal Agency,Joliet,IL,ACTIVE
+WILLIAMSONCOUNTY-TN.GOV,County,Non-Federal Agency,Franklin,TN,ACTIVE
+WILLIAMSONCOUNTYIL.GOV,County,Non-Federal Agency,Marion,IL,ACTIVE
+WILSONCOUNTYTN.GOV,County,Non-Federal Agency,Lebanon,TN,ACTIVE
+WILSONCOUNTYTX.GOV,County,Non-Federal Agency,Floresville,TX,ACTIVE
+WINDHAMCOUNTYVT.GOV,County,Non-Federal Agency,Newfane,VT,ACTIVE
+WINNEBAGOCOUNTYIOWA.GOV,County,Non-Federal Agency,Forest City,IA,ACTIVE
+WOODBURYCOUNTYIOWA.GOV,County,Non-Federal Agency,Sioux City,IA,ACTIVE
+WORCESTERCOUNTYMD.GOV,County,Non-Federal Agency,Snow Hill,MD,ACTIVE
+YANCEYCOUNTYNC.GOV,County,Non-Federal Agency,Burnsville,NC,ACTIVE
+YAZOOCOUNTYMS.GOV,County,Non-Federal Agency,Yazoo City,MS,ACTIVE
+YCSOAZ.GOV,County,Non-Federal Agency,Prescott,AZ,ACTIVE
+YORKCOUNTY.GOV,County,Non-Federal Agency,Yorktown,VA,ACTIVE
+YORKCOUNTYMAINE.GOV,County,Non-Federal Agency,Alfred,ME,ACTIVE
+YORKCOUNTYME.GOV,County,Non-Federal Agency,Alfred,ME,ACTIVE
+YORKCOUNTYPA.GOV,County,Non-Federal Agency,York,PA,ACTIVE
+YUMACOUNTYARIZONA.GOV,County,Non-Federal Agency,Yuma,AZ,ACTIVE
+YUMACOUNTYAZ.GOV,County,Non-Federal Agency,Yuma,AZ,ACTIVE
+ZAPATACOUNTYTX.GOV,County,Non-Federal Agency,Zapata,TX,ACTIVE

--- a/dotgov-domains/2016-06-30-federal.csv
+++ b/dotgov-domains/2016-06-30-federal.csv
@@ -1,0 +1,1349 @@
+Domain Name,Domain Type,Agency,City,State,Status
+ACUS.GOV,Federal Agency,Administrative Conference of the United States,WASHINGTON,DC,ACTIVE
+ACHP.GOV,Federal Agency,Advisory Council on Historic Preservation,Washington,DC,ACTIVE
+PRESERVEAMERICA.GOV,Federal Agency,Advisory Council on Historic Preservation,Washington,DC,ACTIVE
+ADF.GOV,Federal Agency,African Development Foundation,Washington,DC,ACTIVE
+USADF.GOV,Federal Agency,African Development Foundation,Washington,DC,ACTIVE
+ABMC.GOV,Federal Agency,American Battle Monuments Commission,Arlington,VA,ACTIVE
+AMTRAKOIG.GOV,Federal Agency,AMTRAK,Washington,DC,ACTIVE
+ARC.GOV,Federal Agency,Appalachian Regional Commission,Washington,DC,ACTIVE
+ASC.GOV,Federal Agency,Appraisal Subcommittee,Washington,DC,ACTIVE
+AFRH.GOV,Federal Agency,Armed Forces Retirement Home,Washington,DC,ACTIVE
+CIA.GOV,Federal Agency,Central Intelligence Agency,Washington,DC,ACTIVE
+IC.GOV,Federal Agency,Central Intelligence Agency,Washington,DC,ACTIVE
+ISTAC.GOV,Federal Agency,Central Intelligence Agency,Washington,DC,ACTIVE
+NCTC.GOV,Federal Agency,Central Intelligence Agency,Washington,DC,ACTIVE
+ODCI.GOV,Federal Agency,Central Intelligence Agency,Washington,DC,ACTIVE
+OPENSOURCE.GOV,Federal Agency,Central Intelligence Agency,Washington,DC,ACTIVE
+OSDE.GOV,Federal Agency,Central Intelligence Agency,Reston,VA,ACTIVE
+TTIC.GOV,Federal Agency,Central Intelligence Agency,Washington,DC,ACTIVE
+UCIA.GOV,Federal Agency,Central Intelligence Agency,Washington,DC,ACTIVE
+CHRISTOPHERCOLUMBUSFOUNDATION.GOV,Federal Agency,Christopher Columbus Fellowship Foundation,Washington,DC,ACTIVE
+CAP.GOV,Federal Agency,Civil Air Patrol,BIRMINGHAM,MI,ACTIVE
+CAPNHQ.GOV,Federal Agency,Civil Air Patrol,MAXWELL AFB,AL,ACTIVE
+ABILITYONE.FED.US,Federal Agency,Comm for People Who Are Blind/Severly Disabled,Arlington,VA,ACTIVE
+ABILITYONE.GOV,Federal Agency,Comm for People Who Are Blind/Severly Disabled,Arlington,VA,ACTIVE
+JWOD.GOV,Federal Agency,Comm for People Who Are Blind/Severly Disabled,Arlington,VA,ACTIVE
+GOODLETTSVILLE.GOV,Federal Agency,Commission on Civil Rights,Goodlettsville,TN,ACTIVE
+CFTC.GOV,Federal Agency,Commodity Futures Trading Commission,Washington,DC,ACTIVE
+SMARTCHECK.GOV,Federal Agency,Commodity Futures Trading Commission,Washington,DC,ACTIVE
+WHISTLEBLOWER.GOV,Federal Agency,Commodity Futures Trading Commission,Washington,DC,ACTIVE
+COMPLIANCE.GOV,Federal Agency,Congressional Office of Compliance,Washington,DC,ACTIVE
+BCFP.GOV,Federal Agency,Consumer Financial Protection Bureau,Washington,DC,ACTIVE
+CFPA.GOV,Federal Agency,Consumer Financial Protection Bureau,Washington,DC,ACTIVE
+CFPB.GOV,Federal Agency,Consumer Financial Protection Bureau,Washington,DC,ACTIVE
+CONSUMERBUREAU.GOV,Federal Agency,Consumer Financial Protection Bureau,Washington,DC,ACTIVE
+CONSUMERFINANCE.GOV,Federal Agency,Consumer Financial Protection Bureau,Washington,DC,ACTIVE
+CONSUMERFINANCIAL.GOV,Federal Agency,Consumer Financial Protection Bureau,Washington,DC,ACTIVE
+CONSUMERFINANCIALBUREAU.GOV,Federal Agency,Consumer Financial Protection Bureau,Washington,DC,ACTIVE
+CONSUMERFINANCIALPROTECTIONBUREAU.GOV,Federal Agency,Consumer Financial Protection Bureau,Washington,DC,ACTIVE
+CONSUMERPROTECTION.GOV,Federal Agency,Consumer Financial Protection Bureau,Washington,DC,ACTIVE
+CONSUMERPROTECTIONBUREAU.GOV,Federal Agency,Consumer Financial Protection Bureau,Washington,DC,ACTIVE
+ANCHORIT.GOV,Federal Agency,Consumer Product Safety Commission,Bethesda,MD,ACTIVE
+ATVSAFETY.GOV,Federal Agency,Consumer Product Safety Commission,Bethesda,MD,ACTIVE
+CPSC.GOV,Federal Agency,Consumer Product Safety Commission,Bethesda,MD,ACTIVE
+DRYWALLRESPONSE.GOV,Federal Agency,Consumer Product Safety Commission,Bethesda,MD,ACTIVE
+POOLSAFELY.GOV,Federal Agency,Consumer Product Safety Commission,Bethesda,MD,ACTIVE
+POOLSAFETY.GOV,Federal Agency,Consumer Product Safety Commission,Bethesda,MD,ACTIVE
+RECALLS.GOV,Federal Agency,Consumer Product Safety Commission,Bethesda,MD,ACTIVE
+SAFERPRODUCT.GOV,Federal Agency,Consumer Product Safety Commission,Bethesda,MD,ACTIVE
+SAFERPRODUCTS.GOV,Federal Agency,Consumer Product Safety Commission,Bethesda,MD,ACTIVE
+SEGURIDADCONSUMIDOR.GOV,Federal Agency,Consumer Product Safety Commission,Bethesda,MD,ACTIVE
+AMERICORE.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC,ACTIVE
+AMERICORP.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC,ACTIVE
+AMERICORPS.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC,ACTIVE
+AMERICORPSCONNECT.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC,ACTIVE
+AMERICORPSWEEK.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC,ACTIVE
+CNCS.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC,ACTIVE
+CNCSOIG.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC,ACTIVE
+CNS.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC,ACTIVE
+FEDERALMENTORINGCOUNCIL.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC,ACTIVE
+GETINVOLVED.GOV,Federal Agency,Corporation for National & Community Service,Washington ,DC,ACTIVE
+LEARNANDSERVE.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC,ACTIVE
+MENTOR.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC,ACTIVE
+MLKDAY.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC,ACTIVE
+NATIONALSERVICE.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC,ACTIVE
+NATIONALSERVICEGEAR.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC,ACTIVE
+NATIONALSERVICERESOURCES.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC,ACTIVE
+PRESIDENTIALSERVICEAWARDS.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC,ACTIVE
+SENIORCORPS.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC,ACTIVE
+SERVE.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC,ACTIVE
+SERVICE.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC,ACTIVE
+SERVICELEARNING.GOV,Federal Agency,Corporation for National & Community Service,Washington ,DC,ACTIVE
+SERVIR.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC,ACTIVE
+VISTA.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC,ACTIVE
+VISTACAMPUS.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC,ACTIVE
+VOLUNTEERINGINAMERICA.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC,ACTIVE
+CIGIE.GOV,Federal Agency,Council of Inspector General on Integrity and Efficiency,WASHINGTON,DC,ACTIVE
+IGNET.GOV,Federal Agency,Council of Inspector General on Integrity and Efficiency,Washington,DC,ACTIVE
+OVERSIGHT.GOV,Federal Agency,Council of Inspector General on Integrity and Efficiency,Washington,DC,ACTIVE
+CSOSA.FED.US,Federal Agency,Court Services and Offender Supervision,Washington,DC,ACTIVE
+CSOSA.GOV,Federal Agency,Court Services and Offender Supervision,Washington,DC,ACTIVE
+PRETRIALSERVICES.GOV,Federal Agency,Court Services and Offender Supervision,Washington,DC,ACTIVE
+PSA.GOV,Federal Agency,Court Services and Offender Supervision,Washington,DC,ACTIVE
+DNFSB.GOV,Federal Agency,Defense Nuclear Facilities Safety Board,Washington,DC,ACTIVE
+DRA.GOV,Federal Agency,Delta Regional Authority,Clarksdale,MS,ACTIVE
+DENALI.GOV,Federal Agency,Denali Commission,Anchorage,AK,ACTIVE
+FEA.GOV,Federal Agency,Denali Commission,Anchorage,AK,ACTIVE
+AFF.GOV,Federal Agency,Department of Agriculture,Boise,ID,ACTIVE
+AG.GOV,Federal Agency,Department of Agriculture,Fort Collins,CO,ACTIVE
+ARS-GRIN.GOV,Federal Agency,Department of Agriculture,Beltsville,MD,ACTIVE
+ARSUSDA.GOV,Federal Agency,Department of Agriculture,Beltsville,MD,ACTIVE
+ASKKAREN.GOV,Federal Agency,Department of Agriculture,Washington,DC,ACTIVE
+BEFOODSAFE.GOV,Federal Agency,Department of Agriculture,Washington,DC,ACTIVE
+BIOPREFERRED.GOV,Federal Agency,Department of Agriculture,Washington,DC,ACTIVE
+BOSQUE.GOV,Federal Agency,Department of Agriculture,Albuquerque,NM,ACTIVE
+CHOOSEMYPLATE.GOV,Federal Agency,Department of Agriculture,Alexandria,VA,ACTIVE
+COASTALAMERICA.GOV,Federal Agency,Department of Agriculture,Washington,DC,ACTIVE
+DIETARYGUIDELINES.GOV,Federal Agency,Department of Agriculture,Alexandria,VA,ACTIVE
+EMPOWHR.GOV,Federal Agency,Department of Agriculture,New Orleans,LA,ACTIVE
+EXECSEC.GOV,Federal Agency,Department of Agriculture,Washington,DC,ACTIVE
+FARMERCLAIMS.GOV,Federal Agency,Department of Agriculture,St. Louis,MO,ACTIVE
+FEMALEFARMERCLAIMS.GOV,Federal Agency,Department of Agriculture,St. Louis,MO,ACTIVE
+FIREINSTITUTE.GOV,Federal Agency,Department of Agriculture,Tucson,AZ,ACTIVE
+FOODSAFETYJOBS.GOV,Federal Agency,Department of Agriculture,Washington,DC,ACTIVE
+FOODSAFETYWORKINGGROUP.GOV,Federal Agency,Department of Agriculture,Washington,DC,ACTIVE
+FORESTSANDRANGELANDS.GOV,Federal Agency,Department of Agriculture,Washington,DC,ACTIVE
+FS.FED.US,Federal Agency,Department of Agriculture,Washington,DC,ACTIVE
+GREEN.GOV,Federal Agency,Department of Agriculture,Washington,DC,ACTIVE
+HISPANICFARMERCLAIMS.GOV,Federal Agency,Department of Agriculture,St. Louis,MO,ACTIVE
+ICBEMP.GOV,Federal Agency,Department of Agriculture,Portland,OR,ACTIVE
+IIOG.GOV,Federal Agency,Department of Agriculture,Meridian,ID,ACTIVE
+INVASIVESPECIESINFO.GOV,Federal Agency,Department of Agriculture,Beltsville,MD,ACTIVE
+IPM.GOV,Federal Agency,Department of Agriculture,Washington,DC,ACTIVE
+ISITDONEYET.GOV,Federal Agency,Department of Agriculture,Washington,DC,ACTIVE
+ITAP.GOV,Federal Agency,Department of Agriculture,Beltsville,MD,ACTIVE
+JUNIORFORESTRANGER.GOV,Federal Agency,Department of Agriculture,Washington,DC,ACTIVE
+LATINOFARMERCLAIMS.GOV,Federal Agency,Department of Agriculture,St. Louis,MO,ACTIVE
+LCACOMMONS.GOV,Federal Agency,Department of Agriculture,Beltsville,MD,ACTIVE
+MTBS.GOV,Federal Agency,Department of Agriculture,Salt Lake City,UT,ACTIVE
+NAFRI.GOV,Federal Agency,Department of Agriculture,Tucson,AZ,ACTIVE
+NEL.GOV,Federal Agency,Department of Agriculture,Alexandria,VA,ACTIVE
+NUTRITION.GOV,Federal Agency,Department of Agriculture,Washington,DC,ACTIVE
+NUTRITIONEVIDENCELIBRARY.GOV,Federal Agency,Department of Agriculture,Alexandria,VA,ACTIVE
+NWCG.GOV,Federal Agency,Department of Agriculture,Boise,ID,ACTIVE
+PREGUNTELEAKAREN.GOV,Federal Agency,Department of Agriculture,Washington,DC,ACTIVE
+RECREATION.GOV,Federal Agency,Department of Agriculture,Ogden,UT,ACTIVE
+REO.GOV,Federal Agency,Department of Agriculture,Portland,OR,ACTIVE
+SMOKEYBEAR.GOV,Federal Agency,Department of Agriculture,Washington,DC,ACTIVE
+START2FARM.GOV,Federal Agency,Department of Agriculture,Beltsville,MD,ACTIVE
+SYMBOLS.GOV,Federal Agency,Department of Agriculture,Washington,DC,ACTIVE
+THEPEOPLESGARDEN.GOV,Federal Agency,Department of Agriculture,Wahington,DC,ACTIVE
+USDA.GOV,Federal Agency,Department of Agriculture,Ft. Collins,CO,ACTIVE
+USDAPII.GOV,Federal Agency,Department of Agriculture,Washington,DC,ACTIVE
+WILDFIRE.GOV,Federal Agency,Department of Agriculture,Boise,ID,ACTIVE
+WOMENFARMERCLAIMS.GOV,Federal Agency,Department of Agriculture,St. Louis,MO,ACTIVE
+WOODSY.GOV,Federal Agency,Department of Agriculture,Washington,DC,ACTIVE
+WOODSYOWL.GOV,Federal Agency,Department of Agriculture,Washington,DC,ACTIVE
+AP.GOV,Federal Agency,Department of Commerce,Washington,DC,ACTIVE
+AVIATIONWEATHER.GOV,Federal Agency,Department of Commerce,Silver Spring,MD,ACTIVE
+BEA.GOV,Federal Agency,Department of Commerce,Washington,DC,ACTIVE
+BLDRDOC.GOV,Federal Agency,Department of Commerce,Boulder,CO,ACTIVE
+BUYUSA.GOV,Federal Agency,Department of Commerce,Washington,DC,ACTIVE
+CBP.GOV,Federal Agency,Department of Commerce,Alexandria,VA,ACTIVE
+CENSUS.GOV,Federal Agency,Department of Commerce,Suitland,MD,ACTIVE
+CIVILRIGHTSUSA.GOV,Federal Agency,Department of Commerce,Alexandria,VA,ACTIVE
+CLIMATE.GOV,Federal Agency,Department of Commerce,Silver Spring,MD,ACTIVE
+CLIMATECHANGE.GOV,Federal Agency,Department of Commerce,Oak Ridge,TN,ACTIVE
+COMMERCE.GOV,Federal Agency,Department of Commerce,Washington,DC,ACTIVE
+COOP-USPTO.GOV,Federal Agency,Department of Commerce,Arlington,VA,ACTIVE
+DIGITALLITERACY.GOV,Federal Agency,Department of Commerce,Washington,DC,ACTIVE
+DNSOPS.GOV,Federal Agency,Department of Commerce,Gaithersburg,MD,ACTIVE
+DOC.GOV,Federal Agency,Department of Commerce,Washington,DC,ACTIVE
+DROUGHT.GOV,Federal Agency,Department of Commerce,Asheville,NC,ACTIVE
+EDA.GOV,Federal Agency,Department of Commerce,Washington,DC,ACTIVE
+ESA.GOV,Federal Agency,Department of Commerce,Washington,DC,ACTIVE
+EXPORT.GOV,Federal Agency,Department of Commerce,Washington,DC,ACTIVE
+FCSM.GOV,Federal Agency,Department of Commerce,Suitland,MD,SERVER-HOLD
+FIRSTNET.GOV,Federal Agency,Department of Commerce,Washington,DC,ACTIVE
+FISHWATCH.GOV,Federal Agency,Department of Commerce,Silver Spring,MD,ACTIVE
+GETYOUHOME.GOV,Federal Agency,Department of Commerce,Alexandria,VA,ACTIVE
+GLOBALENTRY.GOV,Federal Agency,Department of Commerce,Alexandria,VA,ACTIVE
+GOES-R.GOV,Federal Agency,Department of Commerce,Greenbelt,MD,ACTIVE
+GPS.GOV,Federal Agency,Department of Commerce,Washington,DC,ACTIVE
+HURRICANES.GOV,Federal Agency,Department of Commerce,Miami,FL,ACTIVE
+ITDS.GOV,Federal Agency,Department of Commerce,Springfield,VA,ACTIVE
+MANUFACTURING.GOV,Federal Agency,Department of Commerce,Washington,DC,ACTIVE
+MAPSTATS.GOV,Federal Agency,Department of Commerce,Washington,DC,SERVER-HOLD
+MARINECADASTRE.GOV,Federal Agency,Department of Commerce,Charleston,SC,ACTIVE
+MBDA.GOV,Federal Agency,Department of Commerce,Washington,DC,ACTIVE
+MGI.GOV,Federal Agency,Department of Commerce,Gaithersburg,MD,ACTIVE
+NEHRP.GOV,Federal Agency,Department of Commerce,Gaithersburg,MD,ACTIVE
+NIST.GOV,Federal Agency,Department of Commerce,Gaithersburg,MD,ACTIVE
+NOAA.GOV,Federal Agency,Department of Commerce,Silver Spring,MD,ACTIVE
+NTIS.GOV,Federal Agency,Department of Commerce,Alexandria,VA,ACTIVE
+OFCM.GOV,Federal Agency,Department of Commerce,Silver Spring,MD,ACTIVE
+PAPAHANAUMOKUAKEA.GOV,Federal Agency,Department of Commerce,Silver Spring,MD,ACTIVE
+PRIVACYSHIELD.GOV,Federal Agency,Department of Commerce,Washington,DC,ACTIVE
+PSCR.GOV,Federal Agency,Department of Commerce,Boulder,CO,ACTIVE
+SDR.GOV,Federal Agency,Department of Commerce,Washington,DC,ACTIVE
+SELECTUSA.GOV,Federal Agency,Department of Commerce,Washington,DC,ACTIVE
+SPACEWEATHER.GOV,Federal Agency,Department of Commerce,Boulder,CO,ACTIVE
+SPECTRUM.GOV,Federal Agency,Department of Commerce,Washington,DC,ACTIVE
+STANDARDS.GOV,Federal Agency,Department of Commerce,Gaithersburg,MD,ACTIVE
+TIME.GOV,Federal Agency,Department of Commerce,Boulder,CO,ACTIVE
+TRADE.GOV,Federal Agency,Department of Commerce,Washington,DC,ACTIVE
+TSUNAMI.GOV,Federal Agency,Department of Commerce,Palmer,AK,ACTIVE
+USPTO.GOV,Federal Agency,Department of Commerce,Washington,DC,ACTIVE
+WDOL.GOV,Federal Agency,Department of Commerce,Alexandria,VA,ACTIVE
+WEATHER.GOV,Federal Agency,Department of Commerce,Silver Spring,MD,ACTIVE
+ADLNET.GOV,Federal Agency,Department of Defense,Washington,DC,ACTIVE
+AFTAC.GOV,Federal Agency,Department of Defense,Patrick AFB,FL,ACTIVE
+ALTUSANDC.GOV,Federal Agency,Department of Defense,"patrick, afb",FL,ACTIVE
+BRAC.GOV,Federal Agency,Department of Defense,Alexandria,VA,ACTIVE
+CMTS.GOV,Federal Agency,Department of Defense,Mobile,AL,ACTIVE
+CNSS.GOV,Federal Agency,Department of Defense,Ft George G. Meade,MD,ACTIVE
+CTOC.GOV,Federal Agency,Department of Defense,Starke,FL,ACTIVE
+CTTSO.GOV,Federal Agency,Department of Defense,Arlington,VA,ACTIVE
+DC3ON.GOV,Federal Agency,Department of Defense,Linthicum,MD,ACTIVE
+DEFENSE.GOV,Federal Agency,Department of Defense,Fort Meade,MD,ACTIVE
+DOD.GOV,Federal Agency,Department of Defense,Fort Meade,MD,ACTIVE
+EACLEARINGHOUSE.GOV,Federal Agency,Department of Defense,Arlington,VA,ACTIVE
+ERDC.GOV,Federal Agency,Department of Defense,Vicksburg,MS,ACTIVE
+FVAP.GOV,Federal Agency,Department of Defense,Alexandria,VA,ACTIVE
+IAD.GOV,Federal Agency,Department of Defense,Ft Meade,MD,ACTIVE
+IOSS.GOV,Federal Agency,Department of Defense,Greenbelt,MD,ACTIVE
+ITC.GOV,Federal Agency,Department of Defense,Ft. Washington,MD,ACTIVE
+JCCS.GOV,Federal Agency,Department of Defense,Alexandria,VA,ACTIVE
+MCRMC.GOV,Federal Agency,Department of Defense,Arlington,VA,ACTIVE
+MOJAVEDATA.GOV,Federal Agency,Department of Defense,Barstow,CA,ACTIVE
+MTMC.GOV,Federal Agency,Department of Defense,Alexandria,VA,ACTIVE
+MYPAY.GOV,Federal Agency,Department of Defense,Pensacola,FL,ACTIVE
+NCR.GOV,Federal Agency,Department of Defense,Washington,DC,ACTIVE
+NRO.GOV,Federal Agency,Department of Defense,Chantilly,VA,ACTIVE
+NROJR.GOV,Federal Agency,Department of Defense,Chantilly,VA,ACTIVE
+NSA.GOV,Federal Agency,Department of Defense,Ft. Meade,MD,ACTIVE
+NSEP.GOV,Federal Agency,Department of Defense,Arlington,VA,ACTIVE
+OEA.GOV,Federal Agency,Department of Defense,Arlington,VA,ACTIVE
+OSDBU.GOV,Federal Agency,Department of Defense,Washington,DC,ACTIVE
+PENTAGON.GOV,Federal Agency,Department of Defense,Fort Meade,MD,ACTIVE
+SITEIDIQ.GOV,Federal Agency,Department of Defense,Arlington,VA,ACTIVE
+TSWG.GOV,Federal Agency,Department of Defense,Arlington,VA,ACTIVE
+USANDC.GOV,Federal Agency,Department of Defense,Patrick AFB,FL,ACTIVE
+AAPI.GOV,Federal Agency,Department of Education,Washington,DC,ACTIVE
+BFELOB.GOV,Federal Agency,Department of Education,Washington,DC,ACTIVE
+CHILDSTATS.GOV,Federal Agency,Department of Education,Washington,DC,ACTIVE
+COLLEGENAVIGATOR.GOV,Federal Agency,Department of Education,Washington,DC,ACTIVE
+ED.GOV,Federal Agency,Department of Education,Washington,DC,ACTIVE
+EDPUBS.GOV,Federal Agency,Department of Education,Washington ,DC,ACTIVE
+EDUCATION.GOV,Federal Agency,Department of Education,Washington,DC,ACTIVE
+FAFSA.GOV,Federal Agency,Department of Education,Washington,DC,ACTIVE
+FSAPUBS.GOV,Federal Agency,Department of Education,Washington,DC,ACTIVE
+G5.GOV,Federal Agency,Department of Education,Washington,DC,ACTIVE
+NAGB.GOV,Federal Agency,Department of Education,Washington,DC,ACTIVE
+NATIONSREPORTCARD.GOV,Federal Agency,Department of Education,Washington,DC,ACTIVE
+STUDENTAID.GOV,Federal Agency,Department of Education,Washington,DC,ACTIVE
+STUDENTLOANS.GOV,Federal Agency,Department of Education,Washington,DC,ACTIVE
+AMESLAB.GOV,Federal Agency,Department of Energy,Ames,IA,ACTIVE
+ANL.GOV,Federal Agency,Department of Energy,Argonne,IL,ACTIVE
+ARM.GOV,Federal Agency,Department of Energy,Richland,WA,ACTIVE
+BIOMASSBOARD.GOV,Federal Agency,Department of Energy,Washington,DC,ACTIVE
+BNL.GOV,Federal Agency,Department of Energy,Upton,NY,ACTIVE
+BPA.GOV,Federal Agency,Department of Energy,Portland,OR,ACTIVE
+BRC.GOV,Federal Agency,Department of Energy,Washington,DC,ACTIVE
+BUILDINGAMERICA.GOV,Federal Agency,Department of Energy,Golden,CO,ACTIVE
+CASL.GOV,Federal Agency,Department of Energy,Oak Ridge,TN,ACTIVE
+CEBAF.GOV,Federal Agency,Department of Energy,Newport News,VA,ACTIVE
+CENDI.GOV,Federal Agency,Department of Energy,Oak Ridge,TN,ACTIVE
+CRT2014-2024REVIEW.GOV,Federal Agency,Department of Energy,Portland,OR,ACTIVE
+DOE.GOV,Federal Agency,Department of Energy,Washington,DC,ACTIVE
+DOEAL.GOV,Federal Agency,Department of Energy,Albuquerque,NM,ACTIVE
+EIA.GOV,Federal Agency,Department of Energy,Washington,DC,ACTIVE
+ENERGY.GOV,Federal Agency,Department of Energy,Washington,DC,ACTIVE
+ENERGYCODES.GOV,Federal Agency,Department of Energy,Richland,WA,ACTIVE
+ENERGYPLUS.GOV,Federal Agency,Department of Energy,Washington,DC,ACTIVE
+ENERGYSAVER.GOV,Federal Agency,Department of Energy,Washington,DC,ACTIVE
+ENERGYSAVERS.GOV,Federal Agency,Department of Energy,Washington,DC,ACTIVE
+FNAL.GOV,Federal Agency,Department of Energy,Batavia,IL,ACTIVE
+FUELECONOMY.GOV,Federal Agency,Department of Energy,Oak Ridge,TN,ACTIVE
+HANFORD.GOV,Federal Agency,Department of Energy,Richland,WA,ACTIVE
+HIGHPERFORMANCEBUILDINGS.GOV,Federal Agency,Department of Energy,Golden,CO,ACTIVE
+HOMEENERGYSCORE.GOV,Federal Agency,Department of Energy,Washington,DC,ACTIVE
+HYDROGEN.GOV,Federal Agency,Department of Energy,Washington,DC,ACTIVE
+INEL.GOV,Federal Agency,Department of Energy,Idaho Falls,ID,ACTIVE
+INL.GOV,Federal Agency,Department of Energy,Idaho Falls,ID,ACTIVE
+ISOTOPE.GOV,Federal Agency,Department of Energy,Oak Ridge,TN,ACTIVE
+ISOTOPES.GOV,Federal Agency,Department of Energy,Oak Ridge,TN,ACTIVE
+KAPL.GOV,Federal Agency,Department of Energy,Schenectady,NY,ACTIVE
+LANL.GOV,Federal Agency,Department of Energy,Los Alamos,NM,ACTIVE
+LBL.GOV,Federal Agency,Department of Energy,Berkeley,CA,ACTIVE
+LLNL.GOV,Federal Agency,Department of Energy,Livermore,CA,ACTIVE
+NCCRC.GOV,Federal Agency,Department of Energy,Oak Ridge,TN,ACTIVE
+NCCS.GOV,Federal Agency,Department of Energy,Oak Ridge,TN,ACTIVE
+NCRC.GOV,Federal Agency,Department of Energy,Oak Ridge,TN,ACTIVE
+NERSC.GOV,Federal Agency,Department of Energy,Berkeley,CA,ACTIVE
+NEUP.GOV,Federal Agency,Department of Energy,Washington,DC,ACTIVE
+NREL.GOV,Federal Agency,Department of Energy,Golden,CO,ACTIVE
+NRELHUB.GOV,Federal Agency,Department of Energy,Golden,CO,ACTIVE
+NTRC.GOV,Federal Agency,Department of Energy,Knoxville,TN,ACTIVE
+NUCLEAR.GOV,Federal Agency,Department of Energy,Washington,DC,ACTIVE
+ORAU.GOV,Federal Agency,Department of Energy,Oak Ridge,TN,ACTIVE
+ORNL.GOV,Federal Agency,Department of Energy,Oak Ridge,TN,ACTIVE
+OSTI.GOV,Federal Agency,Department of Energy,Oak Ridge,TN,ACTIVE
+PNL.GOV,Federal Agency,Department of Energy,Richland,WA,ACTIVE
+PNNL.GOV,Federal Agency,Department of Energy,Richland,WA,ACTIVE
+RL.GOV,Federal Agency,Department of Energy,Richland,WA,ACTIVE
+SALMONRECOVERY.GOV,Federal Agency,Department of Energy,Portland,OR,ACTIVE
+SANDIA.GOV,Federal Agency,Department of Energy,Albuquerque,NM,ACTIVE
+SCIDAC.GOV,Federal Agency,Department of Energy,Oak Ridge,TN,ACTIVE
+SCIENCE.GOV,Federal Agency,Department of Energy,Oak Ridge,TN,ACTIVE
+SCIENCEACCELERATOR.GOV,Federal Agency,Department of Energy,Oak Ridge,TN,ACTIVE
+SMARTGRID.GOV,Federal Agency,Department of Energy,Washington,DC,ACTIVE
+SNS.GOV,Federal Agency,Department of Energy,Oak Ridge,TN,ACTIVE
+SOLARDECATHLON.GOV,Federal Agency,Department of Energy,Golden,CO,ACTIVE
+SRS.GOV,Federal Agency,Department of Energy,Aiken,SC,ACTIVE
+SWPA.GOV,Federal Agency,Department of Energy,Tulsa,OK,ACTIVE
+UNNPP.GOV,Federal Agency,Department of Energy,West Mifflin,PA,ACTIVE
+UNRPNET.GOV,Federal Agency,Department of Energy,Washington,DC,ACTIVE
+WAPA.GOV,Federal Agency,Department of Energy,Lakewood,CO,ACTIVE
+WINDPOWERINGAMERICA.GOV,Federal Agency,Department of Energy,Golden,CO,ACTIVE
+YMP.GOV,Federal Agency,Department of Energy,Las Vegas,NV,ACTIVE
+ACF.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+ACL.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+AFTERSCHOOL.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+AGING.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+AGINGSTATS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+AHCPR.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE
+AHRQ.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE
+AIDS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+ALZHEIMERS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+AOA.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+BAM.GOV,Federal Agency,Department of Health And Human Services,Atlanta,GA,ACTIVE
+BESTBONESFOREVER.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+BETOBACCOFREE.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+BIOETHICS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+BIOSECURITYBOARD.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+BRAINHEALTH.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+CANCER.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE
+CANCERNET.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE
+CDC.GOV,Federal Agency,Department of Health And Human Services,Atlanta,GA,ACTIVE
+CHILDWELFARE.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+CLINICALTRIAL.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE
+CLINICALTRIALS.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE
+CLUBDRUGS.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE
+CMS.GOV,Federal Agency,Department of Health And Human Services,Baltimore,MD,ACTIVE
+COLLEGEDRINKINGPREVENTION.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE
+CUIDADODESALUD.GOV,Federal Agency,Department of Health And Human Services,Baltimore,MD,ACTIVE
+DHHS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+DIABETESCOMMITTEE.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+DOCLINE.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE
+DONACIONDEORGANOS.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE
+DRUGABUSE.GOV,Federal Agency,Department of Health And Human Services,Baltimore,MD,ACTIVE
+DRUGFREEWORKPLACE.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE
+EDISON.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE
+ELDERCARE.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+ENDINGTHEDOCUMENTGAME.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+ERRP.GOV,Federal Agency,Department of Health And Human Services,Baltimore,MD,ACTIVE
+FATHERHOOD.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+FDA.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE
+FINDYOUTHINFO.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE
+FITNESS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+FLU.GOV,Federal Agency,Department of Health And Human Services,Washington ,DC,ACTIVE
+FOODSAFETY.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+FRESHEMPIRE.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+FRUITSANDVEGGIESMATTER.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+GENBANK.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE
+GENOME.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE
+GIRLSHEALTH.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+GLOBALHEALTH.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE
+GRANTS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+GRANTSOLUTIONS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+GUIDELINE.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE
+GUIDELINES.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE
+HCQUALITYCOMMISSION.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE
+HEALTH.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+HEALTHCARE.GOV,Federal Agency,Department of Health And Human Services,Baltimore,MD,ACTIVE
+HEALTHDATA.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+HEALTHFINDER.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+HEALTHINDICATORS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+HEALTHIT.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+HEALTHREFORM.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+HEALTHYPEOPLE.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+HEARTTRUTH.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE
+HHS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+HHSOIG.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+HHSOPS.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE
+HIV.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+HRSA.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE
+IDEALAB.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+IEDISON.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE
+IHS.GOV,Federal Agency,Department of Health And Human Services,Albuquerque,NM,ACTIVE
+INSUREKIDSNOW.GOV,Federal Agency,Department of Health And Human Services,Baltimore,MD,ACTIVE
+KNOWTHEFACTSFIRST.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+LOCATORPLUS.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE
+LONGTERMCARE.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+MEDICAID.GOV,Federal Agency,Department of Health And Human Services,Baltimore,MD,ACTIVE
+MEDICALCOUNTERMEASURES.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+MEDICALRESERVECORPS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+MEDICARE.GOV,Federal Agency,Department of Health And Human Services,Baltimore,MD,ACTIVE
+MEDLINE.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE
+MEDLINEPLUS.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE
+MENTALHEALTH.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE
+MESH.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE
+MIMEDICARE.GOV,Federal Agency,Department of Health And Human Services,Baltimore,MD,ACTIVE
+MYMEDICARE.GOV,Federal Agency,Department of Health And Human Services,Baltimore,MD,ACTIVE
+NATIONALCHILDRENSSTUDY.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE
+NCIFCRF.GOV,Federal Agency,Department of Health And Human Services,Frederick,MD,ACTIVE
+NGC.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE
+NIH.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE
+NIHSENIORHEALTH.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE
+NIOSH.GOV,Federal Agency,Department of Health And Human Services,Atlanta,GA,ACTIVE
+NLM.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE
+NNLM.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE
+ORGANDONOR.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE
+PANDEMICFLU.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+PHE.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+PSC.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE
+PUBMED.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE
+PUBMEDCENTRAL.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE
+QUIC.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE
+QUICK.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE
+RECOVERYMONTH.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE
+SAFEYOUTH.GOV,Federal Agency,Department of Health And Human Services,Atlanta,GA,ACTIVE
+SAMHSA.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE
+SELECTAGENTS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+SMOKEFREE.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE
+STEROIDABUSE.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE
+STOPALCOHOLABUSE.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+STOPBULLYING.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+STOPMEDICAREFRAUD.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+SURGEONGENERAL.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+THECOOLSPOT.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE
+THEREALCOST.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+THISFREELIFE.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+TISSUEENGINEERING.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE
+TOBACCO.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+USABILITY.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+USBM.GOV,Federal Agency,Department of Health And Human Services,Atlanta,GA,ACTIVE
+USPHS.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE
+VACCINES.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+WHAGING.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+WHITEHOUSECONFERENCEONAGING.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+WOMENSHEALTH.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+YOUTH.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+BIOMETRICS.GOV,Federal Agency,Department of Homeland Security,Arlington,VA,ACTIVE
+CITIZENCORPS.GOV,Federal Agency,Department of Homeland Security,Washington,DC,ACTIVE
+CPNIREPORTING.GOV,Federal Agency,Department of Homeland Security,Washington,DC,ACTIVE
+DHS.GOV,Federal Agency,Department of Homeland Security,Washington,DC,ACTIVE
+DISASTERASSISTANCE.GOV,Federal Agency,Department of Homeland Security,Bluemont,VA,ACTIVE
+FEMA.GOV,Federal Agency,Department of Homeland Security,Washington,DC,ACTIVE
+FIRSTRESPONDER.GOV,Federal Agency,Department of Homeland Security,Washington,DC,ACTIVE
+FIRSTRESPONDERTRAINING.GOV,Federal Agency,Department of Homeland Security,Washington,DC,ACTIVE
+FLETA.GOV,Federal Agency,Department of Homeland Security,Glynco,GA,ACTIVE
+FLETC.GOV,Federal Agency,Department of Homeland Security,Glynco,GA,ACTIVE
+FLIGHTSCHOOLCANDIDATES.GOV,Federal Agency,Department of Homeland Security,Rockville,MD,ACTIVE
+FLOODSMART.GOV,Federal Agency,Department of Homeland Security,Bluemont,VA,ACTIVE
+HOMELANDSECURITY.GOV,Federal Agency,Department of Homeland Security,Washington,DC,ACTIVE
+ICE.GOV,Federal Agency,Department of Homeland Security,Washington,DC,ACTIVE
+LISTO.GOV,Federal Agency,Department of Homeland Security,Washington,DC,ACTIVE
+LLIS.GOV,Federal Agency,Department of Homeland Security,Washington,DC,ACTIVE
+NMSC.GOV,Federal Agency,Department of Homeland Security,St Augustine,FL,ACTIVE
+READY.GOV,Federal Agency,Department of Homeland Security,Washington,DC,ACTIVE
+READYBUSINESS.GOV,Federal Agency,Department of Homeland Security,Washington,DC,ACTIVE
+SAFECOMPROGRAM.GOV,Federal Agency,Department of Homeland Security,Washington,DC,ACTIVE
+SAFETYACT.GOV,Federal Agency,Department of Homeland Security,Washington,DC,ACTIVE
+SECRETSERVICE.GOV,Federal Agency,Department of Homeland Security,Washington D.C.,DC,ACTIVE
+TSA.GOV,Federal Agency,Department of Homeland Security,Arlington,VA,ACTIVE
+US-CERT.GOV,Federal Agency,Department of Homeland Security,Washington,DC,ACTIVE
+USCG.GOV,Federal Agency,Department of Homeland Security,Alexandria,VA,ACTIVE
+USCIS.GOV,Federal Agency,Department of Homeland Security,Washington,DC,ACTIVE
+USSS.GOV,Federal Agency,Department of Homeland Security,Washington,DC,ACTIVE
+DISASTERHOUSING.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC,ACTIVE
+FHA.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC,ACTIVE
+GINNIEMAE.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC,ACTIVE
+HOMESALES.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC,ACTIVE
+HUD.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC,ACTIVE
+HUDOIG.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC,ACTIVE
+HUDUSER.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC,ACTIVE
+NATIONALHOUSING.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC,ACTIVE
+NATIONALHOUSINGLOCATOR.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC,ACTIVE
+NHL.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC,ACTIVE
+NLS.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC,ACTIVE
+ADA.GOV,Federal Agency,Department of Justice,Rockville,MD,ACTIVE
+ADR.GOV,Federal Agency,Department of Justice,Rockville,MD,ACTIVE
+AMBERALERT.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+ATF.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE
+ATFONLINE.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE
+BATS.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+BIOMETRICCOE.GOV,Federal Agency,Department of Justice,Clarksburg,WV,ACTIVE
+BJA.GOV,Federal Agency,Department of Justice,Washington ,DC,ACTIVE
+BJS.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE
+BOP.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE
+CJIS.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE
+CRIMESOLUTIONS.GOV,Federal Agency,Department of Justice,Washinton ,DC,ACTIVE
+CRIMEVICTIMS.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+CYBERCRIME.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE
+DEA.GOV,Federal Agency,Department of Justice,Rockville,MD,ACTIVE
+DEADIVERSION.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+DEAECOM.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+DEALS.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE
+DNA.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+DOJ.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+DSAC.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+EGUARDIAN.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE
+EPIC.GOV,Federal Agency,Department of Justice,Rockville,MD,ACTIVE
+EPIC2.GOV,Federal Agency,Department of Justice,Arlington ,VA,ACTIVE
+ESP.GOV,Federal Agency,Department of Justice,Falls Church,VA,ACTIVE
+ESPANOLFORLAWENFORCEMENT.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+FARA.GOV,Federal Agency,Department of Justice,potomac,MD,ACTIVE
+FBI.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE
+FBIJOBS.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE
+FIRSTFREEDOM.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+FOIA.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE
+FORENSICSCIENCE.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE
+FORFEITURE.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+FPI.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE
+GETSMARTABOUTDRUGS.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+HELPINGAMERICASYOUTH.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+IC3.GOV,Federal Agency,Department of Justice,Fairmont,WV,ACTIVE
+INTERPOL.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+IPRCENTER.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE
+JUSTICE.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE
+JUSTTHINKTWICE.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+JUVENILECOUNCIL.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+LEARNATF.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE
+LEARNDOJ.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE
+LEO.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+LEP.GOV,Federal Agency,Department of Justice,Rockville,MD,ACTIVE
+LOOKSTOOGOOD.GOV,Federal Agency,Department of Justice,Fairmont,WV,ACTIVE
+LOOKSTOOGOODTOBETRUE.GOV,Federal Agency,Department of Justice,Fairmont,WV,ACTIVE
+MALWAREINVESTIGATOR.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE
+MEDALOFVALOR.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+METHRESOURCES.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+NAMUS.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+NATIONALGANGCENTER.GOV,Federal Agency,Department of Justice,Tallahassee,FL,ACTIVE
+NCIRC.GOV,Federal Agency,Department of Justice,Tallahassee,FL,ACTIVE
+NCJRS.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+NIBIN.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE
+NICIC.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE
+NICSEZCHECKFBI.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE
+NIEM.GOV,Federal Agency,Department of Justice,Tallahassee,FL,ACTIVE
+NIJ.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE
+NMVTIS.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE
+NSOPR.GOV,Federal Agency,Department of Justice,Tallahassee,FL,ACTIVE
+NSOPW.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE
+NVTC.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE
+OJJDP.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+OJP.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE
+OVC.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+OVCTTAC.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+PROJECTSAFECHILDHOOD.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+PROJECTSAFENEIGHBORHOODS.GOV,Federal Agency,Department of Justice,Rockville,MD,ACTIVE
+PSN.GOV,Federal Agency,Department of Justice,Rocckville,MD,ACTIVE
+PSOB.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+RCFL.GOV,Federal Agency,Department of Justice,McLean,VA,ACTIVE
+REENTRY.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+SCRA.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+SERVICEMEMBERS.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+SMART.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE
+STOPFRAUD.GOV,Federal Agency,Department of Justice,Rockville,MD,ACTIVE
+TECHTRACK.GOV,Federal Agency,Department of Justice,Arlington,VA,ACTIVE
+TRIBALJUSTICEANDSAFETY.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+UCRDATATOOL.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE
+UNICOR.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE
+USDOJ.GOV,Federal Agency,Department of Justice,Rockville,MD,ACTIVE
+USERRA.GOV,Federal Agency,Department of Justice,Potpmac,MD,ACTIVE
+USMARSHALS.GOV,Federal Agency,Department of Justice,Rockville,MD,ACTIVE
+VCF.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE
+VEHICLEHISTORY.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+AMERICASHEROESATWORK.GOV,Federal Agency,Department of Labor,Washington,DC,ACTIVE
+BENEFITS.GOV,Federal Agency,Department of Labor,Washington,DC,ACTIVE
+BLS.GOV,Federal Agency,Department of Labor,Washington,DC,ACTIVE
+DISABILITY.GOV,Federal Agency,Department of Labor,Washington,DC,ACTIVE
+DOL-ESA.GOV,Federal Agency,Department of Labor,Washington,DC,ACTIVE
+DOL.GOV,Federal Agency,Department of Labor,Washington,DC,ACTIVE
+DOLETA.GOV,Federal Agency,Department of Labor,Washington,DC,ACTIVE
+GOVBENEFITS.GOV,Federal Agency,Department of Labor,Washington,DC,ACTIVE
+GOVLOANS.GOV,Federal Agency,Department of Labor,Washington,DC,ACTIVE
+JOBCORPS.GOV,Federal Agency,Department of Labor,Austin,TX,ACTIVE
+LABOR.GOV,Federal Agency,Department of Labor,Washington,DC,ACTIVE
+MSHA.GOV,Federal Agency,Department of Labor,Arlington,VA,ACTIVE
+MYNEXTMOVE.GOV,Federal Agency,Department of Labor,Washington,DC,ACTIVE
+OSHA.GOV,Federal Agency,Department of Labor,Washington,DC,ACTIVE
+UNIONREPORTS.GOV,Federal Agency,Department of Labor,Washington,DC,ACTIVE
+VETERANS.GOV,Federal Agency,Department of Labor,Washington,DC,ACTIVE
+WHISTLEBLOWERS.GOV,Federal Agency,Department of Labor,Washington,DC,ACTIVE
+WRP.GOV,Federal Agency,Department of Labor,Washington,DC,ACTIVE
+YOUTHRULES.GOV,Federal Agency,Department of Labor,Washington,DC,ACTIVE
+AMERICA.GOV,Federal Agency,Department of State,Washington,DC,ACTIVE
+CONTINENTALSHELF.GOV,Federal Agency,Department of State,Washington,DC,ACTIVE
+CWC.GOV,Federal Agency,Department of State,Washington,DC,ACTIVE
+ECOPARTNERSHIPS.GOV,Federal Agency,Department of State,Washington,DC,ACTIVE
+FAN.GOV,Federal Agency,Department of State,Washington,DC,ACTIVE
+FOREIGNASSISTANCE.GOV,Federal Agency,Department of State,Washington,DC,ACTIVE
+FSGB.GOV,Federal Agency,Department of State,Washington,DC,ACTIVE
+GHI.GOV,Federal Agency,Department of State,Washington,DC,ACTIVE
+HUMANRIGHTS.GOV,Federal Agency,Department of State,Washington ,DC,ACTIVE
+IAWG.GOV,Federal Agency,Department of State,Washington,DC,ACTIVE
+IBWC.GOV,Federal Agency,Department of State,El Paso,TX,ACTIVE
+ICASS.GOV,Federal Agency,Department of State,Washington,DC,ACTIVE
+OSAC.GOV,Federal Agency,Department of State,Washington,DC,ACTIVE
+PEPFAR.GOV,Federal Agency,Department of State,Washington,DC,ACTIVE
+STATE.GOV,Federal Agency,Department of State,Washington,DC,ACTIVE
+USCONSULATE.GOV,Federal Agency,Department of State,Washington,DC,ACTIVE
+USEMBASSY-MEXICO.GOV,Federal Agency,Department of State,Mexico City,11,ACTIVE
+USEMBASSY.GOV,Federal Agency,Department of State,Washington,DC,ACTIVE
+USINT.GOV,Federal Agency,Department of State,Washington,DC,ACTIVE
+USMISSION.GOV,Federal Agency,Department of State,Washington,DC,ACTIVE
+USVPP.GOV,Federal Agency,Department of State,Washington,DC,ACTIVE
+STATEOIG.GOV,Federal Agency,Department of State OIG,Arlington,VA,ACTIVE
+ABANDONEDMINES.GOV,Federal Agency,Department of the Interior,Washington,DC,ACTIVE
+ACWI.GOV,Federal Agency,Department of the Interior,Reston,VA,ACTIVE
+ALASKACENTERS.GOV,Federal Agency,Department of the Interior,Washington,DC,ACTIVE
+AMERICANLATINOMUSEUM.GOV,Federal Agency,Department of the Interior,Washington,WV,ACTIVE
+AMERICASGREATOUTDOORS.GOV,Federal Agency,Department of the Interior,Washington,DC,ACTIVE
+ANSTASKFORCE.GOV,Federal Agency,Department of the Interior,Arlington,VA,ACTIVE
+BIA.GOV,Federal Agency,Department of the Interior,Reston,VA,ACTIVE
+BIOECO.GOV,Federal Agency,Department of the Interior,Denver,CO,ACTIVE
+BLM.GOV,Federal Agency,Department of the Interior,Denver,CO,ACTIVE
+BLMNTL.GOV,Federal Agency,Department of the Interior,Denver,CO,ACTIVE
+BOEM.GOV,Federal Agency,Department of the Interior,Herndon,VA,ACTIVE
+BOEMRE.GOV,Federal Agency,Department of the Interior,Herndon,VA,ACTIVE
+BOR.GOV,Federal Agency,Department of the Interior,Denver,CO,ACTIVE
+BSEE.GOV,Federal Agency,Department of the Interior,Herndon,VA,ACTIVE
+CORALREEF.GOV,Federal Agency,Department of the Interior,Denver,CO,ACTIVE
+CUPCAO.GOV,Federal Agency,Department of the Interior,Denver,CO,ACTIVE
+DOI.GOV,Federal Agency,Department of the Interior,Washington,DC,ACTIVE
+DOIOIG.GOV,Federal Agency,Department of the Interior,RESTON,VA,ACTIVE
+EARTHQUAKE.GOV,Federal Agency,Department of the Interior,Menlo Park,CA,ACTIVE
+EVERGLADESRESTORATION.GOV,Federal Agency,Department of the Interior,Davie,FL,ACTIVE
+FCG.GOV,Federal Agency,Department of the Interior,Denver,CO,ACTIVE
+FGDC.GOV,Federal Agency,Department of the Interior,Reston,VA,ACTIVE
+FIRECODE.GOV,Federal Agency,Department of the Interior,Boise,ID,ACTIVE
+FIRELEADERSHIP.GOV,Federal Agency,Department of the Interior,Boise,ID,ACTIVE
+FIRENET.GOV,Federal Agency,Department of the Interior,Boise,ID,ACTIVE
+FIRESCIENCE.GOV,Federal Agency,Department of the Interior,Boise,ID,ACTIVE
+FWS.GOV,Federal Agency,Department of the Interior,Lakewood,CO,ACTIVE
+GCDAMP.GOV,Federal Agency,Department of the Interior,Denver,CO,ACTIVE
+GCMRC.GOV,Federal Agency,Department of the Interior,Flagstaff,AZ,ACTIVE
+GEOCOMMUNICATOR.GOV,Federal Agency,Department of the Interior,Denver,CO,ACTIVE
+GEOMAC.GOV,Federal Agency,Department of the Interior,Denver,CO,ACTIVE
+GEOPLATFORM.GOV,Federal Agency,Department of the Interior,Washington,DC,ACTIVE
+IAT.GOV,Federal Agency,Department of the Interior,Boise,ID,ACTIVE
+INDIANAFFAIRS.GOV,Federal Agency,Department of the Interior,Reston,VA,ACTIVE
+INTERIOR.GOV,Federal Agency,Department of the Interior,Washington,DC,ACTIVE
+INVASIVESPECIES.GOV,Federal Agency,Department of the Interior,Washington,DC,ACTIVE
+JEM.GOV,Federal Agency,Department of the Interior,Lafayett,LA,ACTIVE
+KLAMATHRESTORATION.GOV,Federal Agency,Department of the Interior,Yreka,CA,ACTIVE
+LACOAST.GOV,Federal Agency,Department of the Interior,Lafayette,LA,ACTIVE
+LANDFIRE.GOV,Federal Agency,Department of the Interior,Sioux Falls,SD,ACTIVE
+LANDIMAGING.GOV,Federal Agency,Department of the Interior,Reston,VA,ACTIVE
+LCA.GOV,Federal Agency,Department of the Interior,Lafayette,LA,ACTIVE
+LCRMSCP.GOV,Federal Agency,Department of the Interior,Denver,CO,ACTIVE
+LMVSCI.GOV,Federal Agency,Department of the Interior,Lafayette,LA,ACTIVE
+LOWERMISSISSIPPIVALLEYSCIENCE.GOV,Federal Agency,Department of the Interior,Lafayette,LA,ACTIVE
+MARINE.GOV,Federal Agency,Department of the Interior,Camarillo,CA,ACTIVE
+MITIGATIONCOMMISSION.GOV,Federal Agency,Department of the Interior,Denver,CO,ACTIVE
+MMS.GOV,Federal Agency,Department of the Interior,Herndon,VA,ACTIVE
+MRLC.GOV,Federal Agency,Department of the Interior,Sioux Falls,SD,ACTIVE
+NATIONALATLAS.GOV,Federal Agency,Department of the Interior,Reston,VA,ACTIVE
+NATIONALMAP.GOV,Federal Agency,Department of the Interior,Reston,VA,ACTIVE
+NATIVEONESTOP.GOV,Federal Agency,Department of the Interior,Reston,VA,ACTIVE
+NBC.GOV,Federal Agency,Department of the Interior,Denver,CO,ACTIVE
+NDEP.GOV,Federal Agency,Department of the Interior,Reston,VA,ACTIVE
+NDOP.GOV,Federal Agency,Department of the Interior,Reston,VA,ACTIVE
+NEMI.GOV,Federal Agency,Department of the Interior,Middleton,WI,ACTIVE
+NFPORS.GOV,Federal Agency,Department of the Interior,Washington,DC,ACTIVE
+NIFC.GOV,Federal Agency,Department of the Interior,Boise,ID,ACTIVE
+NOLAENVIRONMENTAL.GOV,Federal Agency,Department of the Interior,Lafayette,LA,ACTIVE
+NPS.GOV,Federal Agency,Department of the Interior,WASHINGTON DC,DC,ACTIVE
+ONHIR.GOV,Federal Agency,Department of the Interior,Flagstaff,AZ,ACTIVE
+ONRR.GOV,Federal Agency,Department of the Interior,Herndon,VA,ACTIVE
+OSM.GOV,Federal Agency,Department of the Interior,Washington,DC,ACTIVE
+OSMRE.GOV,Federal Agency,Department of the Interior,Washington,DC,ACTIVE
+PIEDRASBLANCAS.GOV,Federal Agency,Department of the Interior,Sacramento,CA,ACTIVE
+REPORTBAND.GOV,Federal Agency,Department of the Interior,Laurel,MD,ACTIVE
+RIVERS.GOV,Federal Agency,Department of the Interior,Burbank,WA,ACTIVE
+SAFECOM.GOV,Federal Agency,Department of the Interior,Boise,ID,ACTIVE
+SCIENCEBASE.GOV,Federal Agency,Department of the Interior,Denver,CO,ACTIVE
+SIERRAWILD.GOV,Federal Agency,Department of the Interior,Yosemite,CA,ACTIVE
+SNAP.GOV,Federal Agency,Department of the Interior,Washington,DC,ACTIVE
+USBR.GOV,Federal Agency,Department of the Interior,Denver,CO,ACTIVE
+USGS.GOV,Federal Agency,Department of the Interior,Reston,VA,ACTIVE
+UTAHFIREINFO.GOV,Federal Agency,Department of the Interior,Denver,CO,ACTIVE
+VOLCANO.GOV,Federal Agency,Department of the Interior,Anchorage,AK,ACTIVE
+VOLUNTEER.GOV,Federal Agency,Department of the Interior,Reston,VA,ACTIVE
+WATERMONITOR.GOV,Federal Agency,Department of the Interior,Reston,VA,ACTIVE
+WILDLIFEADAPTATIONSTRATEGY.GOV,Federal Agency,Department of the Interior,Arlington,VA,ACTIVE
+WLCI.GOV,Federal Agency,Department of the Interior,Denver,CO,ACTIVE
+YOUTHGO.GOV,Federal Agency,Department of the Interior,Shepherdstown,WV,ACTIVE
+AMA.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+AMERICATHEBEAUTIFULQUARTERS.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+ASAP.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+AYUDACONMIBANCO.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+BANKANSWERS.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+BANKCUSTOMER.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+BANKCUSTOMERASSISTANCE.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+BANKHELP.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+BANKNET.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+BEP.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+BFEM.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+BONDPRO.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+CCAC.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+CDFIFUND.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+COMPLAINTREFERRALEXPRESS.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+COMPTROLLEROFTHECURRENCY.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+DIRECTOASUCUENTA.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+EAGLECASH.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+EFTPS.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+ETA-FIND.GOV,Federal Agency,Department of the Treasury,DALLAS,TX,ACTIVE
+ETHICSBURG.GOV,Federal Agency,Department of the Treasury,Parkersburg,WV,ACTIVE
+EYENOTE.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+FEDERALINVESTMENTS.GOV,Federal Agency,Department of the Treasury,Pakersburg,WV,ACTIVE
+FEDERALSPENDING.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+FEDINVEST.GOV,Federal Agency,Department of the Treasury,Parkersburg,WV,ACTIVE
+FEDSPENDING.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+FINANCIALRESEARCH.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+FINANCIALSTABILITY.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+FINCEN.GOV,Federal Agency,Department of the Treasury,Vienna,VA,ACTIVE
+FSOC.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+FTTESTTWAI.GOV,Federal Agency,Department of the Treasury,Hyattsville,MD,ACTIVE
+GODIRECT.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+GWA.GOV,Federal Agency,Department of the Treasury,Hyattsville,MD,ACTIVE
+HELPWITHMYBANK.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+HELPWITHMYCHECKINGACCOUNT.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+HELPWITHMYCREDITCARD.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+HELPWITHMYCREDITCARDBANK.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+HELPWITHMYMORTGAGE.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+HELPWITHMYMORTGAGEBANK.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+IPAC.GOV,Federal Agency,Department of the Treasury,Boston,MA,ACTIVE
+IPP.GOV,Federal Agency,Department of the Treasury,McLean,VA,ACTIVE
+IRS.GOV,Federal Agency,Department of the Treasury,McLean,VA,ACTIVE
+IRSAUCTIONS.GOV,Federal Agency,Department of the Treasury,McLean,VA,ACTIVE
+IRSNET.GOV,Federal Agency,Department of the Treasury,McLean,VA,ACTIVE
+IRSSALES.GOV,Federal Agency,Department of the Treasury,McLean,VA,ACTIVE
+IRSVIDEOS.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+ITS.GOV,Federal Agency,Department of the Treasury,McLean,VA,ACTIVE
+MAKINGHOMEAFFORDABLE.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+MHA.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+MONEYFACTORY.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+MONEYFACTORYSTORE.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+MSB.GOV,Federal Agency,Department of the Treasury,Vienna,VA,ACTIVE
+MYIRA.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+MYMONEY.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+MYRA.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+NATIONALBANK.GOV,Federal Agency,Department of the Treasury,McLean,VA,ACTIVE
+NATIONALBANKHELP.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+NATIONALBANKNET.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+NAVYCASH.GOV,Federal Agency,Department of the Treasury,McLean,VA,ACTIVE
+OCC.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+OCCHELPS.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+OCCNET.GOV,Federal Agency,Department of the Treasury,Landover,MD,ACTIVE
+OTS.GOV,Federal Agency,Department of the Treasury,McLean,VA,ACTIVE
+PATRIOTBONDS.GOV,Federal Agency,Department of the Treasury,Parkersburg,WV,ACTIVE
+PAY.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+PRACOMMENT.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+QATESTTWAI.GOV,Federal Agency,Department of the Treasury,Hyattsville,MD,ACTIVE
+SAVINGSBOND.GOV,Federal Agency,Department of the Treasury,Mclean,VA,ACTIVE
+SAVINGSBONDS.GOV,Federal Agency,Department of the Treasury,McLean,VA,ACTIVE
+SAVINGSBONDWIZARD.GOV,Federal Agency,Department of the Treasury,Mclean,VA,ACTIVE
+SIGTARP.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+SLGS.GOV,Federal Agency,Department of the Treasury,Mclean,VA,ACTIVE
+TAAPS.GOV,Federal Agency,Department of the Treasury,Mclean,VA,ACTIVE
+TAX.GOV,Federal Agency,Department of the Treasury,McLean,VA,ACTIVE
+TCIS.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+TIGTA.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+TIGTANET.GOV,Federal Agency,Department of the Treasury,McLean,VA,ACTIVE
+TRANSPARENCY.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+TREAS.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+TREASLOCKBOX.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+TREASURY.FED.US,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+TREASURY.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+TREASURYAUCTION.GOV,Federal Agency,Department of the Treasury,Parkersburg,WV,ACTIVE
+TREASURYAUCTIONS.GOV,Federal Agency,Department of the Treasury,Mclean,VA,ACTIVE
+TREASURYDIRECT.GOV,Federal Agency,Department of the Treasury,McLean,VA,ACTIVE
+TREASURYECM.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+TREASURYHUNT.GOV,Federal Agency,Department of the Treasury,Parkersburg,WV,ACTIVE
+TREASURYSCAMS.GOV,Federal Agency,Department of the Treasury,Mclean,VA,ACTIVE
+TRS.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+TTB.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+TTBONLINE.GOV,Federal Agency,Department of the Treasury,McLean,VA,ACTIVE
+TTLPLUS.GOV,Federal Agency,Department of the Treasury,St. Louis,MO,ACTIVE
+TWAI.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+USASPENDING.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+USDEBITCARD.GOV,Federal Agency,Department of the Treasury,Mclean,VA,ACTIVE
+USMINT.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+USTREAS.GOV,Federal Agency,Department of the Treasury,McLean,VA,ACTIVE
+VERIFYPAYMENT.GOV,Federal Agency,Department of the Treasury,Parkersburg,WV,ACTIVE
+WIZARD.GOV,Federal Agency,Department of the Treasury,Mclean,VA,ACTIVE
+WORKPLACE.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+911.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE
+BTS.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE
+CFLHD.GOV,Federal Agency,Department of Transportation,Lakewood,CO,ACTIVE
+DISTRACTEDDRIVING.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE
+DISTRACTION.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE
+DOT.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE
+DOTIDEAHUB.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE
+DOTTRAFFICRECORDS.GOV,Federal Agency,Department of Transportation,Room 2202,DC,ACTIVE
+EMS.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE
+ESC.GOV,Federal Agency,Department of Transportation,Oklahoma City,OK,ACTIVE
+FAA.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE
+FAASAFETY.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE
+JCCBI.GOV,Federal Agency,Department of Transportation,Oklahoma City,OK,ACTIVE
+MDA.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE
+NHTSA.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE
+NTDPROGRAM.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE
+PLAINLANGUAGE.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE
+PROTECTYOURMOVE.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE
+SAFEOCS.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE
+SAFERCAR.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE
+SAFERTRUCK.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE
+SHARETHEROADSAFELY.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE
+STRONGPORTS.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE
+SUSTAINABLECOMMUNITIES.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE
+TFHRC.GOV,Federal Agency,Department of Transportation,Mclean,VA,ACTIVE
+TRAFFICSAFETYMARKETING.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE
+TRANSPORTATION.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE
+CDCO.GOV,Federal Agency,Department of Veterans Affairs,Austin,TX,ACTIVE
+NATIONALRESOURCEDIRECTORY.GOV,Federal Agency,Department of Veterans Affairs,Washington,DC,ACTIVE
+NRD.GOV,Federal Agency,Department of Veterans Affairs,Washington,DC,ACTIVE
+VA.GOV,Federal Agency,Department of Veterans Affairs,Washington,DC,ACTIVE
+VETBIZ.GOV,Federal Agency,Department of Veterans Affairs,Washington,DC,ACTIVE
+VETS.GOV,Federal Agency,Department of Veterans Affairs,Washington,DC,ACTIVE
+DNI.GOV,Federal Agency,Director of National Intelligence,McLean,VA,ACTIVE
+IARPA-IDEAS.GOV,Federal Agency,Director of National Intelligence,Washington,DC,ACTIVE
+IARPA.GOV,Federal Agency,Director of National Intelligence,College Park,MD,ACTIVE
+ICJOINTDUTY.GOV,Federal Agency,Director of National Intelligence,Washington,DC,ACTIVE
+INTELINK.GOV,Federal Agency,Director of National Intelligence,Ft. George G. Meade,MD,ACTIVE
+INTELLIGENCE.GOV,Federal Agency,Director of National Intelligence,Washington,DC,ACTIVE
+ISE.GOV,Federal Agency,Director of National Intelligence,Washington ,DC,ACTIVE
+NCIX.GOV,Federal Agency,Director of National Intelligence,Washington,DC,ACTIVE
+NCSC.GOV,Federal Agency,Director of National Intelligence,Bethesda,MD,ACTIVE
+NMIC.GOV,Federal Agency,Director of National Intelligence,Washington,DC,SERVER-HOLD
+ODNI.GOV,Federal Agency,Director of National Intelligence,Washington,DC,ACTIVE
+OSIS.GOV,Federal Agency,Director of National Intelligence,Fort George G. Meade,MD,ACTIVE
+PIX.GOV,Federal Agency,Director of National Intelligence,Washington,DC,ACTIVE
+QART.GOV,Federal Agency,Director of National Intelligence,Washington,DC,ACTIVE
+UGOV.GOV,Federal Agency,Director of National Intelligence,Fort George G Meade,MD,ACTIVE
+AIRNOW.GOV,Federal Agency,Environmental Protection Agency,Durham,NC,ACTIVE
+CBI-EPA.GOV,Federal Agency,Environmental Protection Agency,Durham,NC,ACTIVE
+ENERGYSTAR.GOV,Federal Agency,Environmental Protection Agency,Washington,DC,ACTIVE
+EPA.GOV,Federal Agency,Environmental Protection Agency,Research Triangle Park,NC,ACTIVE
+FDMS.GOV,Federal Agency,Environmental Protection Agency,Washington,DC,ACTIVE
+FEDCENTER.GOV,Federal Agency,Environmental Protection Agency,Champaign,IL,ACTIVE
+FRTR.GOV,Federal Agency,Environmental Protection Agency,Omaha,NE,ACTIVE
+GREENGOV.GOV,Federal Agency,Environmental Protection Agency, Washington,DC,ACTIVE
+OFEE.GOV,Federal Agency,Environmental Protection Agency,Washington,DC,ACTIVE
+REGULATIONS.GOV,Federal Agency,Environmental Protection Agency,Washington,DC,ACTIVE
+RELOCATEFEDS.GOV,Federal Agency,Environmental Protection Agency,Cincinnati,OH,ACTIVE
+SUSTAINABILITY.GOV,Federal Agency,Environmental Protection Agency,Washington,DC,ACTIVE
+URBANWATERS.GOV,Federal Agency,Environmental Protection Agency,Washington,DC,ACTIVE
+EEOC.GOV,Federal Agency,Equal Employment Opportunity Commission,Washington,DC,ACTIVE
+AIDREFUGEES.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE
+ASTRONGMIDDLECLASS.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE
+BUDGET.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE
+CHANGE.GOV,Federal Agency,Executive Office of the President,Arlington,VA,ACTIVE
+EARMARKS.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE
+EGOV.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE
+EOP.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE
+ETHICS.GOV,Federal Agency,Executive Office of the President,Washington ,DC,ACTIVE
+EXRWH.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE
+FISCALCOMMISSION.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE
+HC.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE
+ITDASHBOARD.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE
+JOININGFORCES.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE
+LETSMOVE.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE
+MAX.GOV,Federal Agency,Executive Office of the President,NW,WA,ACTIVE
+NEPA.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE
+NOTALONE.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE
+NSTIC.GOV,Federal Agency,Executive Office of the President,Gaithersburg,MD,ACTIVE
+OMB.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE
+OMBLOG.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE
+ONDCP.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE
+OSTP.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE
+PAYMENTACCURACY.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE
+PCI.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE
+PRESIDIO.GOV,Federal Agency,Executive Office of the President,San Francisco,CA,ACTIVE
+PRESIDIOTRUST.GOV,Federal Agency,Executive Office of the President,San Francisco,CA,ACTIVE
+REACHHIGHER.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE
+SAVE.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE
+SAVEAWARD.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE
+STRONGMIDDLECLASS.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE
+USDIGITALSERVICE.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE
+USDS.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE
+USTR.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE
+WH.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE
+WHITEHOUSE.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE
+WHITEHOUSEDRUGPOLICY.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE
+EXIM.GOV,Federal Agency,Export/Import Bank of the U.S.,Washington,DC,ACTIVE
+EXIMCOOP.GOV,Federal Agency,Export/Import Bank of the U.S.,Washington,DC,ACTIVE
+FCA.GOV,Federal Agency,Farm Credit Administration,McLean,VA,ACTIVE
+FCSIC.GOV,Federal Agency,Farm Credit Administration,McLean,VA,ACTIVE
+BROADBAND.GOV,Federal Agency,Federal Communications Commission,Washington,DC,ACTIVE
+BROADBANDMAP.GOV,Federal Agency,Federal Communications Commission,Washington,DC,ACTIVE
+DTV.GOV,Federal Agency,Federal Communications Commission,Washington,DC,ACTIVE
+FCC.GOV,Federal Agency,Federal Communications Commission,Washington,DC,ACTIVE
+FCCUNIVERSITY.GOV,Federal Agency,Federal Communications Commission,Washington,DC,ACTIVE
+LIFELINE.GOV,Federal Agency,Federal Communications Commission,Washington,DC,ACTIVE
+NBM.GOV,Federal Agency,Federal Communications Commission,Washington,DC,ACTIVE
+OPENINTERNET.GOV,Federal Agency,Federal Communications Commission,Washington,DC,ACTIVE
+ECONOMICINCLUSION.GOV,Federal Agency,Federal Deposit Insurance Corporation,Arlington,VA,ACTIVE
+FDIC.GOV,Federal Agency,Federal Deposit Insurance Corporation,Arlington,VA,ACTIVE
+FDICCONNECT.GOV,Federal Agency,Federal Deposit Insurance Corporation,Arlington,VA,ACTIVE
+FDICIG.GOV,Federal Agency,Federal Deposit Insurance Corporation,Arlington,VA,ACTIVE
+FDICOIG.GOV,Federal Agency,Federal Deposit Insurance Corporation,Washington,DC,ACTIVE
+FDICSALES.GOV,Federal Agency,Federal Deposit Insurance Corporation,Arlington,VA,ACTIVE
+FDICSEGURO.GOV,Federal Agency,Federal Deposit Insurance Corporation,Arlington,VA,ACTIVE
+MYFDIC.GOV,Federal Agency,Federal Deposit Insurance Corporation,Arlington,VA,ACTIVE
+MYFDICINSURANCE.GOV,Federal Agency,Federal Deposit Insurance Corporation,Arlington,VA,ACTIVE
+FEC.GOV,Federal Agency,Federal Elections Commission,Washington,DC,ACTIVE
+FERC.GOV,Federal Agency,Federal Energy Regulatory Commission,Washington,DC,ACTIVE
+FERCALT.GOV,Federal Agency,Federal Energy Regulatory Commission,Washington,DC,ACTIVE
+FHFA.GOV,Federal Agency,Federal Housing Finance Agency,Washington,DC,ACTIVE
+FHFB.GOV,Federal Agency,Federal Housing Finance Agency,Washington,DC,ACTIVE
+HARP.GOV,Federal Agency,Federal Housing Finance Agency,Washington,DC,ACTIVE
+OFHEO.GOV,Federal Agency,Federal Housing Finance Agency,Washington,DC,ACTIVE
+FHFAOIG.GOV,Federal Agency,Federal Housing Finance Agency Office of Inspector General,Washington,DC,ACTIVE
+FLRA.GOV,Federal Agency,Federal Labor Relations Authority,Washington,DC,ACTIVE
+FMC.GOV,Federal Agency,Federal Maritime Commission,Washington,DC,ACTIVE
+FMCS.GOV,Federal Agency,Federal Mediation and Conciliation Service,Washington,DC,ACTIVE
+FBIIC.GOV,Federal Agency,Federal Reserve System,Washington,DC,ACTIVE
+FEDCENTENNIAL.GOV,Federal Agency,Federal Reserve System,Washington,DC,ACTIVE
+FEDERALRESERVE.GOV,Federal Agency,Federal Reserve System,Washington,DC,ACTIVE
+FEDERALRESERVE100.GOV,Federal Agency,Federal Reserve System,Washington ,DC,ACTIVE
+FEDERALRESERVE2013.GOV,Federal Agency,Federal Reserve System,Washington,DC,ACTIVE
+FEDERALRESERVECENTENNIAL.GOV,Federal Agency,Federal Reserve System,Washington ,DC,ACTIVE
+FEDERALRESERVECENTENNIALCELEBRATION.GOV,Federal Agency,Federal Reserve System,Washington,DC,ACTIVE
+FEDERALRESERVECONSUMERHELP.GOV,Federal Agency,Federal Reserve System,Washington,DC,ACTIVE
+FEDPARTNERSHIP.GOV,Federal Agency,Federal Reserve System,Washington,DC,ACTIVE
+FFIEC.GOV,Federal Agency,Federal Reserve System,Washington,DC,ACTIVE
+FRB.FED.US,Federal Agency,Federal Reserve System,Washington,DC,ACTIVE
+FRB.GOV,Federal Agency,Federal Reserve System,Washington,DC,ACTIVE
+FRS.GOV,Federal Agency,Federal Reserve System,Washington,DC,ACTIVE
+NEWMONEY.GOV,Federal Agency,Federal Reserve System,Washington,DC,ACTIVE
+USCURRENCY.GOV,Federal Agency,Federal Reserve System,Washington,DC,ACTIVE
+EXPLORETSP.GOV,Federal Agency,Federal Retirement Thrift Investment Board,Washington,DC,ACTIVE
+FRTIB.GOV,Federal Agency,Federal Retirement Thrift Investment Board,Washington,DC,ACTIVE
+FRTIBTEST.GOV,Federal Agency,Federal Retirement Thrift Investment Board,Washigton,DC,ACTIVE
+TSP.GOV,Federal Agency,Federal Retirement Thrift Investment Board,Washington,DC,ACTIVE
+TSPTEST.GOV,Federal Agency,Federal Retirement Thrift Investment Board,Washington,DC,ACTIVE
+ADMONGO.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE
+ALERTAENLINEA.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE
+ANNUALCREDITREPORT.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE
+CONSUMER.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE
+CONSUMERSENTINEL.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE
+CONSUMERSENTINELNETWORK.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE
+CONSUMIDOR.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE
+DONOTCALL.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE
+DONTSERVETEENS.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE
+ECONSUMER.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE
+FREECREDITREPORT.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE
+FTC.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE
+FTCCOMPLAINTASSISTANT.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE
+FTCEFILE.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE
+HSR.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE
+IDENTITYTHEFT.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE
+IDTHEFT.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE
+NCPW.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE
+ONGUARDONLINE.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE
+ONLINEONGUARD.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE
+PROTECCIONDELCONSUMIDOR.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE
+ROBODEIDENTIDAD.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE
+SENTINEL.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE
+UCE.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE
+USICN.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE
+18F.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+ACQUISITION.GOV,Federal Agency,General Services Administration,Arlington,VA,ACTIVE
+AFADVANTAGE.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+APP.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+APPS.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+BUSINESSUSA.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+BUYACCESSIBLE.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+CAO.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+CBCA.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+CFDA.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+CFO.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+CFOC.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+CHALLENGE.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+CHALLENGES.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+CIO.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+CITIZENSCIENCE.GOV,Federal Agency,General Services Administration,NW,DC,ACTIVE
+CLOUD.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+COMPUTERS4LEARNING.GOV,Federal Agency,General Services Administration,Arlington,VA,ACTIVE
+COMPUTERSFORLEARNING.GOV,Federal Agency,General Services Administration,Arlington,VA,ACTIVE
+CONNECT.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+CONSUMERACTION.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+CONTRACTDIRECTORY.GOV,Federal Agency,General Services Administration,Arlington,VA,ACTIVE
+CPARS.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+DATA.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+DIGITALGOV.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+DOTGOV.GOV,Federal Agency,General Services Administration,Fairfax,VA,ACTIVE
+EAC.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+ECPIC.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+EISENHOWERMEMORIAL.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+EPLS.GOV,Federal Agency,General Services Administration,Arlington,VA,ACTIVE
+ESRS.GOV,Federal Agency,General Services Administration,arlington,VA,ACTIVE
+EVERYKID.GOV,Federal Agency,General Services Administration,Washington DC,DC,ACTIVE
+EVERYKIDINAPARK.GOV,Federal Agency,General Services Administration,Washington DC,DC,ACTIVE
+FACA.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+FACADATABASE.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+FAI.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+FAPIIS.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+FAQ.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+FBO.GOV,Federal Agency,General Services Administration,Arlington,VA,ACTIVE
+FED.US,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+FEDBIZOPPS.GOV,Federal Agency,General Services Administration,Arlington,VA,ACTIVE
+FEDIDCARD.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+FEDINFO.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+FEDRAMP.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+FEDROOMS.GOV,Federal Agency,General Services Administration,Arlington,VA,ACTIVE
+FIDO.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+FIRSTGOV.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+FMI.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+FORMS.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+FPDS.GOV,Federal Agency,General Services Administration,Arlington,VA,ACTIVE
+FPKI-LAB.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+FPKI.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+FRPG.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+FRPP-PA.GOV,Federal Agency,General Services Administration,WASHINGTON,DC,ACTIVE
+FSD.GOV,Federal Agency,General Services Administration,Arlington,VA,ACTIVE
+FSRS.GOV,Federal Agency,General Services Administration,Crystal City,VA,ACTIVE
+GOBIERNO.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+GOBIERNOUSA.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+GOVSALES.GOV,Federal Agency,General Services Administration,Arlington,VA,ACTIVE
+GSA.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+GSAADVANTAGE.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+GSAAUCTIONS.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+GSAIG.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+GSAXCESS.GOV,Federal Agency,General Services Administration,Arlington,VA,ACTIVE
+HOWTO.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+IDMANAGEMENT.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+INFO.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+KIDS.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+LEARNPERFORMANCE.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+LOGIN.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+MYUSA.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+NBRC.GOV,Federal Agency,General Services Administration,Bangor,ME,ACTIVE
+NETWORX.GOV,Federal Agency,General Services Administration,Fairfax,VA,ACTIVE
+NIC.GOV,Federal Agency,General Services Administration,Fairfax,VA,ACTIVE
+PARTNER4SOLUTIONS.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+PCLOB.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+PERFORMANCE.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+PIC.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+PIF.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+PPIRS.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+PRESIDENTIALINNOVATIONFELLOWS.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+PTT.GOV,Federal Agency,General Services Administration,Washington D.C.,DC,ACTIVE
+REALESTATESALES.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+REALPROPERTYPROFILE.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+REGINFO.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+ROCIS.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+SAM.GOV,Federal Agency,General Services Administration,Arlington,VA,ACTIVE
+SANDBOX.GOV,Federal Agency,General Services Administration,Washinton,DC,ACTIVE
+SBST.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+SECTION508.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+SFTOOL.GOV,Federal Agency,General Services Administration,Chicago,IL,ACTIVE
+STRATEGICSOURCING.GOV,Federal Agency,General Services Administration,Arlington,VA,ACTIVE
+SUPPORTTHEVOTER.GOV,Federal Agency,General Services Administration,WASHINGTON,DC,ACTIVE
+UNITEDSTATES.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+US.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+USA.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+USAGOV.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+USAPERFORMANCE.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+USCIRF.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+USGOVERNMENT.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+USIP.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+USSM.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+VEF.GOV,Federal Agency,General Services Administration,Arlington,VA,ACTIVE
+VITM.GOV,Federal Agency,General Services Administration,Arlington,VA,ACTIVE
+VOTE.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+VOTEBYMAIL.GOV,Federal Agency,General Services Administration,SILVER SPRING,MD,ACTIVE
+CONGRESSIONALDIRECTORY.GOV,Federal Agency,Government Printing Office,Washington,DC,ACTIVE
+CONGRESSIONALRECORD.GOV,Federal Agency,Government Printing Office,Washington,DC,ACTIVE
+ECFR.GOV,Federal Agency,Government Printing Office,Washington,DC,ACTIVE
+FDLP.GOV,Federal Agency,Government Printing Office,Washington,DC,ACTIVE
+FDSYS.GOV,Federal Agency,Government Printing Office,Washington,DC,ACTIVE
+FEDERALREGISTER.GOV,Federal Agency,Government Printing Office,Washington,DC,ACTIVE
+FEDREG.GOV,Federal Agency,Government Printing Office,Washington,DC,ACTIVE
+FMSHRC.GOV,Federal Agency,Government Printing Office,Washington,DC,ACTIVE
+GOVINFO.GOV,Federal Agency,Government Printing Office,Washington,DC,ACTIVE
+GPO.GOV,Federal Agency,Government Printing Office,Washington,DC,ACTIVE
+HOUSECALENDAR.GOV,Federal Agency,Government Printing Office,Washington,DC,ACTIVE
+OFR.GOV,Federal Agency,Government Printing Office,Washington,DC,ACTIVE
+OPENWORLD.GOV,Federal Agency,Government Printing Office,Washington,DC,ACTIVE
+PRESIDENTIALDOCUMENTS.GOV,Federal Agency,Government Printing Office,Washington,DC,ACTIVE
+SENATECALENDAR.GOV,Federal Agency,Government Printing Office,Washington,DC,ACTIVE
+STOPFAKES.GOV,Federal Agency,Government Printing Office,Washington,DC,ACTIVE
+USCAPITOLPOLICE.GOV,Federal Agency,Government Printing Office,Washington,DC,ACTIVE
+USCC.GOV,Federal Agency,Government Printing Office,Washington,DC,ACTIVE
+USCODE.GOV,Federal Agency,Government Printing Office,Washington,DC,ACTIVE
+USGOVERNMENTMANUAL.GOV,Federal Agency,Government Printing Office,College Park,MD,ACTIVE
+WELCOMETOUSA.GOV,Federal Agency,Government Printing Office,Washington,DC,ACTIVE
+RESTORETHEGULF.GOV,Federal Agency,Gulf Coast Ecosystem Restoration Council (GCERC),Silver Spring,MD,ACTIVE
+TRUMAN.GOV,Federal Agency,Harry S. Truman Scholarship Foundation,Washington,DC,ACTIVE
+IMLS.GOV,Federal Agency,Institute of Museum and Library Services,Washington,DC,ACTIVE
+IAF.GOV,Federal Agency,Inter-American Foundation,Washington,DC,ACTIVE
+BBG.GOV,Federal Agency,International Broadcasting Bureau,Washington,DC,ACTIVE
+IBB.GOV,Federal Agency,International Broadcasting Bureau,Washington,DC,ACTIVE
+VOA.GOV,Federal Agency,International Broadcasting Bureau,Washington,DC,ACTIVE
+JAMESMADISON.GOV,Federal Agency,James Madison Memorial Fellowship Foundation,Alexandria,VA,ACTIVE
+LSC.GOV,Federal Agency,Legal Services Corporation,Washington,DC,ACTIVE
+AFRICANAMERICANHISTORYMONTH.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+AMERICANMEMORY.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+AMERICASLIBRARY.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+AMERICASSTORY.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+AMERICASTORY.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+ASIANPACIFICHERITAGE.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+COMMISSION.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+CONGRESS.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+COPYRIGHT.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+CRS.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+DIGITALPRESERVATION.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+DIGITIZATIONGUIDELINES.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+HISPANICHERITAGEMONTH.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+JEWISHHERITAGE.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+JEWISHHERITAGEMONTH.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+LAW.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+LCTL.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+LIBRARYOFCONGRESS.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+LIS.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+LITERACY.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+LOC.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+LOCTPS.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+NATIVEAMERICANHERITAGEMONTH.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+PRIMARYSOURCES.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+READ.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+SECTION108.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+TEACHINGPRIMARYSOURCES.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+TEACHINGWITHPRIMARYSOURCES.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+THOMAS.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+TPS.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+UNITEDSTATESCONGRESS.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+USCONGRESS.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+WDL.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+WOMENSHISTORYMONTH.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+MMC.GOV,Federal Agency,Marine Mammal Commission,Bethesda,MD,ACTIVE
+MACPAC.GOV,Federal Agency,Medicaid and CHIP Payment and Access Commission,Washington,DC,ACTIVE
+MEDPAC.GOV,Federal Agency,Medical Payment Advisory Commission,Washington,DC,ACTIVE
+MSPB.GOV,Federal Agency,Merit Systems Protection Board,Washington,DC,ACTIVE
+MCC.GOV,Federal Agency,Millennium Challenge Corporation,Washington,DC,ACTIVE
+ECR.GOV,Federal Agency,Morris K. Udall Foundation,Tucson,AZ,ACTIVE
+UDALL.GOV,Federal Agency,Morris K. Udall Foundation,Tucson,AZ,ACTIVE
+GLOBE.GOV,Federal Agency,National Aeronautics and Space Administration,Greenbelt,MD,ACTIVE
+NASA.GOV,Federal Agency,National Aeronautics and Space Administration,MSFC,AL,ACTIVE
+NSWP.GOV,Federal Agency,National Aeronautics and Space Administration,MSFC,AL,ACTIVE
+SCIJINKS.GOV,Federal Agency,National Aeronautics and Space Administration,MSFC,AL,ACTIVE
+USGEO.GOV,Federal Agency,National Aeronautics and Space Administration,MSFC,AL,ACTIVE
+9-11COMMISSION.GOV,Federal Agency,National Archives and Records Administration,College Park,MD,ACTIVE
+911COMMISSION.GOV,Federal Agency,National Archives and Records Administration,College Park,MD,ACTIVE
+ARCHIVES.GOV,Federal Agency,National Archives and Records Administration,College Park,MD,ACTIVE
+CLINTONLIBRARY.GOV,Federal Agency,National Archives and Records Administration,Little Rock,AR,ACTIVE
+EMERGENCY-FEDERAL-REGISTER.GOV,Federal Agency,National Archives and Records Administration,College Park,MD,ACTIVE
+FCIC.GOV,Federal Agency,National Archives and Records Administration,College Park,MD,ACTIVE
+FORDLIBRARYMUSEUM.GOV,Federal Agency,National Archives and Records Administration,College Park,MD,ACTIVE
+FRC.GOV,Federal Agency,National Archives and Records Administration,College Park,MD,ACTIVE
+GEORGEWBUSHLIBRARY.GOV,Federal Agency,National Archives and Records Administration,College Park,MD,ACTIVE
+HISTORY.GOV,Federal Agency,National Archives and Records Administration,College Park,MD,ACTIVE
+JIMMYCARTERLIBRARY.GOV,Federal Agency,National Archives and Records Administration,College,MD,ACTIVE
+NARA-AT-WORK.GOV,Federal Agency,National Archives and Records Administration,College Park,MD,ACTIVE
+NARA.GOV,Federal Agency,National Archives and Records Administration,College Park,MD,ACTIVE
+NIXONLIBRARY.GOV,Federal Agency,National Archives and Records Administration,College Park,MD,ACTIVE
+OGIS.GOV,Federal Agency,National Archives and Records Administration,College Park,MD,ACTIVE
+OURDOCUMENTS.GOV,Federal Agency,National Archives and Records Administration,College Park,MD,ACTIVE
+REAGANLIBRARY.GOV,Federal Agency,National Archives and Records Administration,College Park,MD,ACTIVE
+RECORDSMANAGEMENT.GOV,Federal Agency,National Archives and Records Administration,College Park,MD,ACTIVE
+WARTIMECONTRACTING.GOV,Federal Agency,National Archives and Records Administration,College Park,MD,ACTIVE
+WEBHARVEST.GOV,Federal Agency,National Archives and Records Administration,College Park,MD,ACTIVE
+NCPC.GOV,Federal Agency,National Capital Planning Commission,Washington,DC,ACTIVE
+NCD.GOV,Federal Agency,National Council on Disability,Washington,DC,ACTIVE
+MYCREDITUNION.GOV,Federal Agency,National Credit Union Administration,Alexandria,VA,ACTIVE
+NCUA.GOV,Federal Agency,National Credit Union Administration,Alexandria,VA,ACTIVE
+ARTS.GOV,Federal Agency,National Endowment for the Arts,Washington,DC,ACTIVE
+NEA.GOV,Federal Agency,National Endowment for the Arts,Washington,DC,ACTIVE
+HUMANITIES.GOV,Federal Agency,National Endowment for the Humanities,Washington,DC,ACTIVE
+NEH.GOV,Federal Agency,National Endowment for the Humanities,Washington,DC,ACTIVE
+PCAH.GOV,Federal Agency,National Endowment for the Humanities,Washington,DC,ACTIVE
+WETHEPEOPLE.GOV,Federal Agency,National Endowment for the Humanities,Washington,DC,ACTIVE
+NGA.GOV,Federal Agency,National Gallery of Art,Washington,DC,ACTIVE
+NIGC.GOV,Federal Agency,National Indian Gaming Commission,Washington,DC,ACTIVE
+NLRB.GOV,Federal Agency,National Labor Relations Board,Washington,DC,ACTIVE
+NMB.GOV,Federal Agency,National Mediation Board,Washington,DC,ACTIVE
+NANO.GOV,Federal Agency,National Nanotechnology Coordination Office,Arlington,VA,ACTIVE
+ARCTIC.GOV,Federal Agency,National Science Foundation,Arlington,VA,ACTIVE
+NSF.GOV,Federal Agency,National Science Foundation,Arlington,VA,ACTIVE
+RESEARCH.GOV,Federal Agency,National Science Foundation,Arlington,VA,ACTIVE
+SAC.GOV,Federal Agency,National Science Foundation,Arlington,VA,ACTIVE
+SCIENCE360.GOV,Federal Agency,National Science Foundation,Arlington,VA,ACTIVE
+USAP.GOV,Federal Agency,National Science Foundation,Arlington,VA,ACTIVE
+INTELLIGENCECAREERS.GOV,Federal Agency,National Security Agency,Ft. Meade,MD,ACTIVE
+LPS.GOV,Federal Agency,National Security Agency,College Park,MD,ACTIVE
+NTSB.GOV,Federal Agency,National Transportation Safety Board,Washington,DC,ACTIVE
+ITRD.GOV,Federal Agency,Networking Information Technology Research and Development (NITRD),Arlington,VA,ACTIVE
+NITRD.GOV,Federal Agency,Networking Information Technology Research and Development (NITRD),Arlington,VA,ACTIVE
+HERITAGEABROAD.GOV,Federal Agency,Non-Federal Agency,Washington,DC,ACTIVE
+IAB.GOV,Federal Agency,Non-Federal Agency,Quantico,VA,ACTIVE
+JUSFC.GOV,Federal Agency,Non-Federal Agency,Washington,DC,ACTIVE
+NWTRB.GOV,Federal Agency,Non-Federal Agency,Arlington,VA,ACTIVE
+PPPL.GOV,Federal Agency,Non-Federal Agency,Princeton,NJ,ACTIVE
+SERVEINDIANA.GOV,Federal Agency,Non-Federal Agency,Indianapolis,IN,ACTIVE
+SJI.GOV,Federal Agency,Non-Federal Agency,Reston,VA,ACTIVE
+WMATC.GOV,Federal Agency,Non-Federal Agency,Silver Spring,MD,ACTIVE
+NRC-GATEWAY.GOV,Federal Agency,Nuclear Regulatory Commission,Rockville,MD,ACTIVE
+NRC.GOV,Federal Agency,Nuclear Regulatory Commission,Rockville,MD,ACTIVE
+OSHRC.GOV,Federal Agency,Occupational Safety & Health Review Commission,Washington,DC,ACTIVE
+INTEGRITY.GOV,Federal Agency,Office of Government Ethics,Washington,DC,ACTIVE
+APPLICATIONMANAGER.GOV,Federal Agency,Office of Personnel Management,Macon,GA,ACTIVE
+CHCOC.GOV,Federal Agency,Office of Personnel Management,Washington,DC,ACTIVE
+E-QIP.GOV,Federal Agency,Office of Personnel Management,Washington,DC,ACTIVE
+EMPLOYEEEXPRESS.GOV,Federal Agency,Office of Personnel Management,Macon,GA,ACTIVE
+FEB.GOV,Federal Agency,Office of Personnel Management,Washington,DC,ACTIVE
+FEDERALJOBS.GOV,Federal Agency,Office of Personnel Management,Macon,GA,ACTIVE
+FEDJOBS.GOV,Federal Agency,Office of Personnel Management,Macon,GA,ACTIVE
+FEDSHIREVETS.GOV,Federal Agency,Office of Personnel Management,Washington,DC,ACTIVE
+FEGLI.GOV,Federal Agency,Office of Personnel Management,Washington,DC,ACTIVE
+FSAFEDS.GOV,Federal Agency,Office of Personnel Management,Washington,DC,ACTIVE
+GOLEARN.GOV,Federal Agency,Office of Personnel Management,Washington,DC,ACTIVE
+GOVERNMENTJOBS.GOV,Federal Agency,Office of Personnel Management,Macon,GA,ACTIVE
+HRU.GOV,Federal Agency,Office of Personnel Management,Washington,DC,ACTIVE
+LMRCOUNCIL.GOV,Federal Agency,Office of Personnel Management,Washington,DC,ACTIVE
+OPM.GOV,Federal Agency,Office of Personnel Management,Macon,GA,ACTIVE
+PAC.GOV,Federal Agency,Office of Personnel Management,Washington,DC,ACTIVE
+PMF.GOV,Federal Agency,Office of Personnel Management,Washington,DC,ACTIVE
+TELEWORK.GOV,Federal Agency,Office of Personnel Management,Washington,DC,ACTIVE
+UNLOCKTALENT.GOV,Federal Agency,Office of Personnel Management,Washington,DC,ACTIVE
+USAJOBS.GOV,Federal Agency,Office of Personnel Management,Washington,DC,ACTIVE
+USALEARNING.GOV,Federal Agency,Office of Personnel Management,Washington,DC,ACTIVE
+USASTAFFING.GOV,Federal Agency,Office of Personnel Management,Macon,GA,ACTIVE
+OPIC.GOV,Federal Agency,Overseas Private Investment Corporation,Washington,DC,ACTIVE
+PBGC.GOV,Federal Agency,Pension Benefit Guaranty Corporation,Washington,DC,ACTIVE
+PRC.GOV,Federal Agency,Postal Rate Commission,Washington,DC,ACTIVE
+RRB.GOV,Federal Agency,Railroad Retirement Board,Chicago,IL,ACTIVE
+INVESTOR.GOV,Federal Agency,Securities and Exchange Commission,Alexandria,VA,ACTIVE
+SEC.GOV,Federal Agency,Securities and Exchange Commission,Alexandria,VA,ACTIVE
+SSS.GOV,Federal Agency,Selective Service System,Arlington,VA,ACTIVE
+BUSINESS.GOV,Federal Agency,Small Business Administration,Washington,DC,ACTIVE
+HSA.GOV,Federal Agency,Small Business Administration,Washington,DC,ACTIVE
+NWBC.GOV,Federal Agency,Small Business Administration,Washington,DC,ACTIVE
+ONLINEWBC.GOV,Federal Agency,Small Business Administration,Washington,DC,ACTIVE
+SBA.GOV,Federal Agency,Small Business Administration,Washington,DC,ACTIVE
+SBIR.GOV,Federal Agency,Small Business Administration,Arlington,VA,ACTIVE
+WOMENBIZ.GOV,Federal Agency,Small Business Administration,Washington,DC,ACTIVE
+ITIS.GOV,Federal Agency,Smithsonian Institution,Washington,DC,ACTIVE
+SEGUROSOCIAL.GOV,Federal Agency,Social Security Administration,Baltimore,MD,ACTIVE
+SOCIALSECURITY.GOV,Federal Agency,Social Security Administration,Baltimore,MD,ACTIVE
+SSA.GOV,Federal Agency,Social Security Administration,Baltimore,MD,ACTIVE
+SSAB.GOV,Federal Agency,Social Security Advisory Board,WASHINGTON,DC,ACTIVE
+STENNIS.GOV,Federal Agency,Stennis Center for Public Service,Starkville,MS,ACTIVE
+STB.GOV,Federal Agency,Surface Transportation Board (STB),Washington,DC,ACTIVE
+TVA.GOV,Federal Agency,Tennessee Valley Authority,Knoxville,TN,ACTIVE
+TVAOIG.GOV,Federal Agency,Tennessee Valley Authority,Knoxville,TN,ACTIVE
+TSC.GOV,Federal Agency,Terrorist Screening Center,Washington,DC,ACTIVE
+PTF.GOV,Federal Agency,The Intelligence Community,Washington,DC,ACTIVE
+AOC.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+CAPITAL.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+CAPITOL.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+CAPITOLFLAGS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+CBO.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+CBONEWS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+CECC.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+CHINA-COMMISSION.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+CHINACOMMISSION.GOV,Federal Agency,The Legislative Branch (Congress),Washington,MD,ACTIVE
+CITIZENCOSPONSORS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+CITIZENS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+COSPONSOR.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+CSCE.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+DEMOCRATICLEADER.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+DEMOCRATICWHIP.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+DEMOCRATS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+DEMS.GOV,Federal Agency,The Legislative Branch (Congress),Washington DC,DC,ACTIVE
+ESECLAB.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+FASAB.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+GAO.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+GAONET.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+GOP.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+GOPCONFERENCE.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,SERVER-HOLD
+GOPLEADER.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+HOUSE.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+HOUSECOMMUNICATIONS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+HOUSEDEMOCRATS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+HOUSEDEMS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+HOUSELIVE.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+HOUSENEWSLETTERS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+JCT.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+LISTENSTOYOU.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+MAJORITYLEADER.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+MAJORITYWHIP.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+PDBCECC.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+PPDCECC.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+REPUBLICANS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+SEN.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+SENATE.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+SENATERESTAURANTS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+SPEAKER.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+TAXREFORM.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+USBG.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+USCAPITAL.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+USCAPITOL.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+USCAPITOLVISITORCENTER.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,SERVER-HOLD
+USCVC.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,SERVER-HOLD
+USHOUSE.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+USHR.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+VISITTHECAPITAL.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+VISITTHECAPITOL.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+SC-US.GOV,Federal Agency,The Supreme Court,Washington,DC,ACTIVE
+SCINET-TEST.GOV,Federal Agency,The Supreme Court,Washington,DC,ACTIVE
+SCINET.GOV,Federal Agency,The Supreme Court,Washington,DC,ACTIVE
+SCUS.GOV,Federal Agency,The Supreme Court,WASHINGTON,DC,ACTIVE
+SUPREME-COURT.GOV,Federal Agency,The Supreme Court,Washington,DC,ACTIVE
+SUPREMECOURT.GOV,Federal Agency,The Supreme Court,Washington,DC,ACTIVE
+SUPREMECOURTUS.GOV,Federal Agency,The Supreme Court,Washington,DC,ACTIVE
+WORLDWAR1CENTENNIAL.GOV,Federal Agency,The United States World War One Centennial Commission,Washington,DC,ACTIVE
+ACCESS-BOARD.GOV,Federal Agency,U. S. Access Board,Washington,DC,ACTIVE
+USHMM.GOV,Federal Agency,U. S. Holocaust Memorial Museum,Washington,DC,ACTIVE
+USITC.GOV,Federal Agency,U. S. International Trade Commission,Washington,DC,ACTIVE
+OSC.GOV,Federal Agency,U. S. Office of Special Counsel,Washington,DC,ACTIVE
+OSCNET.GOV,Federal Agency,U. S. Office of Special Counsel,Washington,DC,ACTIVE
+PEACECORE.GOV,Federal Agency,U. S. Peace Corps,Washington,DC,ACTIVE
+PEACECORP.GOV,Federal Agency,U. S. Peace Corps,Washington,DC,ACTIVE
+PEACECORPS.GOV,Federal Agency,U. S. Peace Corps,Washington,DC,ACTIVE
+CHANGEOFADDRESS.GOV,Federal Agency,U. S. Postal Service,Washington,DC,ACTIVE
+MAIL.GOV,Federal Agency,U. S. Postal Service,Raleigh,NC,ACTIVE
+POSTOFFICE.GOV,Federal Agency,U. S. Postal Service,Raleigh,NC,ACTIVE
+PURCHASING.GOV,Federal Agency,U. S. Postal Service,Raleigh,NC,ACTIVE
+USPIS.GOV,Federal Agency,U. S. Postal Service,Arlington,VA,ACTIVE
+USPS.GOV,Federal Agency,U. S. Postal Service,Raleigh,NC,ACTIVE
+BANKRUPTCY.GOV,Federal Agency,U.S Courts,Washington,DC,ACTIVE
+CAVC.GOV,Federal Agency,U.S Courts,Washington,DC,ACTIVE
+DCSC.GOV,Federal Agency,U.S Courts,Washington,DC,ACTIVE
+FEDCIR.GOV,Federal Agency,U.S Courts,Washington,DC,SERVER-HOLD
+FEDERALCOURTS.GOV,Federal Agency,U.S Courts,Washington,DC,ACTIVE
+FEDERALPROBATION.GOV,Federal Agency,U.S Courts,Washington,DC,ACTIVE
+FEDERALRULES.GOV,Federal Agency,U.S Courts,Washington,DC,ACTIVE
+FJC.GOV,Federal Agency,U.S Courts,Washington,DC,ACTIVE
+JUDICIALCONFERENCE.GOV,Federal Agency,U.S Courts,Washington,DC,ACTIVE
+NMCOURT.FED.US,Federal Agency,U.S Courts,Albuquerque,NM,ACTIVE
+PACER.GOV,Federal Agency,U.S Courts,Washington,DC,ACTIVE
+USBANKRUPTCY.GOV,Federal Agency,U.S Courts,Washington,DC,ACTIVE
+USC.GOV,Federal Agency,U.S Courts,Washington,DC,ACTIVE
+USCAVC.GOV,Federal Agency,U.S Courts,Washington,DC,SERVER-HOLD
+USCOURTS.GOV,Federal Agency,U.S Courts,Washington,DC,ACTIVE
+USCVA.GOV,Federal Agency,U.S Courts,Washington,DC,SERVER-HOLD
+USPROBATION.GOV,Federal Agency,U.S Courts,Washington,DC,ACTIVE
+USSC.GOV,Federal Agency,U.S Courts,Washington,DC,ACTIVE
+USTAXCOURT.GOV,Federal Agency,U.S Courts,Washington,DC,ACTIVE
+VETAPP.GOV,Federal Agency,U.S Courts,Washington,DC,SERVER-HOLD
+CHILDRENINADVERSITY.GOV,Federal Agency,U.S. Agency for International Development,Washington,DC,ACTIVE
+DFAFACTS.GOV,Federal Agency,U.S. Agency for International Development,Washington,DC,ACTIVE
+FEEDTHEFUTURE.GOV,Federal Agency,U.S. Agency for International Development,Washington,DC,ACTIVE
+LETGIRLSLEARN.GOV,Federal Agency,U.S. Agency for International Development,Washington,DC,ACTIVE
+NEGLECTEDDISEASES.GOV,Federal Agency,U.S. Agency for International Development,Washington,DC,ACTIVE
+OFDA.GOV,Federal Agency,U.S. Agency for International Development,Washington,DC,ACTIVE
+PMI.GOV,Federal Agency,U.S. Agency for International Development,Washington,DC,ACTIVE
+USAID.GOV,Federal Agency,U.S. Agency for International Development,Washington,DC,ACTIVE
+USAIDALLNET.GOV,Federal Agency,U.S. Agency for International Development,Arlington,VA,ACTIVE
+USCP.GOV,Federal Agency,U.S. Capitol Police,Washington,DC,ACTIVE
+CHEMSAFETY.GOV,Federal Agency,U.S. Chemical Safety and Hazard Investigation Board,Washington,DC,ACTIVE
+CSB.GOV,Federal Agency,U.S. Chemical Safety and Hazard Investigation Board,Washington,DC,ACTIVE
+SAFETYVIDEOS.GOV,Federal Agency,U.S. Chemical Safety and Hazard Investigation Board,Washington,DC,ACTIVE
+CFA.GOV,Federal Agency,U.S. Commission of Fine Arts,Washington,DC,ACTIVE
+USCCR.GOV,Federal Agency,U.S. Commission on Civil Rights,Washington,DC,ACTIVE
+PEACECORPSOIG.GOV,Federal Agency,"U.S. Postal Service, Office of Inspector General",Washington,DC,ACTIVE
+USPSOIG.GOV,Federal Agency,"U.S. Postal Service, Office of Inspector General",Arlington,VA,ACTIVE
+USTDA.GOV,Federal Agency,U.S. Trade and Development Agency,Arlington,VA,ACTIVE
+CARBONCYCLESCIENCE.GOV,Federal Agency,United Stated Global Change Research Program,Washington,DC,SERVER-HOLD
+GLOBALCHANGE.GOV,Federal Agency,United Stated Global Change Research Program,Washington,DC,ACTIVE
+IPCC-WG2.GOV,Federal Agency,United Stated Global Change Research Program,Stanford,CA,ACTIVE
+USGCRP.GOV,Federal Agency,United Stated Global Change Research Program,Washington,DC,ACTIVE
+OGE.GOV,Federal Agency,United States Office of Government Ethics,Washington,DC,ACTIVE
+ICH.GOV,Federal Agency,US Interagency Council on Homelessness,washington,DC,ACTIVE
+USICH.GOV,Federal Agency,US Interagency Council on Homelessness,Washington,DC,ACTIVE

--- a/dotgov-domains/2016-06-30-full.csv
+++ b/dotgov-domains/2016-06-30-full.csv
@@ -1,0 +1,5662 @@
+Domain Name,Domain Type,Agency,City,State,Status
+SANFRANCISCO.GOV,City,General Services Administration,San Francisco,CA,ACTIVE
+SF.GOV,City,General Services Administration,San Francisco,CA,ACTIVE
+ABERDEENMD.GOV,City,Non-Federal Agency,Aberdeen,MD,ACTIVE
+ABERDEENWA.GOV,City,Non-Federal Agency,Aberdeen,WA,ACTIVE
+ABINGDON-VA.GOV,City,Non-Federal Agency,Abingdon,VA,ACTIVE
+ABINGTONMA.GOV,City,Non-Federal Agency,Abington,MA,ACTIVE
+ABSECONNJ.GOV,City,Non-Federal Agency,Absecon,NJ,ACTIVE
+ACCESSPRINCETONNJ.GOV,City,Non-Federal Agency,Princeton,NJ,ACTIVE
+ACTON-MA.GOV,City,Non-Federal Agency,Acton,MA,ACTIVE
+ACTONMA.GOV,City,Non-Federal Agency,Acton,MA,ACTIVE
+ADAK-AK.GOV,City,Non-Federal Agency,Adak,AK,ACTIVE
+ADAMN.GOV,City,Non-Federal Agency,Ada,MN,ACTIVE
+ADDISONTX.GOV,City,Non-Federal Agency,Addison,TX,ACTIVE
+ADRIANMI.GOV,City,Non-Federal Agency,Adrian,MI,ACTIVE
+AFTONWYOMING.GOV,City,Non-Federal Agency,AFTON,WY,ACTIVE
+AKRONOHIO.GOV,City,Non-Federal Agency,Akron,OH,ACTIVE
+ALAMEDACA.GOV,City,Non-Federal Agency,Alameda,CA,ACTIVE
+ALAMOHEIGHTSTX.GOV,City,Non-Federal Agency,Alamo Heights,TX,ACTIVE
+ALBANYNY.GOV,City,Non-Federal Agency,Albany,NY,ACTIVE
+ALBEMARLENC.GOV,City,Non-Federal Agency,Albemarle,NC,ACTIVE
+ALBUQUERQUE-NM.GOV,City,Non-Federal Agency,Albuquerque,NM,ACTIVE
+ALEKNAGIKAK.GOV,City,Non-Federal Agency,Aleknagik,AK,ACTIVE
+ALEXANDERCITYAL.GOV,City,Non-Federal Agency,Alexander City,AL,ACTIVE
+ALEXANDRIANJ.GOV,City,Non-Federal Agency,Milford,NJ,ACTIVE
+ALEXANDRIAVA.GOV,City,Non-Federal Agency,Alexandria,VA,ACTIVE
+ALFREDME.GOV,City,Non-Federal Agency,Alfred,ME,ACTIVE
+ALGONAC-MI.GOV,City,Non-Federal Agency,Algonac,MI,ACTIVE
+ALGONAWA.GOV,City,Non-Federal Agency,Algona,WA,ACTIVE
+ALGOODTN.GOV,City,Non-Federal Agency,Algood,TN,ACTIVE
+ALIQUIPPAPA.GOV,City,Non-Federal Agency,Aliquippa,PA,ACTIVE
+ALLENDALENJ.GOV,City,Non-Federal Agency,Allendale,NJ,ACTIVE
+ALLENSTOWNNH.GOV,City,Non-Federal Agency,Allenstown,NH,ACTIVE
+ALLENTOWNPA.GOV,City,Non-Federal Agency,Allentown,PA,ACTIVE
+ALLIANCEOH.GOV,City,Non-Federal Agency,Alliance,OH,ACTIVE
+ALMONTMICHIGAN.GOV,City,Non-Federal Agency,Almont,MI,ACTIVE
+ALSTEADNH.GOV,City,Non-Federal Agency,Alstead,NH,ACTIVE
+ALTAVISTAVA.GOV,City,Non-Federal Agency,Altavista,VA,ACTIVE
+ALTON-TX.GOV,City,Non-Federal Agency,Alton,TX,ACTIVE
+ALTOONAPA.GOV,City,Non-Federal Agency,Altoona,PA,ACTIVE
+ALTUSOK.GOV,City,Non-Federal Agency,Altus,OK,ACTIVE
+ALVIN-TX.GOV,City,Non-Federal Agency,Alvin,TX,ACTIVE
+AMARILLO.GOV,City,Non-Federal Agency,Amarillo,TX,ACTIVE
+AMENIANY.GOV,City,Non-Federal Agency,Amenia,NY,ACTIVE
+AMERICUSGA.GOV,City,Non-Federal Agency,Americus,GA,ACTIVE
+AMERYWI.GOV,City,Non-Federal Agency,Amery,WI,ACTIVE
+AMHERSTMA.GOV,City,Non-Federal Agency,Amherst,MA,ACTIVE
+AMHERSTNH.GOV,City,Non-Federal Agency,Amherst,NH,ACTIVE
+AMHERSTVA.GOV,City,Non-Federal Agency,Amherst,VA,ACTIVE
+AMITYARKANSAS.GOV,City,Non-Federal Agency,Amity,AR,ACTIVE
+AMSTERDAMNY.GOV,City,Non-Federal Agency,Amsterdam,NY,ACTIVE
+ANCHORAGEAK.GOV,City,Non-Federal Agency,Anchorage,AK,ACTIVE
+ANDOVER-NH.GOV,City,Non-Federal Agency,Andover,NH,ACTIVE
+ANDOVERMA.GOV,City,Non-Federal Agency,Andover,MA,ACTIVE
+ANDOVERMN.GOV,City,Non-Federal Agency,Andover,MN,ACTIVE
+ANGELFIRENM.GOV,City,Non-Federal Agency,Angel Fire,NM,ACTIVE
+ANGELSCAMP.GOV,City,Non-Federal Agency,City of Angels Camp,CA,ACTIVE
+ANKENYIOWA.GOV,City,Non-Federal Agency,Ankeny,IA,ACTIVE
+ANNATEXAS.GOV,City,Non-Federal Agency,Anna,TX,ACTIVE
+ANNETTATX.GOV,City,Non-Federal Agency,Aledo,TX,ACTIVE
+ANNISTONAL.GOV,City,Non-Federal Agency,Anniston,AL,ACTIVE
+ANTIOCHTOWNSHIPIL.GOV,City,Non-Federal Agency,Lake Villa,IL,ACTIVE
+APPLEVALLEYCA.GOV,City,Non-Federal Agency,Apple Valley,CA,ACTIVE
+APPLEVALLEYUT.GOV,City,Non-Federal Agency,Apple Valley,UT,ACTIVE
+APPOMATTOXVA.GOV,City,Non-Federal Agency,Appomattox,VA,ACTIVE
+AQUINNAH-MA.GOV,City,Non-Federal Agency,Aquinnah,MA,ACTIVE
+ARANSASPASSTX.GOV,City,Non-Federal Agency,Aransas Pass,TX,ACTIVE
+ARCADIA-FL.GOV,City,Non-Federal Agency,Arcadia,FL,ACTIVE
+ARCADIACA.GOV,City,Non-Federal Agency,Arcadia,CA,ACTIVE
+ARCHBALDBOROUGHPA.GOV,City,Non-Federal Agency,Archbald,PA,ACTIVE
+ARCHDALE-NC.GOV,City,Non-Federal Agency,ARCHDALE,NC,ACTIVE
+ARKANSASCITYKS.GOV,City,Non-Federal Agency,Arkansas City,KS,ACTIVE
+ARLINGTON-TX.GOV,City,Non-Federal Agency,Arlington,TX,ACTIVE
+ARLINGTONMA.GOV,City,Non-Federal Agency,Arlington,MA,ACTIVE
+ARLINGTONTX.GOV,City,Non-Federal Agency,Arlington,TX,ACTIVE
+ARLINGTONWA.GOV,City,Non-Federal Agency,Arlington,WA,ACTIVE
+ARTESIANM.GOV,City,Non-Federal Agency,Artesia,NM,ACTIVE
+ARTHUR-IL.GOV,City,Non-Federal Agency,Arthur,IL,ACTIVE
+ASHBURNHAM-MA.GOV,City,Non-Federal Agency,Ashburnham,MA,ACTIVE
+ASHBYMA.GOV,City,Non-Federal Agency,Ashby,MA,ACTIVE
+ASHEBORONC.GOV,City,Non-Federal Agency,Asheboro,NC,ACTIVE
+ASHEVILLENC.GOV,City,Non-Federal Agency,Asheville,NC,ACTIVE
+ASHGROVEMO.GOV,City,Non-Federal Agency,Ash Grove,MO,ACTIVE
+ASHLANDCITYTN.GOV,City,Non-Federal Agency,Ashland City,TN,ACTIVE
+ASHLANDKY.GOV,City,Non-Federal Agency,Ashland,KY,ACTIVE
+ASHVILLEOHIO.GOV,City,Non-Federal Agency,Ashville,OH,ACTIVE
+ATHENSTX.GOV,City,Non-Federal Agency,Athens,TX,ACTIVE
+ATHOL-MA.GOV,City,Non-Federal Agency,Athol,MA,ACTIVE
+ATKINSON-NH.GOV,City,Non-Federal Agency,Atkinson,NH,ACTIVE
+ATLANTAGA.GOV,City,Non-Federal Agency,Atlanta,GA,ACTIVE
+ATLANTISFL.GOV,City,Non-Federal Agency,Atlantis,FL,ACTIVE
+ATRISCO-NM.GOV,City,Non-Federal Agency,Atrisco,NM,ACTIVE
+ATTICA-IN.GOV,City,Non-Federal Agency,Attica,IN,ACTIVE
+AUBREYTX.GOV,City,Non-Federal Agency,Aubrey,TX,ACTIVE
+AUBURNMAINE.GOV,City,Non-Federal Agency,Auburn,ME,ACTIVE
+AUBURNNY.GOV,City,Non-Federal Agency,Auburn,NY,ACTIVE
+AUBURNWA.GOV,City,Non-Federal Agency,Auburn,WA,ACTIVE
+AUGUSTAMAINE.GOV,City,Non-Federal Agency,Augusta,ME,ACTIVE
+AUGUSTAME.GOV,City,Non-Federal Agency,Augusta,ME,ACTIVE
+AURORATEXAS.GOV,City,Non-Federal Agency,Rhome,TX,ACTIVE
+AUSTELLGA.GOV,City,Non-Federal Agency,Austell,GA,ACTIVE
+AUSTINTEXAS.GOV,City,Non-Federal Agency,Austin,TX,ACTIVE
+AUSTINTX.GOV,City,Non-Federal Agency,Austin,TX,ACTIVE
+AVONCT.GOV,City,Non-Federal Agency,Avon,CT,ACTIVE
+AVONDALEAZ.GOV,City,Non-Federal Agency,Avondale,AZ,ACTIVE
+AZTECNM.GOV,City,Non-Federal Agency,Aztec,NM,ACTIVE
+BADENPA.GOV,City,Non-Federal Agency,Baden,PA,ACTIVE
+BAINBRIDGEWA.GOV,City,Non-Federal Agency,Bainbridge Island,WA,ACTIVE
+BAKERSFIELD-CA.GOV,City,Non-Federal Agency,Bakersfield,CA,ACTIVE
+BALHARBOURFL.GOV,City,Non-Federal Agency,Bal Harbour,FL,ACTIVE
+BALTIMORECITY.GOV,City,Non-Federal Agency,Baltimore,MD,ACTIVE
+BANGORMAINE.GOV,City,Non-Federal Agency,Bangor,ME,ACTIVE
+BARLINGAR.GOV,City,Non-Federal Agency,Barling,AR,ACTIVE
+BARRINGTON-IL.GOV,City,Non-Federal Agency,Barrington,IL,ACTIVE
+BARRINGTONHILLS-IL.GOV,City,Non-Federal Agency,Barrington Hills,IL,ACTIVE
+BASSLAKEWI.GOV,City,Non-Federal Agency,Hayward,WI,ACTIVE
+BASTROPTX.GOV,City,Non-Federal Agency,Bastrop,TX,ACTIVE
+BATTLECREEK-MI.GOV,City,Non-Federal Agency,Battle Creek,MI,ACTIVE
+BATTLECREEKMI.GOV,City,Non-Federal Agency,Battle Creek,MI,ACTIVE
+BATTLEFIELDMO.GOV,City,Non-Federal Agency,Battlefield,MO,ACTIVE
+BAXTERMN.GOV,City,Non-Federal Agency,Baxter,MN,ACTIVE
+BAYCOUNTY-MI.GOV,City,Non-Federal Agency,Bay City,MI,ACTIVE
+BAYSIDE-WI.GOV,City,Non-Federal Agency,Bayside,WI,ACTIVE
+BAYSTLOUIS-MS.GOV,City,Non-Federal Agency,Bay St. Louis,MS,ACTIVE
+BAYVILLENY.GOV,City,Non-Federal Agency,Bayville,NY,ACTIVE
+BEACHHAVEN-NJ.GOV,City,Non-Federal Agency,Beach Haven,NJ,ACTIVE
+BEAUMONT-CA.GOV,City,Non-Federal Agency,Beaumont,CA,ACTIVE
+BEAUMONTTEXAS.GOV,City,Non-Federal Agency,Beaumont,TX,ACTIVE
+BEAUXARTS-WA.GOV,City,Non-Federal Agency,Beaux Arts,WA,ACTIVE
+BEAVERCREEKOHIO.GOV,City,Non-Federal Agency,Beavercreek,OH,ACTIVE
+BEAVERPA.GOV,City,Non-Federal Agency,Beaver,PA,ACTIVE
+BEAVERTONOREGON.GOV,City,Non-Federal Agency,Beaverton,OR,ACTIVE
+BEAVERTWP-OH.GOV,City,Non-Federal Agency,North Lima,OH,ACTIVE
+BECKEMEYERIL.GOV,City,Non-Federal Agency,Beckemeyer,IL,ACTIVE
+BEDFORDHEIGHTS.GOV,City,Non-Federal Agency,Bedford Heights,OH,ACTIVE
+BEDFORDMA.GOV,City,Non-Federal Agency,Bedford,MA,ACTIVE
+BEDFORDNY.GOV,City,Non-Federal Agency,Bedford Hills,NY,ACTIVE
+BEDFORDOH.GOV,City,Non-Federal Agency,Bedford,OH,ACTIVE
+BEDFORDTX.GOV,City,Non-Federal Agency,Bedford,TX,ACTIVE
+BEDFORDVA.GOV,City,Non-Federal Agency,Bedford,VA,ACTIVE
+BEECAVETEXAS.GOV,City,Non-Federal Agency,Bee Cave,TX,ACTIVE
+BELAIREKS.GOV,City,Non-Federal Agency,Bel Aire,KS,ACTIVE
+BELEN-NM.GOV,City,Non-Federal Agency,Belen,NM,ACTIVE
+BELLAIRETX.GOV,City,Non-Federal Agency,Bellaire,TX,ACTIVE
+BELLAVISTAAR.GOV,City,Non-Federal Agency,Bella Vista,AR,ACTIVE
+BELLEAIRBLUFFS-FL.GOV,City,Non-Federal Agency,Belleair Bluffs,FL,ACTIVE
+BELLEFONTEPA.GOV,City,Non-Federal Agency,Bellefonte,PA,ACTIVE
+BELLEMEADE-KY.GOV,City,Non-Federal Agency,Louisville,KY,ACTIVE
+BELLERIVEACRESMO.GOV,City,Non-Federal Agency,Normandy,MO,ACTIVE
+BELLEVUEIA.GOV,City,Non-Federal Agency,Bellevue,IA,ACTIVE
+BELLEVUEWA.GOV,City,Non-Federal Agency,Bellevue,WA,ACTIVE
+BELMONT-MA.GOV,City,Non-Federal Agency,Belmont,MA,ACTIVE
+BELMONT.GOV,City,Non-Federal Agency,Belmont,CA,ACTIVE
+BELOITWI.GOV,City,Non-Federal Agency,Beloit,WI,ACTIVE
+BELTONPARKSMO.GOV,City,Non-Federal Agency,Belton,MO,ACTIVE
+BELTONTEXAS.GOV,City,Non-Federal Agency,Belton,TX,ACTIVE
+BENBROOK-TX.GOV,City,Non-Federal Agency,Benbrook,TX,ACTIVE
+BENDOREGON.GOV,City,Non-Federal Agency,Bend,OR,ACTIVE
+BENSALEMPA.GOV,City,Non-Federal Agency,Bensalem,PA,ACTIVE
+BENSONAZ.GOV,City,Non-Federal Agency,Benson,AZ,ACTIVE
+BENTONCHARTERTOWNSHIP-MI.GOV,City,Non-Federal Agency,Benton Harbor,MI,ACTIVE
+BENTONIL.GOV,City,Non-Federal Agency,Benton,IL,ACTIVE
+BEREAKY.GOV,City,Non-Federal Agency,Berea,KY,ACTIVE
+BERKELEYHEIGHTSTWPNJ.GOV,City,Non-Federal Agency,Berkeley Heights,NJ,ACTIVE
+BERLINMD.GOV,City,Non-Federal Agency,Berlin,MD,ACTIVE
+BERLINNH.GOV,City,Non-Federal Agency,Berlin,NH,ACTIVE
+BERNCO.GOV,City,Non-Federal Agency,Albuquerque,NM,ACTIVE
+BERRYVILLEVA.GOV,City,Non-Federal Agency,Berryville,VA,ACTIVE
+BERTHOLD-ND.GOV,City,Non-Federal Agency,Berthold,ND,ACTIVE
+BERWYN-IL.GOV,City,Non-Federal Agency,Berwyn,IL,ACTIVE
+BERWYNHEIGHTSMD.GOV,City,Non-Federal Agency,Berwyn Heights,MD,ACTIVE
+BETHANYBEACH-DE.GOV,City,Non-Federal Agency,Bethany Beach,DE,ACTIVE
+BETHEL-CT.GOV,City,Non-Federal Agency,Bethel,CT,ACTIVE
+BETHEL-OH.GOV,City,Non-Federal Agency,Bethel,OH,ACTIVE
+BETHLEHEM-PA.GOV,City,Non-Federal Agency,Bethlehem,PA,ACTIVE
+BEVERLYHILLS-CA.GOV,City,Non-Federal Agency,Beverly Hills,CA,ACTIVE
+BEVERLYHILLSCA.GOV,City,Non-Federal Agency,Beverly Hills,CA,ACTIVE
+BEVERLYMA.GOV,City,Non-Federal Agency,Beverly,MA,ACTIVE
+BHTX.GOV,City,Non-Federal Agency,Balcones Heights,TX,ACTIVE
+BIGFLATSNY.GOV,City,Non-Federal Agency,Big Flats,NY,ACTIVE
+BIGGS-CA.GOV,City,Non-Federal Agency,Biggs,CA,ACTIVE
+BIGSANDYTX.GOV,City,Non-Federal Agency,Big Sandy,TX,ACTIVE
+BINGHAMTON-NY.GOV,City,Non-Federal Agency,Binghamton,NY,ACTIVE
+BIRMINGHAMAL.GOV,City,Non-Federal Agency,Birmingham,AL,ACTIVE
+BISBEEAZ.GOV,City,Non-Federal Agency,Bisbee,AZ,ACTIVE
+BISCAYNEPARKFL.GOV,City,Non-Federal Agency,Biscayne Park,FL,ACTIVE
+BISMARCKND.GOV,City,Non-Federal Agency,Bismarck,ND,ACTIVE
+BIXBYOK.GOV,City,Non-Federal Agency,Bixby,OK,ACTIVE
+BLACKSBURG.GOV,City,Non-Federal Agency,Blacksburg,VA,ACTIVE
+BLAINEMN.GOV,City,Non-Federal Agency,Blaine,MN,ACTIVE
+BLAIRSVILLE-GA.GOV,City,Non-Federal Agency,Blairsville,GA,ACTIVE
+BLANDING-UT.GOV,City,Non-Federal Agency,Blanding,UT,ACTIVE
+BLENDONTOWNSHIP-MI.GOV,City,Non-Federal Agency,Hudsonville,MI,ACTIVE
+BLISSFIELDMICHIGAN.GOV,City,Non-Federal Agency,Blissfield,MI,ACTIVE
+BLOOMINGDALE-GA.GOV,City,Non-Federal Agency,Bloomingdale,GA,ACTIVE
+BLOOMINGTON-MN.GOV,City,Non-Federal Agency,Bloomington,MN,ACTIVE
+BLOOMINGTONMN.GOV,City,Non-Federal Agency,Bloomington,MN,ACTIVE
+BLUEASH-OH.GOV,City,Non-Federal Agency,Blue Ash,OH,ACTIVE
+BOCARATON-FL.GOV,City,Non-Federal Agency,Boca Raton,FL,ACTIVE
+BOERNE-TX.GOV,City,Non-Federal Agency,BOERNE,TX,ACTIVE
+BOISEIDAHO.GOV,City,Non-Federal Agency,Boise,ID,ACTIVE
+BOLTON-MA.GOV,City,Non-Federal Agency,Bolton,MA,ACTIVE
+BONNEYTEXAS.GOV,City,Non-Federal Agency,Bonney,TX,ACTIVE
+BOONEVILLE-MS.GOV,City,Non-Federal Agency,Booneville,MS,ACTIVE
+BORGERTX.GOV,City,Non-Federal Agency,Borger,TX,ACTIVE
+BOSQUEFARMSNM.GOV,City,Non-Federal Agency,Bosque Farms,NM,ACTIVE
+BOSTON.GOV,City,Non-Federal Agency,Boston,MA,ACTIVE
+BOTHELLWA.GOV,City,Non-Federal Agency,Bothell,WA,ACTIVE
+BOULDER-CO.GOV,City,Non-Federal Agency,Boulder,CO,ACTIVE
+BOULDERCITY-NV.GOV,City,Non-Federal Agency,Boulder City,NV,ACTIVE
+BOULDERCITYNV.GOV,City,Non-Federal Agency,Boulder City,NV,ACTIVE
+BOULDERCOLORADO.GOV,City,Non-Federal Agency,Boulder,CO,ACTIVE
+BOUNTIFULUTAH.GOV,City,Non-Federal Agency,Bountiful,UT,ACTIVE
+BOURBON-IN.GOV,City,Non-Federal Agency,Bremen,IN,ACTIVE
+BOW-NH.GOV,City,Non-Federal Agency,Bow,NH,ACTIVE
+BOWERSDE.GOV,City,Non-Federal Agency,"Frederica,",DE,ACTIVE
+BOWLINGGREEN-MO.GOV,City,Non-Federal Agency,Bowling Green,MO,ACTIVE
+BOWLINGGREENKY.GOV,City,Non-Federal Agency,Bowling Green,KY,ACTIVE
+BOWMAR.GOV,City,Non-Federal Agency,Bow Mar,CO,ACTIVE
+BOXBOROUGH-MA.GOV,City,Non-Federal Agency,Boxborough,MA,ACTIVE
+BOYCEVA.GOV,City,Non-Federal Agency,Boyce,VA,ACTIVE
+BOYLSTON-MA.GOV,City,Non-Federal Agency,Boylston,MA,ACTIVE
+BOZEMAN-MT.GOV,City,Non-Federal Agency,Bozeman,MT,ACTIVE
+BRADLEYBEACHNJ.GOV,City,Non-Federal Agency,Bradley Beach,NJ,ACTIVE
+BRANFORD-CT.GOV,City,Non-Federal Agency,Branford,CT,ACTIVE
+BRANSONMO.GOV,City,Non-Federal Agency,Branson,MO,ACTIVE
+BRASWELLGA.GOV,City,Non-Federal Agency,Rockmart,GA,ACTIVE
+BRAWLEY-CA.GOV,City,Non-Federal Agency,Brawley,CA,ACTIVE
+BRECKENRIDGETX.GOV,City,Non-Federal Agency,Breckenridge,TX,ACTIVE
+BREMENGA.GOV,City,Non-Federal Agency,Bremen,GA,ACTIVE
+BREMERTONWA.GOV,City,Non-Federal Agency,Bremerton,WA,ACTIVE
+BRENTWOOD-TN.GOV,City,Non-Federal Agency,Brentwood,TN,ACTIVE
+BRENTWOODCA.GOV,City,Non-Federal Agency,Brentwood,CA,ACTIVE
+BRENTWOODMD.GOV,City,Non-Federal Agency,Brentwood,MD,ACTIVE
+BRENTWOODNH.GOV,City,Non-Federal Agency,Brentwood,NH,ACTIVE
+BRENTWOODTN.GOV,City,Non-Federal Agency,Brentwood,TN,ACTIVE
+BREWSTER-MA.GOV,City,Non-Federal Agency,Brewster,MA,ACTIVE
+BREWSTERVILLAGE-NY.GOV,City,Non-Federal Agency,Brewster,NY,ACTIVE
+BRICKTOWNSHIP-NJ.GOV,City,Non-Federal Agency,Brick,NJ,ACTIVE
+BRIDGEPORTCT.GOV,City,Non-Federal Agency,Bridgeport,CT,ACTIVE
+BRIDGEPORTWV.GOV,City,Non-Federal Agency,Bridgeport,WV,ACTIVE
+BRIDGEVIEW-IL.GOV,City,Non-Federal Agency,Bridgeview,IL,ACTIVE
+BRIDGEWATERNJ.GOV,City,Non-Federal Agency,Bridgewater,NJ,ACTIVE
+BRIGHTONCO.GOV,City,Non-Federal Agency,Brighton,CO,ACTIVE
+BRIMFIELDOHIO.GOV,City,Non-Federal Agency,Kent,OH,ACTIVE
+BRISTOLCT.GOV,City,Non-Federal Agency,Bristol,CT,ACTIVE
+BRLA.GOV,City,Non-Federal Agency,Baton Rouge,LA,ACTIVE
+BROADVIEW-IL.GOV,City,Non-Federal Agency,Broadview,IL,ACTIVE
+BROKENARROWOK.GOV,City,Non-Federal Agency,Broken Arrow,OK,ACTIVE
+BROOKFIELD-WI.GOV,City,Non-Federal Agency,Brookfield,WI,ACTIVE
+BROOKFIELDCT.GOV,City,Non-Federal Agency,Brookfield,CT,ACTIVE
+BROOKFIELDIL.GOV,City,Non-Federal Agency,Brookfield ,IL,ACTIVE
+BROOKHAVENGA.GOV,City,Non-Federal Agency,Dunwoody,GA,ACTIVE
+BROOKLINEMA.GOV,City,Non-Federal Agency,Brookline,MA,ACTIVE
+BROOKLYNOHIO.GOV,City,Non-Federal Agency,Brooklyn,OH,ACTIVE
+BROOKLYNWI.GOV,City,Non-Federal Agency,Brooklyn,WI,ACTIVE
+BROOMFIELDCO.GOV,City,Non-Federal Agency,Broomfield,CO,ACTIVE
+BROWNSVILLETN.GOV,City,Non-Federal Agency,Brownsville,TN,ACTIVE
+BROWNWOODTEXAS.GOV,City,Non-Federal Agency,Brownwood,TX,ACTIVE
+BRYANTX.GOV,City,Non-Federal Agency,Bryan,TX,ACTIVE
+BRYCECANYONCITYUT.GOV,City,Non-Federal Agency,Bryce Canyon City,UT,ACTIVE
+BRYSONCITYNC.GOV,City,Non-Federal Agency,Bryson City,NC,ACTIVE
+BUCHANAN-VA.GOV,City,Non-Federal Agency,BUCHANAN,VA,ACTIVE
+BUCKEYEAZ.GOV,City,Non-Federal Agency,Buckeye,AZ,ACTIVE
+BUCKSPORTMAINE.GOV,City,Non-Federal Agency,Bucksport,ME,ACTIVE
+BUENAVISTACO.GOV,City,Non-Federal Agency,Buena Vista,CO,ACTIVE
+BULLHEADCITYAZ.GOV,City,Non-Federal Agency,Bullhead City,AZ,ACTIVE
+BULVERDETX.GOV,City,Non-Federal Agency,Bulverde,TX,ACTIVE
+BUNKERHILLTX.GOV,City,Non-Federal Agency,HOUSTON,TX,ACTIVE
+BURBANKCA.GOV,City,Non-Federal Agency,Burbank,CA,ACTIVE
+BURBANKIL.GOV,City,Non-Federal Agency,Burbank,IL,ACTIVE
+BURIENWA.GOV,City,Non-Federal Agency,Burien,WA,ACTIVE
+BURKITTSVILLE-MD.GOV,City,Non-Federal Agency,Burkittsville,MD,ACTIVE
+BURLINGTON-WI.GOV,City,Non-Federal Agency,Burlington,WI,ACTIVE
+BURLINGTONKANSAS.GOV,City,Non-Federal Agency,Burlington,KS,ACTIVE
+BURLINGTONNC.GOV,City,Non-Federal Agency,Burlington,NC,ACTIVE
+BURLINGTONND.GOV,City,Non-Federal Agency,Burlington,ND,ACTIVE
+BURLINGTONVT.GOV,City,Non-Federal Agency,Burlington,VT,ACTIVE
+BURLINGTONWA.GOV,City,Non-Federal Agency,Burlington,WA,ACTIVE
+BURNSHARBOR-IN.GOV,City,Non-Federal Agency,Burns Harbor,IN,ACTIVE
+BURNSVILLEMN.GOV,City,Non-Federal Agency,Burnsville,MN,ACTIVE
+BURR-RIDGE.GOV,City,Non-Federal Agency,Burr Ridge,IL,ACTIVE
+BURRILLVILLE-RI.GOV,City,Non-Federal Agency,Harrisville,RI,ACTIVE
+BURTONMI.GOV,City,Non-Federal Agency,Burton,MI,ACTIVE
+BUTLERWI.GOV,City,Non-Federal Agency,Butler,WI,ACTIVE
+BYESVILLEOH.GOV,City,Non-Federal Agency,Byesville,OH,ACTIVE
+CABOTAR.GOV,City,Non-Federal Agency,Cabot,AR,ACTIVE
+CABQ.GOV,City,Non-Federal Agency,Albuquerque,NM,ACTIVE
+CALAISVERMONT.GOV,City,Non-Federal Agency,East Calais,VT,ACTIVE
+CALDWELLTX.GOV,City,Non-Federal Agency,Caldwell,TX,ACTIVE
+CALEDONIAMN.GOV,City,Non-Federal Agency,Caledonia,MN,ACTIVE
+CALIFORNIACITY-CA.GOV,City,Non-Federal Agency,California City,CA,ACTIVE
+CALUMETTWP-IN.GOV,City,Non-Federal Agency,Gary,IN,ACTIVE
+CAMBRIDGEMA.GOV,City,Non-Federal Agency,Cambridge,MA,ACTIVE
+CAMBRIDGENY.GOV,City,Non-Federal Agency,Cambridge,NY,ACTIVE
+CAMDENMAINE.GOV,City,Non-Federal Agency,Camden,ME,ACTIVE
+CAMDENTN.GOV,City,Non-Federal Agency,Camden,TN,ACTIVE
+CAMPBELLCA.GOV,City,Non-Federal Agency,Campbell,CA,ACTIVE
+CAMPBELLOHIO.GOV,City,Non-Federal Agency,Campbell,OH,ACTIVE
+CANALWINCHESTEROHIO.GOV,City,Non-Federal Agency,Canal Winchester,OH,ACTIVE
+CANANDAIGUANEWYORK.GOV,City,Non-Federal Agency,Canandaigua,NY,ACTIVE
+CANNONFALLSMN.GOV,City,Non-Federal Agency,Cannon Falls,MN,ACTIVE
+CANTONOHIO.GOV,City,Non-Federal Agency,Canton,OH,ACTIVE
+CANTONTWP-OH.GOV,City,Non-Federal Agency,Canton,OH,ACTIVE
+CANTONTX.GOV,City,Non-Federal Agency,Canton,TX,ACTIVE
+CAPECORALFL.GOV,City,Non-Federal Agency,Cape Coral,FL,ACTIVE
+CARBONDALE-PA.GOV,City,Non-Federal Agency,Carbondale,PA,ACTIVE
+CARLISLE-IA.GOV,City,Non-Federal Agency,Carlisle,IA,ACTIVE
+CARLISLEMA.GOV,City,Non-Federal Agency,Carlisle,MA,ACTIVE
+CARLSBADCA.GOV,City,Non-Federal Agency,Carlsbad,CA,ACTIVE
+CARNATIONWA.GOV,City,Non-Federal Agency,Carnation,WA,ACTIVE
+CARNEGIEOK.GOV,City,Non-Federal Agency,Carnegie,OK,ACTIVE
+CARNEYSPOINTNJ.GOV,City,Non-Federal Agency,Carneys Point,NJ,ACTIVE
+CARRBORONC.GOV,City,Non-Federal Agency,Carrboro,NC,ACTIVE
+CARROLLTON-GA.GOV,City,Non-Federal Agency,Carrollton,GA,ACTIVE
+CARTERLAKE-IA.GOV,City,Non-Federal Agency,Carter Lake,IA,ACTIVE
+CARTERSVILLEGA.GOV,City,Non-Federal Agency,Cartersville,GA,ACTIVE
+CARTHAGEMO.GOV,City,Non-Federal Agency,Carthage,MO,ACTIVE
+CARVERMA.GOV,City,Non-Federal Agency,Carver,MA,ACTIVE
+CARYNC.GOV,City,Non-Federal Agency,Cary,NC,ACTIVE
+CASAGRANDEAZ.GOV,City,Non-Federal Agency,Casa Grande,AZ,ACTIVE
+CASPERWY.GOV,City,Non-Federal Agency,Casper,WY,ACTIVE
+CASTROVILLETX.GOV,City,Non-Federal Agency,Castroville,TX,ACTIVE
+CATHEDRALCITY.GOV,City,Non-Federal Agency,Cathedral City,CA,ACTIVE
+CAVESPRINGSAR.GOV,City,Non-Federal Agency,Cave Springs,AR,ACTIVE
+CECILTONMD.GOV,City,Non-Federal Agency,Cecilton ,MD,ACTIVE
+CECILTOWNSHIP-PA.GOV,City,Non-Federal Agency,Cecil,PA,ACTIVE
+CEDARHURST.GOV,City,Non-Federal Agency,cedarhurst,NY,ACTIVE
+CEDARPARKTEXAS.GOV,City,Non-Federal Agency,Cedar Park,TX,ACTIVE
+CEDARRAPIDS-IA.GOV,City,Non-Federal Agency,Cedar Rapids,IA,ACTIVE
+CEDARTOWNGEORGIA.GOV,City,Non-Federal Agency,Cedartown,GA,ACTIVE
+CELINA-TX.GOV,City,Non-Federal Agency,Celina,TX,ACTIVE
+CENTENNIALCO.GOV,City,Non-Federal Agency,Centennial,CO,ACTIVE
+CENTERCO.GOV,City,Non-Federal Agency,Center,CO,ACTIVE
+CENTERLINE.GOV,City,Non-Federal Agency,Center Line,MI,ACTIVE
+CENTERVILLEOHIO.GOV,City,Non-Federal Agency,Centerville,OH,ACTIVE
+CENTERVILLETX.GOV,City,Non-Federal Agency,College Station,TX,ACTIVE
+CENTRAL-LA.GOV,City,Non-Federal Agency,Central,LA,ACTIVE
+CENTRALPOINTOREGON.GOV,City,Non-Federal Agency,Central Point,OR,ACTIVE
+CENTREVILLE-MD.GOV,City,Non-Federal Agency,Centreville,MD,ACTIVE
+CGAZ.GOV,City,Non-Federal Agency,Casa Grande,AZ,ACTIVE
+CHADDSFORDPA.GOV,City,Non-Federal Agency,Chadds Ford,PA,ACTIVE
+CHAMBERSBURGPA.GOV,City,Non-Federal Agency,Chambersburg,PA,ACTIVE
+CHAMBLEEGA.GOV,City,Non-Federal Agency,Chamblee,GA,ACTIVE
+CHAMPAIGN-IL.GOV,City,Non-Federal Agency,Champaign,IL,ACTIVE
+CHAMPAIGNIL.GOV,City,Non-Federal Agency,Champaign,IL,ACTIVE
+CHANDLERAZ.GOV,City,Non-Federal Agency,Chandler,AZ,ACTIVE
+CHARLESTON-SC.GOV,City,Non-Federal Agency,Charleston,SC,ACTIVE
+CHARLESTONWV.GOV,City,Non-Federal Agency,Charleston,WV,ACTIVE
+CHARLESTOWN-NH.GOV,City,Non-Federal Agency,Charlestown,NH,ACTIVE
+CHARLOTTENC.GOV,City,Non-Federal Agency,Charlotte,NC,ACTIVE
+CHARLOTTESVILLEVA.GOV,City,Non-Federal Agency,Charlottesville,VA,ACTIVE
+CHATHAM-MA.GOV,City,Non-Federal Agency,Chatham,MA,ACTIVE
+CHATHAM-VA.GOV,City,Non-Federal Agency,Chatham,VA,ACTIVE
+CHATHAMTOWNSHIP-NJ.GOV,City,Non-Federal Agency,Chatham,NJ,ACTIVE
+CHATSWORTHGA.GOV,City,Non-Federal Agency,Chatsworth,GA,ACTIVE
+CHATTANOOGA.GOV,City,Non-Federal Agency,Chattanooga,TN,ACTIVE
+CHELSEAMA.GOV,City,Non-Federal Agency,Chelsea,MA,ACTIVE
+CHESAPEAKEBEACHMD.GOV,City,Non-Federal Agency,Chesapeake Beach,MD,ACTIVE
+CHESAPEAKECITY-MD.GOV,City,Non-Federal Agency,Chesapeake City,MD,ACTIVE
+CHESHIRE-MA.GOV,City,Non-Federal Agency,Cheshire,MA,ACTIVE
+CHESTER-NY.GOV,City,Non-Federal Agency,Chester,NY,ACTIVE
+CHESTERFIELD.GOV,City,Non-Federal Agency,Chesterfield,VA,ACTIVE
+CHESTERVT.GOV,City,Non-Federal Agency,Chester,VT,ACTIVE
+CHESTNUTHILLTWP-PA.GOV,City,Non-Federal Agency,Brodheadsville,PA,ACTIVE
+CHEVERLY-MD.GOV,City,Non-Federal Agency,Cheverly,MD,ACTIVE
+CHEVYCHASEVILLAGEMD.GOV,City,Non-Federal Agency,Chevy Chase,MD,ACTIVE
+CHICAGO-IL.GOV,City,Non-Federal Agency,Chicago,IL,ACTIVE
+CHICOCA.GOV,City,Non-Federal Agency,Chico,CA,ACTIVE
+CHICOPEEMA.GOV,City,Non-Federal Agency,Chicopee,MA,ACTIVE
+CHILLICOTHEOH.GOV,City,Non-Federal Agency,Chillicothe,OH,ACTIVE
+CHILMARKMA.GOV,City,Non-Federal Agency,Chilmark,MA,ACTIVE
+CHINAGROVENC.GOV,City,Non-Federal Agency,China Grove,NC,ACTIVE
+CHINCOTEAGUE-VA.GOV,City,Non-Federal Agency,Chincoteague,VA,ACTIVE
+CHIPPEWAFALLS-WI.GOV,City,Non-Federal Agency,Chippewa Falls,WI,ACTIVE
+CHOWANCOUNTY-NC.GOV,City,Non-Federal Agency,Edenton,NC,ACTIVE
+CHULAVISTACA.GOV,City,Non-Federal Agency,Chula Vista,CA,ACTIVE
+CHURCHHILLTN.GOV,City,Non-Federal Agency,Church Hill,TN,ACTIVE
+CIBOLOTX.GOV,City,Non-Federal Agency,Cibolo,TX,ACTIVE
+CINCINNATI-OH.GOV,City,Non-Federal Agency,Cincinnati,OH,ACTIVE
+CINCINNATIOHIO.GOV,City,Non-Federal Agency,Cincinnati,OH,ACTIVE
+CITYKANKAKEE-IL.GOV,City,Non-Federal Agency,KANKAKEE,IL,ACTIVE
+CITYOFADAMS-WI.GOV,City,Non-Federal Agency,Adams,WI,ACTIVE
+CITYOFAIKENSC.GOV,City,Non-Federal Agency,Aiken,SC,ACTIVE
+CITYOFALAMEDACA.GOV,City,Non-Federal Agency,Alameda,CA,ACTIVE
+CITYOFALBIONMI.GOV,City,Non-Federal Agency,albion,MI,ACTIVE
+CITYOFALCOA-TN.GOV,City,Non-Federal Agency,Alcoa,TN,ACTIVE
+CITYOFALGOODTN.GOV,City,Non-Federal Agency,Algood,TN,ACTIVE
+CITYOFALMAGA.GOV,City,Non-Federal Agency,Alma,GA,ACTIVE
+CITYOFAUBURNWA.GOV,City,Non-Federal Agency,Auburn,WA,ACTIVE
+CITYOFBAKERLA.GOV,City,Non-Federal Agency,Baker ,LA,ACTIVE
+CITYOFBELOITWI.GOV,City,Non-Federal Agency,Beloit,WI,ACTIVE
+CITYOFBENTONHARBORMI.GOV,City,Non-Federal Agency,Benton Harbor,MI,ACTIVE
+CITYOFBLUERIDGEGA.GOV,City,Non-Federal Agency,Blue Ridge,GA,ACTIVE
+CITYOFBOWIEMD.GOV,City,Non-Federal Agency,Bowie,MD,ACTIVE
+CITYOFBOWMANGA.GOV,City,Non-Federal Agency,Bowman,GA,ACTIVE
+CITYOFBRUNSWICK-GA.GOV,City,Non-Federal Agency,Brunswick,GA,ACTIVE
+CITYOFBURTON-TX.GOV,City,Non-Federal Agency,Burton,TX,ACTIVE
+CITYOFCANALFULTON-OH.GOV,City,Non-Federal Agency,Canal Fulton,OH,ACTIVE
+CITYOFCAYCE-SC.GOV,City,Non-Federal Agency,Cayce,SC,ACTIVE
+CITYOFCHAMPAIGN-IL.GOV,City,Non-Federal Agency,Champaign,IL,ACTIVE
+CITYOFCHAMPAIGNIL.GOV,City,Non-Federal Agency,Champaign,IL,ACTIVE
+CITYOFCHETEK-WI.GOV,City,Non-Federal Agency,Chetek,WI,ACTIVE
+CITYOFCHOTEAU-MT.GOV,City,Non-Federal Agency,Choteau,MT,ACTIVE
+CITYOFCLAYTONGA.GOV,City,Non-Federal Agency,Clayton,GA,ACTIVE
+CITYOFCODY-WY.GOV,City,Non-Federal Agency,Cody,WY,ACTIVE
+CITYOFCONWAY-AR.GOV,City,Non-Federal Agency,Conway,AR,ACTIVE
+CITYOFCOWETA-OK.GOV,City,Non-Federal Agency,Coweta,OK,ACTIVE
+CITYOFCRISFIELD-MD.GOV,City,Non-Federal Agency,Crisfield,MD,ACTIVE
+CITYOFCUDAHYCA.GOV,City,Non-Federal Agency,Cudahy,CA,ACTIVE
+CITYOFDALTON-GA.GOV,City,Non-Federal Agency,Dalton,GA,ACTIVE
+CITYOFDOUGLASGA.GOV,City,Non-Federal Agency,Douglas,GA,ACTIVE
+CITYOFDUNBARWV.GOV,City,Non-Federal Agency,Dunbar,WV,ACTIVE
+CITYOFDUPONTWA.GOV,City,Non-Federal Agency,DuPont,WA,ACTIVE
+CITYOFENGLEWOOD-NJ.GOV,City,Non-Federal Agency,Englewood,NJ,ACTIVE
+CITYOFEUDORAKS.GOV,City,Non-Federal Agency,Eudora,KS,ACTIVE
+CITYOFFAIRFAX-MN.GOV,City,Non-Federal Agency,Fairfax,MN,ACTIVE
+CITYOFFARGO-ND.GOV,City,Non-Federal Agency,Fargo,ND,ACTIVE
+CITYOFFARMERSVILLE-CA.GOV,City,Non-Federal Agency,Farmersville,CA,ACTIVE
+CITYOFFARMINGTON-AR.GOV,City,Non-Federal Agency,Farmington,AR,ACTIVE
+CITYOFFOLKSTON-GA.GOV,City,Non-Federal Agency,Folkston,GA,ACTIVE
+CITYOFFORTOGLETHORPEGA.GOV,City,Non-Federal Agency,FORT OGLETHORPE,GA,ACTIVE
+CITYOFGAFFNEY-SC.GOV,City,Non-Federal Agency,Gaffney,SC,ACTIVE
+CITYOFGALENAPARK-TX.GOV,City,Non-Federal Agency,Galena Park,TX,ACTIVE
+CITYOFGRAVETTE-AR.GOV,City,Non-Federal Agency,Gravette,AR,ACTIVE
+CITYOFGROTON-CT.GOV,City,Non-Federal Agency,Groton,CT,ACTIVE
+CITYOFGROVEOK.GOV,City,Non-Federal Agency,Grove,OK,ACTIVE
+CITYOFGUNNISON-CO.GOV,City,Non-Federal Agency,Gunnison,CO,ACTIVE
+CITYOFHAMPTON-GA.GOV,City,Non-Federal Agency,Hampton,GA,ACTIVE
+CITYOFHARRISON-MI.GOV,City,Non-Federal Agency,Harrison,MI,ACTIVE
+CITYOFHAYWARD-CA.GOV,City,Non-Federal Agency,Hayward,CA,ACTIVE
+CITYOFHAYWARDWI.GOV,City,Non-Federal Agency,Hayward,WI,ACTIVE
+CITYOFHIRAMGA.GOV,City,Non-Federal Agency,HIRAM,GA,ACTIVE
+CITYOFHOKAH-MN.GOV,City,Non-Federal Agency,Hokah,MN,ACTIVE
+CITYOFHOLYOKE-CO.GOV,City,Non-Federal Agency,Holyoke,CO,ACTIVE
+CITYOFHOMER-AK.GOV,City,Non-Federal Agency,Homer,AK,ACTIVE
+CITYOFHONDO-TX.GOV,City,Non-Federal Agency,Hondo,TX,ACTIVE
+CITYOFHOUSTON.GOV,City,Non-Federal Agency,Houston,TX,ACTIVE
+CITYOFHUMBLE-TX.GOV,City,Non-Federal Agency,Humble,TX,ACTIVE
+CITYOFHUMBLETX.GOV,City,Non-Federal Agency,Humble,TX,ACTIVE
+CITYOFHUNTSVILLETX.GOV,City,Non-Federal Agency,Huntsville,TX,ACTIVE
+CITYOFIRONDALEAL.GOV,City,Non-Federal Agency,Irondale,AL,ACTIVE
+CITYOFKEYWEST-FL.GOV,City,Non-Federal Agency,Key West,FL,ACTIVE
+CITYOFKINGMAN.GOV,City,Non-Federal Agency,Kingman,AZ,ACTIVE
+CITYOFKINGSBURG-CA.GOV,City,Non-Federal Agency,Kingsburg,CA,ACTIVE
+CITYOFLACRESCENT-MN.GOV,City,Non-Federal Agency,La Crescent,MN,ACTIVE
+CITYOFLADUE-MO.GOV,City,Non-Federal Agency,Ladue,MO,ACTIVE
+CITYOFLAGRANGEMO.GOV,City,Non-Federal Agency,LaGrange,MO,ACTIVE
+CITYOFLAHABRA-CA.GOV,City,Non-Federal Agency,LA HABRA,CA,ACTIVE
+CITYOFLENEXA-KS.GOV,City,Non-Federal Agency,Lenexa,KS,ACTIVE
+CITYOFLENEXAKS.GOV,City,Non-Federal Agency,Lenexa,KS,ACTIVE
+CITYOFLINDALETX.GOV,City,Non-Federal Agency,LINDALE,TX,ACTIVE
+CITYOFLISBON-IA.GOV,City,Non-Federal Agency,Lisbon,IA,ACTIVE
+CITYOFLUBBOCKTX.GOV,City,Non-Federal Agency,Lubbock,TX,ACTIVE
+CITYOFMACON-MO.GOV,City,Non-Federal Agency,Macon,MO,ACTIVE
+CITYOFMARIONIL.GOV,City,Non-Federal Agency,Marion,IL,ACTIVE
+CITYOFMARIONWI.GOV,City,Non-Federal Agency,MARION,WI,ACTIVE
+CITYOFMCCAYSVILLEGA.GOV,City,Non-Federal Agency,McCaysville,GA,ACTIVE
+CITYOFMENASHA-WI.GOV,City,Non-Federal Agency,Menasha,WI,ACTIVE
+CITYOFMIDLANDMI.GOV,City,Non-Federal Agency,Midland,MI,ACTIVE
+CITYOFMILLBROOK-AL.GOV,City,Non-Federal Agency,Millbrook,AL,ACTIVE
+CITYOFMILLENGA.GOV,City,Non-Federal Agency,Millen,GA,ACTIVE
+CITYOFMONONGAHELA-PA.GOV,City,Non-Federal Agency,Monongahela,PA,ACTIVE
+CITYOFMORROWGA.GOV,City,Non-Federal Agency,Morrow,GA,ACTIVE
+CITYOFMTVERNON-IA.GOV,City,Non-Federal Agency,Mount Vernon,IA,ACTIVE
+CITYOFNANTICOKE-PA.GOV,City,Non-Federal Agency,Nanticoke,PA,ACTIVE
+CITYOFNEWBURGH-NY.GOV,City,Non-Federal Agency,Newburgh,NY,ACTIVE
+CITYOFNEWULM-MN.GOV,City,Non-Federal Agency,New Ulm,MN,ACTIVE
+CITYOFNORMANDY.GOV,City,Non-Federal Agency,St. Louis,MO,ACTIVE
+CITYOFNOVI-MI.GOV,City,Non-Federal Agency,Novi,MI,ACTIVE
+CITYOFOLYMPIA-WA.GOV,City,Non-Federal Agency,Olympia,WA,ACTIVE
+CITYOFOLYMPIAWA.GOV,City,Non-Federal Agency,Olympia,WA,ACTIVE
+CITYOFOMAHA-NE.GOV,City,Non-Federal Agency,Omaha,NE,ACTIVE
+CITYOFPACIFICWA.GOV,City,Non-Federal Agency,Pacific,WA,ACTIVE
+CITYOFPALMVALLEY-TX.GOV,City,Non-Federal Agency,Harlingen,TX,ACTIVE
+CITYOFPARISTN.GOV,City,Non-Federal Agency,Paris,TN,ACTIVE
+CITYOFPARMA-OH.GOV,City,Non-Federal Agency,Parma,OH,ACTIVE
+CITYOFPASSAICNJ.GOV,City,Non-Federal Agency,Passaic,NJ,ACTIVE
+CITYOFPATASKALAOHIO.GOV,City,Non-Federal Agency,Pataskala,OH,ACTIVE
+CITYOFPATTERSONLA.GOV,City,Non-Federal Agency,Patterson,LA,ACTIVE
+CITYOFPEARLANDTX.GOV,City,Non-Federal Agency,Pearland,TX,ACTIVE
+CITYOFPHOENIX.GOV,City,Non-Federal Agency,Phoenix,AZ,ACTIVE
+CITYOFPIGEONFORGETN.GOV,City,Non-Federal Agency,Pigeon Forge,TN,ACTIVE
+CITYOFPLAINVILLE-KS.GOV,City,Non-Federal Agency,Plainville,KS,ACTIVE
+CITYOFPLATTSBURGH-NY.GOV,City,Non-Federal Agency,Plattsburgh,NY,ACTIVE
+CITYOFPLEASANTONCA.GOV,City,Non-Federal Agency,Pleasanton,CA,ACTIVE
+CITYOFPOCOMOKEMD.GOV,City,Non-Federal Agency,Pocomoke City,MD,ACTIVE
+CITYOFPORTLANDTN.GOV,City,Non-Federal Agency,Portland,TN,ACTIVE
+CITYOFREDMOND.GOV,City,Non-Federal Agency,Redmond,WA,ACTIVE
+CITYOFRENONV.GOV,City,Non-Federal Agency,Reno,NV,ACTIVE
+CITYOFROCHESTER.GOV,City,Non-Federal Agency,Rochester,NY,ACTIVE
+CITYOFROCKHILLSC.GOV,City,Non-Federal Agency,Rock Hill,SC,ACTIVE
+CITYOFROCKPORT-IN.GOV,City,Non-Federal Agency,Rockport,IN,ACTIVE
+CITYOFSAFFORD-AZ.GOV,City,Non-Federal Agency,Safford,AZ,ACTIVE
+CITYOFSAFFORDAZ.GOV,City,Non-Federal Agency,Safford,AZ,ACTIVE
+CITYOFSALEMNJ.GOV,City,Non-Federal Agency,Salem,NJ,ACTIVE
+CITYOFSANTAANA-CA.GOV,City,Non-Federal Agency,Santa Ana,CA,ACTIVE
+CITYOFSANTEECA.GOV,City,Non-Federal Agency,Santee,CA,ACTIVE
+CITYOFSEATTLE.GOV,City,Non-Federal Agency,Seattle,WA,ACTIVE
+CITYOFSPARTANBURG-SC.GOV,City,Non-Federal Agency,Spartanburg,SC,ACTIVE
+CITYOFSTMARYSPA.GOV,City,Non-Federal Agency,St. Marys,PA,ACTIVE
+CITYOFSTOCKBRIDGE-GA.GOV,City,Non-Federal Agency,Stockbridge,GA,ACTIVE
+CITYOFSUGAR-LANDTX.GOV,City,Non-Federal Agency,Sugar Land,TX,ACTIVE
+CITYOFSUGARLAND-TX.GOV,City,Non-Federal Agency,Sugar Land,TX,ACTIVE
+CITYOFSUGARLANDTX.GOV,City,Non-Federal Agency,Sugar Land,TX,ACTIVE
+CITYOFSUNRISEFL.GOV,City,Non-Federal Agency,Sunrise,FL,ACTIVE
+CITYOFSUNRISEFLORIDA.GOV,City,Non-Federal Agency,Sunrise,FL,ACTIVE
+CITYOFTITUSVILLEPA.GOV,City,Non-Federal Agency,Titusville,PA,ACTIVE
+CITYOFTORRANCECA.GOV,City,Non-Federal Agency,Torrance,CA,ACTIVE
+CITYOFTUKWILA-WA.GOV,City,Non-Federal Agency,Tukwila,WA,ACTIVE
+CITYOFTYLER-TX.GOV,City,Non-Federal Agency,Tyler,TX,ACTIVE
+CITYOFTYLERTX.GOV,City,Non-Federal Agency,Tyler,TX,ACTIVE
+CITYOFWARRENPA.GOV,City,Non-Federal Agency,Warren,PA,ACTIVE
+CITYOFWASHINGTONGA.GOV,City,Non-Federal Agency,Washington,GA,ACTIVE
+CITYOFWEATHERBYLAKE-MO.GOV,City,Non-Federal Agency,Weatherby Lake,MO,ACTIVE
+CITYOFWESTONLAKES-TX.GOV,City,Non-Federal Agency,Fulshear,TX,ACTIVE
+CITYOFWESTPALMBEACH-FL.GOV,City,Non-Federal Agency,West Palm Beach,FL,ACTIVE
+CITYOFWEYAUWEGA-WI.GOV,City,Non-Federal Agency,Weyauwega,WI,ACTIVE
+CITYOFWHEATON-IL.GOV,City,Non-Federal Agency,Wheaton,IL,ACTIVE
+CITYOFWOODBURYGA.GOV,City,Non-Federal Agency,Woodbury,GA,ACTIVE
+CITYOFWORLANDWY.GOV,City,Non-Federal Agency,Worland,WY,ACTIVE
+CITYOFYUKONOK.GOV,City,Non-Federal Agency,Yukon,OK,ACTIVE
+CITYOLYMPIA-WA.GOV,City,Non-Federal Agency,Olympia,WA,ACTIVE
+CITYOLYMPIAWA.GOV,City,Non-Federal Agency,Olympia,WA,ACTIVE
+CLAIRTON-PA.GOV,City,Non-Federal Agency,Clairton,PA,ACTIVE
+CLARKSTONGA.GOV,City,Non-Federal Agency,Clarkston,GA,ACTIVE
+CLARKSVILLEAR.GOV,City,Non-Federal Agency,Clarksville,AR,ACTIVE
+CLAYTONMO.GOV,City,Non-Federal Agency,Clayton,MO,ACTIVE
+CLEARLAKE-WI.GOV,City,Non-Federal Agency,Clear Lake,WI,ACTIVE
+CLEARLAKESHORES-TX.GOV,City,Non-Federal Agency,Clear Lake Shores,TX,ACTIVE
+CLERMONTFL.GOV,City,Non-Federal Agency,Clermont,FM,ACTIVE
+CLEVELAND-OH.GOV,City,Non-Federal Agency,Cleveland,OH,ACTIVE
+CLEVELANDOHIO.GOV,City,Non-Federal Agency,Cleveland,OH,ACTIVE
+CLEVELANDTN.GOV,City,Non-Federal Agency,Cleveland,TN,ACTIVE
+CLEVELANDWI.GOV,City,Non-Federal Agency,Cleveland,WI,ACTIVE
+CLEWISTON-FL.GOV,City,Non-Federal Agency,Clewiston,FL,ACTIVE
+CLIFFSIDEPARKNJ.GOV,City,Non-Federal Agency,Cliffside Park,NJ,ACTIVE
+CLIFTONAZ.GOV,City,Non-Federal Agency,Clifton,AZ,ACTIVE
+CLIFTONFORGEVA.GOV,City,Non-Federal Agency,Clifton Forge,VA,ACTIVE
+CLINTONMA.GOV,City,Non-Federal Agency,Clinton,MA,ACTIVE
+CLINTONNJ.GOV,City,Non-Federal Agency,New Jersey,NJ,ACTIVE
+CLINTONOK.GOV,City,Non-Federal Agency,Clinton,OK,ACTIVE
+CLINTONTOWNSHIP-MI.GOV,City,Non-Federal Agency,Clinton Township,MI,ACTIVE
+CMSDCA.GOV,City,Non-Federal Agency,Costa Mesa,CA,ACTIVE
+COALCITY-IL.GOV,City,Non-Federal Agency,Coal City,IL,ACTIVE
+COALRUNKY.GOV,City,Non-Federal Agency,Pikeville,KY,ACTIVE
+COHOES-NY.GOV,City,Non-Federal Agency,Cohoes,NY,ACTIVE
+COLCHESTERCT.GOV,City,Non-Federal Agency,Colchester,CT,ACTIVE
+COLCHESTERVT.GOV,City,Non-Federal Agency,Colchester,VT,ACTIVE
+COLDSPRINGKY.GOV,City,Non-Federal Agency,COLD SPRING,KY,ACTIVE
+COLDSPRINGNY.GOV,City,Non-Federal Agency,Cold Spring ,NY,ACTIVE
+COLFAX-CA.GOV,City,Non-Federal Agency,Colfax,CA,ACTIVE
+COLLEGEDALETN.GOV,City,Non-Federal Agency,Collegedale,TN,ACTIVE
+COLLEGEPARKMD.GOV,City,Non-Federal Agency,College Park,MD,ACTIVE
+COLLEGEVILLE-PA.GOV,City,Non-Federal Agency,Collegeville,PA,ACTIVE
+COLLIERVILLETN.GOV,City,Non-Federal Agency,Collierville,TN,ACTIVE
+COLLINCOUNTYTEXAS.GOV,City,Non-Federal Agency,Mckinney,TX,ACTIVE
+COLLINCOUNTYTX.GOV,City,Non-Federal Agency,McKinney,TX,ACTIVE
+COLONIALHEIGHTSVA.GOV,City,Non-Federal Agency,Colonial Heights,VA,ACTIVE
+COLONIE-NY.GOV,City,Non-Federal Agency,Newtonville,NY,ACTIVE
+COLORADOSPRINGS.GOV,City,Non-Federal Agency,Colorado Springs,CO,ACTIVE
+COLRAIN-MA.GOV,City,Non-Federal Agency,Colrain,MA,ACTIVE
+COLTONCA.GOV,City,Non-Federal Agency,Colton,CA,ACTIVE
+COLUMBIAHEIGHTSMN.GOV,City,Non-Federal Agency,Columbia Heights,MN,ACTIVE
+COLUMBIANAOHIO.GOV,City,Non-Federal Agency,Columbiana,OH,ACTIVE
+COLUMBIASC.GOV,City,Non-Federal Agency,Columbia,SC,ACTIVE
+COLUMBIATN.GOV,City,Non-Federal Agency,Columbia,TN,ACTIVE
+COLUMBIATWP-OH.GOV,City,Non-Federal Agency,Columbia Station,OH,ACTIVE
+COLUMBUS.GOV,City,Non-Federal Agency,Columbus,OH,ACTIVE
+COLUMBUSOH.GOV,City,Non-Federal Agency,Columbus,OH,ACTIVE
+COLUMBUSOHIO.GOV,City,Non-Federal Agency,Columbus,OH,ACTIVE
+COMMERCIALPOINTOHIO.GOV,City,Non-Federal Agency,Commercial Point,OH,ACTIVE
+COMO.GOV,City,Non-Federal Agency,Columbia,MO,ACTIVE
+COMSTOCKMI.GOV,City,Non-Federal Agency,Kalamazoo,MI,ACTIVE
+CONCORDMA.GOV,City,Non-Federal Agency,Concord,MA,ACTIVE
+CONCORDNC.GOV,City,Non-Federal Agency,Concord,NC,ACTIVE
+CONCORDNH.GOV,City,Non-Federal Agency,Concord,NH,ACTIVE
+CONCRETEWA.GOV,City,Non-Federal Agency,Concrete,WA,ACTIVE
+CONNEAUTOHIO.GOV,City,Non-Federal Agency,Conneaut,OH,ACTIVE
+CONNERSVILLEIN.GOV,City,Non-Federal Agency,Connersville,IN,ACTIVE
+CONOVERNC.GOV,City,Non-Federal Agency,Conover,NC,ACTIVE
+CONYERSGA.GOV,City,Non-Federal Agency,Conyers,GA,ACTIVE
+COOKEVILLE-TN.GOV,City,Non-Federal Agency,Cookeville,TN,ACTIVE
+COONRAPIDSMN.GOV,City,Non-Federal Agency,Coon Rapids,MN,ACTIVE
+COPPELLTX.GOV,City,Non-Federal Agency,Coppell,TX,ACTIVE
+COPPERASCOVETX.GOV,City,Non-Federal Agency,Copperas Cove,TX,ACTIVE
+COR.GOV,City,Non-Federal Agency,Richardson,TX,ACTIVE
+CORALGABLES-FL.GOV,City,Non-Federal Agency,Coral Gables,FL,ACTIVE
+CORALGABLESFL.GOV,City,Non-Federal Agency,Coral Gables,FL,ACTIVE
+CORBIN-KY.GOV,City,Non-Federal Agency,Corbin,KY,ACTIVE
+CORNINGAR.GOV,City,Non-Federal Agency,Corning,AR,ACTIVE
+CORNWALLNY.GOV,City,Non-Federal Agency,Cornwall,NY,ACTIVE
+CORPUSCHRISTI-TX.GOV,City,Non-Federal Agency,Corpus Christi,TX,ACTIVE
+CORRALESNM.GOV,City,Non-Federal Agency,Corales,NM,ACTIVE
+CORRYPA.GOV,City,Non-Federal Agency,Corry,PA,ACTIVE
+CORUNNA-MI.GOV,City,Non-Federal Agency,Corunna,MI,ACTIVE
+CORVALLISOREGON.GOV,City,Non-Federal Agency,Corvallis,OR,ACTIVE
+CORYDON-IN.GOV,City,Non-Federal Agency,Corydon,IN,ACTIVE
+COSMOPOLISWA.GOV,City,Non-Federal Agency,Cosmopolis,WA,ACTIVE
+COSPRINGS.GOV,City,Non-Federal Agency,Colorado Springs,CO,ACTIVE
+COSTAMESACA.GOV,City,Non-Federal Agency,Costa Mesa,CA,ACTIVE
+COTTAGECITYMD.GOV,City,Non-Federal Agency,Cottage City,MD,ACTIVE
+COTTONWOODAZ.GOV,City,Non-Federal Agency,Cottonwood,AZ,ACTIVE
+COUNTRYSIDE-IL.GOV,City,Non-Federal Agency,Countryside,IL,ACTIVE
+COVINACA.GOV,City,Non-Federal Agency,Covina,CA,ACTIVE
+COVINGTON-OH.GOV,City,Non-Federal Agency,COVINGTON ,OH,ACTIVE
+COVINGTONKY.GOV,City,Non-Federal Agency,Covington,KY,ACTIVE
+COVINGTONWA.GOV,City,Non-Federal Agency,Covington,WA,ACTIVE
+CRANBERRYISLES-ME.GOV,City,Non-Federal Agency,Islesford,ME,ACTIVE
+CRAWFORDSVILLE-IN.GOV,City,Non-Federal Agency,Crawfordsville,IN,ACTIVE
+CREDITRIVER-MN.GOV,City,Non-Federal Agency,Prior Lake,MN,ACTIVE
+CRESTONIOWA.GOV,City,Non-Federal Agency,Creston,IA,ACTIVE
+CRETE-NE.GOV,City,Non-Federal Agency,Crete,NE,ACTIVE
+CREVECOEURMO.GOV,City,Non-Federal Agency,Creve Coeur,MO,ACTIVE
+CROSSROADSTX.GOV,City,Non-Federal Agency,Crossroads,TX,ACTIVE
+CROSSVILLETN.GOV,City,Non-Federal Agency,Crossville,TN,ACTIVE
+CROTONONHUDSON-NY.GOV,City,Non-Federal Agency,Croton-On-Hudson,NY,ACTIVE
+CRYSTALMN.GOV,City,Non-Federal Agency,Crystal,MN,ACTIVE
+CUBAASSESSORIL.GOV,City,Non-Federal Agency,Barrington,IL,ACTIVE
+CUBATWPIL.GOV,City,Non-Federal Agency,Barrington,IL,ACTIVE
+CUDAHY-WI.GOV,City,Non-Federal Agency,Cudahy,WI,ACTIVE
+CULPEPERVA.GOV,City,Non-Federal Agency,Culpeper,VA,ACTIVE
+CUMBERLANDMD.GOV,City,Non-Federal Agency,Cumberland,MD,ACTIVE
+CUMMINGTON-MA.GOV,City,Non-Federal Agency,Cummington,MA,ACTIVE
+CUTLERBAY-FL.GOV,City,Non-Federal Agency,Cutler Bay,FL,ACTIVE
+DACULAGA.GOV,City,Non-Federal Agency,Dacula,GA,ACTIVE
+DAHLONEGA-GA.GOV,City,Non-Federal Agency,Dahlonega,GA,ACTIVE
+DALHARTTX.GOV,City,Non-Federal Agency,Dalhart,TX,ACTIVE
+DALLAS-GA.GOV,City,Non-Federal Agency,Dallas,GA,ACTIVE
+DALLASOR.GOV,City,Non-Federal Agency,Dallas,OR,ACTIVE
+DALLASOREGON.GOV,City,Non-Federal Agency,Dallas,OR,ACTIVE
+DALTON-MA.GOV,City,Non-Federal Agency,Dalton,MA,ACTIVE
+DAMASCUSOREGON.GOV,City,Non-Federal Agency,Damascus,OR,ACTIVE
+DANBURY-CT.GOV,City,Non-Federal Agency,Danbury,CT,ACTIVE
+DANDRIDGETN.GOV,City,Non-Federal Agency,Dandridge,TN,ACTIVE
+DANIABEACHFL.GOV,City,Non-Federal Agency,DANIA BEACH,FL,ACTIVE
+DANVERSMA.GOV,City,Non-Federal Agency,Danvers,MA,ACTIVE
+DANVILLE-VA.GOV,City,Non-Federal Agency,Danville,VA,ACTIVE
+DANVILLEVA.GOV,City,Non-Federal Agency,Danville,VA,ACTIVE
+DARIENCT.GOV,City,Non-Federal Agency,Darien,CT,ACTIVE
+DARIENIL.GOV,City,Non-Federal Agency,Darien,IL,ACTIVE
+DAUGHERTYTOWNSHIP-PA.GOV,City,Non-Federal Agency,New Brighton,PA,ACTIVE
+DAVIE-FL.GOV,City,Non-Federal Agency,Davie,FL,ACTIVE
+DAWSONVILLE-GA.GOV,City,Non-Federal Agency,Dawsonville,GA,ACTIVE
+DAYTON-ME.GOV,City,Non-Federal Agency,Dayton,ME,ACTIVE
+DAYTONOHIO.GOV,City,Non-Federal Agency,Dayton,OH,ACTIVE
+DECATUR-AL.GOV,City,Non-Federal Agency,Decatur,AL,ACTIVE
+DECATURIL.GOV,City,Non-Federal Agency,Decatur,IL,ACTIVE
+DECATURILLINOIS.GOV,City,Non-Federal Agency,Decatur,IL,ACTIVE
+DECATURTX.GOV,City,Non-Federal Agency,Decatur,TX,ACTIVE
+DEDHAM-MA.GOV,City,Non-Federal Agency,Dedham,MA,ACTIVE
+DEERFIELDMICHIGAN.GOV,City,Non-Federal Agency,Deerfield,MI,ACTIVE
+DEERPARK-OH.GOV,City,Non-Federal Agency,Deer Park,OH,ACTIVE
+DEERPARKTX.GOV,City,Non-Federal Agency,Deer Park,TX,ACTIVE
+DEKORRA-WI.GOV,City,Non-Federal Agency,Poynette,WI,ACTIVE
+DELAWARETOWNSHIPPA.GOV,City,Non-Federal Agency,Dingmans Ferry,PA,ACTIVE
+DELRAYBEACHFL.GOV,City,Non-Federal Agency,Delray Beach,FL,ACTIVE
+DELTA-CO.GOV,City,Non-Federal Agency,Delta,CO,ACTIVE
+DELTAMI.GOV,City,Non-Federal Agency,Lansing,MI,ACTIVE
+DELTONAFL.GOV,City,Non-Federal Agency,Deltona,FL,ACTIVE
+DEMOPOLISAL.GOV,City,Non-Federal Agency,Demopolis,AL,ACTIVE
+DENVERCO.GOV,City,Non-Federal Agency,Denver,CO,ACTIVE
+DERBYCT.GOV,City,Non-Federal Agency,Derby,CT,ACTIVE
+DESMOINESWA.GOV,City,Non-Federal Agency,Des Moines,WA,ACTIVE
+DESOTOTEXAS.GOV,City,Non-Federal Agency,DeSoto,TX,ACTIVE
+DETROITMI.GOV,City,Non-Federal Agency,Detroit,MI,ACTIVE
+DEXTERMI.GOV,City,Non-Federal Agency,Dexter,MI,ACTIVE
+DHAZ.GOV,City,Non-Federal Agency,Humboldt,AZ,ACTIVE
+DIAMONDBARCA.GOV,City,Non-Federal Agency,Diamond Bar,CA,ACTIVE
+DICKINSON-TX.GOV,City,Non-Federal Agency,Dickinson,TX,ACTIVE
+DICKINSONTEXAS.GOV,City,Non-Federal Agency,Dickinson,TX,ACTIVE
+DICKSONCITY-PA.GOV,City,Non-Federal Agency,Dickson City,PA,ACTIVE
+DIGHTON-MA.GOV,City,Non-Federal Agency,Dighton,MA,ACTIVE
+DISCOVERWAUKESHA-WI.GOV,City,Non-Federal Agency,Waukesha,WI,ACTIVE
+DONALDOREGON.GOV,City,Non-Federal Agency,Donald,OR,ACTIVE
+DONALDSONVILLE-LA.GOV,City,Non-Federal Agency,Donaldsonville,LA,ACTIVE
+DORAL-FL.GOV,City,Non-Federal Agency,Doral,FL,ACTIVE
+DORALPD-FL.GOV,City,Non-Federal Agency,Doral,FL,ACTIVE
+DOUGLASAZ.GOV,City,Non-Federal Agency,Douglas,AZ,ACTIVE
+DOUGLASVILLEGA.GOV,City,Non-Federal Agency,Douglasville,GA,ACTIVE
+DREW-MS.GOV,City,Non-Federal Agency,Drew,MS,ACTIVE
+DRUIDHILLSKY.GOV,City,Non-Federal Agency,Louisville,KY,ACTIVE
+DUBLIN-CA.GOV,City,Non-Federal Agency,Dublin,CA,ACTIVE
+DUBLINCA.GOV,City,Non-Federal Agency,Dublin,CA,ACTIVE
+DUBLINOHIOUSA.GOV,City,Non-Federal Agency,Dublin,OH,ACTIVE
+DUBOISPA.GOV,City,Non-Federal Agency,DuBois,PA,ACTIVE
+DULUTHMN.GOV,City,Non-Federal Agency,Duluth,MN,ACTIVE
+DUMASTX.GOV,City,Non-Federal Agency,Dumas,TX,ACTIVE
+DUMFRIESVA.GOV,City,Non-Federal Agency,Dumfries,VA,ACTIVE
+DUMONTNJ.GOV,City,Non-Federal Agency,Dumont,NJ,ACTIVE
+DUNCANOK.GOV,City,Non-Federal Agency,Duncan,OK,ACTIVE
+DUNCANVILLETX.GOV,City,Non-Federal Agency,Duncanville,TX,ACTIVE
+DUNDEEVILLAGEMI.GOV,City,Non-Federal Agency,Dundee,MI,ACTIVE
+DUNELLEN-NJ.GOV,City,Non-Federal Agency,Dunellen,NJ,ACTIVE
+DUNMOREPA.GOV,City,Non-Federal Agency,Dunmore,PA,ACTIVE
+DUNSTABLE-MA.GOV,City,Non-Federal Agency,Dunstable,MA,ACTIVE
+DUNWOODYGA.GOV,City,Non-Federal Agency,Dunwoody,GA,ACTIVE
+DUNWOODYGEORGIA.GOV,City,Non-Federal Agency,Dunwoody,GA,ACTIVE
+DUPONTWA.GOV,City,Non-Federal Agency,DuPont,WA,ACTIVE
+DURHAMNC.GOV,City,Non-Federal Agency,Durham,NC,ACTIVE
+DUSHOREPA.GOV,City,Non-Federal Agency,Dushore,PA,ACTIVE
+DUTCHESSNY.GOV,City,Non-Federal Agency,Poughkeepsie,NY,ACTIVE
+DUVALLWA.GOV,City,Non-Federal Agency,Duvall,WA,ACTIVE
+DYERSBURGTN.GOV,City,Non-Federal Agency,Dyersburg,TN,ACTIVE
+EAGARAZ.GOV,City,Non-Federal Agency,Eagar,AZ,ACTIVE
+EAGLE-WI.GOV,City,Non-Federal Agency,Eagle,WI,ACTIVE
+EAGLELAKE-TX.GOV,City,Non-Federal Agency,Eagle Lake,TX,ACTIVE
+EASTBOROUGH-KS.GOV,City,Non-Federal Agency,Eastborough,KS,ACTIVE
+EASTCOVENTRY-PA.GOV,City,Non-Federal Agency,Pottstown,PA,ACTIVE
+EASTHAMPTONCT.GOV,City,Non-Federal Agency,East Hampton,CT,ACTIVE
+EASTHAMPTONNY.GOV,City,Non-Federal Agency,Amagansett,NY,ACTIVE
+EASTHAMPTONVILLAGENY.GOV,City,Non-Federal Agency,East Hampton,NY,ACTIVE
+EASTHARTFORDCT.GOV,City,Non-Federal Agency,East Hartford,CT,ACTIVE
+EASTKINGSTONNH.GOV,City,Non-Federal Agency,East Kingston,NH,ACTIVE
+EASTLONGMEADOWMA.GOV,City,Non-Federal Agency,East Longmeadow,MA,ACTIVE
+EASTMOUNTAINTX.GOV,City,Non-Federal Agency,East Mountain,TX,ACTIVE
+EASTON-PA.GOV,City,Non-Federal Agency,Easton,PA,ACTIVE
+EASTONCT.GOV,City,Non-Federal Agency,Easton,CT,ACTIVE
+EASTONMD.GOV,City,Non-Federal Agency,Easton,MD,ACTIVE
+EASTORANGE-NJ.GOV,City,Non-Federal Agency,East ORange,NJ,ACTIVE
+EASTPALESTINE-OH.GOV,City,Non-Federal Agency,East Palestine,OH,ACTIVE
+EASTPORT-ME.GOV,City,Non-Federal Agency,Eastport,ME,ACTIVE
+EASTRIDGETN.GOV,City,Non-Federal Agency,East Ridge,TN,ACTIVE
+EASTTROYWI.GOV,City,Non-Federal Agency,East Troy,WI,ACTIVE
+EASTVALECA.GOV,City,Non-Federal Agency,Eastvale,CA,ACTIVE
+EASTWINDSOR-CT.GOV,City,Non-Federal Agency,Broad Brook,CT,ACTIVE
+EATONVILLE-WA.GOV,City,Non-Federal Agency,Eatonville,WA,ACTIVE
+EAUCLAIREVILLAGE-MI.GOV,City,Non-Federal Agency,Eau Claire,MI,ACTIVE
+EAUCLAIREWI.GOV,City,Non-Federal Agency,Eau Claire,WI,ACTIVE
+ECORSEMI.GOV,City,Non-Federal Agency,ECORSE,MI,ACTIVE
+EDDINGTONMAINE.GOV,City,Non-Federal Agency,Eddington,ME,ACTIVE
+EDENNY.GOV,City,Non-Federal Agency,Eden,NY,ACTIVE
+EDGEWATERFL.GOV,City,Non-Federal Agency,Edgewater,FL,ACTIVE
+EDGEWOOD-FL.GOV,City,Non-Federal Agency,Edgewood,FL,ACTIVE
+EDGEWOOD-NM.GOV,City,Non-Federal Agency,Edgewood,NM,ACTIVE
+EDINAMN.GOV,City,Non-Federal Agency,Edina,MN,ACTIVE
+EDMONDS-WA.GOV,City,Non-Federal Agency,Edmonds,WA,ACTIVE
+EDMONDSWA.GOV,City,Non-Federal Agency,Edmonds,WA,ACTIVE
+EDMONSTONMD.GOV,City,Non-Federal Agency,Edmonston,MD,ACTIVE
+EHALERTCT.GOV,City,Non-Federal Agency,East Hartford,CT,ACTIVE
+EHAMPTONNY.GOV,City,Non-Federal Agency,East Hampton,NY,ACTIVE
+ELKHARTLAKEWI.GOV,City,Non-Federal Agency,Elkhart Lake,WI,ACTIVE
+ELKOCITYNV.GOV,City,Non-Federal Agency,Elko,NV,ACTIVE
+ELKRIVERMN.GOV,City,Non-Federal Agency,Elk River,MN,ACTIVE
+ELKTONVA.GOV,City,Non-Federal Agency,Elkton,VA,ACTIVE
+ELKTOWNSHIPNJ.GOV,City,Non-Federal Agency,Monroeville,NJ,ACTIVE
+ELLAGO-TX.GOV,City,Non-Federal Agency,El Lago,TX,ACTIVE
+ELLIJAY-GA.GOV,City,Non-Federal Agency,Ellijay,GA,ACTIVE
+ELLINGTON-CT.GOV,City,Non-Federal Agency,Ellington,CT,ACTIVE
+ELLSWORTHMAINE.GOV,City,Non-Federal Agency,Ellsworth,ME,ACTIVE
+ELMIRAGE-AZ.GOV,City,Non-Federal Agency,El Mirage,AZ,ACTIVE
+ELMONTECA.GOV,City,Non-Federal Agency,El Monte,CA,ACTIVE
+ELOYAZ.GOV,City,Non-Federal Agency,Eloy,AZ,ACTIVE
+ELPASOTEXAS.GOV,City,Non-Federal Agency,El Paso,TX,ACTIVE
+EMERALDBAY-TX.GOV,City,Non-Federal Agency,Bullard,TX,ACTIVE
+EMMITSBURGMD.GOV,City,Non-Federal Agency,Emmitsburg,MD,ACTIVE
+EMPORIA-KANSAS.GOV,City,Non-Federal Agency,Emporia,KS,ACTIVE
+ENCINITASCA.GOV,City,Non-Federal Agency,Encinitas,CA,ACTIVE
+ENCINITASCALIFORNIA.GOV,City,Non-Federal Agency,Encinitas,CA,ACTIVE
+ENFIELD-CT.GOV,City,Non-Federal Agency,Enfield,CT,ACTIVE
+ENNISTX.GOV,City,Non-Federal Agency,Ennis,TX,ACTIVE
+ENON-OH.GOV,City,Non-Federal Agency,Enon,OH,ACTIVE
+ENTERPRISEAL.GOV,City,Non-Federal Agency,Enterprise,AL,ACTIVE
+ERIECO.GOV,City,Non-Federal Agency,Erie,CO,ACTIVE
+ESPANOLANM.GOV,City,Non-Federal Agency,Espanola,NM,ACTIVE
+ESSEXCT.GOV,City,Non-Federal Agency,Essex,CT,ACTIVE
+ESTERO-FL.GOV,City,Non-Federal Agency,Estero,FL,ACTIVE
+ETON-GA.GOV,City,Non-Federal Agency,Eton,GA,ACTIVE
+EUGENE-OR.GOV,City,Non-Federal Agency,Eugene,OR,ACTIVE
+EULESSTX.GOV,City,Non-Federal Agency,Euless,TX,ACTIVE
+EUREKA-MT.GOV,City,Non-Federal Agency,Eureka,MT,ACTIVE
+EUREKASPRINGSAR.GOV,City,Non-Federal Agency,Eureka Springs,AR,ACTIVE
+EVANSCOLORADO.GOV,City,Non-Federal Agency,Evans,CO,ACTIVE
+EVERETTWA.GOV,City,Non-Federal Agency,Everett,WA,ACTIVE
+EVESHAM-NJ.GOV,City,Non-Federal Agency,Marlton,NJ,ACTIVE
+EXETERNH.GOV,City,Non-Federal Agency,Exeter,NH,ACTIVE
+FABIUS-NY.GOV,City,Non-Federal Agency,Fabius,NY,ACTIVE
+FAIRFAX-VT.GOV,City,Non-Federal Agency,Fairfax,VT,ACTIVE
+FAIRFAXVA.GOV,City,Non-Federal Agency,Fairfax,VA,ACTIVE
+FAIRFIELDOH.GOV,City,Non-Federal Agency,Fairfield,OH,ACTIVE
+FAIRHOPE-AL.GOV,City,Non-Federal Agency,Fairhope,AL,ACTIVE
+FAIRMONTWV.GOV,City,Non-Federal Agency,Fairmont,WV,ACTIVE
+FAIRMOUNTHEIGHTSMD.GOV,City,Non-Federal Agency,Fairmount Heights,MD,ACTIVE
+FAIRVIEWNC.GOV,City,Non-Federal Agency,Monroe,NC,ACTIVE
+FAIRVIEWOREGON.GOV,City,Non-Federal Agency,Fairview,OR,ACTIVE
+FALLCREEKWI.GOV,City,Non-Federal Agency,Fall Creek,WI,ACTIVE
+FALLONNEVADA.GOV,City,Non-Federal Agency,Fallon,NV,ACTIVE
+FALLSCHURCHCITYVA.GOV,City,Non-Federal Agency,Falls Church,VA,ACTIVE
+FALLSCHURCHVA.GOV,City,Non-Federal Agency,Falls Church,VA,ACTIVE
+FALLSCITYOREGON.GOV,City,Non-Federal Agency,Falls City,OR,ACTIVE
+FARGO-ND.GOV,City,Non-Federal Agency,Fargo,ND,ACTIVE
+FARGOND.GOV,City,Non-Federal Agency,Fargo,ND,ACTIVE
+FARMERSBRANCHTX.GOV,City,Non-Federal Agency,Farmers Branch,TX,ACTIVE
+FARMINGTON-MO.GOV,City,Non-Federal Agency,Farmington,MO,ACTIVE
+FARMVILLENC.GOV,City,Non-Federal Agency,Farmville,NC,ACTIVE
+FARRAGUT-TN.GOV,City,Non-Federal Agency,Farragut,TN,ACTIVE
+FAYETTEVILLE-AR.GOV,City,Non-Federal Agency,Fayetteville,AR,ACTIVE
+FAYETTEVILLEFIRST-AR.GOV,City,Non-Federal Agency,Fayetteville,AR,ACTIVE
+FAYETTEVILLENC.GOV,City,Non-Federal Agency,Fayetteville,NC,ACTIVE
+FAYETTEVILLENY.GOV,City,Non-Federal Agency,Fayetteville,NY,ACTIVE
+FEDERALWAYWA.GOV,City,Non-Federal Agency,Federal Way ,WA,ACTIVE
+FERNDALEMI.GOV,City,Non-Federal Agency,Ferndale,MI,ACTIVE
+FERRISTEXAS.GOV,City,Non-Federal Agency,Ferris,TX,ACTIVE
+FIRESTONECO.GOV,City,Non-Federal Agency,Firestone,CO,ACTIVE
+FISHKILL-NY.GOV,City,Non-Federal Agency,Fishkill,NY,ACTIVE
+FITCHBURGMA.GOV,City,Non-Federal Agency,Fitchburg,MA,ACTIVE
+FITCHBURGWI.GOV,City,Non-Federal Agency,Fitchburg,WI,ACTIVE
+FITZWILLIAM-NH.GOV,City,Non-Federal Agency,Fitzwilliam,NH,ACTIVE
+FLAGSTAFFAZ.GOV,City,Non-Federal Agency,Flagstaff,AZ,ACTIVE
+FLATONIATX.GOV,City,Non-Federal Agency,Flatonia,TX,ACTIVE
+FLORENCE-KY.GOV,City,Non-Federal Agency,Florence,KY,ACTIVE
+FLORENCE-NJ.GOV,City,Non-Federal Agency,Florence,NJ,ACTIVE
+FLORENCEAZ.GOV,City,Non-Federal Agency,Florence,AZ,ACTIVE
+FLORESVILLETX.GOV,City,Non-Federal Agency,Floresville,TX,ACTIVE
+FLORIDACITYFL.GOV,City,Non-Federal Agency,Florida City,FL,ACTIVE
+FORESTGROVE-OR.GOV,City,Non-Federal Agency,FOREST GROVE,OR,ACTIVE
+FORESTHEIGHTSMD.GOV,City,Non-Federal Agency,Forest Heights,MD,ACTIVE
+FORESTPARKOK.GOV,City,Non-Federal Agency,Forest Park,OK,ACTIVE
+FORSYTH-IL.GOV,City,Non-Federal Agency,Forsyth,IL,ACTIVE
+FORTCOLLINS-CO.GOV,City,Non-Federal Agency,Fort Collins,CO,ACTIVE
+FORTLUPTON-CO.GOV,City,Non-Federal Agency,Fort Lupton,CO,ACTIVE
+FORTLUPTONCO.GOV,City,Non-Federal Agency,Fort Lupton,CO,ACTIVE
+FORTMADISON-IA.GOV,City,Non-Federal Agency,Fort Madison,IA,ACTIVE
+FORTMILLSC.GOV,City,Non-Federal Agency,Fort Mill,SC,ACTIVE
+FORTMYERSBEACHFL.GOV,City,Non-Federal Agency,Fort Myers Beach,FL,ACTIVE
+FORTSMITHAR.GOV,City,Non-Federal Agency,Fort Smith,AR,ACTIVE
+FORTWORTH-TEXAS.GOV,City,Non-Federal Agency,Fort Worth,TX,ACTIVE
+FORTWORTH-TX.GOV,City,Non-Federal Agency,Fort Worth,TX,ACTIVE
+FORTWORTHTEXAS.GOV,City,Non-Federal Agency,Fort Worth,TX,ACTIVE
+FOSTORIAOHIO.GOV,City,Non-Federal Agency,Fostoria,OH,ACTIVE
+FOXBOROUGHMA.GOV,City,Non-Federal Agency,Foxborough,MA,ACTIVE
+FRAMINGHAMMA.GOV,City,Non-Federal Agency,Framingham,MA,ACTIVE
+FRANCESTOWN-NH.GOV,City,Non-Federal Agency,Francestown,NH,ACTIVE
+FRANKFORT-IN.GOV,City,Non-Federal Agency,Frankfort,IN,ACTIVE
+FRANKFORT-KY.GOV,City,Non-Federal Agency,Frankfort,KY,ACTIVE
+FRANKLIN-IN.GOV,City,Non-Federal Agency,FRANKLIN,IN,ACTIVE
+FRANKLIN-NJ.GOV,City,Non-Federal Agency,Someret,NJ,ACTIVE
+FRANKLIN-TN.GOV,City,Non-Federal Agency,Franklin,TN,ACTIVE
+FRANKLINNJ.GOV,City,Non-Federal Agency,Somerset,NJ,ACTIVE
+FRANKLINPA.GOV,City,Non-Federal Agency,Franklin,PA,ACTIVE
+FRANKLINTN.GOV,City,Non-Federal Agency,Franklin,TN,ACTIVE
+FRANKLINWI.GOV,City,Non-Federal Agency,Franklin,WI,ACTIVE
+FREDENBERGTWP-MN.GOV,City,Non-Federal Agency,Duluth,MN,ACTIVE
+FREDERICKCO.GOV,City,Non-Federal Agency,Frederick,CO,ACTIVE
+FREDERICKOK.GOV,City,Non-Federal Agency,Frederick,OK,ACTIVE
+FREDERICKSBURGVA.GOV,City,Non-Federal Agency,Fredericksburg,VA,ACTIVE
+FREEHOLDBOROUGHNJ.GOV,City,Non-Federal Agency,Freehold,NJ,ACTIVE
+FREEPORTNY.GOV,City,Non-Federal Agency,Freeport,NY,ACTIVE
+FREETOWNMA.GOV,City,Non-Federal Agency,Assonet,MA,ACTIVE
+FREMONT.GOV,City,Non-Federal Agency,Fremont,CA,ACTIVE
+FREMONTNC.GOV,City,Non-Federal Agency,Fremont,NC,ACTIVE
+FREMONTNE.GOV,City,Non-Federal Agency,Fremont,NE,ACTIVE
+FRENCHSETTLEMENT-LA.GOV,City,Non-Federal Agency,French Settlement,LA,ACTIVE
+FRESNO.GOV,City,Non-Federal Agency,Fresno,CA,ACTIVE
+FRIDLEYMN.GOV,City,Non-Federal Agency,Fridley,MN,ACTIVE
+FRIENDSHIPHEIGHTSMD.GOV,City,Non-Federal Agency,Chevy Chase,MD,ACTIVE
+FRISCOTEXAS.GOV,City,Non-Federal Agency,Frisco,TX,ACTIVE
+FRISCOTX.GOV,City,Non-Federal Agency,Frisco,TX,ACTIVE
+FROMBERG-MT.GOV,City,Non-Federal Agency,Fromberg,MT,ACTIVE
+FRONTROYAL-VA.GOV,City,Non-Federal Agency,Front Royal,VA,ACTIVE
+FRONTROYALVA.GOV,City,Non-Federal Agency,Front Royal,VA,ACTIVE
+FRUITPORTTOWNSHIP-MI.GOV,City,Non-Federal Agency,Fruitport,MI,ACTIVE
+FULSHEARTEXAS.GOV,City,Non-Federal Agency,Fulshear,TX,ACTIVE
+GAHANNA.GOV,City,Non-Federal Agency,Gahanna,OH,ACTIVE
+GALENAKS.GOV,City,Non-Federal Agency,GALENA,KS,ACTIVE
+GALENAOHIO.GOV,City,Non-Federal Agency,Galena,OH,ACTIVE
+GALESBURG-IL.GOV,City,Non-Federal Agency,Galesburg,IL,ACTIVE
+GALLATIN-TN.GOV,City,Non-Federal Agency,Gallatin,TN,ACTIVE
+GALLAWAYTN.GOV,City,Non-Federal Agency,Gallaway,TN,ACTIVE
+GALLOWAYTWP-NJ.GOV,City,Non-Federal Agency,Galloway,NJ,ACTIVE
+GALLUPNM.GOV,City,Non-Federal Agency,GALLUP,NM,ACTIVE
+GALVAIL.GOV,City,Non-Federal Agency,Galva,IL,ACTIVE
+GALVESTONTX.GOV,City,Non-Federal Agency,Galveston,TX,ACTIVE
+GARDENCITY-GA.GOV,City,Non-Federal Agency,Garden City,GA,ACTIVE
+GARDNERKANSAS.GOV,City,Non-Federal Agency,Gardner,KS,ACTIVE
+GARDNERVILLE-NV.GOV,City,Non-Federal Agency,Gardnerville,NV,ACTIVE
+GARLANDTX.GOV,City,Non-Federal Agency,Garland,TX,ACTIVE
+GARNERNC.GOV,City,Non-Federal Agency,Garner,NC,ACTIVE
+GARRETTPARK-MD.GOV,City,Non-Federal Agency,Garrett Park,MD,ACTIVE
+GARRETTPARKMD.GOV,City,Non-Federal Agency,Garrett Park,MD,ACTIVE
+GATLINBURGTN.GOV,City,Non-Federal Agency,Gatlinburg,TN,ACTIVE
+GAUTIER-MS.GOV,City,Non-Federal Agency,Gautier,MS,ACTIVE
+GENEVAOHIO.GOV,City,Non-Federal Agency,Geneva,OH,ACTIVE
+GEORGETOWN-MI.GOV,City,Non-Federal Agency,Jenison,MI,ACTIVE
+GEORGETOWNKY.GOV,City,Non-Federal Agency,Georgetown,KY,ACTIVE
+GEORGETOWNTX.GOV,City,Non-Federal Agency,Georgetown,TX,ACTIVE
+GERMANTOWN-TN.GOV,City,Non-Federal Agency,Germantown,TN,ACTIVE
+GETTYSBURG-PA.GOV,City,Non-Federal Agency,Gettysburg,PA,ACTIVE
+GILBERTAZ.GOV,City,Non-Federal Agency,Gilbert,AZ,ACTIVE
+GILLETTEWY.GOV,City,Non-Federal Agency,Gillette,WY,ACTIVE
+GIRARDKANSAS.GOV,City,Non-Federal Agency,Girard,KS,ACTIVE
+GLASTONBURY-CT.GOV,City,Non-Federal Agency,Glastonbury,CT,ACTIVE
+GLENDALE-WI.GOV,City,Non-Federal Agency,Glendale,WI,ACTIVE
+GLENDALEAZ.GOV,City,Non-Federal Agency,Glendale,AZ,ACTIVE
+GLENDALECA.GOV,City,Non-Federal Agency,Glendale,CA,ACTIVE
+GLENNHEIGHTSTX.GOV,City,Non-Federal Agency,Glenn Heights,TX,ACTIVE
+GLENVIEWKY.GOV,City,Non-Federal Agency,Glenview,KY,ACTIVE
+GLENWILLOW-OH.GOV,City,Non-Federal Agency,Glenwillow,OH,ACTIVE
+GLENWOODSPRINGSCO.GOV,City,Non-Federal Agency,Glenwood Springs,CO,ACTIVE
+GLOBEAZ.GOV,City,Non-Federal Agency,GLOBE,AZ,ACTIVE
+GLOUCESTER-MA.GOV,City,Non-Federal Agency,Gloucester,MA,ACTIVE
+GODDARDKS.GOV,City,Non-Federal Agency,Goddard,KS,ACTIVE
+GODLEYTX.GOV,City,Non-Federal Agency,Godley,TX,ACTIVE
+GOFFSTOWNNH.GOV,City,Non-Federal Agency,Goffstown,NH,ACTIVE
+GOLDBEACHOREGON.GOV,City,Non-Federal Agency,GoldBeach,OR,ACTIVE
+GOLDENVALLEYMN.GOV,City,Non-Federal Agency,Golden Valley,MN,ACTIVE
+GOLDSBORONC.GOV,City,Non-Federal Agency,Goldsboro,NC,ACTIVE
+GOODHOPEAL.GOV,City,Non-Federal Agency,Cullman,AL,ACTIVE
+GOODLETTSVILLE-TN.GOV,City,Non-Federal Agency,Goodlettsville,TN,ACTIVE
+GOODYEARAZ.GOV,City,Non-Federal Agency,Goodyear,AZ,ACTIVE
+GOSHEN-OH.GOV,City,Non-Federal Agency,Goshen,OH,ACTIVE
+GOSHEN-OHIO.GOV,City,Non-Federal Agency,Goshen,OH,ACTIVE
+GOSHENCT.GOV,City,Non-Federal Agency,Goshen,CT,ACTIVE
+GPSHORESMI.GOV,City,Non-Federal Agency,Grosse Pointe Shores,MI,ACTIVE
+GRAFTON-MA.GOV,City,Non-Federal Agency,Grafton,MA,ACTIVE
+GRANBY-CT.GOV,City,Non-Federal Agency,Granby,CT,ACTIVE
+GRANBY-MA.GOV,City,Non-Federal Agency,Granby,MA,ACTIVE
+GRANDTERRACE-CA.GOV,City,Non-Federal Agency,Grand Terrace,CA,ACTIVE
+GRANDVIEW-IN.GOV,City,Non-Federal Agency,Grandview,IN,ACTIVE
+GRANGERIOWA.GOV,City,Non-Federal Agency,Granger,IA,ACTIVE
+GRANITEFALLSWA.GOV,City,Non-Federal Agency,Granite Falls,WA,ACTIVE
+GRANITEQUARRYNC.GOV,City,Non-Federal Agency,Granite Quarry ,NC,ACTIVE
+GRANTFORKIL.GOV,City,Non-Federal Agency,Highland,IL,ACTIVE
+GRANTSPASSOREGON.GOV,City,Non-Federal Agency,Grants Pass,OR,ACTIVE
+GRANTSVILLEUT.GOV,City,Non-Federal Agency,Grantsville,UT,ACTIVE
+GRAPEVINETEXAS.GOV,City,Non-Federal Agency,Grapevine,TX,ACTIVE
+GRAPEVINETX.GOV,City,Non-Federal Agency,Grapevine,TX,ACTIVE
+GREECENY.GOV,City,Non-Federal Agency,Rochester,NY,ACTIVE
+GREENBAYWI.GOV,City,Non-Federal Agency,Green Bay,WI,ACTIVE
+GREENBELTMD.GOV,City,Non-Federal Agency,Greenbelt,MD,ACTIVE
+GREENCASTLEPA.GOV,City,Non-Federal Agency,Greencastle,PA,ACTIVE
+GREENEVILLETN.GOV,City,Non-Federal Agency,Greeneville,TN,ACTIVE
+GREENFIELD-MA.GOV,City,Non-Federal Agency,Greenfield,MA,ACTIVE
+GREENFIELD-NH.GOV,City,Non-Federal Agency,Greenfield,NH,ACTIVE
+GREENHOUSTONTX.GOV,City,Non-Federal Agency,Houston,TX,ACTIVE
+GREENISLANDNY.GOV,City,Non-Federal Agency,Green Island,NY,ACTIVE
+GREENMOUNTAINFALLSCO.GOV,City,Non-Federal Agency,Green Mountain Falls,CO,ACTIVE
+GREENSBORO-GA.GOV,City,Non-Federal Agency,Greensboro,GA,ACTIVE
+GREENSBORO-NC.GOV,City,Non-Federal Agency,Greensboro,NC,ACTIVE
+GREENSBOROGA.GOV,City,Non-Federal Agency,Greensboro,GA,ACTIVE
+GREENVILLENC.GOV,City,Non-Federal Agency,Greenville,NC,ACTIVE
+GREENVILLESC.GOV,City,Non-Federal Agency,Greenville,SC,ACTIVE
+GRESHAMOREGON.GOV,City,Non-Federal Agency,Gresham,OR,ACTIVE
+GREYFOREST-TX.GOV,City,Non-Federal Agency,Grey Forest,TX,ACTIVE
+GRIMESIOWA.GOV,City,Non-Federal Agency,Grimes,IA,ACTIVE
+GROTON-CT.GOV,City,Non-Federal Agency,Groton,CT,ACTIVE
+GROTONMA.GOV,City,Non-Federal Agency,Groton,MA,ACTIVE
+GROTONSD.GOV,City,Non-Federal Agency,Groton,SD,ACTIVE
+GROVECITYOHIO.GOV,City,Non-Federal Agency,Grove City,OH,ACTIVE
+GROVELAND-FL.GOV,City,Non-Federal Agency,Groveland,FL,ACTIVE
+GULFBREEZEFL.GOV,City,Non-Federal Agency,Gulf Breeze,FL,ACTIVE
+GULFPORT-MS.GOV,City,Non-Federal Agency,Gulfport,MS,ACTIVE
+GULFSHORESAL.GOV,City,Non-Federal Agency,Gulf Shores,AL,ACTIVE
+GUNNISONCO.GOV,City,Non-Federal Agency,Gunnison,CO,ACTIVE
+GUNTERSVILLEAL.GOV,City,Non-Federal Agency,Guntersville,AL,ACTIVE
+GUNTERTX.GOV,City,Non-Federal Agency,Gunter,TX,ACTIVE
+GUSTAVUS-AK.GOV,City,Non-Federal Agency,Gustavus,AK,ACTIVE
+GWSCO.GOV,City,Non-Federal Agency,Glenwood Springs,CO,ACTIVE
+HADDONFIELD-NJ.GOV,City,Non-Federal Agency,Haddonfield,NJ,ACTIVE
+HADLEYMA.GOV,City,Non-Federal Agency,Hadley,MA,ACTIVE
+HAHIRAGA.GOV,City,Non-Federal Agency,Hahira,GA,ACTIVE
+HALLANDALEBEACHFL.GOV,City,Non-Federal Agency,hallandale beach,FL,ACTIVE
+HAMILTON-NY.GOV,City,Non-Federal Agency,HAMILTON,NY,ACTIVE
+HAMILTON-OH.GOV,City,Non-Federal Agency,Hamilton,OH,ACTIVE
+HAMPDENMAINE.GOV,City,Non-Federal Agency,Hampden,ME,ACTIVE
+HAMPSTEADMD.GOV,City,Non-Federal Agency,Hampstead,MD,ACTIVE
+HAMPTON.GOV,City,Non-Federal Agency,Hampton,VA,ACTIVE
+HAMPTONGA.GOV,City,Non-Federal Agency,Hampton,GA,ACTIVE
+HAMPTONNH.GOV,City,Non-Federal Agency,Hampton,NH,ACTIVE
+HAMPTONSC.GOV,City,Non-Federal Agency,Hampton,SC,ACTIVE
+HAMPTONVA.GOV,City,Non-Federal Agency,Hampton,VA,ACTIVE
+HANKSVILLEUTAH.GOV,City,Non-Federal Agency,Hanksville,UT,ACTIVE
+HANNIBAL-MO.GOV,City,Non-Federal Agency,Hannibal,MO,ACTIVE
+HANOVER-MA.GOV,City,Non-Federal Agency,Hanover,MA,ACTIVE
+HANOVERVA.GOV,City,Non-Federal Agency,Hanover,VA,ACTIVE
+HANSON-MA.GOV,City,Non-Federal Agency,Hanson,MA,ACTIVE
+HAPPYVALLEYOR.GOV,City,Non-Federal Agency,Happy Valley,OR,ACTIVE
+HARMARTOWNSHIP-PA.GOV,City,Non-Federal Agency,Freeport,PA,ACTIVE
+HARMONYTWP-NJ.GOV,City,Non-Federal Agency,Phillipsburg,NJ,ACTIVE
+HARPERCOUNTYKS.GOV,City,Non-Federal Agency,Anthony,KS,ACTIVE
+HARRAH-OK.GOV,City,Non-Federal Agency,Harrah,OK,ACTIVE
+HARRINGTONPARKNJ.GOV,City,Non-Federal Agency,HARRINGTON PARK,NJ,ACTIVE
+HARRISBURGPA.GOV,City,Non-Federal Agency,Harrisburg,PA,ACTIVE
+HARRISBURGSD.GOV,City,Non-Federal Agency,Harrisburg,SD,ACTIVE
+HARRISON-NY.GOV,City,Non-Federal Agency,Harrison,NY,ACTIVE
+HARRISONBURGVA.GOV,City,Non-Federal Agency,Harrisonburg,VA,ACTIVE
+HARRISONOH.GOV,City,Non-Federal Agency,Harrison,OH,ACTIVE
+HARRISONOHIO.GOV,City,Non-Federal Agency,Harrison,OH,ACTIVE
+HARRISONTWP-PA.GOV,City,Non-Federal Agency,Natrona Heights,PA,ACTIVE
+HARTFORD.GOV,City,Non-Federal Agency,Hartford,CT,ACTIVE
+HARTSVILLESC.GOV,City,Non-Federal Agency,Hartsville,SC,ACTIVE
+HARWICH-MA.GOV,City,Non-Federal Agency,Harwich,MA,ACTIVE
+HASTINGSMN.GOV,City,Non-Federal Agency,Hastings,MN,ACTIVE
+HAVERHILLMA.GOV,City,Non-Federal Agency,Haverhill,MA,ACTIVE
+HAVREDEGRACEMD.GOV,City,Non-Federal Agency,Havre de Grace,MD,ACTIVE
+HAWTHORNECA.GOV,City,Non-Federal Agency,Hawthorne,CA,ACTIVE
+HAYDEN-CO.GOV,City,Non-Federal Agency,Hayden,CO,ACTIVE
+HAYESTOWNSHIPMI.GOV,City,Non-Federal Agency,Charlevoix,MI,ACTIVE
+HAYSIVIRGINIA.GOV,City,Non-Federal Agency,Haysi,VA,ACTIVE
+HAYWARD-CA.GOV,City,Non-Federal Agency,Hayward,CA,ACTIVE
+HAZARDKY.GOV,City,Non-Federal Agency,Hazard,KY,ACTIVE
+HAZLEHURSTGA.GOV,City,Non-Federal Agency,Hazlehurst,GA,ACTIVE
+HEADOFTHEHARBORNY.GOV,City,Non-Federal Agency,Saint James,NY,ACTIVE
+HEATHOHIO.GOV,City,Non-Federal Agency,Heath,OH,ACTIVE
+HEDWIGTX.GOV,City,Non-Federal Agency,Houston,TX,ACTIVE
+HELENAMT.GOV,City,Non-Federal Agency,Helena,MT,ACTIVE
+HELOTES-TX.GOV,City,Non-Federal Agency,Helotes,TX,ACTIVE
+HENDERSONNEVADA.GOV,City,Non-Federal Agency,Henderson,NV,ACTIVE
+HENDERSONNV.GOV,City,Non-Federal Agency,Henderson,NV,ACTIVE
+HENDERSONTN.GOV,City,Non-Federal Agency,Henderson,TN,ACTIVE
+HENDERSONVILLENC.GOV,City,Non-Federal Agency,Hendersonville,NC,ACTIVE
+HEREFORD-TX.GOV,City,Non-Federal Agency,Hereford,TX,ACTIVE
+HERNDON-VA.GOV,City,Non-Federal Agency,Herndon,VA,ACTIVE
+HEYWORTH-IL.GOV,City,Non-Federal Agency,Heyworth,IL,ACTIVE
+HIALEAHFL.GOV,City,Non-Federal Agency,Hialeah,FL,ACTIVE
+HIAWASSEEGA.GOV,City,Non-Federal Agency,Hiawassee,GA,ACTIVE
+HICKORYCREEK-TX.GOV,City,Non-Federal Agency,Hickory Creek,TX,ACTIVE
+HICKORYNC.GOV,City,Non-Federal Agency,Hickory,NC,ACTIVE
+HIDEOUTUTAH.GOV,City,Non-Federal Agency,Hideout,UT,ACTIVE
+HIGHLANDHEIGHTS-KY.GOV,City,Non-Federal Agency,Highland Heights,KY,ACTIVE
+HIGHLANDIL.GOV,City,Non-Federal Agency,Highland,IL,ACTIVE
+HIGHLANDS-NY.GOV,City,Non-Federal Agency,Highland Falls,NY,ACTIVE
+HIGHPOINT-NC.GOV,City,Non-Federal Agency,High Point,NC,ACTIVE
+HIGHPOINTNC.GOV,City,Non-Federal Agency,High Point,NC,ACTIVE
+HILLIARDOHIO.GOV,City,Non-Federal Agency,Hilliard,OH,ACTIVE
+HILLSBORO-OREGON.GOV,City,Non-Federal Agency,HILLSBORO,OR,ACTIVE
+HILLSBOROUGHNC.GOV,City,Non-Federal Agency,Hillsborough,NC,ACTIVE
+HILTONHEADISLANDSC.GOV,City,Non-Federal Agency,Hilton Head Island,SC,ACTIVE
+HINGHAM-MA.GOV,City,Non-Federal Agency,Hingham,MA,ACTIVE
+HIRAM-GA.GOV,City,Non-Federal Agency,Hiram,GA,ACTIVE
+HOBOKENNJ.GOV,City,Non-Federal Agency,Hoboken,NJ,ACTIVE
+HOLBROOKMA.GOV,City,Non-Federal Agency,Holbrook,MA,ACTIVE
+HOLDEN-MA.GOV,City,Non-Federal Agency,Holden,MA,ACTIVE
+HOLDENMA.GOV,City,Non-Federal Agency,HOLDEN,MA,ACTIVE
+HOLDERNESS-NH.GOV,City,Non-Federal Agency,Holderness,NH,ACTIVE
+HOLLANDTOWNSHIPNJ.GOV,City,Non-Federal Agency,Milford,NJ,ACTIVE
+HOLLYWOODPARK-TX.GOV,City,Non-Federal Agency,Hollywood Park,TX,ACTIVE
+HOMERGLENIL.GOV,City,Non-Federal Agency,Homer Glen,IL,ACTIVE
+HOMEWOODIL.GOV,City,Non-Federal Agency,Homewood,IL,ACTIVE
+HONDO-TX.GOV,City,Non-Federal Agency,Hondo,TX,ACTIVE
+HOOPESTON-IL.GOV,City,Non-Federal Agency,Hoopeston,IL,ACTIVE
+HOOVERAL.GOV,City,Non-Federal Agency,Hoover,AL,ACTIVE
+HOOVERALABAMA.GOV,City,Non-Federal Agency,Hoover,AL,ACTIVE
+HOPEDALE-MA.GOV,City,Non-Federal Agency,Hopedale,MA,ACTIVE
+HOPEWELLVA.GOV,City,Non-Federal Agency,HOPEWELL,VA,ACTIVE
+HOPKINSPARK-IL.GOV,City,Non-Federal Agency,Hopkins Park,IL,ACTIVE
+HOPKINSVILLE-KY.GOV,City,Non-Federal Agency,Hopkinsville,KY,ACTIVE
+HOPKINTON-NH.GOV,City,Non-Federal Agency,Hopkinton,NH,ACTIVE
+HOPKINTONMA.GOV,City,Non-Federal Agency,Hopkinton,MA,ACTIVE
+HORICONNY.GOV,City,Non-Federal Agency,Brant Lake,NY,ACTIVE
+HORIZONCITY-TX.GOV,City,Non-Federal Agency,Horizon City,TX,ACTIVE
+HORSESHOE-BAY-TX.GOV,City,Non-Federal Agency,Horseshoe Bay,TX,ACTIVE
+HOUSTON-AK.GOV,City,Non-Federal Agency,Houston,AK,ACTIVE
+HOUSTONTX.GOV,City,Non-Federal Agency,Houston,TX,ACTIVE
+HPCA.GOV,City,Non-Federal Agency,Huntington Park,CA,ACTIVE
+HRPDCVA.GOV,City,Non-Federal Agency,Chesapeake,VA,ACTIVE
+HUACHUCACITYAZ.GOV,City,Non-Federal Agency,Huachuca City,AZ,ACTIVE
+HUDSONNH.GOV,City,Non-Federal Agency,Hudson,NH,ACTIVE
+HUETTER-ID.GOV,City,Non-Federal Agency,POST FALLS,ID,ACTIVE
+HULMEVILLE-PA.GOV,City,Non-Federal Agency,Hulmeville,PA,ACTIVE
+HUMBLETX.GOV,City,Non-Federal Agency,Humble,TX,ACTIVE
+HUNTINGBURG-IN.GOV,City,Non-Federal Agency,Huntingburg,IN,ACTIVE
+HUNTINGTONBEACHCA.GOV,City,Non-Federal Agency,Huntington Beach,CA,ACTIVE
+HUNTINGTONNY.GOV,City,Non-Federal Agency,Huntington,NY,ACTIVE
+HUNTSPOINT-WA.GOV,City,Non-Federal Agency,Hunts Point,WA,ACTIVE
+HUNTSVILLEAL.GOV,City,Non-Federal Agency,Huntsville,AL,ACTIVE
+HUNTSVILLETX.GOV,City,Non-Federal Agency,Huntsville,TX,ACTIVE
+HURLOCK-MD.GOV,City,Non-Federal Agency,Hurlock,MD,ACTIVE
+HURONTOWNSHIP-MI.GOV,City,Non-Federal Agency,New Boston,MI,ACTIVE
+HURST-TEXAS.GOV,City,Non-Federal Agency,Hurst,TX,ACTIVE
+HURSTTX.GOV,City,Non-Federal Agency,Hurst,TX,ACTIVE
+HUTTOTX.GOV,City,Non-Federal Agency,Hutto,TX,ACTIVE
+HVLNC.GOV,City,Non-Federal Agency,Hendersonville,NC,ACTIVE
+IDABEL-OK.GOV,City,Non-Federal Agency,Idabel,OK,ACTIVE
+IDAHOFALLSIDAHO.GOV,City,Non-Federal Agency,Idaho Falls,ID,ACTIVE
+ILWACO-WA.GOV,City,Non-Federal Agency,Ilwaco,WA,ACTIVE
+IMPERIALBEACHCA.GOV,City,Non-Federal Agency,Imperial Beach,CA,ACTIVE
+INCLINEVILLAGE-NV.GOV,City,Non-Federal Agency,INCLINE VILLAGE,NV,ACTIVE
+INDEPENDENCEKS.GOV,City,Non-Federal Agency,INDEPENDENCE,KS,ACTIVE
+INDEPENDENCEMO.GOV,City,Non-Federal Agency,Independence,MO,ACTIVE
+INDEPENDENCEOHIO.GOV,City,Non-Federal Agency,Independence,OH,ACTIVE
+INDIANAPOLIS-IN.GOV,City,Non-Federal Agency,Indianapolis,IN,ACTIVE
+INDIANHEADPARK-IL.GOV,City,Non-Federal Agency,Indian Head Park,IL,ACTIVE
+INDIANOLAIOWA.GOV,City,Non-Federal Agency,Indianola,IA,ACTIVE
+INDIANOLAMS.GOV,City,Non-Federal Agency,Indianola,MS,ACTIVE
+INDIANPOINT-MO.GOV,City,Non-Federal Agency,Branson,MO,ACTIVE
+INDY.GOV,City,Non-Federal Agency,Indianapolis,IN,ACTIVE
+INGLESIDETX.GOV,City,Non-Federal Agency,Ingleside,TX,ACTIVE
+INTERLACHEN-FL.GOV,City,Non-Federal Agency,Interlachen,FL,ACTIVE
+INVERNESS-FL.GOV,City,Non-Federal Agency,Inverness,FL,ACTIVE
+INVERNESS-IL.GOV,City,Non-Federal Agency,Inverness,IL,ACTIVE
+IPSWICH-MA.GOV,City,Non-Federal Agency,Ipswich,MA,ACTIVE
+IPSWICHMA.GOV,City,Non-Federal Agency,Ipswich,MA,ACTIVE
+IRONTONMO.GOV,City,Non-Federal Agency,Ironton,MO,ACTIVE
+IRVINGTONNY.GOV,City,Non-Federal Agency,Irvington,NY,ACTIVE
+IRWINDALECA.GOV,City,Non-Federal Agency,Irwindale,CA,ACTIVE
+ISLIP-NY.GOV,City,Non-Federal Agency,Islip,NY,ACTIVE
+ISLIPNY.GOV,City,Non-Federal Agency,Islip,NY,ACTIVE
+ISLIPTOWN-NY.GOV,City,Non-Federal Agency,Islip,NY,ACTIVE
+ISSAQUAHWA.GOV,City,Non-Federal Agency,Issaquah,WA,ACTIVE
+JACINTOCITY-TX.GOV,City,Non-Federal Agency,Jacinto City,TX,ACTIVE
+JACKSON-SC.GOV,City,Non-Federal Agency,Jackson,SC,ACTIVE
+JACKSONMS.GOV,City,Non-Federal Agency,Jackson,MS,ACTIVE
+JACKSONTOWNSHIP-PA.GOV,City,Non-Federal Agency,Myerstown,PA,ACTIVE
+JACKSONTOWNSHIPPA.GOV,City,Non-Federal Agency,Jackson Township,PA,ACTIVE
+JACKSONTWP-PA.GOV,City,Non-Federal Agency,Reeders,PA,ACTIVE
+JACKSONVILLENC.GOV,City,Non-Federal Agency,Jacksonville,NC,ACTIVE
+JAMESTOWN-NC.GOV,City,Non-Federal Agency,Jamestown,NC,ACTIVE
+JAMESTOWNRI.GOV,City,Non-Federal Agency,Jamestown,RI,ACTIVE
+JAMESTOWNTN.GOV,City,Non-Federal Agency,Jamestown,TN,ACTIVE
+JANESVILLEMN.GOV,City,Non-Federal Agency,Janesville,MN,ACTIVE
+JEFFERSONCITYMO.GOV,City,Non-Federal Agency,Jefferson City,MO,ACTIVE
+JEFFERSONTOWNKY.GOV,City,Non-Federal Agency,Jeffersontown,KY,ACTIVE
+JEMEZSPRINGS-NM.GOV,City,Non-Federal Agency,Jemez Springs,NM,ACTIVE
+JERICHOVT.GOV,City,Non-Federal Agency,Jericho,VT,ACTIVE
+JEROME-OH.GOV,City,Non-Federal Agency,Plain City,OH,ACTIVE
+JERSEYCITYNJ.GOV,City,Non-Federal Agency,Jersey City,NJ,ACTIVE
+JESUPGA.GOV,City,Non-Federal Agency,Jesup,GA,ACTIVE
+JOHNSCREEKGA.GOV,City,Non-Federal Agency,Johns Creek,GA,ACTIVE
+JOHNSONCITYTN.GOV,City,Non-Federal Agency,Johnson City,TN,ACTIVE
+JONESVILLENC.GOV,City,Non-Federal Agency,Jonesville,NC,ACTIVE
+JORDANMN.GOV,City,Non-Federal Agency,Jordan,MN,ACTIVE
+JUNCTIONCITY-KS.GOV,City,Non-Federal Agency,Junction City,KS,ACTIVE
+JUNCTIONCITYOREGON.GOV,City,Non-Federal Agency,Junction City,OR,ACTIVE
+JUPITERFL.GOV,City,Non-Federal Agency,Jupiter,FL,ACTIVE
+KANNAPOLISNC.GOV,City,Non-Federal Agency,Concord,NC,ACTIVE
+KANSASCITYMO.GOV,City,Non-Federal Agency,Kansas City,MO,ACTIVE
+KCMO.GOV,City,Non-Federal Agency,Kansas City,MO,ACTIVE
+KEANSBURGNJ.GOV,City,Non-Federal Agency,Keansburg,NJ,ACTIVE
+KELSO.GOV,City,Non-Federal Agency,Kelso,WA,ACTIVE
+KEMAH-TX.GOV,City,Non-Federal Agency,Kemah,TX,ACTIVE
+KENMOREWA.GOV,City,Non-Federal Agency,Kenmore,WA,ACTIVE
+KENNEBUNKPORTME.GOV,City,Non-Federal Agency,Kennebunkport,ME,ACTIVE
+KENNESAW-GA.GOV,City,Non-Federal Agency,Kennesaw,GA,ACTIVE
+KENTWA.GOV,City,Non-Federal Agency,Kent,WA,ACTIVE
+KERRVILLETX.GOV,City,Non-Federal Agency,Kerrville,TX,ACTIVE
+KILLEENTEXAS.GOV,City,Non-Federal Agency,Killeen,TX,ACTIVE
+KILLINGLYCT.GOV,City,Non-Federal Agency,Danielson,CT,ACTIVE
+KINDERHOOK-NY.GOV,City,Non-Federal Agency,Niverville,NY,ACTIVE
+KINGSLANDGA.GOV,City,Non-Federal Agency,Kingsland,GA,ACTIVE
+KINGSPORTTN.GOV,City,Non-Federal Agency,Kingsport,TN,ACTIVE
+KINGSTON-NY.GOV,City,Non-Federal Agency,Kingston,NY,ACTIVE
+KINGSTONSPRINGS-TN.GOV,City,Non-Federal Agency,Kingston Springs,TN,ACTIVE
+KINROSSTOWNSHIP-MI.GOV,City,Non-Federal Agency,Kincheloe,MI,ACTIVE
+KINSTONNC.GOV,City,Non-Federal Agency,Kinston,NC,ACTIVE
+KIRKLANDWA.GOV,City,Non-Federal Agency,Kirkland,WA,ACTIVE
+KISSIMMEE-FL.GOV,City,Non-Federal Agency,Kissimmee,FL,ACTIVE
+KISSIMMEEFL.GOV,City,Non-Federal Agency,Kissimmee,FL,ACTIVE
+KITTERYME.GOV,City,Non-Federal Agency,Kittery,ME,ACTIVE
+KITTYHAWKNC.GOV,City,Non-Federal Agency,Kitty Hawk,NC,ACTIVE
+KNIGHTDALENC.GOV,City,Non-Federal Agency,Knightdale,NC,ACTIVE
+KNOXVILLEIA.GOV,City,Non-Federal Agency,Knoxville,IA,ACTIVE
+KNOXVILLEIOWA.GOV,City,Non-Federal Agency,Knoxville,IA,ACTIVE
+KNOXVILLETN.GOV,City,Non-Federal Agency,Knoxville,TN,ACTIVE
+KUNAID.GOV,City,Non-Federal Agency,Kuna,ID,ACTIVE
+LACKAWANNANY.GOV,City,Non-Federal Agency,Lackawanna,NY,ACTIVE
+LACKAWAXENTOWNSHIPPA.GOV,City,Non-Federal Agency,Hawley,PA,ACTIVE
+LAFOLLETTETN.GOV,City,Non-Federal Agency,LaFollette,TN,ACTIVE
+LAGRANGEGA.GOV,City,Non-Federal Agency,LaGrange,GA,ACTIVE
+LAGRANGENY.GOV,City,Non-Federal Agency,Lagrangeville,NY,ACTIVE
+LAGUNAHILLSCA.GOV,City,Non-Federal Agency,Laguna Hills,CA,ACTIVE
+LAHABRACA.GOV,City,Non-Federal Agency,LA HABRA,CA,ACTIVE
+LAKEFORESTCA.GOV,City,Non-Federal Agency,Lake Forest,CA,ACTIVE
+LAKEGROVENY.GOV,City,Non-Federal Agency,Lake Grove,NY,ACTIVE
+LAKEJACKSON-TX.GOV,City,Non-Federal Agency,Lake Jackson,TX,ACTIVE
+LAKEJACKSONTX.GOV,City,Non-Federal Agency,Lake Jackson,TX,ACTIVE
+LAKELANDGA.GOV,City,Non-Federal Agency,Lakeland,GA,ACTIVE
+LAKELANDTN.GOV,City,Non-Federal Agency,Lakeland,TN,ACTIVE
+LAKEPARKNC.GOV,City,Non-Federal Agency,Indian Trail,NC,ACTIVE
+LAKEPROVIDENCELA.GOV,City,Non-Federal Agency,Lake Providence,LA,ACTIVE
+LAKESITETN.GOV,City,Non-Federal Agency,Lakesite,TN,ACTIVE
+LAKESTATION-IN.GOV,City,Non-Federal Agency,Lake Station,IN,ACTIVE
+LAKESTEVENSWA.GOV,City,Non-Federal Agency,Lake Stevens,WA,ACTIVE
+LAKEVILLE-MN.GOV,City,Non-Federal Agency,Lakeville,MN,ACTIVE
+LAKEVILLEMN.GOV,City,Non-Federal Agency,Lakeville,MN,ACTIVE
+LAKEVILLEMNFIRE.GOV,City,Non-Federal Agency,Lakeville,MN,ACTIVE
+LAKEWAY-TX.GOV,City,Non-Federal Agency,Lakeway,TX,ACTIVE
+LAKEWOODNJ.GOV,City,Non-Federal Agency,Lakewood,NJ,ACTIVE
+LANCASTERCITYSC.GOV,City,Non-Federal Agency,Lancaster,SC,ACTIVE
+LANCASTERNY.GOV,City,Non-Federal Agency,Lancaster,NY,ACTIVE
+LANESBORO-MN.GOV,City,Non-Federal Agency,Lanesboro,MN,ACTIVE
+LANESBOROUGH-MA.GOV,City,Non-Federal Agency,LANESBOROUGH,MA,ACTIVE
+LANSINGMI.GOV,City,Non-Federal Agency,Lansing,MI,ACTIVE
+LANTABUS-PA.GOV,City,Non-Federal Agency,Allentown,PA,ACTIVE
+LAPORTETX.GOV,City,Non-Federal Agency,La Porte,TX,ACTIVE
+LAREDOTEXAS.GOV,City,Non-Federal Agency,Laredo,TX,ACTIVE
+LASALLE-IL.GOV,City,Non-Federal Agency,LaSalle,IL,ACTIVE
+LASVEGASNEVADA.GOV,City,Non-Federal Agency,Las Vegas,NV,ACTIVE
+LASVEGASNM.GOV,City,Non-Federal Agency,Las Vegas,NM,ACTIVE
+LAUDERDALEBYTHESEA-FL.GOV,City,Non-Federal Agency,Lauderdale By The Sea,FL,ACTIVE
+LAUDERHILL-FL.GOV,City,Non-Federal Agency,Lauderhill,FL,ACTIVE
+LAUDERHILLFL.GOV,City,Non-Federal Agency,Lauderhill,FL,ACTIVE
+LAVERGNETN.GOV,City,Non-Federal Agency,La Vergne,TN,ACTIVE
+LAVERNIA-TX.GOV,City,Non-Federal Agency,La Vernia,TX,ACTIVE
+LAWRENCEBURGTN.GOV,City,Non-Federal Agency,Lawrenceburg,TN,ACTIVE
+LAWTONMI.GOV,City,Non-Federal Agency,Lawton,MI,ACTIVE
+LAWTONOK.GOV,City,Non-Federal Agency,Lawton,OK,ACTIVE
+LBTS-FL.GOV,City,Non-Federal Agency,Lauderdale-By-The-Sea,FL,ACTIVE
+LEADVILLE-CO.GOV,City,Non-Federal Agency,Leadville,CO,ACTIVE
+LEAGUECITY-TX.GOV,City,Non-Federal Agency,League City,TX,ACTIVE
+LEAGUECITYTX.GOV,City,Non-Federal Agency,League City,TX,ACTIVE
+LEANDERTX.GOV,City,Non-Federal Agency,Leander,TX,ACTIVE
+LEBANONCT.GOV,City,Non-Federal Agency,Lebanon,CT,ACTIVE
+LEBANONNH.GOV,City,Non-Federal Agency,Lebanon,NH,ACTIVE
+LEBANONOHIO.GOV,City,Non-Federal Agency,Lebanon,OH,ACTIVE
+LECLAIREIOWA.GOV,City,Non-Federal Agency,LECLAIRE,IA,ACTIVE
+LEEDSALABAMA.GOV,City,Non-Federal Agency,Leeds,AL,ACTIVE
+LEESBURGFLORIDA.GOV,City,Non-Federal Agency,Leesburg,FL,ACTIVE
+LEESBURGVA.GOV,City,Non-Federal Agency,Leesburg,VA,ACTIVE
+LEESVILLELA.GOV,City,Non-Federal Agency,LEESVILLE,LA,ACTIVE
+LEHI-UT.GOV,City,Non-Federal Agency,Lehi,UT,ACTIVE
+LENEXA-KS.GOV,City,Non-Federal Agency,Lenexa,KS,ACTIVE
+LENOIR-NC.GOV,City,Non-Federal Agency,Lenoir,NC,ACTIVE
+LENOIRCITYTN.GOV,City,Non-Federal Agency,Lenoir City,TN,ACTIVE
+LEOMINSTER-MA.GOV,City,Non-Federal Agency,Leominster,MA,ACTIVE
+LEONIANJ.GOV,City,Non-Federal Agency,Leonia,NJ,ACTIVE
+LEONVALLEYTEXAS.GOV,City,Non-Federal Agency,Leon Valley,TX,ACTIVE
+LEROYTOWNSHIP-MI.GOV,City,Non-Federal Agency,Webberville,MI,ACTIVE
+LETSMOVEBRIDGEPORTCT.GOV,City,Non-Federal Agency,Bridgeport,CT,ACTIVE
+LEWISBURGTN.GOV,City,Non-Federal Agency,Lewisburg,TN,ACTIVE
+LEWISTONMAINE.GOV,City,Non-Federal Agency,Lewiston,ME,ACTIVE
+LEXINGTONKY.GOV,City,Non-Federal Agency,lexington,KY,ACTIVE
+LEXINGTONNC.GOV,City,Non-Federal Agency,Lexington,NC,ACTIVE
+LEXINGTONTN.GOV,City,Non-Federal Agency,Lexington,TN,ACTIVE
+LEXINGTONVA.GOV,City,Non-Federal Agency,Lexington,VA,ACTIVE
+LHCAZ.GOV,City,Non-Federal Agency,Lake Havasu City,AZ,ACTIVE
+LIBERTYHILLTX.GOV,City,Non-Federal Agency,Liberty Hill,TX,ACTIVE
+LIBERTYIN.GOV,City,Non-Federal Agency,Liberty,IN,ACTIVE
+LIBERTYLAKEWA.GOV,City,Non-Federal Agency,Liberty Lake,WA,ACTIVE
+LIBERTYMISSOURI.GOV,City,Non-Federal Agency,Liberty,MO,ACTIVE
+LIBERTYMO.GOV,City,Non-Federal Agency,Liberty,MO,ACTIVE
+LIMERICK-ME.GOV,City,Non-Federal Agency,Limerick,ME,ACTIVE
+LINCOLNCA.GOV,City,Non-Federal Agency,Lincoln,CA,ACTIVE
+LINCOLNIL.GOV,City,Non-Federal Agency,Lincoln,IL,ACTIVE
+LINCOLNSHIREIL.GOV,City,Non-Federal Agency,Lincolnshire,IL,ACTIVE
+LINDALE-TX.GOV,City,Non-Federal Agency,Lindale,TX,ACTIVE
+LINDALETX.GOV,City,Non-Federal Agency,Lindale,TX,ACTIVE
+LINDENWOLDNJ.GOV,City,Non-Federal Agency,Lindenwold,NJ,ACTIVE
+LINNDALEVILLAGE-OH.GOV,City,Non-Federal Agency,Linndale,OH,ACTIVE
+LINTON-IN.GOV,City,Non-Federal Agency,Linton,IN,ACTIVE
+LITCHFIELD-NH.GOV,City,Non-Federal Agency,Litchfield,NH,ACTIVE
+LITCHFIELDNH.GOV,City,Non-Federal Agency,Litchfield,NH,ACTIVE
+LITTLEROCKAR.GOV,City,Non-Federal Agency,Little Rock,AR,ACTIVE
+LOCKHAVENPA.GOV,City,Non-Federal Agency,Lock Haven,PA,ACTIVE
+LOCKPORTNY.GOV,City,Non-Federal Agency,Lockport,NY,ACTIVE
+LOCUSTGROVE-GA.GOV,City,Non-Federal Agency,Locust Grove,GA,ACTIVE
+LODI.GOV,City,Non-Federal Agency,Lodi,CA,ACTIVE
+LODICA.GOV,City,Non-Federal Agency,Lodi,CA,ACTIVE
+LOGANCO.GOV,City,Non-Federal Agency,Sterling,CO,ACTIVE
+LOGANTOWNSHIP-PA.GOV,City,Non-Federal Agency,Altoona,PA,ACTIVE
+LOGANVILLE-GA.GOV,City,Non-Federal Agency,Loganville,GA,ACTIVE
+LOMALINDA-CA.GOV,City,Non-Federal Agency,Loma Linda,CA,ACTIVE
+LONDONBRITAINTOWNSHIP-PA.GOV,City,Non-Federal Agency,Landenberg,PA,ACTIVE
+LONDONKY.GOV,City,Non-Federal Agency,London,KY,ACTIVE
+LONEOAKTX.GOV,City,Non-Federal Agency,LONE OAK,TX,ACTIVE
+LONGBEACH.GOV,City,Non-Federal Agency,Long Beach,CA,ACTIVE
+LONGBEACHNY.GOV,City,Non-Federal Agency,Long Beach,NY,ACTIVE
+LONGBEACHWA.GOV,City,Non-Federal Agency,Long Beach,WA,ACTIVE
+LONGHILLNJ.GOV,City,Non-Federal Agency,Long Hill,NJ,ACTIVE
+LONGLAKEMN.GOV,City,Non-Federal Agency,Long Lake,MN,ACTIVE
+LONGMONTCOLORADO.GOV,City,Non-Federal Agency,Longmont,CO,ACTIVE
+LONGPORTNJ.GOV,City,Non-Federal Agency,Longport,NJ,ACTIVE
+LONGVIEW-WA.GOV,City,Non-Federal Agency,Longview,WA,ACTIVE
+LONGVIEWTEXAS.GOV,City,Non-Federal Agency,Longview,TX,ACTIVE
+LONGVIEWTX.GOV,City,Non-Federal Agency,Longview,TX,ACTIVE
+LONGVIEWWA.GOV,City,Non-Federal Agency,Longview,WA,ACTIVE
+LORENATX.GOV,City,Non-Federal Agency,Lorena,TX,ACTIVE
+LOSALTOSCA.GOV,City,Non-Federal Agency,Los Altos,CA,ACTIVE
+LOSANGELES-CA.GOV,City,Non-Federal Agency,Los Angeles,CA,ACTIVE
+LOSGATOSCA.GOV,City,Non-Federal Agency,Los Gatos,CA,ACTIVE
+LOSLUNASNM.GOV,City,Non-Federal Agency,Los Lunas,NM,ACTIVE
+LOSRANCHOSNM.GOV,City,Non-Federal Agency,Los Ranchos de Albuquerque,NM,ACTIVE
+LOTT-TX.GOV,City,Non-Federal Agency,Lott,TX,ACTIVE
+LOUISBURGKANSAS.GOV,City,Non-Federal Agency,Louisburg,KS,ACTIVE
+LOUISVILLECO.GOV,City,Non-Federal Agency,Louisville,CO,ACTIVE
+LOUISVILLEKY.GOV,City,Non-Federal Agency,Louisville,KY,ACTIVE
+LOUISVILLETN.GOV,City,Non-Federal Agency,Louisville,TN,ACTIVE
+LOVEJOY-GA.GOV,City,Non-Federal Agency,Lovejoy,GA,ACTIVE
+LOVETTSVILLEVA.GOV,City,Non-Federal Agency,Lovettsville,VA,ACTIVE
+LOVINGTON-IL.GOV,City,Non-Federal Agency,Lovington,IL,ACTIVE
+LOWELL-OR.GOV,City,Non-Federal Agency,Lowell,OR,ACTIVE
+LOWELLARKANSAS.GOV,City,Non-Federal Agency,Lowell,AR,ACTIVE
+LOWERALLOWAYSCREEK-NJ.GOV,City,Non-Federal Agency,Hancocks Bridge,NJ,ACTIVE
+LOWERPAXTON-PA.GOV,City,Non-Federal Agency,Harrisburg,PA,ACTIVE
+LUBBOCKTX.GOV,City,Non-Federal Agency,Lubbock,TX,ACTIVE
+LUDINGTON-MI.GOV,City,Non-Federal Agency,Ludington,MI,ACTIVE
+LUNENBURGMA.GOV,City,Non-Federal Agency,Lunenburg,MA,ACTIVE
+LYMAN-ME.GOV,City,Non-Federal Agency,Lyman,ME,ACTIVE
+LYMANSC.GOV,City,Non-Federal Agency,Lyman,SC,ACTIVE
+LYMECT.GOV,City,Non-Federal Agency,Lyme,CT,ACTIVE
+LYMENH.GOV,City,Non-Federal Agency,Lyme,NH,ACTIVE
+LYNCHBURGVA.GOV,City,Non-Federal Agency,Lynchburg,VA,ACTIVE
+LYNDEBOROUGHNH.GOV,City,Non-Federal Agency,Lyndeborough,NH,ACTIVE
+LYNDONKS.GOV,City,Non-Federal Agency,Lyndon,KS,ACTIVE
+LYNNMA.GOV,City,Non-Federal Agency,Lynn,MA,ACTIVE
+LYNNWOODWA.GOV,City,Non-Federal Agency,Lynnwood,WA,ACTIVE
+LYONSTOWNSHIPIL.GOV,City,Non-Federal Agency,Countryside,IL,ACTIVE
+MACOMB-MI.GOV,City,Non-Federal Agency,Macomb,MI,ACTIVE
+MACONGA.GOV,City,Non-Federal Agency,Macon,GA,ACTIVE
+MADEIRABEACHFL.GOV,City,Non-Federal Agency,Madeira Beach,FL,ACTIVE
+MADERA-CA.GOV,City,Non-Federal Agency,Madera,CA,ACTIVE
+MADISON-AL.GOV,City,Non-Federal Agency,Madison,AL,ACTIVE
+MADISON-IN.GOV,City,Non-Federal Agency,Madison,IN,ACTIVE
+MADISONAL.GOV,City,Non-Federal Agency,Madison,AL,ACTIVE
+MADISONLAKEMN.GOV,City,Non-Federal Agency,Madison LAke,MN,ACTIVE
+MAHARISHIVEDICCITY-IOWA.GOV,City,Non-Federal Agency,Maharishi Vedic City,IA,ACTIVE
+MAHOMET-IL.GOV,City,Non-Federal Agency,Mahomet,IL,ACTIVE
+MAHWAH-NJ.GOV,City,Non-Federal Agency,Mahwah,NJ,ACTIVE
+MAIDENNC.GOV,City,Non-Federal Agency,Maiden,NC,ACTIVE
+MALIBU-CA.GOV,City,Non-Federal Agency,Malibu,CA,ACTIVE
+MALVERNAR.GOV,City,Non-Federal Agency,Malvern,AR,ACTIVE
+MAMARONECK-NY.GOV,City,Non-Federal Agency,Mamaroneck,NY,ACTIVE
+MAMARONECKVILLAGENY.GOV,City,Non-Federal Agency,Mamaroneck,NY,ACTIVE
+MANASQUAN-NJ.GOV,City,Non-Federal Agency,MANASQUAN,NJ,ACTIVE
+MANASSASPARKVA.GOV,City,Non-Federal Agency,Manassas Park,VA,ACTIVE
+MANASSASVA.GOV,City,Non-Federal Agency,Manassas,VA,ACTIVE
+MANCHESTER-GA.GOV,City,Non-Federal Agency,Manchester,GA,ACTIVE
+MANCHESTER-VT.GOV,City,Non-Federal Agency,Manchester Center,VT,ACTIVE
+MANCHESTERCT.GOV,City,Non-Federal Agency,Manchester,CT,ACTIVE
+MANCHESTERMD.GOV,City,Non-Federal Agency,MANCHESTER,MD,ACTIVE
+MANCHESTERMO.GOV,City,Non-Federal Agency,Manchester,MO,ACTIVE
+MANCHESTERNH.GOV,City,Non-Federal Agency,Manchester,NH,ACTIVE
+MANISTEEMI.GOV,City,Non-Federal Agency,Traverse City,MI,ACTIVE
+MANITOUSPRINGS-CO.GOV,City,Non-Federal Agency,Colorado Springs,CO,ACTIVE
+MANKATO-MN.GOV,City,Non-Federal Agency,Mankato,MN,ACTIVE
+MANKATOMN.GOV,City,Non-Federal Agency,Mankato,MN,ACTIVE
+MANSFIELD-TX.GOV,City,Non-Federal Agency,Mansfield,TX,ACTIVE
+MANSFIELDCT.GOV,City,Non-Federal Agency,Mansfield,CT,ACTIVE
+MANSFIELDGA.GOV,City,Non-Federal Agency,Mans,GA,ACTIVE
+MANSFIELDTEXAS.GOV,City,Non-Federal Agency,Mansfield,TX,ACTIVE
+MANSFIELDTOWNSHIP-NJ.GOV,City,Non-Federal Agency,Port Murray,NJ,ACTIVE
+MANTUATOWNSHIPOHIO.GOV,City,Non-Federal Agency,Mantua,OH,ACTIVE
+MAPLEGROVEMN.GOV,City,Non-Federal Agency,Maple Grove,MN,ACTIVE
+MAPLEVALLEYWA.GOV,City,Non-Federal Agency,Maple Valley,WA,ACTIVE
+MAPLEWOODMN.GOV,City,Non-Federal Agency,Maplewood,MN,ACTIVE
+MARANAAZ.GOV,City,Non-Federal Agency,Marana,AZ,ACTIVE
+MARBLEFALLSTX.GOV,City,Non-Federal Agency,Marble Falls,TX,ACTIVE
+MARICOPA-AZ.GOV,City,Non-Federal Agency,Maricopa,AZ,ACTIVE
+MARIONKY.GOV,City,Non-Federal Agency,Marion,KY,ACTIVE
+MARIONMA.GOV,City,Non-Federal Agency,Marion,MA,ACTIVE
+MARIONSC.GOV,City,Non-Federal Agency,Marion,SC,ACTIVE
+MARKESANWI.GOV,City,Non-Federal Agency,Markesan,WI,ACTIVE
+MARLBORO-NJ.GOV,City,Non-Federal Agency,Marlboro,NJ,ACTIVE
+MARLBOROUGH-MA.GOV,City,Non-Federal Agency,Marlborough,MA,ACTIVE
+MARLOWNH.GOV,City,Non-Federal Agency,Marlow,NH,ACTIVE
+MAROAILLINOIS.GOV,City,Non-Federal Agency,Maroa,IL,ACTIVE
+MARSHALL-IL.GOV,City,Non-Federal Agency,Marshall,IL,ACTIVE
+MARSHFIELDMO.GOV,City,Non-Federal Agency,Marshfield,MO,ACTIVE
+MARTINSVILLE-VA.GOV,City,Non-Federal Agency,Martinsville,VA,ACTIVE
+MARYSVILLEWA.GOV,City,Non-Federal Agency,Marysville,WA,ACTIVE
+MARYVILLE-TN.GOV,City,Non-Federal Agency,maryville,TN,ACTIVE
+MASHPEEMA.GOV,City,Non-Federal Agency,Mashpee,MA,ACTIVE
+MASTICBEACHVILLAGENY.GOV,City,Non-Federal Agency,Mastic Beach,NY,ACTIVE
+MATTHEWSNC.GOV,City,Non-Federal Agency,Matthews,NC,ACTIVE
+MAYAGUEZPR.GOV,City,Non-Federal Agency,Mayaguez,PR,ACTIVE
+MAYFIELDKY.GOV,City,Non-Federal Agency,Mayfield,KY,ACTIVE
+MCCOMB-MS.GOV,City,Non-Federal Agency,McComb,MS,ACTIVE
+MCDONOUGH-GA.GOV,City,Non-Federal Agency,McDonough,GA,ACTIVE
+MCKEESPORT-PA.GOV,City,Non-Federal Agency,McKeesport,PA,ACTIVE
+MCKENZIETN.GOV,City,Non-Federal Agency,McKenzie,TN,ACTIVE
+MCMINNVILLEOREGON.GOV,City,Non-Federal Agency,McMinnville,OR,ACTIVE
+MCTX.GOV,City,Non-Federal Agency,Missouri City,TX,ACTIVE
+MEADOWSPLACETX.GOV,City,Non-Federal Agency,Meadows Place,TX,ACTIVE
+MECHANICVILLENY.GOV,City,Non-Federal Agency,Mechanicville,NY,ACTIVE
+MEDFORD-MA.GOV,City,Non-Federal Agency,Medford,MA,ACTIVE
+MEDINA-WA.GOV,City,Non-Federal Agency,Medina,WA,ACTIVE
+MEDINAMN.GOV,City,Non-Federal Agency,Medina,MN,ACTIVE
+MELVILLELA.GOV,City,Non-Federal Agency,Melville,LA,ACTIVE
+MEMPHISTN.GOV,City,Non-Federal Agency,Memphis,TN,ACTIVE
+MENDONMA.GOV,City,Non-Federal Agency,Mendon,MA,ACTIVE
+MENOMONIE-WI.GOV,City,Non-Federal Agency,Menomonie,WI,ACTIVE
+MENTONEALABAMA.GOV,City,Non-Federal Agency,Mentone,AL,ACTIVE
+MERCERISLANDWA.GOV,City,Non-Federal Agency,Mercer Island,WA,ACTIVE
+MERCHANTVILLENJ.GOV,City,Non-Federal Agency,Merchantville,NJ,ACTIVE
+MERIDENCT.GOV,City,Non-Federal Agency,Meriden,CT,ACTIVE
+MERRIMACKNH.GOV,City,Non-Federal Agency,Merrimack,NH,ACTIVE
+MESAAZ.GOV,City,Non-Federal Agency,Mesa,AZ,ACTIVE
+MESILLANM.GOV,City,Non-Federal Agency,Mesilla,NM,ACTIVE
+MESQUITENV.GOV,City,Non-Federal Agency,Mesquite,NV,ACTIVE
+MESQUITETX.GOV,City,Non-Federal Agency,Mesquite,TX,ACTIVE
+MIAMIAZ.GOV,City,Non-Federal Agency,Miami,AZ,ACTIVE
+MIAMIBEACHFL.GOV,City,Non-Federal Agency,Miami Beach,FL,ACTIVE
+MIAMIGARDENS-FL.GOV,City,Non-Federal Agency,Miami Gardens,FL,ACTIVE
+MIAMILAKES-FL.GOV,City,Non-Federal Agency,Miami Lakes,FL,ACTIVE
+MIAMISPRINGS-FL.GOV,City,Non-Federal Agency,Miami Springs,FL,ACTIVE
+MIAMITOWNSHIPOH.GOV,City,Non-Federal Agency,Milford,OH,ACTIVE
+MIAMITWPOH.GOV,City,Non-Federal Agency,Milford,OH,ACTIVE
+MIDDLEBURGVA.GOV,City,Non-Federal Agency,Middleburg,VA,ACTIVE
+MIDDLESEXBORO-NJ.GOV,City,Non-Federal Agency,Middlesex,NJ,ACTIVE
+MIDDLETONMA.GOV,City,Non-Federal Agency,Middleton,MA,ACTIVE
+MIDDLETONNH.GOV,City,Non-Federal Agency,Middleton,NH,ACTIVE
+MIDDLETOWN-CT.GOV,City,Non-Federal Agency,Middletown,CT,ACTIVE
+MIDDLETOWNCT.GOV,City,Non-Federal Agency,Middletown,CT,ACTIVE
+MIDDLETOWNVA.GOV,City,Non-Federal Agency,Middletown,VA,ACTIVE
+MIDLANDTEXAS.GOV,City,Non-Federal Agency,Midland,TX,ACTIVE
+MIDLOTHIANTX.GOV,City,Non-Federal Agency,Midlothian,TX,ACTIVE
+MIDWAY-NC.GOV,City,Non-Federal Agency,Winston-Salem,NC,ACTIVE
+MIFFLIN-OH.GOV,City,Non-Federal Agency,Gahanna,OH,ACTIVE
+MILAN-NY.GOV,City,Non-Federal Agency,Milan,NY,ACTIVE
+MILANMO.GOV,City,Non-Federal Agency,Milan,MO,ACTIVE
+MILANOHIO.GOV,City,Non-Federal Agency,Milan,OH,ACTIVE
+MILFORD-CT.GOV,City,Non-Federal Agency,Milford,CT,ACTIVE
+MILFORD-DE.GOV,City,Non-Federal Agency,Milford,DE,ACTIVE
+MILFORDNE.GOV,City,Non-Federal Agency,Milford,NE,ACTIVE
+MILLIKENCO.GOV,City,Non-Federal Agency,Milliken,CO,ACTIVE
+MILLIKENCOLORADO.GOV,City,Non-Federal Agency,Milliken,CO,ACTIVE
+MILLINGTONTN.GOV,City,Non-Federal Agency,Millington,TN,ACTIVE
+MILLSTONENJ.GOV,City,Non-Federal Agency,Millstone,NJ,ACTIVE
+MILLSWY.GOV,City,Non-Federal Agency,Mills,WY,ACTIVE
+MILLVILLENJ.GOV,City,Non-Federal Agency,Millville,NJ,ACTIVE
+MILTON-WI.GOV,City,Non-Federal Agency,Milton,WI,ACTIVE
+MILWAUKEE.GOV,City,Non-Federal Agency,Milwaukee,WI,ACTIVE
+MILWAUKIEOREGON.GOV,City,Non-Federal Agency,Milwaukie,OR,ACTIVE
+MINEOLA-NY.GOV,City,Non-Federal Agency,Mineola,NY,ACTIVE
+MINERALWELLSTX.GOV,City,Non-Federal Agency,Mineral Wells,TX,ACTIVE
+MINNEAPOLIS-MN.GOV,City,Non-Federal Agency,Minneapolis,MN,ACTIVE
+MINNEAPOLISMN.GOV,City,Non-Federal Agency,Minneapolis,MN,ACTIVE
+MINNETONKA-MN.GOV,City,Non-Federal Agency,Minnetonka,MN,ACTIVE
+MIRAMARFL.GOV,City,Non-Federal Agency,Miramar,FL,ACTIVE
+MISSIONHILLSKS.GOV,City,Non-Federal Agency,Mission Hills,KS,ACTIVE
+MISSOULA-MT.GOV,City,Non-Federal Agency,Missoula,MT,ACTIVE
+MISSOURICITYTEXAS.GOV,City,Non-Federal Agency,Missouri City,TX,ACTIVE
+MISSOURICITYTX.GOV,City,Non-Federal Agency,Missouri City,TX,ACTIVE
+MITCHELL-IN.GOV,City,Non-Federal Agency,Mitchell,IN,ACTIVE
+MOBILE-AL.GOV,City,Non-Federal Agency,Mobile,AL,ACTIVE
+MOCKSVILLENC.GOV,City,Non-Federal Agency,Mocksville,NC,ACTIVE
+MONROEGA.GOV,City,Non-Federal Agency,Monroe,GA,ACTIVE
+MONROEMI.GOV,City,Non-Federal Agency,Monroe,MI,ACTIVE
+MONROETWP-OH.GOV,City,Non-Federal Agency,Bethel,OH,ACTIVE
+MONROEWA.GOV,City,Non-Federal Agency,Monroe,WA,ACTIVE
+MONTAGUE-MA.GOV,City,Non-Federal Agency,Turners Falls,MA,ACTIVE
+MONTCLAIRCA.GOV,City,Non-Federal Agency,Montclair,CA,ACTIVE
+MONTEREYMA.GOV,City,Non-Federal Agency,Monterey,MA,ACTIVE
+MONTGOMERYAL.GOV,City,Non-Federal Agency,Montgomery,AL,ACTIVE
+MONTGOMERYMA.GOV,City,Non-Federal Agency,Montgomery,MA,ACTIVE
+MONTGOMERYOHIO.GOV,City,Non-Federal Agency,Montgomery,OH,ACTIVE
+MONTGOMERYTEXAS.GOV,City,Non-Federal Agency,Montgomery,TX,ACTIVE
+MONTICELLOIN.GOV,City,Non-Federal Agency,Monticello,IN,ACTIVE
+MOODYALABAMA.GOV,City,Non-Federal Agency,Moody,AL,ACTIVE
+MOORESVILLE-NC.GOV,City,Non-Federal Agency,Mooresville,NC,ACTIVE
+MOORPARKCA.GOV,City,Non-Federal Agency,Moorpark,CA,ACTIVE
+MOREHEAD-KY.GOV,City,Non-Federal Agency,Morehead,KY,ACTIVE
+MORGANTONNC.GOV,City,Non-Federal Agency,Morganton,NC,ACTIVE
+MORGANTOWNWV.GOV,City,Non-Federal Agency,Morgantown,WV,ACTIVE
+MORIARTYNM.GOV,City,Non-Federal Agency,Moriarty,NM,ACTIVE
+MORROBAYCA.GOV,City,Non-Federal Agency,Morro Bay,CA,ACTIVE
+MORTON-IL.GOV,City,Non-Federal Agency,Morton,IL,ACTIVE
+MOULTONBOROUGHNH.GOV,City,Non-Federal Agency,Moultonborough,NH,ACTIVE
+MOUNTAINAIRNM.GOV,City,Non-Federal Agency,Mountainair,NM,ACTIVE
+MOUNTAINHOUSECA.GOV,City,Non-Federal Agency,Mountain House,CA,ACTIVE
+MOUNTAINPARK-GA.GOV,City,Non-Federal Agency,Mountain Park,GA,ACTIVE
+MOUNTAINVIEW.GOV,City,Non-Federal Agency,Mountain View,CA,ACTIVE
+MOUNTCARMELTN.GOV,City,Non-Federal Agency,Mount Carmel,TN,ACTIVE
+MOUNTKISCONY.GOV,City,Non-Federal Agency,Mount Kisco,NY,ACTIVE
+MOUNTPLEASANTTN.GOV,City,Non-Federal Agency,Mount Pleasant,TN,ACTIVE
+MOUNTPOCONO-PA.GOV,City,Non-Federal Agency,Mount Pocono,PA,ACTIVE
+MOUNTPROSPECT-IL.GOV,City,Non-Federal Agency,Mount Prospect,IL,ACTIVE
+MOUNTPROSPECTIL.GOV,City,Non-Federal Agency,Mount Prospect,IL,ACTIVE
+MOUNTVERNONWA.GOV,City,Non-Federal Agency,Mount Vernon,WA,ACTIVE
+MQUEBRADILLASPR.GOV,City,Non-Federal Agency,Quebradillas,PR,ACTIVE
+MSVFL.GOV,City,Non-Federal Agency,Miami Shores,FL,ACTIVE
+MTCRESTEDBUTTE-CO.GOV,City,Non-Federal Agency,Mt. Crested Butte,CO,ACTIVE
+MTJULIET-TN.GOV,City,Non-Federal Agency,Mt Juliet,TN,ACTIVE
+MTPLEASANTWI.GOV,City,Non-Federal Agency,Mount Pleasant,WI,ACTIVE
+MTSHASTACA.GOV,City,Non-Federal Agency,Mt. Shasta,CA,ACTIVE
+MUKILTEOWA.GOV,City,Non-Federal Agency,Mukilteo,WA,ACTIVE
+MUNDELEIN-IL.GOV,City,Non-Federal Agency,Mundelein,IL,ACTIVE
+MUNDYTWP-MI.GOV,City,Non-Federal Agency,Swartz Creek,MI,ACTIVE
+MURFREESBOROTN.GOV,City,Non-Federal Agency,Murfreesboro,TN,ACTIVE
+MURPHYSBORO-IL.GOV,City,Non-Federal Agency,Murphysboro,IL,ACTIVE
+MURPHYTX.GOV,City,Non-Federal Agency,Murphy,TX,ACTIVE
+MURRAYKY.GOV,City,Non-Federal Agency,Murray,KY,ACTIVE
+MURRIETACA.GOV,City,Non-Federal Agency,Murrieta,CA,ACTIVE
+MUSCATINEIOWA.GOV,City,Non-Federal Agency,Muscatine,IA,ACTIVE
+MUSKEGON-MI.GOV,City,Non-Federal Agency,Muskegon,MI,ACTIVE
+MVPD.GOV,City,Non-Federal Agency,Mountain View,CA,ACTIVE
+MYARLINGTONTX.GOV,City,Non-Federal Agency,Arlington,TX,ACTIVE
+MYCOLUMBUS.GOV,City,Non-Federal Agency,Columbus,OH,ACTIVE
+MYDELRAYBEACHFL.GOV,City,Non-Federal Agency,Delray Beach,FL,ACTIVE
+NAGSHEADNC.GOV,City,Non-Federal Agency,Nags Head,NC,ACTIVE
+NANTICOKECITY-PA.GOV,City,Non-Federal Agency,NANTICOKE,PA,ACTIVE
+NANTUCKET-MA.GOV,City,Non-Federal Agency,Nantucket,MA,ACTIVE
+NAPA-CA.GOV,City,Non-Federal Agency,Napa,CA,ACTIVE
+NAPLESCITYUT.GOV,City,Non-Federal Agency,Naples,UT,ACTIVE
+NARBERTHPA.GOV,City,Non-Federal Agency,Narberth,PA,ACTIVE
+NARRAGANSETTRI.GOV,City,Non-Federal Agency,Narragansett,RI,ACTIVE
+NASHOTAH-WI.GOV,City,Non-Federal Agency,Nashotah,WI,ACTIVE
+NASHUANH.GOV,City,Non-Federal Agency,Nashua,NH,ACTIVE
+NASHVILLE.GOV,City,Non-Federal Agency,Nashville,TN,ACTIVE
+NATCHITOCHESLA.GOV,City,Non-Federal Agency,Natchitoches,LA,ACTIVE
+NATIONALCITYCA.GOV,City,Non-Federal Agency,National City,CA,ACTIVE
+NAUGATUCK-CT.GOV,City,Non-Federal Agency,Naugatuck,CT,ACTIVE
+NAVASOTATX.GOV,City,Non-Federal Agency,Navasota,TX,ACTIVE
+NAZARETHBOROUGHPA.GOV,City,Non-Federal Agency,Nazareth,PA,ACTIVE
+NBCA.GOV,City,Non-Federal Agency,Newport Beach,CA,ACTIVE
+NEBRASKACITYNE.GOV,City,Non-Federal Agency,Nebraska City,NE,ACTIVE
+NEEDHAMMA.GOV,City,Non-Federal Agency,NEEDHAM,MA,ACTIVE
+NEVADACITYCA.GOV,City,Non-Federal Agency,Nevada City,CA,ACTIVE
+NEVADAMO.GOV,City,Non-Federal Agency,Nevada,MO,ACTIVE
+NEVILLEISLAND-PA.GOV,City,Non-Federal Agency,Pittsburgh,PA,ACTIVE
+NEWARKDE.GOV,City,Non-Federal Agency,Newark,DE,ACTIVE
+NEWAUBURNMN.GOV,City,Non-Federal Agency,New Auburn,MN,ACTIVE
+NEWBEDFORD-MA.GOV,City,Non-Federal Agency,New Bedford,MA,ACTIVE
+NEWBERGOREGON.GOV,City,Non-Federal Agency,Newberg,OR,ACTIVE
+NEWBOSTONNH.GOV,City,Non-Federal Agency,New Boston,NH,ACTIVE
+NEWBRIGHTONMN.GOV,City,Non-Federal Agency,New Brighton,MN,ACTIVE
+NEWBRITAINCT.GOV,City,Non-Federal Agency,New Britain,CT,ACTIVE
+NEWBURGH-IN.GOV,City,Non-Federal Agency,Newburgh,IN,ACTIVE
+NEWBURGHHTSOH.GOV,City,Non-Federal Agency,Newburgh Heights,OH,ACTIVE
+NEWCANAANCT.GOV,City,Non-Federal Agency,New Canaan,CT,ACTIVE
+NEWCARROLLTONMD.GOV,City,Non-Federal Agency,New Carrollton,MD,ACTIVE
+NEWCASTLEPA.GOV,City,Non-Federal Agency,New Castle,PA,ACTIVE
+NEWCONCORD-OH.GOV,City,Non-Federal Agency,New Concord,OH,ACTIVE
+NEWFIELDSNH.GOV,City,Non-Federal Agency,Newfields,NH,ACTIVE
+NEWHARMONY-IN.GOV,City,Non-Federal Agency,New Harmony,IN,ACTIVE
+NEWHAVENCT.GOV,City,Non-Federal Agency,New Haven,CT,ACTIVE
+NEWHOPEMN.GOV,City,Non-Federal Agency,New Hope,MN,ACTIVE
+NEWINGTONCT.GOV,City,Non-Federal Agency,Newington,CT,ACTIVE
+NEWMARKETNH.GOV,City,Non-Federal Agency,Newmarket,NH,ACTIVE
+NEWMARLBOROUGHMA.GOV,City,Non-Federal Agency,Mill River,MA,ACTIVE
+NEWNANGA.GOV,City,Non-Federal Agency,Newnan,GA,ACTIVE
+NEWORLEANS-LA.GOV,City,Non-Federal Agency,New Orleans,LA,ACTIVE
+NEWORLEANSLA.GOV,City,Non-Federal Agency,New Orleans,LA,ACTIVE
+NEWPORT-RI.GOV,City,Non-Federal Agency,Newport,RI,ACTIVE
+NEWPORTBEACH-CA.GOV,City,Non-Federal Agency,Newport Beach,CA,ACTIVE
+NEWPORTBEACHCA.GOV,City,Non-Federal Agency,Newport Beach,CA,ACTIVE
+NEWPORTKY.GOV,City,Non-Federal Agency,Newport,KY,ACTIVE
+NEWPORTNEWSVA.GOV,City,Non-Federal Agency,Newport News,VA,ACTIVE
+NEWPORTOREGON.GOV,City,Non-Federal Agency,Newport,OR,ACTIVE
+NEWRICHMONDWI.GOV,City,Non-Federal Agency,New Richmond ,WI,ACTIVE
+NEWRUSSIATOWNSHIP-OH.GOV,City,Non-Federal Agency,Oberlin,OH,ACTIVE
+NEWTON-NH.GOV,City,Non-Federal Agency,Newton,NH,ACTIVE
+NEWTONNC.GOV,City,Non-Federal Agency,Newton,NC,ACTIVE
+NEWTOWN-CT.GOV,City,Non-Federal Agency,Newtown,CT,ACTIVE
+NEWTOWNOHIO.GOV,City,Non-Federal Agency,Newtown,OH,ACTIVE
+NEWTOWNPA.GOV,City,Non-Federal Agency,Newtown,PA,ACTIVE
+NEWWINDSOR-NY.GOV,City,Non-Federal Agency,New Windsor,NY,ACTIVE
+NEWWINDSORMD.GOV,City,Non-Federal Agency,New Windsor,MD,ACTIVE
+NIAGARAFALLSNY.GOV,City,Non-Federal Agency,Niagara Falls,NY,ACTIVE
+NIAGARAFALLSNYCARTS.GOV,City,Non-Federal Agency,Niagara Falls,NY,ACTIVE
+NICHOLSHILLS-OK.GOV,City,Non-Federal Agency,Nichols Hills,OK,ACTIVE
+NILES-IL.GOV,City,Non-Federal Agency,Niles,IL,ACTIVE
+NILESTWPMI.GOV,City,Non-Federal Agency,Niles,MI,ACTIVE
+NINNEKAHOK.GOV,City,Non-Federal Agency,NINNEKAH,OK,ACTIVE
+NISSEQUOGUENY.GOV,City,Non-Federal Agency,St. James,NY,ACTIVE
+NIXAMO.GOV,City,Non-Federal Agency,Nixa,MO,ACTIVE
+NNVA.GOV,City,Non-Federal Agency,Newport News,VA,ACTIVE
+NOGALESAZ.GOV,City,Non-Federal Agency,Nogales,AZ,ACTIVE
+NOLA.GOV,City,Non-Federal Agency,New Orleans,LA,ACTIVE
+NOLAERB.GOV,City,Non-Federal Agency,New Orleans,LA,ACTIVE
+NOLAIPM.GOV,City,Non-Federal Agency,New Orleans,LA,ACTIVE
+NOLAOIG.GOV,City,Non-Federal Agency,New Orleans,LA,ACTIVE
+NOLENSVILLETN.GOV,City,Non-Federal Agency,Nolensville,TN,ACTIVE
+NORFOLK.GOV,City,Non-Federal Agency,Norfolk,VA,ACTIVE
+NORFOLKNE.GOV,City,Non-Federal Agency,Norfolk,NE,ACTIVE
+NORFOLKVA.GOV,City,Non-Federal Agency,Norfolk,VA,ACTIVE
+NORMANDYPARKWA.GOV,City,Non-Federal Agency,Normandy Park,WA,ACTIVE
+NORMANOK.GOV,City,Non-Federal Agency,Norman,OK,ACTIVE
+NORMANPARKGA.GOV,City,Non-Federal Agency,Norman Park,GA,ACTIVE
+NORRIDGE-IL.GOV,City,Non-Federal Agency,Norridge,IL,ACTIVE
+NORTHADAMS-MA.GOV,City,Non-Federal Agency,North Adams,MA,ACTIVE
+NORTHAMPTONMA.GOV,City,Non-Federal Agency,Northampton,MA,ACTIVE
+NORTHANDOVERMA.GOV,City,Non-Federal Agency,North Andover,MA,ACTIVE
+NORTHBENDWA.GOV,City,Non-Federal Agency,North Bend,WA,ACTIVE
+NORTHBOROUGH-MA.GOV,City,Non-Federal Agency,Northborough,MA,ACTIVE
+NORTHBROOKIL.GOV,City,Non-Federal Agency,Northbrook,IL,ACTIVE
+NORTHBRUNSWICKNJ.GOV,City,Non-Federal Agency,North Brunswick,NJ,ACTIVE
+NORTHCANTONOHIO.GOV,City,Non-Federal Agency,North Canton,OH,ACTIVE
+NORTHFIELD-VT.GOV,City,Non-Federal Agency,Northfield,VT,ACTIVE
+NORTHFIELDMA.GOV,City,Non-Federal Agency,Northfield,MA,ACTIVE
+NORTHFIELDMI.GOV,City,Non-Federal Agency,Whitmore Lake,MI,ACTIVE
+NORTHFIELDVILLAGE-OH.GOV,City,Non-Federal Agency,NORTHFIELD,OH,ACTIVE
+NORTHHAMPTON-NH.GOV,City,Non-Federal Agency,North Hampton,NH,ACTIVE
+NORTHHAVEN-CT.GOV,City,Non-Federal Agency,North Haven,CT,ACTIVE
+NORTHHEMPSTEADNY.GOV,City,Non-Federal Agency,MANHASSET,NY,ACTIVE
+NORTHLEBANONTWPPA.GOV,City,Non-Federal Agency,Lebanon,PA,ACTIVE
+NORTHPORTNY.GOV,City,Non-Federal Agency,Northport,NY,ACTIVE
+NORTHPROVIDENCERI.GOV,City,Non-Federal Agency,North Providence,RI,ACTIVE
+NORTHREADINGMA.GOV,City,Non-Federal Agency,North Reading,MA,ACTIVE
+NORTHSIOUXCITY-SD.GOV,City,Non-Federal Agency,N. Sioux City,SD,ACTIVE
+NORTHSTONINGTONCT.GOV,City,Non-Federal Agency,North Stonington,CT,ACTIVE
+NORTHUNIONTOWNSHIP-PA.GOV,City,Non-Federal Agency,Lemont Furnace,PA,ACTIVE
+NORTHVERNON-IN.GOV,City,Non-Federal Agency,North Vernon,IN,ACTIVE
+NORTONVA.GOV,City,Non-Federal Agency,Norton,VA,ACTIVE
+NORWALKCA.GOV,City,Non-Federal Agency,Norwalk,CA,ACTIVE
+NORWAYMI.GOV,City,Non-Federal Agency,Norway,MI,ACTIVE
+NORWOOD-MA.GOV,City,Non-Federal Agency,Norwood,MA,ACTIVE
+NORWOODMA.GOV,City,Non-Federal Agency,Norwood,MA,ACTIVE
+NOTTINGHAM-NH.GOV,City,Non-Federal Agency,Nottingham,NH,ACTIVE
+NOWATAOK.GOV,City,Non-Federal Agency,Nowata,OK,ACTIVE
+NSIDFL.GOV,City,Non-Federal Agency,Coral Springs,FL,ACTIVE
+NYACK-NY.GOV,City,Non-Federal Agency,Nyack,NY,ACTIVE
+NYC-NY.GOV,City,Non-Federal Agency,Brooklyn,NY,ACTIVE
+NYC.GOV,City,Non-Federal Agency,Brooklyn,NY,ACTIVE
+OAK-BROOK-IL.GOV,City,Non-Federal Agency,OAK BROOK,IL,ACTIVE
+OAKBLUFFSMA.GOV,City,Non-Federal Agency,Oak Bluffs,MA,ACTIVE
+OAKHAM-MA.GOV,City,Non-Federal Agency,Oakham,MA,ACTIVE
+OAKLAND-ME.GOV,City,Non-Federal Agency,Oakland,ME,ACTIVE
+OAKLANDCA.GOV,City,Non-Federal Agency,Oakland,CA,ACTIVE
+OAKLANDPARKFL.GOV,City,Non-Federal Agency,Oakland Park,FL,ACTIVE
+OAKLAWN-IL.GOV,City,Non-Federal Agency,OAK LAWN,IL,ACTIVE
+OAKPARKMI.GOV,City,Non-Federal Agency,Oak Park,MI,ACTIVE
+OAKRIDGETN.GOV,City,Non-Federal Agency,"Oak Ridge, TN 37830 United States",TN,ACTIVE
+OAKWOODOHIO.GOV,City,Non-Federal Agency,Oakwood,OH,ACTIVE
+OBERLINKANSAS.GOV,City,Non-Federal Agency,Oberlin,KS,ACTIVE
+OCCOQUANVA.GOV,City,Non-Federal Agency,Occoquan,VA,ACTIVE
+OCEANAWV.GOV,City,Non-Federal Agency,Oceana,WV,ACTIVE
+OCEANCITYMD.GOV,City,Non-Federal Agency,Ocean City ,MD,ACTIVE
+OCEANGATE-NJ.GOV,City,Non-Federal Agency,Ocean Gate,NJ,ACTIVE
+OCEANSPRINGS-MS.GOV,City,Non-Federal Agency,Ocean Springs,MS,ACTIVE
+OCONOMOWOC-WI.GOV,City,Non-Federal Agency,Oconomowoc,WI,ACTIVE
+ODESSA-TX.GOV,City,Non-Federal Agency,Odessa,TX,ACTIVE
+OGALLALA-NE.GOV,City,Non-Federal Agency,Ogallala,NE,ACTIVE
+OGDEN-KS.GOV,City,Non-Federal Agency,Ogden ,KS,ACTIVE
+OLDLYME-CT.GOV,City,Non-Federal Agency,Old Lyme,CT,ACTIVE
+OLDSAYBROOKCT.GOV,City,Non-Federal Agency,Old Saybrook,CT,ACTIVE
+OLIVERSPRINGS-TN.GOV,City,Non-Federal Agency,Oliver Springs,TN,ACTIVE
+OLYMPIA-WA.GOV,City,Non-Federal Agency,Olympia,WA,ACTIVE
+OLYMPIAWA.GOV,City,Non-Federal Agency,Olympia,WA,ACTIVE
+OMAHA-NE.GOV,City,Non-Federal Agency,Omaha,NE,ACTIVE
+ONTARIOCA.GOV,City,Non-Federal Agency,Ontario,CA,ACTIVE
+OPALOCKAFL.GOV,City,Non-Federal Agency,OPALOCKA,FL,ACTIVE
+OPELIKA-AL.GOV,City,Non-Federal Agency,Opelika,AL,ACTIVE
+ORANGE-CT.GOV,City,Non-Federal Agency,Orange,CT,ACTIVE
+ORLANDOFL.GOV,City,Non-Federal Agency,Orlando,FL,ACTIVE
+ORMONDBEACH-FL.GOV,City,Non-Federal Agency,Ormond Beach,FL,ACTIVE
+ORONOCOTOWNSHIP-MN.GOV,City,Non-Federal Agency,Oronoco,MN,ACTIVE
+OROVALLEYAZ.GOV,City,Non-Federal Agency,Oro Valley,AZ,ACTIVE
+OSAGEBEACH-MO.GOV,City,Non-Federal Agency,OSAGE BEACH,MO,ACTIVE
+OSCODATOWNSHIPMI.GOV,City,Non-Federal Agency,Oscoda,MI,ACTIVE
+OTAYWATER.GOV,City,Non-Federal Agency,Spring Valley,CA,ACTIVE
+OTHELLOWA.GOV,City,Non-Federal Agency,Othello,WA,ACTIVE
+OTISFIELDME.GOV,City,Non-Federal Agency,OTISFIELD,ME,ACTIVE
+OTTAWAKS.GOV,City,Non-Federal Agency,Ottawa,KS,ACTIVE
+OXFORD-CT.GOV,City,Non-Federal Agency,Oxford,CT,ACTIVE
+OYSTERBAY-NY.GOV,City,Non-Federal Agency,Oyster Bay,NY,ACTIVE
+PACIFICWA.GOV,City,Non-Federal Agency,Pacific,WA,ACTIVE
+PADUCAHKY.GOV,City,Non-Federal Agency,Paducah,KY,ACTIVE
+PAGEAZ.GOV,City,Non-Federal Agency,Page,AZ,ACTIVE
+PALATKA-FL.GOV,City,Non-Federal Agency,Palatka,FL,ACTIVE
+PALMETTOBAY-FL.GOV,City,Non-Federal Agency,Palmetto Bay,FL,ACTIVE
+PALMSPRINGS-CA.GOV,City,Non-Federal Agency,Palm Springs,CA,ACTIVE
+PALMSPRINGSCA.GOV,City,Non-Federal Agency,Palm Springs,CA,ACTIVE
+PALOALTO-CA.GOV,City,Non-Federal Agency,Palo Alto,CA,ACTIVE
+PALOSHILLS-IL.GOV,City,Non-Federal Agency,Palos Hills,IL,ACTIVE
+PANORAMAVILLAGETX.GOV,City,Non-Federal Agency,Panorama Village,TX,ACTIVE
+PARADISEVALLEYAZ.GOV,City,Non-Federal Agency,Paradise Valley,AZ,ACTIVE
+PARISTEXAS.GOV,City,Non-Federal Agency,Paris,TX,ACTIVE
+PARISTN.GOV,City,Non-Federal Agency,Paris,TN,ACTIVE
+PARKERSBURGWV.GOV,City,Non-Federal Agency,Parkersburg,WV,ACTIVE
+PARKVILLEMO.GOV,City,Non-Federal Agency,Parkville,MO,ACTIVE
+PARMAHEIGHTSOH.GOV,City,Non-Federal Agency,Parma Heights,OH,ACTIVE
+PASADENACA.GOV,City,Non-Federal Agency,Pasadena,CA,ACTIVE
+PASADENATX.GOV,City,Non-Federal Agency,Pasadena,TX,ACTIVE
+PASCO-WA.GOV,City,Non-Federal Agency,Pasco,WA,ACTIVE
+PATAGONIA-AZ.GOV,City,Non-Federal Agency,Patagonia,AZ,ACTIVE
+PATERSONNJ.GOV,City,Non-Federal Agency,Paterson,NJ,ACTIVE
+PAWLING-NY.GOV,City,Non-Federal Agency,Pawling,NY,ACTIVE
+PAWNEEROCK-KS.GOV,City,Non-Federal Agency,Pawnee Rock,KS,ACTIVE
+PAXTONFL.GOV,City,Non-Federal Agency,Laurel Hill,FL,ACTIVE
+PAYSONAZ.GOV,City,Non-Federal Agency,Payson,AZ,ACTIVE
+PEABODY-MA.GOV,City,Non-Federal Agency,Peabody,MA,ACTIVE
+PEABODYMA.GOV,City,Non-Federal Agency,PEABODY,MA,ACTIVE
+PEARLANDTX.GOV,City,Non-Federal Agency,Pearland,TX,ACTIVE
+PECOSTX.GOV,City,Non-Federal Agency,Pecos,TX,ACTIVE
+PEMBROKE-MA.GOV,City,Non-Federal Agency,Pembroke,MA,ACTIVE
+PEORIAAZ.GOV,City,Non-Federal Agency,Peoria,AZ,ACTIVE
+PEORIAHEIGHTS-IL.GOV,City,Non-Federal Agency,Peoria Heights,IL,ACTIVE
+PEQUOTLAKES-MN.GOV,City,Non-Federal Agency,Pequot Lakes,MN,ACTIVE
+PERMITTINGROGERSAR.GOV,City,Non-Federal Agency,Rogers,AR,ACTIVE
+PERRY-WI.GOV,City,Non-Federal Agency,Mount Horeb,WI,ACTIVE
+PERRYTOWNSHIP-IN.GOV,City,Non-Federal Agency,Indianapolis,IN,ACTIVE
+PETERBOROUGHNH.GOV,City,Non-Federal Agency,Peterborough,NH,ACTIVE
+PETERSBURGAK.GOV,City,Non-Federal Agency,Petersburg,AK,ACTIVE
+PETERSBURGVA.GOV,City,Non-Federal Agency,Petersburg,VA,ACTIVE
+PFLUGERVILLETX.GOV,City,Non-Federal Agency,Pflugerville,TX,ACTIVE
+PHARR-TX.GOV,City,Non-Federal Agency,Pharr,TX,ACTIVE
+PHILA.GOV,City,Non-Federal Agency,Philadelphia,PA,ACTIVE
+PHILIPSBURGMT.GOV,City,Non-Federal Agency,Philipsburg,MT,ACTIVE
+PHILLIPSTON-MA.GOV,City,Non-Federal Agency,Phillipston,MA,ACTIVE
+PHOENIX.GOV,City,Non-Federal Agency,Phoenix,AZ,ACTIVE
+PHOENIXOREGON.GOV,City,Non-Federal Agency,Phoenix,OR,ACTIVE
+PIEDMONT-OK.GOV,City,Non-Federal Agency,PIEDMONT,OK,ACTIVE
+PIERMONT-NY.GOV,City,Non-Federal Agency,Piermont,NY,ACTIVE
+PIKEVILLEKY.GOV,City,Non-Federal Agency,Pikeville,KY,ACTIVE
+PILOTPOINTAK.GOV,City,Non-Federal Agency,Pilot Point,AK,ACTIVE
+PINEBLUFFSWY.GOV,City,Non-Federal Agency,Pine Bluffs,WY,ACTIVE
+PINEHURSTNC.GOV,City,Non-Federal Agency,Pinehurst,NC,ACTIVE
+PINEPLAINS-NY.GOV,City,Non-Federal Agency,Pine Plains,NY,ACTIVE
+PINETOPLAKESIDEAZ.GOV,City,Non-Federal Agency,LAKESIDE,AZ,ACTIVE
+PINEVILLENC.GOV,City,Non-Federal Agency,Pineville,NC,ACTIVE
+PITTSBORONC.GOV,City,Non-Federal Agency,Pittsboro,NC,ACTIVE
+PITTSBURGCA.GOV,City,Non-Federal Agency,PITTSBURG,CA,ACTIVE
+PITTSBURGHPA.GOV,City,Non-Federal Agency,Pittsburgh,PA,ACTIVE
+PITTSFIELD-MI.GOV,City,Non-Federal Agency,Ann Arbor,MI,ACTIVE
+PITTSFIELDNH.GOV,City,Non-Federal Agency,Pittsfield,NH,ACTIVE
+PLAINFIELDNJ.GOV,City,Non-Federal Agency,Plainfield,NJ,ACTIVE
+PLANDOMEHEIGHTS-NY.GOV,City,Non-Federal Agency,Manhasset,NY,ACTIVE
+PLANO.GOV,City,Non-Federal Agency,Plano,TX,ACTIVE
+PLATTSBURG-MO.GOV,City,Non-Federal Agency,Plattsburg,MO,ACTIVE
+PLEASANTONCA.GOV,City,Non-Federal Agency,Pleasanton,CA,ACTIVE
+PLEASANTONTX.GOV,City,Non-Federal Agency,Pleasanton,TX,ACTIVE
+PLEASANTPRAIRIE-WI.GOV,City,Non-Federal Agency,Pleasant Prairie,WI,ACTIVE
+PLEASANTPRAIRIEWI.GOV,City,Non-Federal Agency,Pleasant Prairie,WI,ACTIVE
+PLEASANTVALLEY-NY.GOV,City,Non-Federal Agency,Pleasant Valley,NY,ACTIVE
+PLEASANTVILLE-NY.GOV,City,Non-Federal Agency,Pleasantville,NY,ACTIVE
+PLOVERWI.GOV,City,Non-Federal Agency,Plover,WI,ACTIVE
+PLUMSTEAD.GOV,City,Non-Federal Agency,Plumsteadville,PA,ACTIVE
+PLYMOUTH-MA.GOV,City,Non-Federal Agency,Plymouth,MA,ACTIVE
+PLYMOUTHMN.GOV,City,Non-Federal Agency,Plymouth,MN,ACTIVE
+POCOMOKEMD.GOV,City,Non-Federal Agency,Pocomoke City,MD,ACTIVE
+POCONOPA.GOV,City,Non-Federal Agency,Tannersville,PA,ACTIVE
+POLKCITYIA.GOV,City,Non-Federal Agency,Polk City,IA,ACTIVE
+POMFRETCT.GOV,City,Non-Federal Agency,Pomfret Center,CT,ACTIVE
+POMPANOBEACHFL.GOV,City,Non-Federal Agency,Pompano Beach,FL,ACTIVE
+POMPEY-NY.GOV,City,Non-Federal Agency,MANLIUS,NY,ACTIVE
+PONCACITYOK.GOV,City,Non-Federal Agency,Ponca City,OK,ACTIVE
+POOLER-GA.GOV,City,Non-Federal Agency,Pooler,GA,ACTIVE
+POOLESVILLEMD.GOV,City,Non-Federal Agency,Poolesville,MD,ACTIVE
+POPLARBLUFF-MO.GOV,City,Non-Federal Agency,Poplar Bluff,MO,ACTIVE
+POPLARVILLEMS.GOV,City,Non-Federal Agency,Poplarvile,MS,ACTIVE
+POQUOSON-VA.GOV,City,Non-Federal Agency,Poquioson,VA,ACTIVE
+PORTAGE-MI.GOV,City,Non-Federal Agency,Portage,MI,ACTIVE
+PORTAGEMI.GOV,City,Non-Federal Agency,Portage,MI,ACTIVE
+PORTAGEWI.GOV,City,Non-Federal Agency,Portage,WI,ACTIVE
+PORTALESNM.GOV,City,Non-Federal Agency,Portales,NM,ACTIVE
+PORTARTHURTX.GOV,City,Non-Federal Agency,Port Arthur,TX,ACTIVE
+PORTCLINTON-OH.GOV,City,Non-Federal Agency,Port Clinton,OH,ACTIVE
+PORTERVILLE-CA.GOV,City,Non-Federal Agency,Porterville,CA,ACTIVE
+PORTERVILLECA.GOV,City,Non-Federal Agency,Porterville,CA,ACTIVE
+PORTLANDMAINE.GOV,City,Non-Federal Agency,Portland,ME,ACTIVE
+PORTLANDOREGON.GOV,City,Non-Federal Agency,Portland,OR,ACTIVE
+PORTLANDTX.GOV,City,Non-Federal Agency,Portland,TX,ACTIVE
+PORTSMOUTHVA.GOV,City,Non-Federal Agency,Portsmouth,VA,ACTIVE
+PORTSMOUTHVIRGINIA.GOV,City,Non-Federal Agency,Portsmouth,VA,ACTIVE
+POTTERTWP-PA.GOV,City,Non-Federal Agency,Monaca,PA,ACTIVE
+POWHATANVA.GOV,City,Non-Federal Agency,Powhatan,VA,ACTIVE
+POYNETTE-WI.GOV,City,Non-Federal Agency,Poynette,WI,ACTIVE
+PRAIRIEDUCHIEN-WI.GOV,City,Non-Federal Agency,Prairie du Chien,WI,ACTIVE
+PRAIRIEVIEWTEXAS.GOV,City,Non-Federal Agency,Prairie View,TX,ACTIVE
+PRATTVILLE-AL.GOV,City,Non-Federal Agency,Prattville,AL,ACTIVE
+PRATTVILLEAL.GOV,City,Non-Federal Agency,Prattville,AL,ACTIVE
+PRESCOTT-AZ.GOV,City,Non-Federal Agency,Prescott,AZ,ACTIVE
+PRESCOTTVALLEY-AZ.GOV,City,Non-Federal Agency,Prescott Valley,AZ,ACTIVE
+PRESQUEISLEMAINE.GOV,City,Non-Federal Agency,Presque Isle,ME,ACTIVE
+PRIESTRIVER-ID.GOV,City,Non-Federal Agency,Priest River,ID,ACTIVE
+PRINCETONNJ.GOV,City,Non-Federal Agency,Princeton,NJ,ACTIVE
+PRINCETONTX.GOV,City,Non-Federal Agency,Princeton,TX,ACTIVE
+PRINCETONWV.GOV,City,Non-Federal Agency,Princeton,WV,ACTIVE
+PROCTORMN.GOV,City,Non-Federal Agency,Proctor,MN,ACTIVE
+PROSPERTX.GOV,City,Non-Federal Agency,Prosper,TX,ACTIVE
+PROVIDENCERI.GOV,City,Non-Federal Agency,Providence,RI,ACTIVE
+PULLMAN-WA.GOV,City,Non-Federal Agency,Pullman,WA,ACTIVE
+PURCELLVILLEVA.GOV,City,Non-Federal Agency,Purcellville,VA,ACTIVE
+QUAKERTOWN-PA.GOV,City,Non-Federal Agency,Quakertown,PA,ACTIVE
+QUINCYIL.GOV,City,Non-Federal Agency,Quincy,IL,ACTIVE
+QUINCYMA.GOV,City,Non-Federal Agency,Quincy,MA,ACTIVE
+RADFORDVA.GOV,City,Non-Federal Agency,Radford,VA,ACTIVE
+RALEIGHNC.GOV,City,Non-Federal Agency,Raleigh,NC,ACTIVE
+RAMAPO-NY.GOV,City,Non-Federal Agency,Suffern,NY,ACTIVE
+RANCHOMIRAGECA.GOV,City,Non-Federal Agency,Rancho Mirage,CA,ACTIVE
+RANDOLPH-MA.GOV,City,Non-Federal Agency,Randolph,MA,ACTIVE
+RANDOLPHTOWNSHIPOHIO.GOV,City,Non-Federal Agency,Randolph,OH,ACTIVE
+RANGELY-CO.GOV,City,Non-Federal Agency,Rangely,CO,ACTIVE
+RANGELYCO.GOV,City,Non-Federal Agency,Rangely,CO,ACTIVE
+RATONNM.GOV,City,Non-Federal Agency,Raton,NM,ACTIVE
+RAYCITYGA.GOV,City,Non-Federal Agency,Ray City,GA,ACTIVE
+RAYMONDNH.GOV,City,Non-Federal Agency,Raymond,NH,ACTIVE
+READINGMA.GOV,City,Non-Federal Agency,READING,MA,ACTIVE
+READINGPA.GOV,City,Non-Federal Agency,Reading,PA,ACTIVE
+READYHOUSTONTX.GOV,City,Non-Federal Agency,Houston,TX,ACTIVE
+READYSOUTHTEXAS.GOV,City,Non-Federal Agency,San Antonio,TX,ACTIVE
+READYWESTLINNOR.GOV,City,Non-Federal Agency,West Linn,OR,ACTIVE
+REDBANKTN.GOV,City,Non-Federal Agency,Red Bank,TN,ACTIVE
+REDBAY-AL.GOV,City,Non-Federal Agency,Red Bay,AL,ACTIVE
+REDDING-CA.GOV,City,Non-Federal Agency,Redding,CA,ACTIVE
+REDMOND.GOV,City,Non-Federal Agency,Redmond,WA,ACTIVE
+REEDSBURGWI.GOV,City,Non-Federal Agency,Reedsburg,WI,ACTIVE
+REIDSVILLENC.GOV,City,Non-Federal Agency,Reidsville,NC,ACTIVE
+REMINGTON-VA.GOV,City,Non-Federal Agency,Remington,VA,ACTIVE
+RENO.GOV,City,Non-Federal Agency,Reno,NV,ACTIVE
+RENONV.GOV,City,Non-Federal Agency,Reno,NV,ACTIVE
+RENSSELAERNY.GOV,City,Non-Federal Agency,Rensselaer,NY,ACTIVE
+RENTONWA.GOV,City,Non-Federal Agency,Renton,WA,ACTIVE
+RHEACOUNTYTN.GOV,City,Non-Federal Agency,Dayton,TN,ACTIVE
+RHINEBECK-NY.GOV,City,Non-Federal Agency,Rhinebeck,NY,ACTIVE
+RHINEBECKNY.GOV,City,Non-Federal Agency,Rhinebeck,NY,ACTIVE
+RIALTOCA.GOV,City,Non-Federal Agency,Rialto,CA,ACTIVE
+RICETX.GOV,City,Non-Federal Agency,Rice,TX,ACTIVE
+RICHFIELDWI.GOV,City,Non-Federal Agency,Hubertus,WI,ACTIVE
+RICHLANDMS.GOV,City,Non-Federal Agency,Richland,MS,ACTIVE
+RICHLANDS-VA.GOV,City,Non-Federal Agency,Richlands,VA,ACTIVE
+RICHLANDSNC.GOV,City,Non-Federal Agency,Richlands,NC,ACTIVE
+RICHMOND-VA.GOV,City,Non-Federal Agency,Richmond,VA,ACTIVE
+RICHMONDHILL-GA.GOV,City,Non-Federal Agency,Richmond Hill ,GA,ACTIVE
+RICHMONDINDIANA.GOV,City,Non-Federal Agency,Richmond,IN,ACTIVE
+RICHMONDTX.GOV,City,Non-Federal Agency,RICHMOND,TX,ACTIVE
+RICHMONDVA.GOV,City,Non-Federal Agency,Richmond,VA,ACTIVE
+RICHMONDVT.GOV,City,Non-Federal Agency,Richmond,VT,ACTIVE
+RICHWOODTX.GOV,City,Non-Federal Agency,Richwood,TX,ACTIVE
+RICHWOODWV.GOV,City,Non-Federal Agency,Richwood,WV,ACTIVE
+RIDGECREST-CA.GOV,City,Non-Federal Agency,Ridgecrest,CA,ACTIVE
+RIDGEFIELDNJ.GOV,City,Non-Federal Agency,Ridgefield,NJ,ACTIVE
+RIDGELANDSC.GOV,City,Non-Federal Agency,Ridgeland,SC,ACTIVE
+RIORANCHONM.GOV,City,Non-Federal Agency,Rio Rancho,NM,ACTIVE
+RITZVILLE-WA.GOV,City,Non-Federal Agency,Ritzville,WA,ACTIVE
+RIVERDALEGA.GOV,City,Non-Federal Agency,Riverdale,GA,ACTIVE
+RIVERDALENJ.GOV,City,Non-Federal Agency,Riverdale,NJ,ACTIVE
+RIVERDALEPARKMD.GOV,City,Non-Federal Agency,Riverdale,MD,ACTIVE
+RIVERSIDECA.GOV,City,Non-Federal Agency,Riverside,CA,ACTIVE
+RIVERTONWY.GOV,City,Non-Federal Agency,Riverton,WY,ACTIVE
+ROAMINGSHORESOH.GOV,City,Non-Federal Agency,Roaming Shores,OH,ACTIVE
+ROANOKEVA.GOV,City,Non-Federal Agency,Roanoke,VA,ACTIVE
+ROBINSONPA.GOV,City,Non-Federal Agency,McDonald,PA,ACTIVE
+ROCHELLEPARKNJ.GOV,City,Non-Federal Agency,Rochelle Park,NJ,ACTIVE
+ROCHESTERMN.GOV,City,Non-Federal Agency,Rochester,MN,ACTIVE
+ROCKFORD-IL.GOV,City,Non-Federal Agency,Rockford,IL,ACTIVE
+ROCKFORDIL.GOV,City,Non-Federal Agency,Rockford,IL,ACTIVE
+ROCKHALLMD.GOV,City,Non-Federal Agency,Rock Hall,MD,ACTIVE
+ROCKLAND-MA.GOV,City,Non-Federal Agency,Rockland,MA,ACTIVE
+ROCKLANDMAINE.GOV,City,Non-Federal Agency,Rockland,ME,ACTIVE
+ROCKMART-GA.GOV,City,Non-Federal Agency,Rockmart,GA,ACTIVE
+ROCKPORTMA.GOV,City,Non-Federal Agency,Rockport,MA,ACTIVE
+ROCKPORTMAINE.GOV,City,Non-Federal Agency,Rockport,ME,ACTIVE
+ROCKVILLE-IN.GOV,City,Non-Federal Agency,Rockville,IN,ACTIVE
+ROCKVILLEMD.GOV,City,Non-Federal Agency,Rockville,MD,ACTIVE
+ROCKWELLNC.GOV,City,Non-Federal Agency,Rockwell,NC,ACTIVE
+ROCKYHILL-NJ.GOV,City,Non-Federal Agency,Rocky Hill,NJ,ACTIVE
+ROCKYHILLCT.GOV,City,Non-Federal Agency,Rocky Hill,CT,ACTIVE
+ROCKYMOUNTNC.GOV,City,Non-Federal Agency,Rocky Mount,NC,ACTIVE
+ROGERSAR.GOV,City,Non-Federal Agency,Rogers,AR,ACTIVE
+ROGERSMN.GOV,City,Non-Federal Agency,Rogers,MN,ACTIVE
+ROLESVILLENC.GOV,City,Non-Federal Agency,Rolesville,NC,ACTIVE
+ROLLINGHILLSESTATES-CA.GOV,City,Non-Federal Agency,Rolling Hills Estates,CA,ACTIVE
+ROLLINGHILLSESTATESCA.GOV,City,Non-Federal Agency,Rolling Hills Estates,CA,ACTIVE
+ROME-NY.GOV,City,Non-Federal Agency,Rome,NY,ACTIVE
+ROMI.GOV,City,Non-Federal Agency,Royal Oak,MI,ACTIVE
+ROMULUS-MI.GOV,City,Non-Federal Agency,Romulus,MI,ACTIVE
+ROSENBERGTX.GOV,City,Non-Federal Agency,Rosenberg,TX,ACTIVE
+ROSEVILLE-MI.GOV,City,Non-Federal Agency,Roseville,MI,ACTIVE
+ROSLYNNY.GOV,City,Non-Federal Agency,Roslyn,NY,ACTIVE
+ROSWELL-NM.GOV,City,Non-Federal Agency,Roswell,NM,ACTIVE
+ROUNDROCKTEXAS.GOV,City,Non-Federal Agency,Round Rock,TX,ACTIVE
+ROWE-MA.GOV,City,Non-Federal Agency,Rowe,MA,ACTIVE
+ROWLETTTX.GOV,City,Non-Federal Agency,Rowlett,TX,ACTIVE
+ROXBURY-CT.GOV,City,Non-Federal Agency,Roxbury,CT,ACTIVE
+ROYALOAKMI.GOV,City,Non-Federal Agency,Royal Oak,MI,ACTIVE
+ROYALSTON-MA.GOV,City,Non-Federal Agency,Royalston,MA,ACTIVE
+RPVCA.GOV,City,Non-Federal Agency,Rancho Palos Verdes,CA,ACTIVE
+RRNM.GOV,City,Non-Federal Agency,Rio Rancho,NM,ACTIVE
+RUIDOSO-NM.GOV,City,Non-Federal Agency,Ruidoso,NM,ACTIVE
+RUMSONNJ.GOV,City,Non-Federal Agency,Rumson,NJ,ACTIVE
+RUSSELLSPOINT-OH.GOV,City,Non-Federal Agency,Russells Point,OH,ACTIVE
+RYENY.GOV,City,Non-Federal Agency,Rye,NY,ACTIVE
+SACKETSHARBOR-NY.GOV,City,Non-Federal Agency,Sackets Harbor,NY,ACTIVE
+SADDLEBROOKNJ.GOV,City,Non-Federal Agency,Saddlebrook,NJ,ACTIVE
+SADDLEROCKNY.GOV,City,Non-Federal Agency,SADDLE ROCK,NY,ACTIVE
+SAFFORD-AZ.GOV,City,Non-Federal Agency,Safford,AZ,ACTIVE
+SAFFORDAZ.GOV,City,Non-Federal Agency,Safford,AZ,ACTIVE
+SAGHARBORNY.GOV,City,Non-Federal Agency,Sag Harbor,NY,ACTIVE
+SAHUARITAAZ.GOV,City,Non-Federal Agency,Sahuarita,AZ,ACTIVE
+SAINTPETERMN.GOV,City,Non-Federal Agency,Saint Peter,MN,ACTIVE
+SALADOTX.GOV,City,Non-Federal Agency,Salado,TX,ACTIVE
+SALEMCT.GOV,City,Non-Federal Agency,Salem,CT,ACTIVE
+SALEMVA.GOV,City,Non-Federal Agency,Salem,VA,ACTIVE
+SALISBURYMA.GOV,City,Non-Federal Agency,Salisbury,MA,ACTIVE
+SALISBURYNC.GOV,City,Non-Federal Agency,Salisbury,NC,ACTIVE
+SALTLAKECITY-UT.GOV,City,Non-Federal Agency,Salt Lake City,UT,ACTIVE
+SAMMAMISHWA.GOV,City,Non-Federal Agency,Sammamish,WA,ACTIVE
+SANANTONIO.GOV,City,Non-Federal Agency,San Antonio,TX,ACTIVE
+SANDIEGO.GOV,City,Non-Federal Agency,San Diego,CA,ACTIVE
+SANDYSPRINGSGA.GOV,City,Non-Federal Agency,Sandy Springs,GA,ACTIVE
+SANFORDFL.GOV,City,Non-Federal Agency,Sanford,FL,ACTIVE
+SANFRANCISCO-CA.GOV,City,Non-Federal Agency,San Francisco,CA,ACTIVE
+SANJOSECA.GOV,City,Non-Federal Agency,San Jose,CA,ACTIVE
+SANMARCOSTEXAS.GOV,City,Non-Federal Agency,San Marcos,TX,ACTIVE
+SANMARCOSTX.GOV,City,Non-Federal Agency,San Marcos,TX,ACTIVE
+SANMARINOCA.GOV,City,Non-Federal Agency,San Marino,CA,ACTIVE
+SANNET.GOV,City,Non-Federal Agency,San Diego,CA,ACTIVE
+SANPABLOCA.GOV,City,Non-Federal Agency,San Pablo,CA,ACTIVE
+SANTAANA-CA.GOV,City,Non-Federal Agency,Santa Ana,CA,ACTIVE
+SANTABARBARACA.GOV,City,Non-Federal Agency,Santa Barbara,CA,ACTIVE
+SANTACLARACA.GOV,City,Non-Federal Agency,Santa Clara,CA,ACTIVE
+SANTACLARITACA.GOV,City,Non-Federal Agency,Santa Clarita,CA,ACTIVE
+SANTAFENM.GOV,City,Non-Federal Agency,Santa Fe,NM,ACTIVE
+SANTAMONICACA.GOV,City,Non-Federal Agency,Santa Monica,CA,ACTIVE
+SARANACLAKENY.GOV,City,Non-Federal Agency,Saranac Lake,NY,ACTIVE
+SARDISCITYAL.GOV,City,Non-Federal Agency,SARDIS CITY,AL,ACTIVE
+SAUGUS-MA.GOV,City,Non-Federal Agency,Saugus,MA,ACTIVE
+SAULTSTEMARIE-MI.GOV,City,Non-Federal Agency,Sault Ste Marie,MI,ACTIVE
+SAVANNA-IL.GOV,City,Non-Federal Agency,Savanna,IL,ACTIVE
+SAVANNAHGA.GOV,City,Non-Federal Agency,Savannah,GA,ACTIVE
+SBMTD.GOV,City,Non-Federal Agency,Santa Barbara,CA,ACTIVE
+SCHENECTADYNY.GOV,City,Non-Federal Agency,Schenectady,NY,ACTIVE
+SCHERTZ-TX.GOV,City,Non-Federal Agency,Schertz,TX,ACTIVE
+SCIENCEHILL-KY.GOV,City,Non-Federal Agency,Science Hill,KY,ACTIVE
+SCITUATEMA.GOV,City,Non-Federal Agency,Scituate,MA,ACTIVE
+SCOTCHPLAINSNJ.GOV,City,Non-Federal Agency,SCOTCH PLAINS,NJ,ACTIVE
+SCOTTSDALEAZ.GOV,City,Non-Federal Agency,Scottsdale,AZ,ACTIVE
+SCRANTONPA.GOV,City,Non-Federal Agency,Scranton,PA,ACTIVE
+SEABROOKTX.GOV,City,Non-Federal Agency,Seabrook,TX,ACTIVE
+SEACLIFF-NY.GOV,City,Non-Federal Agency,Sea Cliff,NY,ACTIVE
+SEALBEACHCA.GOV,City,Non-Federal Agency,Seal Beach,CA,ACTIVE
+SEARANCHLAKESFLORIDA.GOV,City,Non-Federal Agency,Sea Ranch Lakes,FL,ACTIVE
+SEATPLEASANTMD.GOV,City,Non-Federal Agency,Seat Pleasant,MD,ACTIVE
+SEATTLE.GOV,City,Non-Federal Agency,Seattle,WA,ACTIVE
+SEBEWAINGMI.GOV,City,Non-Federal Agency,Sebewaing,MI,ACTIVE
+SECAUCUSNJ.GOV,City,Non-Federal Agency,Secaucus,NJ,ACTIVE
+SEDONAAZ.GOV,City,Non-Federal Agency,Sedona,AZ,ACTIVE
+SEEKONK-MA.GOV,City,Non-Federal Agency,Seekonk,MA,ACTIVE
+SEGUINTEXAS.GOV,City,Non-Federal Agency,Seguin,TX,ACTIVE
+SELAHWA.GOV,City,Non-Federal Agency,Selah,WA,ACTIVE
+SELLERSBURG-IN.GOV,City,Non-Federal Agency,Sellersburg,IN,ACTIVE
+SELMA-AL.GOV,City,Non-Federal Agency,Selma,AL,ACTIVE
+SENECASC.GOV,City,Non-Federal Agency,Seneca,SC,ACTIVE
+SEQUIMWA.GOV,City,Non-Federal Agency,SEQUIM,WA,ACTIVE
+SHAFTSBURYVT.GOV,City,Non-Federal Agency,Shaftsbury,VT,ACTIVE
+SHAKOPEEMN.GOV,City,Non-Federal Agency,Shakopee,MN,ACTIVE
+SHEBOYGANFALLS-WI.GOV,City,Non-Federal Agency,Sheboygan Falls,WI,ACTIVE
+SHEBOYGANWI.GOV,City,Non-Federal Agency,Sheboygan,WI,ACTIVE
+SHEFFIELDMA.GOV,City,Non-Federal Agency,Sheffield,MA,ACTIVE
+SHELTERCOVE-CA.GOV,City,Non-Federal Agency,Whitethorn,CA,ACTIVE
+SHERWOODOREGON.GOV,City,Non-Federal Agency,Sherwood,OR,ACTIVE
+SHIRLEY-MA.GOV,City,Non-Federal Agency,Shirley,MA,ACTIVE
+SHIVELYKY.GOV,City,Non-Federal Agency,Shively,KY,ACTIVE
+SHORELINE-WA.GOV,City,Non-Federal Agency,Shoreline,WA,ACTIVE
+SHORELINEWA.GOV,City,Non-Federal Agency,Shoreline,WA,ACTIVE
+SHOREVIEWMN.GOV,City,Non-Federal Agency,Shoreview,MN,ACTIVE
+SHOWLOWAZ.GOV,City,Non-Federal Agency,Show Low,AZ,ACTIVE
+SHREVEPORTLA.GOV,City,Non-Federal Agency,Shreveport,LA,ACTIVE
+SHREWSBURYMA.GOV,City,Non-Federal Agency,Shrewsbury,MA,ACTIVE
+SIERRAVISTAAZ.GOV,City,Non-Federal Agency,Sierra Vista,AZ,ACTIVE
+SIGNALMOUNTAINTN.GOV,City,Non-Federal Agency,Signal Mountain,TN,ACTIVE
+SILVERCITYNM.GOV,City,Non-Federal Agency,Silver City,NM,ACTIVE
+SILVERSPRINGTWP-PA.GOV,City,Non-Federal Agency,Mechanicsburg,PA,ACTIVE
+SIMONTONTEXAS.GOV,City,Non-Federal Agency,simonton,TX,ACTIVE
+SIMSBURY-CT.GOV,City,Non-Federal Agency,Simsbury,CT,ACTIVE
+SIOUXFALLSSD.GOV,City,Non-Federal Agency,Sioux Falls,SD,ACTIVE
+SISTERBAYWI.GOV,City,Non-Federal Agency,Sister Bay,WI,ACTIVE
+SLEEPYHOLLOWNY.GOV,City,Non-Federal Agency,Sleepy Hollow,NY,ACTIVE
+SLIPPERYROCKBOROUGHPA.GOV,City,Non-Federal Agency,Slippery Rock,PA,ACTIVE
+SMITHFIELDRI.GOV,City,Non-Federal Agency,Smithfield,RI,ACTIVE
+SMITHFIELDVA.GOV,City,Non-Federal Agency,Smithfield,VA,ACTIVE
+SMITHTOWNNY.GOV,City,Non-Federal Agency,Smithtown,NY,ACTIVE
+SMYRNAGA.GOV,City,Non-Federal Agency,Smyrna,GA,ACTIVE
+SNOHOMISHWA.GOV,City,Non-Federal Agency,Snohomish,WA,ACTIVE
+SNOWFLAKE-AZ.GOV,City,Non-Federal Agency,Snowflake,AZ,ACTIVE
+SOCORRONM.GOV,City,Non-Federal Agency,Socorro,NM,ACTIVE
+SODDY-DAISY-TN.GOV,City,Non-Federal Agency,Soddy-Daisy,TN,ACTIVE
+SODDY-DAISYTN.GOV,City,Non-Federal Agency,Soddy-Daisy,TN,ACTIVE
+SODDYDAISY-TN.GOV,City,Non-Federal Agency,Soddy-Daisy,TN,ACTIVE
+SODDYDAISYTN.GOV,City,Non-Federal Agency,Soddy-daisy,TN,ACTIVE
+SOLWAYTOWNSHIP-MN.GOV,City,Non-Federal Agency,Cloquet,MN,ACTIVE
+SOMERSCT.GOV,City,Non-Federal Agency,Somers,CT,ACTIVE
+SOMERSETTX.GOV,City,Non-Federal Agency,Somerset,TX,ACTIVE
+SOMERTONAZ.GOV,City,Non-Federal Agency,Somerton,AZ,ACTIVE
+SOMERVILLEMA.GOV,City,Non-Federal Agency,Somerville,MA,ACTIVE
+SOMERVILLETN.GOV,City,Non-Federal Agency,Town of Somerville,TN,ACTIVE
+SORRENTOLA.GOV,City,Non-Federal Agency,Sorrento,LA,ACTIVE
+SOUTHABINGTONPA.GOV,City,Non-Federal Agency,Chinchilla,PA,ACTIVE
+SOUTHAMBOYNJ.GOV,City,Non-Federal Agency,South Amboy,NJ,ACTIVE
+SOUTHAMPTONTOWNNY.GOV,City,Non-Federal Agency,Southampton,NY,ACTIVE
+SOUTHBEND-WA.GOV,City,Non-Federal Agency,South Bend,WA,ACTIVE
+SOUTHBENDIN.GOV,City,Non-Federal Agency,South Bend,IN,ACTIVE
+SOUTHBRUNSWICKNJ.GOV,City,Non-Federal Agency,South Brunswick,NJ,ACTIVE
+SOUTHBURLINGTONVT.GOV,City,Non-Federal Agency,South Burlington,VT,ACTIVE
+SOUTHBURY-CT.GOV,City,Non-Federal Agency,Southbury,CT,ACTIVE
+SOUTHEAST-NY.GOV,City,Non-Federal Agency,BREWSTER,NY,ACTIVE
+SOUTHHADLEYMA.GOV,City,Non-Federal Agency,South Hadley,MA,ACTIVE
+SOUTHJORDANUTAH.GOV,City,Non-Federal Agency,South Jordan,UT,ACTIVE
+SOUTHMIAMIFL.GOV,City,Non-Federal Agency,South Miami,FL,ACTIVE
+SOUTHOLDTOWNNY.GOV,City,Non-Federal Agency,Southold,NY,ACTIVE
+SOUTHPADRETEXAS.GOV,City,Non-Federal Agency,South Padre Island,TX,ACTIVE
+SOUTHPASADENACA.GOV,City,Non-Federal Agency,South Pasadena,CA,ACTIVE
+SOUTHPITTSBURG-TN.GOV,City,Non-Federal Agency,South Pittsburg,TN,ACTIVE
+SOUTHWILLIAMSPORT-PA.GOV,City,Non-Federal Agency,South Williamsport,PA,ACTIVE
+SPEEDWAYIN.GOV,City,Non-Federal Agency,Speedway,IN,ACTIVE
+SPENCERMA.GOV,City,Non-Federal Agency,Spencer,MA,ACTIVE
+SPERRYOK.GOV,City,Non-Federal Agency,Sperry,OK,ACTIVE
+SPIRITLAKEID.GOV,City,Non-Federal Agency,Spirit Lake,ID,ACTIVE
+SPRINGCITYPA.GOV,City,Non-Federal Agency,Spring City,PA,ACTIVE
+SPRINGDALEAR.GOV,City,Non-Federal Agency,Springdale,AR,ACTIVE
+SPRINGERVILLEAZ.GOV,City,Non-Federal Agency,Springerville,AZ,ACTIVE
+SPRINGFIELD-MA.GOV,City,Non-Federal Agency,Springfield,MA,ACTIVE
+SPRINGFIELD-OR.GOV,City,Non-Federal Agency,Springfield,OR,ACTIVE
+SPRINGFIELDMA.GOV,City,Non-Federal Agency,Springfield,MA,ACTIVE
+SPRINGFIELDMO.GOV,City,Non-Federal Agency,Springfield,MO,ACTIVE
+SPRINGFIELDOHIO.GOV,City,Non-Federal Agency,Springfield,OH,ACTIVE
+SPRINGHILLKS.GOV,City,Non-Federal Agency,Spring Hill,KS,ACTIVE
+SPRINGHILLLOUISIANA.GOV,City,Non-Federal Agency,Springhill,LA,ACTIVE
+SPRUCEPINE-NC.GOV,City,Non-Federal Agency,Spruce Pine,NC,ACTIVE
+STAFFORDNJ.GOV,City,Non-Federal Agency,Manawhakin,NJ,ACTIVE
+STAFFORDTX.GOV,City,Non-Federal Agency,stafford,TX,ACTIVE
+STAMFORDCT.GOV,City,Non-Federal Agency,Stamford,CT,ACTIVE
+STANHOPENJ.GOV,City,Non-Federal Agency,Stanhope,NJ,ACTIVE
+STARNC.GOV,City,Non-Federal Agency,Star,NC,ACTIVE
+STATECOLLEGEPA.GOV,City,Non-Federal Agency,State College,PA,ACTIVE
+STATESBOROGA.GOV,City,Non-Federal Agency,Statesboro,GA,ACTIVE
+STAYTONOREGON.GOV,City,Non-Federal Agency,Stayton,OR,ACTIVE
+STCHARLESCITYMO.GOV,City,Non-Federal Agency,Saint Charles,MO,ACTIVE
+STCHARLESIL.GOV,City,Non-Federal Agency,St. Charles,IL,ACTIVE
+STCROIXFALLSWI.GOV,City,Non-Federal Agency,City of St. Croix Falls,WI,ACTIVE
+STEPHENVILLETX.GOV,City,Non-Federal Agency,Stephenville,TX,ACTIVE
+STERLING-IL.GOV,City,Non-Federal Agency,Sterling,IL,ACTIVE
+STERLING-MA.GOV,City,Non-Federal Agency,Sterling,MA,ACTIVE
+STERLINGHEIGHTSMI.GOV,City,Non-Federal Agency,Sterling Heights,MI,ACTIVE
+STJOHNSAZ.GOV,City,Non-Federal Agency,St. Johns,AZ,ACTIVE
+STLOUIS-MO.GOV,City,Non-Federal Agency,St. Louis,MO,ACTIVE
+STLUCIECO.GOV,City,Non-Federal Agency,Ft. Pierce,FL,ACTIVE
+STMARYSGA.GOV,City,Non-Federal Agency,ST. MARYS,GA,ACTIVE
+STMARYSPA.GOV,City,Non-Federal Agency,St. Marys,PA,ACTIVE
+STMATTHEWSKY.GOV,City,Non-Federal Agency,Louisville,KY,ACTIVE
+STOCKTONCA.GOV,City,Non-Federal Agency,Stockton,CA,ACTIVE
+STONEHAM-MA.GOV,City,Non-Federal Agency,Stoneham,MA,ACTIVE
+STONINGTON-CT.GOV,City,Non-Federal Agency,Stonington,CT,ACTIVE
+STPAUL.GOV,City,Non-Federal Agency,Saint Paul,MN,ACTIVE
+STPETE-FL.GOV,City,Non-Federal Agency,St. Petersburg,FL,ACTIVE
+STRATHAMNH.GOV,City,Non-Federal Agency,Stratham,NH,ACTIVE
+STURGIS-SD.GOV,City,Non-Federal Agency,Sturgis,SD,ACTIVE
+STURGISMI.GOV,City,Non-Federal Agency,Sturgis,MI,ACTIVE
+STURTEVANT-WI.GOV,City,Non-Federal Agency,Sturtevant,WI,ACTIVE
+SUDBURY-MA.GOV,City,Non-Federal Agency,Sudbury,MA,ACTIVE
+SUFFOLK-VA.GOV,City,Non-Federal Agency,Suffolk,VA,ACTIVE
+SUGAR-LANDCITYTX.GOV,City,Non-Federal Agency,Sugar Land,TX,ACTIVE
+SUGAR-LANDTX.GOV,City,Non-Federal Agency,Sugar Land,TX,ACTIVE
+SUGARCITYIDAHO.GOV,City,Non-Federal Agency,Sugar City,ID,ACTIVE
+SUGARGROVEIL.GOV,City,Non-Federal Agency,Sugar Grove,IL,ACTIVE
+SUGARLAND-CITYTX.GOV,City,Non-Federal Agency,Sugar Land,TX,ACTIVE
+SUGARLAND-TX.GOV,City,Non-Federal Agency,Sugar Land,TX,ACTIVE
+SUGARLANDCITY-TX.GOV,City,Non-Federal Agency,Sugar Land,TX,ACTIVE
+SUGARLANDCITYTX.GOV,City,Non-Federal Agency,Sugar Land,TX,ACTIVE
+SUGARLANDTX.GOV,City,Non-Federal Agency,Sugar Land,TX,ACTIVE
+SULLIVANOHIO.GOV,City,Non-Federal Agency,Sullivan,OH,ACTIVE
+SUMMERVILLESC.GOV,City,Non-Federal Agency,Summerville,SC,ACTIVE
+SUMNERWA.GOV,City,Non-Federal Agency,Sumner,WA,ACTIVE
+SUMTERSC.GOV,City,Non-Federal Agency,Sumter,SC,ACTIVE
+SUNLANDPARK-NM.GOV,City,Non-Federal Agency,Sunland Park,NM,ACTIVE
+SUNNYSIDE-WA.GOV,City,Non-Federal Agency,Sunnyside,WA,ACTIVE
+SUNRISEBEACH-MO.GOV,City,Non-Federal Agency,Sunrise Beach,MO,ACTIVE
+SUNSETBEACHNC.GOV,City,Non-Federal Agency,Sunset Beach,NC,ACTIVE
+SUPERIORAZ.GOV,City,Non-Federal Agency,Superior,AZ,ACTIVE
+SUPERIORCOLORADO.GOV,City,Non-Federal Agency,Superior,CO,ACTIVE
+SURGOINSVILLETN.GOV,City,Non-Federal Agency,Surgoinsville,TN,ACTIVE
+SURPRISEAZ.GOV,City,Non-Federal Agency,Surprise,AZ,ACTIVE
+SUTTON-NH.GOV,City,Non-Federal Agency,Sutton,NH,ACTIVE
+SYLACAUGAAL.GOV,City,Non-Federal Agency,Sylacauga,AL,ACTIVE
+SYRACUSEKS.GOV,City,Non-Federal Agency,Syracuse,KS,ACTIVE
+TABERNACLENJ.GOV,City,Non-Federal Agency,Tabernacle,NJ,ACTIVE
+TACOMAWA.GOV,City,Non-Federal Agency,Tacoma,WA,ACTIVE
+TAFTTX.GOV,City,Non-Federal Agency,TAFT,TX,ACTIVE
+TALLAPOOSAGA.GOV,City,Non-Federal Agency,Tallapoosa,GA,ACTIVE
+TALLASSEE-AL.GOV,City,Non-Federal Agency,Millbrook,AL,ACTIVE
+TALLULAH-LA.GOV,City,Non-Federal Agency,Tallulah,LA,ACTIVE
+TALLULAHFALLSGA.GOV,City,Non-Federal Agency,Tallulah Falls,GA,ACTIVE
+TAMPAFL.GOV,City,Non-Federal Agency,Tampa,FL,ACTIVE
+TAPPAHANNOCK-VA.GOV,City,Non-Federal Agency,Tappahannock,VA,ACTIVE
+TAUNTON-MA.GOV,City,Non-Federal Agency,Taunton,MA,ACTIVE
+TAYLORMILLKY.GOV,City,Non-Federal Agency,Taylor Mill,KY,ACTIVE
+TAYLORSVILLEUT.GOV,City,Non-Federal Agency,Taylorsville ,UT,ACTIVE
+TAYLORTX.GOV,City,Non-Federal Agency,Taylor,TX,ACTIVE
+TEANECKNJ.GOV,City,Non-Federal Agency,Teaneck,NJ,ACTIVE
+TEGACAYSC.GOV,City,Non-Federal Agency,Tega Cay,SC,ACTIVE
+TELLURIDE-CO.GOV,City,Non-Federal Agency,Telluride,CO,ACTIVE
+TEMECULACA.GOV,City,Non-Federal Agency,Temecula,CA,ACTIVE
+TEMPE.GOV,City,Non-Federal Agency,Tempe,AZ,ACTIVE
+TEMPLETX.GOV,City,Non-Federal Agency,Temple,TX,ACTIVE
+TENNILLE-GA.GOV,City,Non-Federal Agency,Tennille,GA,ACTIVE
+THECOLONYTX.GOV,City,Non-Federal Agency,The Colony,TX,ACTIVE
+THEWOODLANDS-TX.GOV,City,Non-Federal Agency,The Woodlands,TX,ACTIVE
+THEWOODLANDSTOWNSHIP-TX.GOV,City,Non-Federal Agency,The Woodlands,TX,ACTIVE
+THOMASVILLE-NC.GOV,City,Non-Federal Agency,Thomasville,NC,ACTIVE
+THORNEBAY-AK.GOV,City,Non-Federal Agency,Thorne Bay,AK,ACTIVE
+TIFFINOHIO.GOV,City,Non-Federal Agency,Tiffin,OH,ACTIVE
+TIGARD-OR.GOV,City,Non-Federal Agency,Tigard,OR,ACTIVE
+TILLAMOOKOR.GOV,City,Non-Federal Agency,Tillamook,OR,ACTIVE
+TIMNATH-CO.GOV,City,Non-Federal Agency,Timnath,CO,ACTIVE
+TINLEYPARK-IL.GOV,City,Non-Federal Agency,Tinley Park,IL,ACTIVE
+TINLEYPARKIL.GOV,City,Non-Federal Agency,Tinley Park,IL,ACTIVE
+TIOGATX.GOV,City,Non-Federal Agency,Tioga,TX,ACTIVE
+TIPPCITYOHIO.GOV,City,Non-Federal Agency,Tipp City,OH,ACTIVE
+TISBURYMA.GOV,City,Non-Federal Agency,Tisbury,MA,ACTIVE
+TOBYHANNATWPPA.GOV,City,Non-Federal Agency,Pocono Pines,PA,ACTIVE
+TOLLAND-MA.GOV,City,Non-Federal Agency,Tolland,MA,ACTIVE
+TOMBALLTX.GOV,City,Non-Federal Agency,Tomball,TX,ACTIVE
+TOMPKINSVILLEKY.GOV,City,Non-Federal Agency,Tompkinsville,KY,ACTIVE
+TONTITOWNAR.GOV,City,Non-Federal Agency,Tontitown,AR,ACTIVE
+TOPSFIELD-MA.GOV,City,Non-Federal Agency,Topsfield,MA,ACTIVE
+TORRANCECA.GOV,City,Non-Federal Agency,Torrance,CA,ACTIVE
+TORREYUTAH.GOV,City,Non-Federal Agency,Torrey,UT,ACTIVE
+TORRINGTON-CT.GOV,City,Non-Federal Agency,Torrington,CT,ACTIVE
+TORRINGTONWY.GOV,City,Non-Federal Agency,Torrington,WY,ACTIVE
+TOWERLAKES-IL.GOV,City,Non-Federal Agency,Tower Lakes,IL,ACTIVE
+TOWNOFBETHLEHEM-NY.GOV,City,Non-Federal Agency,Delmar,NY,ACTIVE
+TOWNOFBLOWINGROCKNC.GOV,City,Non-Federal Agency,Blowing Rock,NC,ACTIVE
+TOWNOFBLYTHEWOODSC.GOV,City,Non-Federal Agency,Blythewood,SC,ACTIVE
+TOWNOFCALLAHAN-FL.GOV,City,Non-Federal Agency,Callahan,FL,ACTIVE
+TOWNOFCARRBORONC.GOV,City,Non-Federal Agency,Carrboro,NC,ACTIVE
+TOWNOFCARYNC.GOV,City,Non-Federal Agency,Cary,NC,ACTIVE
+TOWNOFCATSKILLNY.GOV,City,Non-Federal Agency,Catskill,NY,ACTIVE
+TOWNOFCHADBOURNNC.GOV,City,Non-Federal Agency,Chadbourn,NC,ACTIVE
+TOWNOFCLAYTONNC.GOV,City,Non-Federal Agency,Clayton,NC,ACTIVE
+TOWNOFDUNNWI.GOV,City,Non-Federal Agency,McFarland,WI,ACTIVE
+TOWNOFEASTHAVEN-CT.GOV,City,Non-Federal Agency,East Haven,CT,ACTIVE
+TOWNOFHALFMOON-NY.GOV,City,Non-Federal Agency,Halfmoon,NY,ACTIVE
+TOWNOFHAVERHILL-FL.GOV,City,Non-Federal Agency,Haverhill,FL,ACTIVE
+TOWNOFHAYDENAZ.GOV,City,Non-Federal Agency,Hayden,AZ,ACTIVE
+TOWNOFHOMECROFTIN.GOV,City,Non-Federal Agency,Indianapolis,IN,ACTIVE
+TOWNOFHOUNSFIELD-NY.GOV,City,Non-Federal Agency,Watertown,NY,ACTIVE
+TOWNOFISLIP-NY.GOV,City,Non-Federal Agency,Islip,NY,ACTIVE
+TOWNOFKEENENY.GOV,City,Non-Federal Agency,Keene,NY,ACTIVE
+TOWNOFKENTNY.GOV,City,Non-Federal Agency,Kent Lakes,NY,ACTIVE
+TOWNOFLAPOINTEWI.GOV,City,Non-Federal Agency,La Pointe,WI,ACTIVE
+TOWNOFLAVETA-CO.GOV,City,Non-Federal Agency,La Veta,CO,ACTIVE
+TOWNOFMAYNARD-MA.GOV,City,Non-Federal Agency,Maynard,MA,ACTIVE
+TOWNOFMONTEAGLE-TN.GOV,City,Non-Federal Agency,Monteagle,TN,ACTIVE
+TOWNOFNASHVILLENC.GOV,City,Non-Federal Agency,Nashville,NC,ACTIVE
+TOWNOFNORTH-SC.GOV,City,Non-Federal Agency,North,SC,ACTIVE
+TOWNOFNORTHEASTNY.GOV,City,Non-Federal Agency,Millerton,NY,ACTIVE
+TOWNOFORANGEVA.GOV,City,Non-Federal Agency,Orange,VA,ACTIVE
+TOWNOFOYSTERBAY-NY.GOV,City,Non-Federal Agency,Oyster Bay,NY,ACTIVE
+TOWNOFPALERMONY.GOV,City,Non-Federal Agency,FULTON,NY,ACTIVE
+TOWNOFPENNINGTONVA.GOV,City,Non-Federal Agency,Pennington Gap,VA,ACTIVE
+TOWNOFPOUGHKEEPSIE-NY.GOV,City,Non-Federal Agency,POUGHKEEPSIE,NY,ACTIVE
+TOWNOFRAMAPO-NY.GOV,City,Non-Federal Agency,Suffern,NY,ACTIVE
+TOWNOFRIVERHEADNY.GOV,City,Non-Federal Agency,Riverhead,NY,ACTIVE
+TOWNOFROBERSONVILLE-NC.GOV,City,Non-Federal Agency,Robersonville,NC,ACTIVE
+TOWNOFSHIELDS-WI.GOV,City,Non-Federal Agency,Montello,WI,ACTIVE
+TOWNOFSHIRLEY-MA.GOV,City,Non-Federal Agency,Shirley,MA,ACTIVE
+TOWNOFSMYRNA-TN.GOV,City,Non-Federal Agency,Smyrna,TN,ACTIVE
+TOWNOFSTLEO-FL.GOV,City,Non-Federal Agency,Saint Leo,FL,ACTIVE
+TOWNOFSURFSIDEFL.GOV,City,Non-Federal Agency,Surfside,FL,ACTIVE
+TOWNOFTROPICUT.GOV,City,Non-Federal Agency,Tropic,UT,ACTIVE
+TOWNOFTROUTVILLE-VA.GOV,City,Non-Federal Agency,Troutville,VA,ACTIVE
+TOWNOFVASSNC.GOV,City,Non-Federal Agency,Vass,NC,ACTIVE
+TOWNOFWALLINGFORD-CT.GOV,City,Non-Federal Agency,Wallingford,CT,ACTIVE
+TOWNOFWALWORTHNY.GOV,City,Non-Federal Agency,Walworth,NY,ACTIVE
+TOWNOFWARREN-RI.GOV,City,Non-Federal Agency,Warren,RI,ACTIVE
+TOWNOFWASHINGTONVA.GOV,City,Non-Federal Agency,Washington,VA,ACTIVE
+TOWNOFWILLSBORONY.GOV,City,Non-Federal Agency,Willsboro,NY,ACTIVE
+TOWNOFWOODSTOCKVA.GOV,City,Non-Federal Agency,Woodstock,VA,ACTIVE
+TOWNSHIPOFTABERNACLE-NJ.GOV,City,Non-Federal Agency,Tabernacle,NJ,ACTIVE
+TRAVERSECITYMI.GOV,City,Non-Federal Agency,Traverse City,MI,ACTIVE
+TRENTONGA.GOV,City,Non-Federal Agency,trenton,GA,ACTIVE
+TRICOUNTYCONSERVANCY-IN.GOV,City,Non-Federal Agency,Plainfield,IN,ACTIVE
+TRINITY-NC.GOV,City,Non-Federal Agency,Trinity,NC,ACTIVE
+TRINITYAL.GOV,City,Non-Federal Agency,Trinity,AL,ACTIVE
+TROPHYCLUBTX.GOV,City,Non-Federal Agency,Trophy Club,TX,ACTIVE
+TROUTDALEOREGON.GOV,City,Non-Federal Agency,Troutdale,OR,ACTIVE
+TROUTMANNC.GOV,City,Non-Federal Agency,Troutman,NC,ACTIVE
+TROYAL.GOV,City,Non-Federal Agency,Troy,AL,ACTIVE
+TROYMI.GOV,City,Non-Federal Agency,Troy,MI,ACTIVE
+TROYNY.GOV,City,Non-Federal Agency,Troy,NY,ACTIVE
+TROYOHIO.GOV,City,Non-Federal Agency,Troy,OH,ACTIVE
+TRUMANSBURG-NY.GOV,City,Non-Federal Agency,Trumansburg,NY,ACTIVE
+TRUMBULL-CT.GOV,City,Non-Federal Agency,Trumbull,CT,ACTIVE
+TRURO-MA.GOV,City,Non-Federal Agency,Truro,MA,ACTIVE
+TUALATINOREGON.GOV,City,Non-Federal Agency,TUALATIN,OR,ACTIVE
+TUCKERGA.GOV,City,Non-Federal Agency,Tucker,GA,ACTIVE
+TUCSONAZ.GOV,City,Non-Federal Agency,Tucson,AZ,ACTIVE
+TUKWILA-WA.GOV,City,Non-Federal Agency,Tukwila,WA,ACTIVE
+TUKWILAWA.GOV,City,Non-Federal Agency,Tukwila,WA,ACTIVE
+TULIA-TX.GOV,City,Non-Federal Agency,Tulia,TX,ACTIVE
+TULLAHOMATN.GOV,City,Non-Federal Agency,Tullahoma,TN,ACTIVE
+TUMWATERWA.GOV,City,Non-Federal Agency,Tumwater,WA,ACTIVE
+TUPELOMS.GOV,City,Non-Federal Agency,Tupelo,MS,ACTIVE
+TUPPERLAKENY.GOV,City,Non-Federal Agency,Tupper Lake,NY,ACTIVE
+TUSAYAN-AZ.GOV,City,Non-Federal Agency,Tusayan,AZ,ACTIVE
+TUSAYANAZ.GOV,City,Non-Federal Agency,Grand Canyon,AZ,ACTIVE
+TUSCALOOSA-AL.GOV,City,Non-Federal Agency,Tuscaloosa,AL,ACTIVE
+TUSKEGEEALABAMA.GOV,City,Non-Federal Agency,Tuskegee,AL,ACTIVE
+TUXEDOPARK-NY.GOV,City,Non-Federal Agency,Sloatsburg,NY,ACTIVE
+TWPOCEANNJ.GOV,City,Non-Federal Agency,Waretown,NJ,ACTIVE
+TYNGSBOROUGHMA.GOV,City,Non-Federal Agency,Tyngsborough,MA,ACTIVE
+TYRINGHAM-MA.GOV,City,Non-Federal Agency,Tyringham,MA,ACTIVE
+UCTX.GOV,City,Non-Federal Agency,Universal City,TX,ACTIVE
+UNDERHILLVT.GOV,City,Non-Federal Agency,"Underhill, Ctr",VT,ACTIVE
+UNIONBEACHNJ.GOV,City,Non-Federal Agency,Union Beach,NJ,ACTIVE
+UNIONCITY-IN.GOV,City,Non-Federal Agency,Union City,IN,ACTIVE
+UNIONCITYNJ.GOV,City,Non-Federal Agency,Union City,NJ,ACTIVE
+UNIONCITYTN.GOV,City,Non-Federal Agency,UNION CITY,TN,ACTIVE
+UNIONGAPWA.GOV,City,Non-Federal Agency,Union Gap,WA,ACTIVE
+UNIONSPRINGSAL.GOV,City,Non-Federal Agency,Union Springs,AL,ACTIVE
+UNIONTWP-HCNJ.GOV,City,Non-Federal Agency,HAMPTON,NJ,ACTIVE
+UNITYNH.GOV,City,Non-Federal Agency,Charlestown,NH,ACTIVE
+UNIVERSALCITYTEXAS.GOV,City,Non-Federal Agency,Universal City,TX,ACTIVE
+UPLANDCA.GOV,City,Non-Federal Agency,UPLAND,CA,ACTIVE
+UPPERMARLBOROMD.GOV,City,Non-Federal Agency,Upper Marlboro,MD,ACTIVE
+UPPERUWCHLAN-PA.GOV,City,Non-Federal Agency,Chester Springs,PA,ACTIVE
+UPTONMA.GOV,City,Non-Federal Agency,Upton,MA,ACTIVE
+URBANNAVA.GOV,City,Non-Federal Agency,Urbanna,VA,ACTIVE
+UTICA-IL.GOV,City,Non-Federal Agency,Utica,IL,ACTIVE
+UVALDETX.GOV,City,Non-Federal Agency,Uvalde,TX,ACTIVE
+UXBRIDGE-MA.GOV,City,Non-Federal Agency,Uxbridge,MA,ACTIVE
+VANMETERIA.GOV,City,Non-Federal Agency,Van Meter,IA,ACTIVE
+VBHIL.GOV,City,Non-Federal Agency,Barrington Hills,IL,ACTIVE
+VENETAOREGON.GOV,City,Non-Federal Agency,Veneta,OR,ACTIVE
+VERMONTVILLE-MI.GOV,City,Non-Federal Agency,Vermontville,MI,ACTIVE
+VERNON-CT.GOV,City,Non-Federal Agency,Vernon,CT,ACTIVE
+VERNONIA-OR.GOV,City,Non-Federal Agency,Vernonia,OR,ACTIVE
+VERNONTWP-PA.GOV,City,Non-Federal Agency,Meadville,PA,ACTIVE
+VERNONTX.GOV,City,Non-Federal Agency,Vernon,TX,ACTIVE
+VERONAWI.GOV,City,Non-Federal Agency,Verona,WI,ACTIVE
+VICKSBURGMS.GOV,City,Non-Federal Agency,Vicksburg,MS,ACTIVE
+VICTORVILLECA.GOV,City,Non-Federal Agency,Victorville,CA,ACTIVE
+VICTORYGARDENSNJ.GOV,City,Non-Federal Agency,Victory Gardens,NJ,ACTIVE
+VIDALIAGA.GOV,City,Non-Federal Agency,VIDALIA,GA,ACTIVE
+VIENNAVA.GOV,City,Non-Federal Agency,VIENNA,VA,ACTIVE
+VILLAGEOFBABYLONNY.GOV,City,Non-Federal Agency,Babylon,NY,ACTIVE
+VILLAGEOFCAMILLUS-NY.GOV,City,Non-Federal Agency,CAMILLUS,NY,ACTIVE
+VILLAGEOFCRESTWOODIL.GOV,City,Non-Federal Agency,Crestwood,IL,ACTIVE
+VILLAGEOFDUNLAP-IL.GOV,City,Non-Federal Agency,Dunlap,IL,ACTIVE
+VILLAGEOFGOSHEN-NY.GOV,City,Non-Federal Agency,Goshen,NY,ACTIVE
+VILLAGEOFGOUVERNEURNY.GOV,City,Non-Federal Agency,Gouverneur,NY,ACTIVE
+VILLAGEOFHEMPSTEADNY.GOV,City,Non-Federal Agency,Hemsptead,NY,ACTIVE
+VILLAGEOFKENSINGTONNY.GOV,City,Non-Federal Agency,Great Neck,NY,ACTIVE
+VILLAGEOFLINDENHURSTNY.GOV,City,Non-Federal Agency,Lindenhurst,NY,ACTIVE
+VILLAGEOFMAMARONECKNY.GOV,City,Non-Federal Agency,Mamaroneck,NY,ACTIVE
+VILLAGEOFMAZOMANIEWI.GOV,City,Non-Federal Agency,Mazomanie,WI,ACTIVE
+VILLAGEOFMCCOMBOH.GOV,City,Non-Federal Agency,McComb,OH,ACTIVE
+VILLAGEOFMISENHEIMERNC.GOV,City,Non-Federal Agency,Misenheimer,NC,ACTIVE
+VILLAGEOFNEWHAVEN-MI.GOV,City,Non-Federal Agency,New Haven,MI,ACTIVE
+VILLAGEOFNEWHOLLAND-OH.GOV,City,Non-Federal Agency,New Holland,OH,ACTIVE
+VILLAGEOFNEWTOWNOHIO.GOV,City,Non-Federal Agency,Newtown,OH,ACTIVE
+VILLAGEOFPHOENIX-NY.GOV,City,Non-Federal Agency,Phoenix,NY,ACTIVE
+VILLAGEOFPINEHURSTNC.GOV,City,Non-Federal Agency,Pinehurst,NC,ACTIVE
+VILLAGEOFQUOGUENY.GOV,City,Non-Federal Agency,Quogue,NY,ACTIVE
+VILLAGEOFRHINEBECKNY.GOV,City,Non-Federal Agency,Rhinebeck,NY,ACTIVE
+VILLAGEOFSCOTIANY.GOV,City,Non-Federal Agency,Scotia,NY,ACTIVE
+VILLAGEOFVOLENTE-TX.GOV,City,Non-Federal Agency,Volente,TX,ACTIVE
+VILLAGEOFWAUCONDA-IL.GOV,City,Non-Federal Agency,Wauconda,IL,ACTIVE
+VINTONVA.GOV,City,Non-Federal Agency,Vinton,VA,ACTIVE
+VIRGINIAGARDENS-FL.GOV,City,Non-Federal Agency,Virginia Gardens,FL,ACTIVE
+VOLENTETEXAS.GOV,City,Non-Federal Agency,Volente,TX,ACTIVE
+VOLUNTOWN.GOV,City,Non-Federal Agency,Voluntown,CT,ACTIVE
+VONORMYTX.GOV,City,Non-Federal Agency,Von Ormy,TX,ACTIVE
+WACOTX.GOV,City,Non-Federal Agency,Waco,TX,ACTIVE
+WAITEHILLOH.GOV,City,Non-Federal Agency,Waite Hill,OH,ACTIVE
+WAKEFORESTNC.GOV,City,Non-Federal Agency,WAKE FOREST,NC,ACTIVE
+WALDENTN.GOV,City,Non-Federal Agency,Signal Mountain,TN,ACTIVE
+WALKER-LA.GOV,City,Non-Federal Agency,Walker,LA,ACTIVE
+WALKERSVILLEMD.GOV,City,Non-Federal Agency,Walkersville,MD,ACTIVE
+WALLAWALLAWA.GOV,City,Non-Federal Agency,Walla Walla,WA,ACTIVE
+WALLINGFORDCT.GOV,City,Non-Federal Agency,Wallingford,CT,ACTIVE
+WALNUTGROVEMS.GOV,City,Non-Federal Agency,Walnut Grove,MS,ACTIVE
+WALTONHILLSOHIO.GOV,City,Non-Federal Agency,Walton Hills,OH,ACTIVE
+WANATAH-IN.GOV,City,Non-Federal Agency,Wanatah,IN,ACTIVE
+WAPPINGERSFALLSNY.GOV,City,Non-Federal Agency,Wappingers Falls,NY,ACTIVE
+WARNERROBINSGA.GOV,City,Non-Federal Agency,Warner Robins,GA,ACTIVE
+WARRACRES-OK.GOV,City,Non-Federal Agency,Warr Acres,OK,ACTIVE
+WARREN-MA.GOV,City,Non-Federal Agency,Warren,MA,ACTIVE
+WARRENPA.GOV,City,Non-Federal Agency,Warren,PA,ACTIVE
+WARRENTONVA.GOV,City,Non-Federal Agency,Warrenton,VA,ACTIVE
+WARWICKRI.GOV,City,Non-Federal Agency,Warwick,RI,ACTIVE
+WASHINGTON-WARRENAIRPORT-NC.GOV,City,Non-Federal Agency,WASHINGTON,NC,ACTIVE
+WASHINGTONBORO-NJ.GOV,City,Non-Federal Agency,Washington,NJ,ACTIVE
+WASHINGTONISLAND-WI.GOV,City,Non-Federal Agency,Washington Island,WI,ACTIVE
+WASHINGTONPA.GOV,City,Non-Federal Agency,Washington,PA,ACTIVE
+WASHINGTONVA.GOV,City,Non-Federal Agency,Washington,VA,ACTIVE
+WASHINGTONVILLE-NY.GOV,City,Non-Federal Agency,Washingtonville,NY,ACTIVE
+WASHINGTONVIRGINIA.GOV,City,Non-Federal Agency,Washington,VA,ACTIVE
+WATCHUNGNJ.GOV,City,Non-Federal Agency,Watchung,NJ,ACTIVE
+WATERBORO-ME.GOV,City,Non-Federal Agency,East Waterboro,ME,ACTIVE
+WATERFORDMI.GOV,City,Non-Federal Agency,Waterford,MI,ACTIVE
+WATERTOWN-MA.GOV,City,Non-Federal Agency,Watertown,MA,ACTIVE
+WATERTOWN-NY.GOV,City,Non-Federal Agency,Watertown,NY,ACTIVE
+WATERVILLE-ME.GOV,City,Non-Federal Agency,Waterville,ME,ACTIVE
+WAUCONDA-IL.GOV,City,Non-Federal Agency,Wauconda,IL,ACTIVE
+WAUKEGANIL.GOV,City,Non-Federal Agency,Waukegan,IL,ACTIVE
+WAUKESHA-WI.GOV,City,Non-Federal Agency,Waukesha,WI,ACTIVE
+WAVELAND-MS.GOV,City,Non-Federal Agency,Waveland,MS,ACTIVE
+WAYNESBURGPA.GOV,City,Non-Federal Agency,Waynesburg,PA,ACTIVE
+WAYNESVILLENC.GOV,City,Non-Federal Agency,Waynesville,NC,ACTIVE
+WEATHERFORDTX.GOV,City,Non-Federal Agency,Weatherford,TX,ACTIVE
+WEATHERLYPA.GOV,City,Non-Federal Agency,Weatherly,PA,ACTIVE
+WEBSTER-MA.GOV,City,Non-Federal Agency,Webster,MA,ACTIVE
+WEBSTER-NH.GOV,City,Non-Federal Agency,Webster,NH,ACTIVE
+WEBSTERFL.GOV,City,Non-Federal Agency,Webster,FL,ACTIVE
+WEEHAWKENNJ.GOV,City,Non-Federal Agency,Weehawken,NJ,ACTIVE
+WELAKA-FL.GOV,City,Non-Federal Agency,Welaka,FL,ACTIVE
+WELLESLEYMA.GOV,City,Non-Federal Agency,Wellesley,MA,ACTIVE
+WELLFLEET-MA.GOV,City,Non-Federal Agency,Wellfleet,MA,ACTIVE
+WELLINGTONCOLORADO.GOV,City,Non-Federal Agency,Wellington,CO,ACTIVE
+WELLINGTONFL.GOV,City,Non-Federal Agency,Wellington,FL,ACTIVE
+WELLSBURGWV.GOV,City,Non-Federal Agency,WELLSBURG,WV,ACTIVE
+WENATCHEEWA.GOV,City,Non-Federal Agency,Wenatchee,WA,ACTIVE
+WESLACOTX.GOV,City,Non-Federal Agency,Weslaco,TX,ACTIVE
+WESSONMS.GOV,City,Non-Federal Agency,Wesson,MS,ACTIVE
+WESTALLISWI.GOV,City,Non-Federal Agency,West Allis,WI,ACTIVE
+WESTAMPTONNJ.GOV,City,Non-Federal Agency,Westampton,NJ,ACTIVE
+WESTBENDWI.GOV,City,Non-Federal Agency,West Bend,WI,ACTIVE
+WESTBOYLSTON-MA.GOV,City,Non-Federal Agency,West Boylston,MA,ACTIVE
+WESTBUECHELKY.GOV,City,Non-Federal Agency,WEST BUECHEL,KY,ACTIVE
+WESTCOLUMBIASC.GOV,City,Non-Federal Agency,West Columbia,SC,ACTIVE
+WESTFARGOND.GOV,City,Non-Federal Agency,Bismarck,ND,ACTIVE
+WESTFIELDNJ.GOV,City,Non-Federal Agency,Westfield,NJ,ACTIVE
+WESTFORD-MA.GOV,City,Non-Federal Agency,Westford,MA,ACTIVE
+WESTFORDMA.GOV,City,Non-Federal Agency,Westford,MA,ACTIVE
+WESTFORKAR.GOV,City,Non-Federal Agency,West Fork,AR,ACTIVE
+WESTFRANKFORT-IL.GOV,City,Non-Federal Agency,West Frankfort,IL,ACTIVE
+WESTHARTFORDCT.GOV,City,Non-Federal Agency,West Hartford,CT,ACTIVE
+WESTHAVEN-CT.GOV,City,Non-Federal Agency,West Haven,CT,ACTIVE
+WESTJEFFERSONOHIO.GOV,City,Non-Federal Agency,West Jefferson,OH,ACTIVE
+WESTLINNOREGON.GOV,City,Non-Federal Agency,West Linn,OR,ACTIVE
+WESTMILTONOHIO.GOV,City,Non-Federal Agency,West Milton,OH,ACTIVE
+WESTMINSTER-CA.GOV,City,Non-Federal Agency,Westminster,CA,ACTIVE
+WESTMINSTER-MA.GOV,City,Non-Federal Agency,Westminster,MA,ACTIVE
+WESTMINSTERMD.GOV,City,Non-Federal Agency,Westminster,MD,ACTIVE
+WESTMORELANDTN.GOV,City,Non-Federal Agency,Westmoreland,TN,ACTIVE
+WESTONCT.GOV,City,Non-Federal Agency,Weston,CT,ACTIVE
+WESTONFL.GOV,City,Non-Federal Agency,Weston,FL,ACTIVE
+WESTONWI.GOV,City,Non-Federal Agency,Weston,WI,ACTIVE
+WESTPALMBEACH-FL.GOV,City,Non-Federal Agency,West Palm Beach,FL,ACTIVE
+WESTPORT-MA.GOV,City,Non-Federal Agency,Westport,MA,ACTIVE
+WESTPORTCT.GOV,City,Non-Federal Agency,Westport,CT,ACTIVE
+WESTSTOCKBRIDGE-MA.GOV,City,Non-Federal Agency,West Stockbridge,MA,ACTIVE
+WESTTISBURY-MA.GOV,City,Non-Federal Agency,West Tisbury,MA,ACTIVE
+WESTUTX.GOV,City,Non-Federal Agency,West University Place ,TX,ACTIVE
+WESTVALLEYCITY-UT.GOV,City,Non-Federal Agency,West Valley City,UT,ACTIVE
+WESTWOOD-MA.GOV,City,Non-Federal Agency,Westwood,MA,ACTIVE
+WESTWOODMA.GOV,City,Non-Federal Agency,Westwood,MA,ACTIVE
+WESTWOODNJ.GOV,City,Non-Federal Agency,Westwood,NJ,ACTIVE
+WETHERSFIELDCT.GOV,City,Non-Federal Agency,Wethersfield,CT,ACTIVE
+WHEELINGIL.GOV,City,Non-Federal Agency,Wheeling,IL,ACTIVE
+WHEELINGWV.GOV,City,Non-Federal Agency,Wheeling,WV,ACTIVE
+WHITECOUNTY-IL.GOV,City,Non-Federal Agency,Carmi,IL,ACTIVE
+WHITEHOUSEOH.GOV,City,Non-Federal Agency,Whitehouse,OH,ACTIVE
+WHITEPLAINSNY.GOV,City,Non-Federal Agency,White Plains,NY,ACTIVE
+WHITEWATER-WI.GOV,City,Non-Federal Agency,Whitewater,WI,ACTIVE
+WHITINGWI.GOV,City,Non-Federal Agency,Stevens Point,WI,ACTIVE
+WHITTIERALASKA.GOV,City,Non-Federal Agency,Whittier,AK,ACTIVE
+WICHITA.GOV,City,Non-Federal Agency,Wichita,KS,ACTIVE
+WICHITAFALLSTX.GOV,City,Non-Federal Agency,Wichita Falls,TX,ACTIVE
+WILBRAHAM-MA.GOV,City,Non-Federal Agency,Wilbraham,MA,ACTIVE
+WILDWOOD-FL.GOV,City,Non-Federal Agency,Wildwood,FL,ACTIVE
+WILKINSBURGPA.GOV,City,Non-Federal Agency,Wilkinsburg,PA,ACTIVE
+WILLAMINAOREGON.GOV,City,Non-Federal Agency,Willamina,OR,ACTIVE
+WILLARDNM.GOV,City,Non-Federal Agency,Willard,NM,ACTIVE
+WILLIAMSAZ.GOV,City,Non-Federal Agency,Williams,AZ,ACTIVE
+WILLIAMSBURGVA.GOV,City,Non-Federal Agency,Williamsburg,VA,ACTIVE
+WILLIAMSPORTMD.GOV,City,Non-Federal Agency,WILLIAMSPORT,MD,ACTIVE
+WILLIAMSTOWNMA.GOV,City,Non-Federal Agency,Williamstown,MA,ACTIVE
+WILLINGBORONJ.GOV,City,Non-Federal Agency,Willingboro,NJ,ACTIVE
+WILLINGTONCT.GOV,City,Non-Federal Agency,Willington,CT,ACTIVE
+WILLISTONFL.GOV,City,Non-Federal Agency,Williston,FL,ACTIVE
+WILLMARMN.GOV,City,Non-Federal Agency,Willmar,MN,ACTIVE
+WILLOUGHBYHILLS-OH.GOV,City,Non-Federal Agency,Willoughby Hills,OH,ACTIVE
+WILLOWSPRINGS-IL.GOV,City,Non-Federal Agency,Willow Springs,IL,ACTIVE
+WILMINGTONDE.GOV,City,Non-Federal Agency,Wilmington,DE,ACTIVE
+WILMINGTONMA.GOV,City,Non-Federal Agency,wilmington,MA,ACTIVE
+WILTONNH.GOV,City,Non-Federal Agency,Wilton,NH,ACTIVE
+WINCHESTER-IN.GOV,City,Non-Federal Agency,Winchester,IN,ACTIVE
+WINCHESTER-NH.GOV,City,Non-Federal Agency,Winchester,NH,ACTIVE
+WINCHESTERVA.GOV,City,Non-Federal Agency,Winchester,VA,ACTIVE
+WINDCREST-TX.GOV,City,Non-Federal Agency,Windcrest,TX,ACTIVE
+WINDGAP-PA.GOV,City,Non-Federal Agency,Wind Gap,PA,ACTIVE
+WINDHAMNH.GOV,City,Non-Federal Agency,Windham,NH,ACTIVE
+WINDSOR-VA.GOV,City,Non-Federal Agency,Windsor,VA,ACTIVE
+WINDSORWI.GOV,City,Non-Federal Agency,DeForest,WI,ACTIVE
+WINNECONNEWI.GOV,City,Non-Federal Agency,Winneconne,WI,ACTIVE
+WINSLOW-ME.GOV,City,Non-Federal Agency,Winslow,ME,ACTIVE
+WINSLOWAZ.GOV,City,Non-Federal Agency,Winslow,AZ,ACTIVE
+WOBURNMA.GOV,City,Non-Federal Agency,Woburn,MA,ACTIVE
+WOODBURN-OR.GOV,City,Non-Federal Agency,Woodburn,OR,ACTIVE
+WOODBURYMN.GOV,City,Non-Federal Agency,Woodbury,MN,ACTIVE
+WOODFIN-NC.GOV,City,Non-Federal Agency,Woodfin,NC,ACTIVE
+WOODHEIGHTS-MO.GOV,City,Non-Federal Agency,Wood Heights,MO,ACTIVE
+WOODSTOCKCT.GOV,City,Non-Federal Agency,Woodstock,CT,ACTIVE
+WOODSTOCKGA.GOV,City,Non-Federal Agency,Woodstock,GA,ACTIVE
+WOODSTOCKIL.GOV,City,Non-Federal Agency,Woodstock,IL,ACTIVE
+WOODVILLE-TX.GOV,City,Non-Federal Agency,Woodville,TX,ACTIVE
+WORCESTERMA.GOV,City,Non-Federal Agency,Worcester,MA,ACTIVE
+WRGA.GOV,City,Non-Federal Agency,Warner Robins,GA,ACTIVE
+WSPMN.GOV,City,Non-Federal Agency,West Saint Paul,MN,ACTIVE
+WVC-UT.GOV,City,Non-Federal Agency,West Valley,UT,ACTIVE
+WYLIETEXAS.GOV,City,Non-Federal Agency,Wylie,TX,ACTIVE
+WYOMINGMI.GOV,City,Non-Federal Agency,Wyoming,MI,ACTIVE
+WYOMINGOHIO.GOV,City,Non-Federal Agency,Wyoming,OH,ACTIVE
+XENIA-OH.GOV,City,Non-Federal Agency,Xenia,OH,ACTIVE
+YAKIMAWA.GOV,City,Non-Federal Agency,Yakima,WA,ACTIVE
+YAMHILLCOUNTY-OR.GOV,City,Non-Federal Agency,McMinnville,OR,ACTIVE
+YONKERSNY.GOV,City,Non-Federal Agency,Yonkers,NY,ACTIVE
+YORKTOWNTX.GOV,City,Non-Federal Agency,Yorktown,TX,ACTIVE
+YOUNGSTOWNOHIO.GOV,City,Non-Federal Agency,Youngstown,OH,ACTIVE
+YOUNGSVILLELA.GOV,City,Non-Federal Agency,Youngsville,LA,ACTIVE
+YUCAIPA-CA.GOV,City,Non-Federal Agency,Yucaipa,CA,ACTIVE
+YUMAAZ.GOV,City,Non-Federal Agency,Yuma,AZ,ACTIVE
+ZILWAUKEEMICHIGAN.GOV,City,Non-Federal Agency,Zilwaukee,MI,ACTIVE
+ADAMSCOUNTYMS.GOV,County,Non-Federal Agency,Natchez,MS,ACTIVE
+ADAMSCOUNTYOH.GOV,County,Non-Federal Agency,West Union,OH,ACTIVE
+AIKENCOUNTYSC.GOV,County,Non-Federal Agency,Aiken,SC,ACTIVE
+ALBANYCOUNTYNY.GOV,County,Non-Federal Agency,Albany,NY,ACTIVE
+ALEXANDERCOUNTY-NC.GOV,County,Non-Federal Agency,Taylorsville,NC,ACTIVE
+ALEXANDERCOUNTYNC.GOV,County,Non-Federal Agency,Taylorsville,NC,ACTIVE
+ALLEGHANYCOUNTY-NC.GOV,County,Non-Federal Agency,Sparta,NC,ACTIVE
+ALLEGHENYCOUNTYPA.GOV,County,Non-Federal Agency,Pittsburgh,PA,ACTIVE
+ALPINECOUNTYCA.GOV,County,Non-Federal Agency,Markleeville,CA,ACTIVE
+AMITECOUNTYMS.GOV,County,Non-Federal Agency,Liberty,MS,ACTIVE
+ANDROSCOGGINCOUNTYMAINE.GOV,County,Non-Federal Agency,Auburn,ME,ACTIVE
+ANOKACOUNTYMN.GOV,County,Non-Federal Agency,Anoka,MN,ACTIVE
+APPOMATTOXCOUNTYVA.GOV,County,Non-Federal Agency,Appomattox,VA,ACTIVE
+ARANSASCOUNTYTX.GOV,County,Non-Federal Agency,Rockport,TX,ACTIVE
+AUGUSTACOUNTY-VA.GOV,County,Non-Federal Agency,Verona,VA,ACTIVE
+AUGUSTACOUNTYVA.GOV,County,Non-Federal Agency,Verona,VA,ACTIVE
+AVERYCOUNTYNC.GOV,County,Non-Federal Agency,Newland,NC,ACTIVE
+BACACOUNTYCO.GOV,County,Non-Federal Agency,Springfield,CO,ACTIVE
+BALDWINCOUNTYAL.GOV,County,Non-Federal Agency,Bay Minette,AL,ACTIVE
+BALTIMORECOUNTYMD.GOV,County,Non-Federal Agency,Towson,MD,ACTIVE
+BAMBERGCOUNTYSC.GOV,County,Non-Federal Agency,Bamberg,SC,ACTIVE
+BARNSTABLECOUNTY-MA.GOV,County,Non-Federal Agency,Barnstable,MA,ACTIVE
+BARRONCOUNTYWI.GOV,County,Non-Federal Agency,Barron,WI,ACTIVE
+BASTROPCOUNTYTEXAS.GOV,County,Non-Federal Agency,Bastrop,TX,ACTIVE
+BAYCOUNTY911-MI.GOV,County,Non-Federal Agency,Bay City,MI,ACTIVE
+BAYCOUNTYFL.GOV,County,Non-Federal Agency,Panama City,FL,ACTIVE
+BCCIRCLK.GOV,County,Non-Federal Agency,Princeton,IL,ACTIVE
+BEAVERCOUNTYPA.GOV,County,Non-Federal Agency,Beaver,PA,ACTIVE
+BEDFORDCOUNTYVA.GOV,County,Non-Federal Agency,Bedford,VA,ACTIVE
+BENTONCOUNTYAR.GOV,County,Non-Federal Agency,Bentonville,AR,ACTIVE
+BENTONCOUNTYMS.GOV,County,Non-Federal Agency,Ashland,MS,ACTIVE
+BENTONCOUNTYTN.GOV,County,Non-Federal Agency,Camden,TN,ACTIVE
+BERKELEYCOUNTYSC.GOV,County,Non-Federal Agency,Moncks Corner,SC,ACTIVE
+BERRIENCOUNTY-MI.GOV,County,Non-Federal Agency,St. Joseph,MI,ACTIVE
+BIGHORNCOUNTYMT.GOV,County,Non-Federal Agency,Hardin,MT,ACTIVE
+BIGHORNCOUNTYWY.GOV,County,Non-Federal Agency,Basin,WY,ACTIVE
+BILLINGSCOUNTYND.GOV,County,Non-Federal Agency,Medora,ND,ACTIVE
+BLAINECOUNTY-MT.GOV,County,Non-Federal Agency,CHINOOK,MT,ACTIVE
+BLANDCOUNTYVA.GOV,County,Non-Federal Agency,Bland,VA,ACTIVE
+BLUEEARTHCOUNTYMN.GOV,County,Non-Federal Agency,Mankato,MN,ACTIVE
+BONNERCOUNTYID.GOV,County,Non-Federal Agency,Sandpoint,ID,ACTIVE
+BOONECOUNTY-AR.GOV,County,Non-Federal Agency,Harrison,AR,ACTIVE
+BOSSIERPARISHLA.GOV,County,Non-Federal Agency,Benton ,LA,ACTIVE
+BOTETOURTVA.GOV,County,Non-Federal Agency,Fincastle,VA,ACTIVE
+BOULDERCOUNTYCOLORADO.GOV,County,Non-Federal Agency,Boulder,CO,ACTIVE
+BOWMANCOUNTYND.GOV,County,Non-Federal Agency,Bismarck,ND,ACTIVE
+BOYDCOUNTYKY.GOV,County,Non-Federal Agency,Catlettsburg,KY,ACTIVE
+BRADFORDCOUNTYFL.GOV,County,Non-Federal Agency,Starke,FL,ACTIVE
+BRADLEYCOUNTYTN.GOV,County,Non-Federal Agency,Cleveland,TN,ACTIVE
+BRANCHCOUNTYMI.GOV,County,Non-Federal Agency,Coldwater,MI,ACTIVE
+BRAZORIACOUNTY-TX.GOV,County,Non-Federal Agency,Angleton,TX,ACTIVE
+BRAZORIACOUNTY.GOV,County,Non-Federal Agency,Angleton,TX,ACTIVE
+BRAZORIACOUNTYTX.GOV,County,Non-Federal Agency,Angleton,TX,ACTIVE
+BRAZOSCOUNTYTX.GOV,County,Non-Federal Agency,Bryan,TX,ACTIVE
+BRECKINRIDGECOUNTYKY.GOV,County,Non-Federal Agency,Hardinsburg,KY,ACTIVE
+BREVARDFL.GOV,County,Non-Federal Agency,Viera,FL,ACTIVE
+BROOKINGSCOUNTYSD.GOV,County,Non-Federal Agency,Brookings,SD,ACTIVE
+BROOMECOUNTYNY.GOV,County,Non-Federal Agency,Binghamton,NY,ACTIVE
+BROWNCOUNTY-IN.GOV,County,Non-Federal Agency,Nashville,IN,ACTIVE
+BROWNCOUNTYOHIO.GOV,County,Non-Federal Agency,Georgetown,OH,ACTIVE
+BROWNCOUNTYWI.GOV,County,Non-Federal Agency,Green Bay,WI,ACTIVE
+BRUNSWICKCOUNTYNC.GOV,County,Non-Federal Agency,Bolivia,NC,ACTIVE
+BUCHANANCOUNTY-VA.GOV,County,Non-Federal Agency,Grundy,VA,ACTIVE
+BUNCOMBECOUNTYNC.GOV,County,Non-Federal Agency,Asheville,NC,ACTIVE
+BUREAUCOUNTY-IL.GOV,County,Non-Federal Agency,Princeton,IL,ACTIVE
+CABARRUSCOUNTYNC.GOV,County,Non-Federal Agency,Concord,NC,ACTIVE
+CALHOUNCOUNTYAL.GOV,County,Non-Federal Agency,Anniston,AL,ACTIVE
+CALHOUNCOUNTYMI.GOV,County,Non-Federal Agency,Marshall,MI,ACTIVE
+CALLOWAYCOUNTY-KY.GOV,County,Non-Federal Agency,Murray,KY,ACTIVE
+CAMBRIACOUNTYPA.GOV,County,Non-Federal Agency,Ebensburg,PA,ACTIVE
+CAMDENCOUNTYNC.GOV,County,Non-Federal Agency,Camden,NC,ACTIVE
+CAMPBELLCOUNTYKY.GOV,County,Non-Federal Agency,Newport,KY,ACTIVE
+CAMPBELLCOUNTYTN.GOV,County,Non-Federal Agency,Jacksboro,TN,ACTIVE
+CAMPBELLCOUNTYVA.GOV,County,Non-Federal Agency,Rustburg,VA,ACTIVE
+CANDLERCO-GA.GOV,County,Non-Federal Agency,Metter,GA,ACTIVE
+CAPECOD-MA.GOV,County,Non-Federal Agency,Barnstable,MA,ACTIVE
+CAPEMAYCOUNTYNJ.GOV,County,Non-Federal Agency,Cape May Court House,NJ,ACTIVE
+CAPITALALERT.GOV,County,Non-Federal Agency,Fairfax,VA,ACTIVE
+CAPITALERT.GOV,County,Non-Federal Agency,Fairfax,VA,ACTIVE
+CAPITALREGION.GOV,County,Non-Federal Agency,Fairfax,VA,ACTIVE
+CAROLINECOUNTYVA.GOV,County,Non-Federal Agency,Bowling Green,VA,ACTIVE
+CARROLLCOUNTYIN.GOV,County,Non-Federal Agency,Delphi,IN,ACTIVE
+CARTERCOUNTYTN.GOV,County,Non-Federal Agency,Elizabethton,TN,ACTIVE
+CARTERETCOUNTYNC.GOV,County,Non-Federal Agency,Beaufort,NC,ACTIVE
+CASCADECOUNTYMT.GOV,County,Non-Federal Agency,Great Falls,MT,ACTIVE
+CASSCOUNTYND.GOV,County,Non-Federal Agency,Bismarck,ND,ACTIVE
+CASWELLCOUNTYNC.GOV,County,Non-Federal Agency,Yanceyville,NC,ACTIVE
+CATAWBACOUNTYNC.GOV,County,Non-Federal Agency,Newton,NC,ACTIVE
+CATRONCOUNTYNM.GOV,County,Non-Federal Agency,Reserve,NM,ACTIVE
+CECILCOUNTYMD.GOV,County,Non-Federal Agency,Elkton,MD,ACTIVE
+CEDARCOUNTYMO.GOV,County,Non-Federal Agency,Stockton,MO,ACTIVE
+CENTRECOUNTYPA.GOV,County,Non-Federal Agency,Bellefonte,PA,ACTIVE
+CHAMBERSCOUNTYAL.GOV,County,Non-Federal Agency,Lafayette,AL,ACTIVE
+CHAMBERSTX.GOV,County,Non-Federal Agency,Anahuac,TX,ACTIVE
+CHARLESCOUNTYMD.GOV,County,Non-Federal Agency,La Plata,MD,ACTIVE
+CHARLOTTECOUNTYFL.GOV,County,Non-Federal Agency,Port Charlotte,FL,ACTIVE
+CHARLTONCOUNTYGA.GOV,County,Non-Federal Agency,Folkston,GA,ACTIVE
+CHATHAMCOUNTYGA.GOV,County,Non-Federal Agency,Savannah,GA,ACTIVE
+CHEATHAMCOUNTYTN.GOV,County,Non-Federal Agency,Ashland City,TN,ACTIVE
+CHELANCOUNTYWA.GOV,County,Non-Federal Agency,Wenatchee,WA,ACTIVE
+CHEROKEECOUNTY-AL.GOV,County,Non-Federal Agency,Centre,AL,ACTIVE
+CHEROKEECOUNTY-KS.GOV,County,Non-Federal Agency,Columbus,KS,ACTIVE
+CHEROKEECOUNTY-NC.GOV,County,Non-Federal Agency,Murphy,NC,ACTIVE
+CHEROKEECOUNTYKS.GOV,County,Non-Federal Agency,Columbus,KS,ACTIVE
+CHEROKEECOUNTYSC.GOV,County,Non-Federal Agency,Gaffney,SC,ACTIVE
+CHESTERFIELDCOUNTY.GOV,County,Non-Federal Agency,Chesterfield,VA,ACTIVE
+CHEYENNECOUNTY-CO.GOV,County,Non-Federal Agency,CHEYENNE WELLS,CO,ACTIVE
+CHIPPEWACOUNTYMI.GOV,County,Non-Federal Agency,Sault Ste Marie,MI,ACTIVE
+CHRISTIANCOUNTYKY.GOV,County,Non-Federal Agency,Hopkinsville,KY,ACTIVE
+CHRISTIANCOUNTYMO.GOV,County,Non-Federal Agency,Ozark,MO,ACTIVE
+CLARKCOUNTYNV.GOV,County,Non-Federal Agency,Las Vegas,NV,ACTIVE
+CLARKCOUNTYOHIO.GOV,County,Non-Federal Agency,Springfield,OH,ACTIVE
+CLARKECOUNTY.GOV,County,Non-Federal Agency,Berryville,VA,ACTIVE
+CLARKECOUNTYMS.GOV,County,Non-Federal Agency,Quitman,MS,ACTIVE
+CLATSOPCOUNTYOR.GOV,County,Non-Federal Agency,Astoria,OR,ACTIVE
+CLAYCOUNTYMN.GOV,County,Non-Federal Agency,Moorhead,MN,ACTIVE
+CLAYCOUNTYMO.GOV,County,Non-Federal Agency,Liberty,MO,ACTIVE
+CLAYTONCOUNTYGA.GOV,County,Non-Federal Agency,Jonesboro,GA,ACTIVE
+CLAYTONCOUNTYIA.GOV,County,Non-Federal Agency,Elkader,IA,ACTIVE
+CLERMONTCOUNTYOHIO.GOV,County,Non-Federal Agency,Batavia,OH,ACTIVE
+CLINTONCOUNTY-IA.GOV,County,Non-Federal Agency,Clinton,IA,ACTIVE
+COLUMBIACOUNTYGA.GOV,County,Non-Federal Agency,Evans,GA,ACTIVE
+COLUMBIACOUNTYNY.GOV,County,Non-Federal Agency,Hudson,NY,ACTIVE
+CONVERSECOUNTYWY.GOV,County,Non-Federal Agency,Douglas,WY,ACTIVE
+COOKCOUNTYIL.GOV,County,Non-Federal Agency,Chicago,IL,ACTIVE
+COOPERCOUNTYMO.GOV,County,Non-Federal Agency,Boonville,MO,ACTIVE
+COPIAHCOUNTYMS.GOV,County,Non-Federal Agency,Hazlehurst,MS,ACTIVE
+CORONADOCA.GOV,County,Non-Federal Agency,Coronado,CA,ACTIVE
+COSCPINALCOUNTYAZ.GOV,County,Non-Federal Agency,Florence,AZ,ACTIVE
+COSTILLACOUNTY-CO.GOV,County,Non-Federal Agency,San Luis,CO,ACTIVE
+COUNTYOFVENTURACA.GOV,County,Non-Federal Agency,VENTURA,CA,ACTIVE
+COVINGTONCOUNTYMS.GOV,County,Non-Federal Agency,Collins,MS,ACTIVE
+CRAIGCOUNTYVA.GOV,County,Non-Federal Agency,New Castle,VA,ACTIVE
+CRAVENCOUNTYNC.GOV,County,Non-Federal Agency,New Bern,NC,ACTIVE
+CRAWFORDCOUNTYKANSAS.GOV,County,Non-Federal Agency,Girard,KS,ACTIVE
+CRAWFORDCOUNTYMO.GOV,County,Non-Federal Agency,Steelville,MO,ACTIVE
+CULPEPERCOUNTY.GOV,County,Non-Federal Agency,Culpeper,VA,ACTIVE
+CUMBERLANDCOUNTYTN.GOV,County,Non-Federal Agency,Crossville,TN,ACTIVE
+CURRITUCKCOUNTYNC.GOV,County,Non-Federal Agency,Currituck,NC,ACTIVE
+DADECOUNTY-GA.GOV,County,Non-Federal Agency,Trenton,GA,ACTIVE
+DAKOTACOUNTYMN.GOV,County,Non-Federal Agency,Hastings,MN,ACTIVE
+DALLASCOUNTY-TX.GOV,County,Non-Federal Agency,Dallas,TX,ACTIVE
+DALLASCOUNTYIOWA.GOV,County,Non-Federal Agency,Adel,IA,ACTIVE
+DARECOUNTYNC.GOV,County,Non-Federal Agency,Manteo,NC,ACTIVE
+DAVIDSONCOUNTYNC.GOV,County,Non-Federal Agency,Lexington,NC,ACTIVE
+DAVIECOUNTYNC.GOV,County,Non-Federal Agency,Mocksville,NC,ACTIVE
+DAVISCOUNTYUT4HEALTH.GOV,County,Non-Federal Agency,Farmington,UT,ACTIVE
+DAVISCOUNTYUTAH.GOV,County,Non-Federal Agency,Farmington,UT,ACTIVE
+DAVISUT4HEALTH.GOV,County,Non-Federal Agency,Farmington,UT,ACTIVE
+DAWSONCOUNTYNE.GOV,County,Non-Federal Agency,Lexington,NE,ACTIVE
+DCONC.GOV,County,Non-Federal Agency,Durham,NC,ACTIVE
+DECATURCOUNTYGA.GOV,County,Non-Federal Agency,Bainbridge,GA,ACTIVE
+DEKALBCOUNTYGA.GOV,County,Non-Federal Agency,Decatur,GA,ACTIVE
+DEKALBCOUNTYIL.GOV,County,Non-Federal Agency,Sycamore,IL,ACTIVE
+DESOTOCOUNTYMS.GOV,County,Non-Federal Agency,HERNANDO,MS,ACTIVE
+DICKINSONCOUNTYMI.GOV,County,Non-Federal Agency,Iron Mountain,MI,ACTIVE
+DICKSONCOUNTYTN.GOV,County,Non-Federal Agency,Charlotte,TN,ACTIVE
+DOUGLASCOUNTY-NE.GOV,County,Non-Federal Agency,Omaha,NE,ACTIVE
+DOUGLASCOUNTYNV.GOV,County,Non-Federal Agency,Minden,NV,ACTIVE
+DUNNCOUNTYWI.GOV,County,Non-Federal Agency,Menomonie,WI,ACTIVE
+DURHAMCOUNTYNC.GOV,County,Non-Federal Agency,Durham,NC,ACTIVE
+ECTORCOUNTYTX.GOV,County,Non-Federal Agency,Odessa,TX,ACTIVE
+EDGECOMBECOUNTYNC.GOV,County,Non-Federal Agency,Tarboro,NC,ACTIVE
+ELBERTCOUNTY-CO.GOV,County,Non-Federal Agency,Kiowa,CO,ACTIVE
+EMANUELCO-GA.GOV,County,Non-Federal Agency,Swainsboro,GA,ACTIVE
+ERIE.GOV,County,Non-Federal Agency,Buffalo,NY,ACTIVE
+ERIECOUNTYPA.GOV,County,Non-Federal Agency,Erie,PA,ACTIVE
+EUREKACOUNTYNV.GOV,County,Non-Federal Agency,Eureka,NV,ACTIVE
+FAIRFAXCOUNTY.GOV,County,Non-Federal Agency,Fairfax,VA,ACTIVE
+FAIRFAXCOUNTYVA.GOV,County,Non-Federal Agency,Fairfax,VA,ACTIVE
+FAIRFAXCOUNTYVIRGINIA.GOV,County,Non-Federal Agency,Fairfax,VA,ACTIVE
+FAIRFIELDCOUNTYOHIO.GOV,County,Non-Federal Agency,Lancaster,OH,ACTIVE
+FAUQUIERCOUNTY.GOV,County,Non-Federal Agency,Warrenton,VA,ACTIVE
+FENTRESSCOUNTYTN.GOV,County,Non-Federal Agency,Jamestown,TN,ACTIVE
+FORTBENDCOUNTYTX.GOV,County,Non-Federal Agency,Richmond,TX,ACTIVE
+FRANKLINCOUNTYGA.GOV,County,Non-Federal Agency,Carnesville,GA,ACTIVE
+FRANKLINCOUNTYIL.GOV,County,Non-Federal Agency,Benton,IL,ACTIVE
+FRANKLINCOUNTYMAINE.GOV,County,Non-Federal Agency,Farmington,ME,ACTIVE
+FRANKLINCOUNTYOHIO.GOV,County,Non-Federal Agency,Columbus,OH,ACTIVE
+FRANKLINCOUNTYPA.GOV,County,Non-Federal Agency,Chambersburg,PA,ACTIVE
+FRANKLINCOUNTYVA.GOV,County,Non-Federal Agency,Rocky Mount,VA,ACTIVE
+FREDERICKCOUNTYMD.GOV,County,Non-Federal Agency,Frederick,MD,ACTIVE
+FREDERICKCOUNTYVA.GOV,County,Non-Federal Agency,Winchester,VA,ACTIVE
+FREMONTCOUNTYWY.GOV,County,Non-Federal Agency,Lander,WY,ACTIVE
+FRIOCOUNTY-TX.GOV,County,Non-Federal Agency,Pearsall,TX,ACTIVE
+FULTONCOUNTYGA.GOV,County,Non-Federal Agency,Atlanta,GA,ACTIVE
+FULTONCOUNTYNY.GOV,County,Non-Federal Agency,Johnstown,NY,ACTIVE
+GADSDENCOUNTYFL.GOV,County,Non-Federal Agency,Quincy,FL,ACTIVE
+GALVESTONCOUNTYTX.GOV,County,Non-Federal Agency,Galveston,TX,ACTIVE
+GARFIELDCOUNTY-CO.GOV,County,Non-Federal Agency,Glenwood Springs,CO,ACTIVE
+GATESCOUNTYNC.GOV,County,Non-Federal Agency,Gatesville,NC,ACTIVE
+GEORGECOUNTYMS.GOV,County,Non-Federal Agency,Lucedale,MS,ACTIVE
+GGSC.GOV,County,Non-Federal Agency,Greenville,SC,ACTIVE
+GIBSONCOUNTY-IN.GOV,County,Non-Federal Agency,Princeton,IN,ACTIVE
+GILACOUNTYAZ.GOV,County,Non-Federal Agency,Globe,AZ,ACTIVE
+GILMERCOUNTY-GA.GOV,County,Non-Federal Agency,Ellijay,GA,ACTIVE
+GILMERCOUNTYWV.GOV,County,Non-Federal Agency,GLENVILLE,WV,ACTIVE
+GLOUCESTERCOUNTYNJ.GOV,County,Non-Federal Agency,Woodbury,NJ,ACTIVE
+GOGEBICCOUNTYMI.GOV,County,Non-Federal Agency,Bessemer,MI,ACTIVE
+GOLIADCOUNTYTX.GOV,County,Non-Federal Agency,Goliad,TX,ACTIVE
+GRADYCOUNTYGA.GOV,County,Non-Federal Agency,Cairo,GA,ACTIVE
+GRAINGERCOUNTYTN.GOV,County,Non-Federal Agency,Rutledge,TN,ACTIVE
+GRANTCOUNTY-OR.GOV,County,Non-Federal Agency,Canyon City,OR,ACTIVE
+GRANTCOUNTYWA.GOV,County,Non-Federal Agency,Ephrata,WA,ACTIVE
+GRAYSONCOUNTYVA.GOV,County,Non-Federal Agency,Independence,VA,ACTIVE
+GREENECOUNTYGA.GOV,County,Non-Federal Agency,Greensboro,GA,ACTIVE
+GREENECOUNTYMO.GOV,County,Non-Federal Agency,Springfield,MO,ACTIVE
+GREENECOUNTYMS.GOV,County,Non-Federal Agency,Leaksville,MS,ACTIVE
+GREENECOUNTYNC.GOV,County,Non-Federal Agency,Snow Hill,NC,ACTIVE
+GREENECOUNTYVA.GOV,County,Non-Federal Agency,Stanardsville,VA,ACTIVE
+GREENHARRISCOUNTYTX.GOV,County,Non-Federal Agency,Houston,TX,ACTIVE
+GREENMCHENRYCOUNTYIL.GOV,County,Non-Federal Agency,Woodstock,IL,ACTIVE
+GREENMCHENRYCOUNTYILLINOIS.GOV,County,Non-Federal Agency,Woodstock,IL,ACTIVE
+GREENSVILLECOUNTYVA.GOV,County,Non-Federal Agency,Emporia,VA,ACTIVE
+GREENVILLECOUNTYSC.GOV,County,Non-Federal Agency,Greenville,SC,ACTIVE
+GREENWOODSC.GOV,County,Non-Federal Agency,Greenwood,SC,ACTIVE
+GRIGGSCOUNTYND.GOV,County,Non-Federal Agency,Bismarck,ND,ACTIVE
+GULFCOUNTY-FL.GOV,County,Non-Federal Agency,Port St. Joe,FL,ACTIVE
+GWINNETTCOUNTYGA.GOV,County,Non-Federal Agency,Lawrenceville,GA,ACTIVE
+HABERSHAMCOUNTY-GA.GOV,County,Non-Federal Agency,Clarkesville,GA,ACTIVE
+HAINESALASKA.GOV,County,Non-Federal Agency,Haines,AK,ACTIVE
+HALIFAXCOUNTYVA.GOV,County,Non-Federal Agency,Halifax,VA,ACTIVE
+HALLCOUNTYGA.GOV,County,Non-Federal Agency,Gainesville,GA,ACTIVE
+HALLCOUNTYNE.GOV,County,Non-Federal Agency,Grand Island,NE,ACTIVE
+HAMBLENCOUNTYTN.GOV,County,Non-Federal Agency,Morristown,TN,ACTIVE
+HAMILTONCOUNTYFLORIDA.GOV,County,Non-Federal Agency,Jasper,FL,ACTIVE
+HAMILTONCOUNTYNY.GOV,County,Non-Federal Agency,Lake Pleasent,NY,ACTIVE
+HAMILTONCOUNTYOHIO.GOV,County,Non-Federal Agency,Cincinnati,OH,ACTIVE
+HAMILTONTN.GOV,County,Non-Federal Agency,Chattanooga,TN,ACTIVE
+HANCOCKCOUNTY-IL.GOV,County,Non-Federal Agency,Carthage,IL,ACTIVE
+HANCOCKCOUNTYGA.GOV,County,Non-Federal Agency,Sparta,GA,ACTIVE
+HANCOCKCOUNTYMS.GOV,County,Non-Federal Agency,Bay St. Louis,MS,ACTIVE
+HANOVER.GOV,County,Non-Federal Agency,Hanover,VA,ACTIVE
+HANOVERCOUNTY.GOV,County,Non-Federal Agency,Hanover,VA,ACTIVE
+HANOVERCOUNTYVA.GOV,County,Non-Federal Agency,Hanover,VA,ACTIVE
+HARALSONCOUNTYGA.GOV,County,Non-Federal Agency,Buchanan,GA,ACTIVE
+HARDINCOUNTYIA.GOV,County,Non-Federal Agency,Eldora,IA,ACTIVE
+HARRISCOUNTYGA.GOV,County,Non-Federal Agency,Hamilton,GA,ACTIVE
+HARRISCOUNTYTX.GOV,County,Non-Federal Agency,Houston,TX,ACTIVE
+HARRISONCOUNTY-MS.GOV,County,Non-Federal Agency,Gulfport,MS,ACTIVE
+HARRISONCOUNTYWV.GOV,County,Non-Federal Agency,Clarksburg,WV,ACTIVE
+HARTCOUNTYGA.GOV,County,Non-Federal Agency,Hartwell,GA,ACTIVE
+HAWAIICOUNTY.GOV,County,Non-Federal Agency,Hilo,HI,ACTIVE
+HAWKINSCOUNTYTN.GOV,County,Non-Federal Agency,Rogersville,TN,ACTIVE
+HAYWOODCOUNTYNC.GOV,County,Non-Federal Agency,Waynesville,NC,ACTIVE
+HCSHERIFF.GOV,County,Non-Federal Agency,Chattanooga,TN,ACTIVE
+HENDERSONCOUNTYTN.GOV,County,Non-Federal Agency,Lexington,TN,ACTIVE
+HENRYCOUNTYVA.GOV,County,Non-Federal Agency,Martinsville,VA,ACTIVE
+HERTFORDCOUNTYNC.GOV,County,Non-Federal Agency,Winton,NC,ACTIVE
+HINSDALECOUNTY-CO.GOV,County,Non-Federal Agency,Lake City,CO,ACTIVE
+HOWARDCOUNTYIN.GOV,County,Non-Federal Agency,Kokomo,IN,ACTIVE
+HOWARDCOUNTYMARYLAND.GOV,County,Non-Federal Agency,Ellicott City,MD,ACTIVE
+HOWARDCOUNTYMD.GOV,County,Non-Federal Agency,Ellicott City,MD,ACTIVE
+HURONCOUNTY-OH.GOV,County,Non-Federal Agency,Norwalk,OH,ACTIVE
+HYDECOUNTYNC.GOV,County,Non-Federal Agency,Swanquarter,NC,ACTIVE
+ICATCO.GOV,County,Non-Federal Agency,Newton,NC,ACTIVE
+ISLANDCOUNTYWA.GOV,County,Non-Federal Agency,Coupeville,WA,ACTIVE
+ISSAQUENACOUNTYMS.GOV,County,Non-Federal Agency,Mayersville,MS,ACTIVE
+JACKSONCOGA.GOV,County,Non-Federal Agency,Jefferson,GA,ACTIVE
+JACKSONCOUNTY-IL.GOV,County,Non-Federal Agency,Murphysboro,IL,ACTIVE
+JAMESCITYCOUNTYVA.GOV,County,Non-Federal Agency,Williamsburg,VA,ACTIVE
+JASPERCOUNTYIN.GOV,County,Non-Federal Agency,Rensselaer,IN,ACTIVE
+JASPERCOUNTYSC.GOV,County,Non-Federal Agency,Ridgeland,SC,ACTIVE
+JEFFERSONCOUNTY-MT.GOV,County,Non-Federal Agency,Boulder,MT,ACTIVE
+JEFFERSONCOUNTYFL.GOV,County,Non-Federal Agency,Monticello,FL,ACTIVE
+JEFFERSONCOUNTYGA.GOV,County,Non-Federal Agency,LOUISVILLE,GA,ACTIVE
+JEFFERSONCOUNTYMS.GOV,County,Non-Federal Agency,Fayette,MS,ACTIVE
+JEFFERSONCOUNTYTN.GOV,County,Non-Federal Agency,Dandridge,TN,ACTIVE
+JEFFERSONCOUNTYWI.GOV,County,Non-Federal Agency,Jefferson,WI,ACTIVE
+JENNINGSCOUNTY-IN.GOV,County,Non-Federal Agency,Vernon,IN,ACTIVE
+JIMWELLSCOUNTY-TX.GOV,County,Non-Federal Agency,Alice,TX,ACTIVE
+JONESCOUNTYNC.GOV,County,Non-Federal Agency,Trenton,NC,ACTIVE
+KANAWHACOUNTYWV.GOV,County,Non-Federal Agency,Charleston,WV,ACTIVE
+KAUAI.GOV,County,Non-Federal Agency,Lihue,HI,ACTIVE
+KEITHCOUNTYNE.GOV,County,Non-Federal Agency,Ogallala,NE,ACTIVE
+KENNEBECCOUNTY-ME.GOV,County,Non-Federal Agency,Augusta,ME,ACTIVE
+KENTCOUNTYMI.GOV,County,Non-Federal Agency,Grand Rapids,MI,ACTIVE
+KERNCOG-CA.GOV,County,Non-Federal Agency,Bakersfield,CA,ACTIVE
+KINGCOUNTY.GOV,County,Non-Federal Agency,Seattle,WA,ACTIVE
+KINGGEORGECOUNTYVA.GOV,County,Non-Federal Agency,King George,VA,ACTIVE
+KINGSBURYNY.GOV,County,Non-Federal Agency,Hudson Falls,NY,ACTIVE
+KNOXCOUNTYMAINE.GOV,County,Non-Federal Agency,Rockland,ME,ACTIVE
+KNOXCOUNTYTEXAS.GOV,County,Non-Federal Agency,Benjamin,TX,ACTIVE
+LACOUNTY.GOV,County,Non-Federal Agency,Downey,CA,ACTIVE
+LAKECOUNTYCA.GOV,County,Non-Federal Agency,Lakeport,CA,ACTIVE
+LAKECOUNTYIL.GOV,County,Non-Federal Agency,Waukegan,IL,ACTIVE
+LAKECOUNTYOHIO.GOV,County,Non-Federal Agency,Painesville,OH,ACTIVE
+LAKEMT.GOV,County,Non-Federal Agency,Polson,MT,ACTIVE
+LAMARCOUNTYMS.GOV,County,Non-Federal Agency,Purvis,MS,ACTIVE
+LANCASTERCOUNTYPA.GOV,County,Non-Federal Agency,Lancaster,PA,ACTIVE
+LAPAZCOUNTYAZ.GOV,County,Non-Federal Agency,Parker,AZ,ACTIVE
+LAUDERDALECOUNTYAL.GOV,County,Non-Federal Agency,Florence,AL,ACTIVE
+LAWRENCECOUNTYTN.GOV,County,Non-Federal Agency,Lawrenceburg,TN,ACTIVE
+LCCOUNTYMT.GOV,County,Non-Federal Agency,Helena,MT,ACTIVE
+LEE-COUNTY-FL.GOV,County,Non-Federal Agency,Fort Myers,FL,ACTIVE
+LEECOUNTYNC.GOV,County,Non-Federal Agency,Sanford,NC,ACTIVE
+LEONCOUNTYFL.GOV,County,Non-Federal Agency,Tallahassee,FL,ACTIVE
+LEWISCOUNTYWA.GOV,County,Non-Federal Agency,Chehalis,WA,ACTIVE
+LIBERTYCOUNTY-GA.GOV,County,Non-Federal Agency,Hinesville,GA,ACTIVE
+LIMESTONECOUNTY-AL.GOV,County,Non-Federal Agency,Athens,AL,ACTIVE
+LIMESTONECOUNTYEMA-AL.GOV,County,Non-Federal Agency,Athens,AL,ACTIVE
+LINCOLNCOUNTYNM.GOV,County,Non-Federal Agency,Carrizozo,NM,ACTIVE
+LIVINGSTONCOUNTYIL.GOV,County,Non-Federal Agency,Pontiac,IL,ACTIVE
+LIVINGSTONPARISHLA.GOV,County,Non-Federal Agency,Livingston,LA,ACTIVE
+LOGANCOUNTYCO.GOV,County,Non-Federal Agency,Sterling,CO,ACTIVE
+LOGANCOUNTYIL.GOV,County,Non-Federal Agency,Lincoln,IL,ACTIVE
+LOUDONCOUNTY-TN.GOV,County,Non-Federal Agency,Loudon,TN,ACTIVE
+LOUDOUN.GOV,County,Non-Federal Agency,Leesburg,VA,ACTIVE
+LOUDOUNCOUNTYVA.GOV,County,Non-Federal Agency,Leesburg,VA,ACTIVE
+LOWNDESCOUNTYGA.GOV,County,Non-Federal Agency,Valdosta,GA,ACTIVE
+LUCASCOUNTYOH.GOV,County,Non-Federal Agency,Toledo,OH,ACTIVE
+LUMPKINCOUNTY.GOV,County,Non-Federal Agency,Dahlonega,GA,ACTIVE
+MACOMBCOUNTYMI.GOV,County,Non-Federal Agency,Mount Clemens,MI,ACTIVE
+MACONBIBBCOUNTYGA.GOV,County,Non-Federal Agency,Macon,GA,ACTIVE
+MACONCOUNTYGA.GOV,County,Non-Federal Agency,Oglethorpe,GA,ACTIVE
+MACONCOUNTYTN.GOV,County,Non-Federal Agency,Lafayette,TN,ACTIVE
+MACOUPINCOUNTYIL.GOV,County,Non-Federal Agency,Carlinville,IL,ACTIVE
+MADISONCOUNTYAL.GOV,County,Non-Federal Agency,Huntsville,AL,ACTIVE
+MADISONCOUNTYMT.GOV,County,Non-Federal Agency,Virginia City,MT,ACTIVE
+MADISONCOUNTYNC.GOV,County,Non-Federal Agency,Marshall,NC,ACTIVE
+MADISONCOUNTYTN.GOV,County,Non-Federal Agency,Jackson,TN,ACTIVE
+MAHONINGCOUNTYOH.GOV,County,Non-Federal Agency,Youngstown,OH,ACTIVE
+MANISTEECOUNTYMI.GOV,County,Non-Federal Agency,Manistee,MI,ACTIVE
+MARICOPA.GOV,County,Non-Federal Agency,Phoenix,AZ,ACTIVE
+MARIONCOUNTY-MO.GOV,County,Non-Federal Agency,Hannibal,MO,ACTIVE
+MARSHALLCOUNTYIA.GOV,County,Non-Federal Agency,Marshalltown,IA,ACTIVE
+MARSHALLCOUNTYKY.GOV,County,Non-Federal Agency,Benton,KY,ACTIVE
+MATHEWSCOUNTYVA.GOV,County,Non-Federal Agency,Mathews,VA,ACTIVE
+MAUICOUNTY-HI.GOV,County,Non-Federal Agency,Wailuku,HI,ACTIVE
+MAUICOUNTY.GOV,County,Non-Federal Agency,Wailuku,HI,ACTIVE
+MAURYCOUNTY-TN.GOV,County,Non-Federal Agency,Columbia,TN,ACTIVE
+MCCRACKENCOUNTYKY.GOV,County,Non-Federal Agency,Paducah,KY,ACTIVE
+MCDONALDCOUNTYMO.GOV,County,Non-Federal Agency,Pineville,MO,ACTIVE
+MCHENRYCOUNTYIL.GOV,County,Non-Federal Agency,Woodstock,IL,ACTIVE
+MCHENRYCOUNTYILLINOIS.GOV,County,Non-Federal Agency,Woodstock,IL,ACTIVE
+MCINTOSHCOUNTY-GA.GOV,County,Non-Federal Agency,Darien,GA,ACTIVE
+MCLEANCOUNTYIL.GOV,County,Non-Federal Agency,Bloomington,IL,ACTIVE
+MCLEANCOUNTYND.GOV,County,Non-Federal Agency,Washburn,ND,ACTIVE
+MCMINNCOUNTYTN.GOV,County,Non-Federal Agency,Athens,TN,ACTIVE
+MEADEKY.GOV,County,Non-Federal Agency,Brandenburg,KY,ACTIVE
+MECKLENBURGCOUNTYNC.GOV,County,Non-Federal Agency,Charlotte,NC,ACTIVE
+MEETEETSECD-WY.GOV,County,Non-Federal Agency,Meeteetse,WY,ACTIVE
+MERCEDCOUNTYCA.GOV,County,Non-Federal Agency,Merced,CA,ACTIVE
+MERIWETHERCOUNTYGA.GOV,County,Non-Federal Agency,Greenville,GA,ACTIVE
+MIAMI-DADE.GOV,County,Non-Federal Agency,Miami,FL,ACTIVE
+MIAMICOUNTYIN.GOV,County,Non-Federal Agency,Peru,IN,ACTIVE
+MIAMICOUNTYOHIO.GOV,County,Non-Federal Agency,Troy,OH,ACTIVE
+MIAMIDADE.GOV,County,Non-Federal Agency,Miami,FL,ACTIVE
+MIAMIDADECOUNTY-FL.GOV,County,Non-Federal Agency,Miami,FL,ACTIVE
+MIAMIDADECOUNTYFL.GOV,County,Non-Federal Agency,Miami,FL,ACTIVE
+MIDDLESEXCOUNTYNJ.GOV,County,Non-Federal Agency,New Brunswick,NJ,ACTIVE
+MILWAUKEECOUNTYWI.GOV,County,Non-Federal Agency,Milwaukee,WI,ACTIVE
+MOBILECOUNTYAL.GOV,County,Non-Federal Agency,Mobile,AL,ACTIVE
+MONROECOUNTY-FL.GOV,County,Non-Federal Agency,Key West,FL,ACTIVE
+MONROECOUNTY.GOV,County,Non-Federal Agency,Rochester,NY,ACTIVE
+MONROECOUNTYAL.GOV,County,Non-Federal Agency,Monroeville,AL,ACTIVE
+MONROECOUNTYPA.GOV,County,Non-Federal Agency,Stroudsburg,PA,ACTIVE
+MONTGOMERYCOUNTYGA.GOV,County,Non-Federal Agency,mt. vernon,GA,ACTIVE
+MONTGOMERYCOUNTYMD.GOV,County,Non-Federal Agency,Rockville,MD,ACTIVE
+MONTGOMERYCOUNTYVA.GOV,County,Non-Federal Agency,Christiansburg,VA,ACTIVE
+MOORECOUNTYNC.GOV,County,Non-Federal Agency,Carthage,NC,ACTIVE
+MORGANCOUNTY-OH.GOV,County,Non-Federal Agency,McConnelsville,OH,ACTIVE
+MORGANCOUNTYTN.GOV,County,Non-Federal Agency,wartburg,TN,ACTIVE
+MORGANCOUNTYWV.GOV,County,Non-Federal Agency,Berkeley Springs,WV,ACTIVE
+MORRILLCOUNTYNE.GOV,County,Non-Federal Agency,Bridgeport,NE,ACTIVE
+MORRISCOUNTYNJ.GOV,County,Non-Federal Agency,Morristown,NJ,ACTIVE
+MORROWCOUNTYOHIO.GOV,County,Non-Federal Agency,Mount Gilead,OH,ACTIVE
+NASHCOUNTYNC.GOV,County,Non-Federal Agency,Nashville,NC,ACTIVE
+NASSAUCOUNTYNY.GOV,County,Non-Federal Agency,Mineola,NY,ACTIVE
+NATRONACOUNTY-WY.GOV,County,Non-Federal Agency,Casper,WY,ACTIVE
+NAVAJOCOUNTYAZ.GOV,County,Non-Federal Agency,Holbrook,AZ,ACTIVE
+NELSONCOUNTY-VA.GOV,County,Non-Federal Agency,Lovingston,VA,ACTIVE
+NIAGARACOUNTY-NY.GOV,County,Non-Federal Agency,LOCKPORT,NY,ACTIVE
+NOBLECOUNTYOHIO.GOV,County,Non-Federal Agency,Caldwell,OH,ACTIVE
+NORTONCOUNTYKS.GOV,County,Non-Federal Agency,Norton,KS,ACTIVE
+NWCLEANAIRWA.GOV,County,Non-Federal Agency,Mount Vernon,WA,ACTIVE
+OAKLANDCOUNTYMI.GOV,County,Non-Federal Agency,Pontiac,MI,ACTIVE
+OGEMAWCOUNTYMI.GOV,County,Non-Federal Agency,West Branch,MI,ACTIVE
+OGLETHORPECOUNTYGA.GOV,County,Non-Federal Agency,Lexington,GA,ACTIVE
+OHIOCOUNTYKY.GOV,County,Non-Federal Agency,Hartford,KY,ACTIVE
+OHIOCOUNTYWV.GOV,County,Non-Federal Agency,Wheeling,WV,ACTIVE
+OLDHAMCOUNTYKY.GOV,County,Non-Federal Agency,La Grange,KY,ACTIVE
+ORANGECOUNTY-VA.GOV,County,Non-Federal Agency,ORANGE,VA,ACTIVE
+ORANGECOUNTYNC.GOV,County,Non-Federal Agency,Hillsborough,NC,ACTIVE
+ORANGECOUNTYVA.GOV,County,Non-Federal Agency,Orange,VA,ACTIVE
+ORANGECOUNTYVT.GOV,County,Non-Federal Agency,Chelsea,VT,ACTIVE
+ORLEANSCOUNTYNY.GOV,County,Non-Federal Agency,Albion,NY,ACTIVE
+OSWEGOCOUNTYNY.GOV,County,Non-Federal Agency,Oswego,NY,ACTIVE
+OTSEGOCOUNTYMI.GOV,County,Non-Federal Agency,Gaylord,MI,ACTIVE
+OURAYCOUNTYCO.GOV,County,Non-Federal Agency,Ouray,CO,ACTIVE
+PARKECOUNTY-IN.GOV,County,Non-Federal Agency,Rockville,IN,ACTIVE
+PAYNECOUNTYOK.GOV,County,Non-Federal Agency,Stillwater,OK,ACTIVE
+PEMBINACOUNTYND.GOV,County,Non-Federal Agency,Cavalier,ND,ACTIVE
+PENDERCOUNTYNC.GOV,County,Non-Federal Agency,Burgaw,NC,ACTIVE
+PERQUIMANSCOUNTYNC.GOV,County,Non-Federal Agency,Hertford,NC,ACTIVE
+PICKENSCOUNTYGA.GOV,County,Non-Federal Agency,Jasper,GA,ACTIVE
+PIERCECOUNTYGA.GOV,County,Non-Federal Agency,Blackshear,GA,ACTIVE
+PIERCECOUNTYND.GOV,County,Non-Federal Agency,Rugby,ND,ACTIVE
+PIERCECOUNTYWA.GOV,County,Non-Federal Agency,Tacoma,WA,ACTIVE
+PIKECOUNTY-MO.GOV,County,Non-Federal Agency,Bowling Green,MO,ACTIVE
+PIKECOUNTYKY.GOV,County,Non-Federal Agency,Pikeville,KY,ACTIVE
+PIMA.GOV,County,Non-Federal Agency,Tucson,AZ,ACTIVE
+PINALCOUNTYAZ.GOV,County,Non-Federal Agency,Florence,AZ,ACTIVE
+PINELLAS.GOV,County,Non-Federal Agency,Clearwater,FL,ACTIVE
+PITTCOUNTYNC.GOV,County,Non-Federal Agency,Greenville,NC,ACTIVE
+PITTSYLVANIACOUNTYVA.GOV,County,Non-Federal Agency,Chatham,VA,ACTIVE
+PLYMOUTHCOUNTY-MA.GOV,County,Non-Federal Agency,Plymouth,MA,ACTIVE
+POLKCOUNTYGA.GOV,County,Non-Federal Agency,Cedartown,GA,ACTIVE
+POLKCOUNTYIOWA.GOV,County,Non-Federal Agency,Des Moines,IA,ACTIVE
+PORTAGECOUNTYWI.GOV,County,Non-Federal Agency,Stevens Point,WI,ACTIVE
+POSEYCOUNTYIN.GOV,County,Non-Federal Agency,Mount Vernon,IN,ACTIVE
+POTTAWATTAMIECOUNTY-IA.GOV,County,Non-Federal Agency,COUNCIL BLUFFS,IA,ACTIVE
+POTTCOUNTY-IA.GOV,County,Non-Federal Agency,COUNCIL BLUFFS,IA,ACTIVE
+POWELLCOUNTYMT.GOV,County,Non-Federal Agency,Deer Lodge,MT,ACTIVE
+PRESTONCOUNTYWV.GOV,County,Non-Federal Agency,Kingwood,WV,ACTIVE
+PRINCEGEORGECOUNTYVA.GOV,County,Non-Federal Agency,Prince George,VA,ACTIVE
+PRINCEGEORGESCOUNTYMD.GOV,County,Non-Federal Agency,Largo,MD,ACTIVE
+PUEBLOCOUNTYCO.GOV,County,Non-Federal Agency,Pueblo,CO,ACTIVE
+PULASKICOUNTYIL.GOV,County,Non-Federal Agency,Ullin,IL,ACTIVE
+PULASKICOUNTYVA.GOV,County,Non-Federal Agency,Pulaski,VA,ACTIVE
+PUTNAMCOUNTYNY.GOV,County,Non-Federal Agency,Carmel,NY,ACTIVE
+PUTNAMCOUNTYOHIO.GOV,County,Non-Federal Agency,Ottawa,OH,ACTIVE
+PUTNAMCOUNTYTN.GOV,County,Non-Federal Agency,Cookeville,TN,ACTIVE
+QUAYCOUNTY-NM.GOV,County,Non-Federal Agency,Tucumcari,NM,ACTIVE
+RANDOLPHCOUNTY-MO.GOV,County,Non-Federal Agency,Huntsville,MO,ACTIVE
+RANDOLPHCOUNTYALABAMA.GOV,County,Non-Federal Agency,Wedowee,AL,ACTIVE
+RANDOLPHCOUNTYNC.GOV,County,Non-Federal Agency,Asheboro,NC,ACTIVE
+RAPPAHANNOCKCOUNTYVA.GOV,County,Non-Federal Agency,Washington,VA,ACTIVE
+READYALBANYCOUNTY-NY.GOV,County,Non-Federal Agency,Albany,NY,ACTIVE
+READYHARRISCOUNTYTX.GOV,County,Non-Federal Agency,Houston,TX,ACTIVE
+READYMCHENRYCOUNTYIL.GOV,County,Non-Federal Agency,Woodstock,IL,ACTIVE
+READYMCHENRYCOUNTYILLINOIS.GOV,County,Non-Federal Agency,Woodstock,IL,ACTIVE
+REYNOLDSCOUNTY-MO.GOV,County,Non-Federal Agency,Centerville,MO,ACTIVE
+RILEYCOUNTYKS.GOV,County,Non-Federal Agency,Manhattan,KS,ACTIVE
+ROANECOUNTYTN.GOV,County,Non-Federal Agency,Kingston,TN,ACTIVE
+ROANOKECOUNTY-VA.GOV,County,Non-Federal Agency,Roanoke,VA,ACTIVE
+ROANOKECOUNTYVA.GOV,County,Non-Federal Agency,Roanoke,VA,ACTIVE
+ROANOKECOUNTYVIRGINIA.GOV,County,Non-Federal Agency,Roanoke,VA,ACTIVE
+ROCKBRIDGECOUNTYVA.GOV,County,Non-Federal Agency,Lexington,VA,ACTIVE
+ROCKCOUNTY-WI.GOV,County,Non-Federal Agency,Janesville,WI,ACTIVE
+ROCKDALECOUNTYGA.GOV,County,Non-Federal Agency,Conyers,GA,ACTIVE
+ROCKINGHAMCOUNTYVA.GOV,County,Non-Federal Agency,Harrisonburg,VA,ACTIVE
+ROSEBUDCOUNTYMT.GOV,County,Non-Federal Agency,Forsyth,MT,ACTIVE
+ROSSCOUNTYOHIO.GOV,County,Non-Federal Agency,Chillicothe,OH,ACTIVE
+RUTHERFORDCOUNTYNC.GOV,County,Non-Federal Agency,Rutherfordton,NC,ACTIVE
+RUTHERFORDCOUNTYTN.GOV,County,Non-Federal Agency,Murfreesboro,TN,ACTIVE
+SAGUACHECOUNTY-CO.GOV,County,Non-Federal Agency,Saguache,CO,ACTIVE
+SALEMCOUNTYNJ.GOV,County,Non-Federal Agency,Salem,NJ,ACTIVE
+SANDIEGOCOUNTY.GOV,County,Non-Federal Agency,San Diego,CA,ACTIVE
+SANDOVALCOUNTYNM.GOV,County,Non-Federal Agency,Bernalillo,NM,ACTIVE
+SANMIGUELCOUNTYCO.GOV,County,Non-Federal Agency,TELLURIDE,CO,ACTIVE
+SANPETECOUNTY-UT.GOV,County,Non-Federal Agency,Manti,UT,ACTIVE
+SANTACLARACOUNTYCA.GOV,County,Non-Federal Agency,San Jose,CA,ACTIVE
+SANTACRUZCOUNTYAZ.GOV,County,Non-Federal Agency,Nogales,AZ,ACTIVE
+SANTAFECOUNTYNM.GOV,County,Non-Federal Agency,Santa Fe,NM,ACTIVE
+SARATOGACOUNTYNY.GOV,County,Non-Federal Agency,Ballston Spa,NY,ACTIVE
+SAUKCOUNTYWI.GOV,County,Non-Federal Agency,Baraboo,WI,ACTIVE
+SBCOUNTY.GOV,County,Non-Federal Agency,San Bernardino,CA,ACTIVE
+SCHOHARIECOUNTY-NY.GOV,County,Non-Federal Agency,Schoharie,NY,ACTIVE
+SCOTTCOUNTY-TN.GOV,County,Non-Federal Agency,Huntsville,TN,ACTIVE
+SCOTTCOUNTYMN.GOV,County,Non-Federal Agency,Shakopee,MN,ACTIVE
+SCOTTCOUNTYMS.GOV,County,Non-Federal Agency,Forest,MS,ACTIVE
+SEBASTIANCOUNTYAR.GOV,County,Non-Federal Agency,Fort Smith,AR,ACTIVE
+SENECACOUNTYOHIO.GOV,County,Non-Federal Agency,Tiffin,OH,ACTIVE
+SEQUATCHIECOUNTY-TN.GOV,County,Non-Federal Agency,Dunlap,TN,ACTIVE
+SEVIERCOUNTYTN.GOV,County,Non-Federal Agency,Sevierville,TN,ACTIVE
+SHARKEYCOUNTYMS.GOV,County,Non-Federal Agency,Rolling Fork,MS,ACTIVE
+SHELBYCOUNTYTN.GOV,County,Non-Federal Agency,Memphis,TN,ACTIVE
+SIERRACOUNTYNM.GOV,County,Non-Federal Agency,Truth or Consequences,NM,ACTIVE
+SNOHOMISHCOUNTYWA.GOV,County,Non-Federal Agency,Everett,WA,ACTIVE
+SONOMACOUNTYCA.GOV,County,Non-Federal Agency,Santa Rosa,CA,ACTIVE
+SPENCERCOUNTYKY.GOV,County,Non-Federal Agency,Taylorsville,KY,ACTIVE
+SPOTSYLVANIACOUNTY-VA.GOV,County,Non-Federal Agency,Spotsylvania,VA,ACTIVE
+SPOTSYLVANIACOUNTYVA.GOV,County,Non-Federal Agency,Spotsylvania,VA,ACTIVE
+STAFFORDCOUNTYVA.GOV,County,Non-Federal Agency,Stafford,VA,ACTIVE
+STANLYCOUNTYNC.GOV,County,Non-Federal Agency,Albemarle,NC,ACTIVE
+STARKCOUNTYND.GOV,County,Non-Federal Agency,Bismarck,ND,ACTIVE
+STARKCOUNTYOHIO.GOV,County,Non-Federal Agency,Canton,OH,ACTIVE
+STCHARLESPARISH-LA.GOV,County,Non-Federal Agency,Hahnville,LA,ACTIVE
+STCLAIRCOUNTYIL.GOV,County,Non-Federal Agency,Belleville,IL,ACTIVE
+STEARNSCOUNTYMN.GOV,County,Non-Federal Agency,Saint Cloud,MN,ACTIVE
+STEPHENSCOUNTYTX.GOV,County,Non-Federal Agency,Breckenridge,TX,ACTIVE
+STEWARTCOUNTYGA.GOV,County,Non-Federal Agency,Lumpkin,GA,ACTIVE
+STJOHN-LA.GOV,County,Non-Federal Agency,LaPlace,LA,ACTIVE
+STJOHNBAPTISTPARISHLA.GOV,County,Non-Federal Agency,LaPlace,LA,ACTIVE
+STLOUISCOUNTYMN.GOV,County,Non-Federal Agency,Duluth,MN,ACTIVE
+STMARYPARISHLA.GOV,County,Non-Federal Agency,FRANKLIN,LA,ACTIVE
+STOKESCOUNTYNC.GOV,County,Non-Federal Agency,Danbury,NC,ACTIVE
+STONECOUNTYMS.GOV,County,Non-Federal Agency,Wiggins,MS,ACTIVE
+STORYCOUNTYIOWA.GOV,County,Non-Federal Agency,Nevada,IA,ACTIVE
+SUFFOLKCOUNTYNY.GOV,County,Non-Federal Agency,Hauppauge,NY,ACTIVE
+SULLIVANCOUNTYNH.GOV,County,Non-Federal Agency,Newport,NH,ACTIVE
+SULLIVANCOUNTYTN.GOV,County,Non-Federal Agency,Blountville,TN,ACTIVE
+SUMMERSCOUNTYWV.GOV,County,Non-Federal Agency,Hinton,WV,ACTIVE
+SUMMITCOUNTYCO.GOV,County,Non-Federal Agency,Breckenridge,CO,ACTIVE
+SUMTERCOUNTYFL.GOV,County,Non-Federal Agency,Bushnell,FL,ACTIVE
+SURRYCOUNTYVA.GOV,County,Non-Federal Agency,Surry,VA,ACTIVE
+SUSSEXCOUNTYDE.GOV,County,Non-Federal Agency,Georgetown,DE,ACTIVE
+SUSSEXCOUNTYVA.GOV,County,Non-Federal Agency,Sussex,VA,ACTIVE
+SWAINCOUNTYNC.GOV,County,Non-Federal Agency,Bryson City,NC,ACTIVE
+TALBOTCOUNTYMD.GOV,County,Non-Federal Agency,Easton,MD,ACTIVE
+TAMACOUNTYIOWA.GOV,County,Non-Federal Agency,Toledo,IA,ACTIVE
+TARRANTCOUNTYTX.GOV,County,Non-Federal Agency,Fort Worth,TX,ACTIVE
+TETONCOUNTYIDAHO.GOV,County,Non-Federal Agency,Driggs,ID,ACTIVE
+TEXASCOUNTYMISSOURI.GOV,County,Non-Federal Agency,Houston,MO,ACTIVE
+THAYERCOUNTYNE.GOV,County,Non-Federal Agency,Hebron,NE,ACTIVE
+THOMASCOUNTYGA.GOV,County,Non-Federal Agency,Thomasville,GA,ACTIVE
+THOMASCOUNTYKS.GOV,County,Non-Federal Agency,Colby,KS,ACTIVE
+THURSTONCOUNTYWA.GOV,County,Non-Federal Agency,Olympia,WA,ACTIVE
+TOMGREENCOUNTYTX.GOV,County,Non-Federal Agency,San Angelo,TX,ACTIVE
+TOMPKINSCOUNTYNY.GOV,County,Non-Federal Agency,Ithaca,NY,ACTIVE
+TOOELECOUNTYUT.GOV,County,Non-Federal Agency,Tooele,UT,ACTIVE
+TOOLECOUNTYMT.GOV,County,Non-Federal Agency,Shelby,MT,ACTIVE
+TOOMBSCOUNTYGA.GOV,County,Non-Federal Agency,Lyons,GA,ACTIVE
+TRAVISCOUNTYTX.GOV,County,Non-Federal Agency,Austin,TX,ACTIVE
+TROUSDALECOUNTYTN.GOV,County,Non-Federal Agency,Hartsville,TN,ACTIVE
+ULSTERCOUNTYNY.GOV,County,Non-Federal Agency,Kingston,NY,ACTIVE
+UNICOICOUNTYTN.GOV,County,Non-Federal Agency,Erwin,TN,ACTIVE
+UNIONCOUNTY-FL.GOV,County,Non-Federal Agency,Lake Butler,FL,ACTIVE
+UNIONCOUNTYGA.GOV,County,Non-Federal Agency,Blairsveille,GA,ACTIVE
+UNIONCOUNTYIL.GOV,County,Non-Federal Agency,Jonesboro,IL,ACTIVE
+UNIONCOUNTYIN.GOV,County,Non-Federal Agency,Liberty,IN,ACTIVE
+UNIONCOUNTYNC.GOV,County,Non-Federal Agency,Monroe,NC,ACTIVE
+UTAHCOUNTY.GOV,County,Non-Federal Agency,Provo,UT,ACTIVE
+VALLEYCOUNTYMT.GOV,County,Non-Federal Agency,Glasgow,MT,ACTIVE
+VANBURENCOUNTYIA.GOV,County,Non-Federal Agency,Keosauqua,IA,ACTIVE
+VILASCOUNTYWI.GOV,County,Non-Federal Agency,Eagle River,WI,ACTIVE
+VINTONCOUNTYOHIO.GOV,County,Non-Federal Agency,McArthur,OH,ACTIVE
+WARRENCOUNTYKY.GOV,County,Non-Federal Agency,Bowling Green,KY,ACTIVE
+WARRENCOUNTYNC.GOV,County,Non-Federal Agency,Warrenton,NC,ACTIVE
+WARRENCOUNTYNY.GOV,County,Non-Federal Agency,Lake George,NY,ACTIVE
+WARRENCOUNTYTN.GOV,County,Non-Federal Agency,McMinnville,TN,ACTIVE
+WARRICKCOUNTY.GOV,County,Non-Federal Agency,Boonville,IN,ACTIVE
+WASHAKIECOUNTYWY.GOV,County,Non-Federal Agency,Worland,WY,ACTIVE
+WASHINGTONCOUNTYGA.GOV,County,Non-Federal Agency,Sandersville,GA,ACTIVE
+WASHINGTONCOUNTYKS.GOV,County,Non-Federal Agency,Washington,KS,ACTIVE
+WASHINGTONCOUNTYNY.GOV,County,Non-Federal Agency,Fort Edward,NY,ACTIVE
+WASHTENAWCOUNTY-MI.GOV,County,Non-Federal Agency,Ann Arbor,MI,ACTIVE
+WAUKESHACOUNTY-WI.GOV,County,Non-Federal Agency,Waukesha,WI,ACTIVE
+WAUKESHACOUNTY.GOV,County,Non-Federal Agency,Waukesha,WI,ACTIVE
+WAYNECOUNTY-GA.GOV,County,Non-Federal Agency,JESUP,GA,ACTIVE
+WAYNECOUNTYMS.GOV,County,Non-Federal Agency,Waynesboro,MS,ACTIVE
+WAYNECOUNTYPA.GOV,County,Non-Federal Agency,Honesdale,PA,ACTIVE
+WEAKLEYCOUNTYTN.GOV,County,Non-Federal Agency,Dresden,TN,ACTIVE
+WEBBCOUNTYTX.GOV,County,Non-Federal Agency,Laredo,TX,ACTIVE
+WEBERCOUNTYUTAH.GOV,County,Non-Federal Agency,Ogden,UT,ACTIVE
+WEBSTERCOUNTYMO.GOV,County,Non-Federal Agency,Marshfield,MO,ACTIVE
+WESTCHESTERCOUNTYNY.GOV,County,Non-Federal Agency,White Plains,NY,ACTIVE
+WESTFELICIANAPARISH-LA.GOV,County,Non-Federal Agency,St. Francisville,LA,ACTIVE
+WHITECOUNTYGA.GOV,County,Non-Federal Agency,Cleveland,GA,ACTIVE
+WHITECOUNTYTN.GOV,County,Non-Federal Agency,Sparta,TN,ACTIVE
+WHITEPINECOUNTYNV.GOV,County,Non-Federal Agency,Ely,NV,ACTIVE
+WILLCOUNTY-IL.GOV,County,Non-Federal Agency,Joliet,IL,ACTIVE
+WILLIAMSONCOUNTY-TN.GOV,County,Non-Federal Agency,Franklin,TN,ACTIVE
+WILLIAMSONCOUNTYIL.GOV,County,Non-Federal Agency,Marion,IL,ACTIVE
+WILSONCOUNTYTN.GOV,County,Non-Federal Agency,Lebanon,TN,ACTIVE
+WILSONCOUNTYTX.GOV,County,Non-Federal Agency,Floresville,TX,ACTIVE
+WINDHAMCOUNTYVT.GOV,County,Non-Federal Agency,Newfane,VT,ACTIVE
+WINNEBAGOCOUNTYIOWA.GOV,County,Non-Federal Agency,Forest City,IA,ACTIVE
+WOODBURYCOUNTYIOWA.GOV,County,Non-Federal Agency,Sioux City,IA,ACTIVE
+WORCESTERCOUNTYMD.GOV,County,Non-Federal Agency,Snow Hill,MD,ACTIVE
+YANCEYCOUNTYNC.GOV,County,Non-Federal Agency,Burnsville,NC,ACTIVE
+YAZOOCOUNTYMS.GOV,County,Non-Federal Agency,Yazoo City,MS,ACTIVE
+YCSOAZ.GOV,County,Non-Federal Agency,Prescott,AZ,ACTIVE
+YORKCOUNTY.GOV,County,Non-Federal Agency,Yorktown,VA,ACTIVE
+YORKCOUNTYMAINE.GOV,County,Non-Federal Agency,Alfred,ME,ACTIVE
+YORKCOUNTYME.GOV,County,Non-Federal Agency,Alfred,ME,ACTIVE
+YORKCOUNTYPA.GOV,County,Non-Federal Agency,York,PA,ACTIVE
+YUMACOUNTYARIZONA.GOV,County,Non-Federal Agency,Yuma,AZ,ACTIVE
+YUMACOUNTYAZ.GOV,County,Non-Federal Agency,Yuma,AZ,ACTIVE
+ZAPATACOUNTYTX.GOV,County,Non-Federal Agency,Zapata,TX,ACTIVE
+ACUS.GOV,Federal Agency,Administrative Conference of the United States,WASHINGTON,DC,ACTIVE
+ACHP.GOV,Federal Agency,Advisory Council on Historic Preservation,Washington,DC,ACTIVE
+PRESERVEAMERICA.GOV,Federal Agency,Advisory Council on Historic Preservation,Washington,DC,ACTIVE
+ADF.GOV,Federal Agency,African Development Foundation,Washington,DC,ACTIVE
+USADF.GOV,Federal Agency,African Development Foundation,Washington,DC,ACTIVE
+ABMC.GOV,Federal Agency,American Battle Monuments Commission,Arlington,VA,ACTIVE
+AMTRAKOIG.GOV,Federal Agency,AMTRAK,Washington,DC,ACTIVE
+ARC.GOV,Federal Agency,Appalachian Regional Commission,Washington,DC,ACTIVE
+ASC.GOV,Federal Agency,Appraisal Subcommittee,Washington,DC,ACTIVE
+AFRH.GOV,Federal Agency,Armed Forces Retirement Home,Washington,DC,ACTIVE
+CIA.GOV,Federal Agency,Central Intelligence Agency,Washington,DC,ACTIVE
+IC.GOV,Federal Agency,Central Intelligence Agency,Washington,DC,ACTIVE
+ISTAC.GOV,Federal Agency,Central Intelligence Agency,Washington,DC,ACTIVE
+NCTC.GOV,Federal Agency,Central Intelligence Agency,Washington,DC,ACTIVE
+ODCI.GOV,Federal Agency,Central Intelligence Agency,Washington,DC,ACTIVE
+OPENSOURCE.GOV,Federal Agency,Central Intelligence Agency,Washington,DC,ACTIVE
+OSDE.GOV,Federal Agency,Central Intelligence Agency,Reston,VA,ACTIVE
+TTIC.GOV,Federal Agency,Central Intelligence Agency,Washington,DC,ACTIVE
+UCIA.GOV,Federal Agency,Central Intelligence Agency,Washington,DC,ACTIVE
+CHRISTOPHERCOLUMBUSFOUNDATION.GOV,Federal Agency,Christopher Columbus Fellowship Foundation,Washington,DC,ACTIVE
+CAP.GOV,Federal Agency,Civil Air Patrol,BIRMINGHAM,MI,ACTIVE
+CAPNHQ.GOV,Federal Agency,Civil Air Patrol,MAXWELL AFB,AL,ACTIVE
+ABILITYONE.FED.US,Federal Agency,Comm for People Who Are Blind/Severly Disabled,Arlington,VA,ACTIVE
+ABILITYONE.GOV,Federal Agency,Comm for People Who Are Blind/Severly Disabled,Arlington,VA,ACTIVE
+JWOD.GOV,Federal Agency,Comm for People Who Are Blind/Severly Disabled,Arlington,VA,ACTIVE
+GOODLETTSVILLE.GOV,Federal Agency,Commission on Civil Rights,Goodlettsville,TN,ACTIVE
+CFTC.GOV,Federal Agency,Commodity Futures Trading Commission,Washington,DC,ACTIVE
+SMARTCHECK.GOV,Federal Agency,Commodity Futures Trading Commission,Washington,DC,ACTIVE
+WHISTLEBLOWER.GOV,Federal Agency,Commodity Futures Trading Commission,Washington,DC,ACTIVE
+COMPLIANCE.GOV,Federal Agency,Congressional Office of Compliance,Washington,DC,ACTIVE
+BCFP.GOV,Federal Agency,Consumer Financial Protection Bureau,Washington,DC,ACTIVE
+CFPA.GOV,Federal Agency,Consumer Financial Protection Bureau,Washington,DC,ACTIVE
+CFPB.GOV,Federal Agency,Consumer Financial Protection Bureau,Washington,DC,ACTIVE
+CONSUMERBUREAU.GOV,Federal Agency,Consumer Financial Protection Bureau,Washington,DC,ACTIVE
+CONSUMERFINANCE.GOV,Federal Agency,Consumer Financial Protection Bureau,Washington,DC,ACTIVE
+CONSUMERFINANCIAL.GOV,Federal Agency,Consumer Financial Protection Bureau,Washington,DC,ACTIVE
+CONSUMERFINANCIALBUREAU.GOV,Federal Agency,Consumer Financial Protection Bureau,Washington,DC,ACTIVE
+CONSUMERFINANCIALPROTECTIONBUREAU.GOV,Federal Agency,Consumer Financial Protection Bureau,Washington,DC,ACTIVE
+CONSUMERPROTECTION.GOV,Federal Agency,Consumer Financial Protection Bureau,Washington,DC,ACTIVE
+CONSUMERPROTECTIONBUREAU.GOV,Federal Agency,Consumer Financial Protection Bureau,Washington,DC,ACTIVE
+ANCHORIT.GOV,Federal Agency,Consumer Product Safety Commission,Bethesda,MD,ACTIVE
+ATVSAFETY.GOV,Federal Agency,Consumer Product Safety Commission,Bethesda,MD,ACTIVE
+CPSC.GOV,Federal Agency,Consumer Product Safety Commission,Bethesda,MD,ACTIVE
+DRYWALLRESPONSE.GOV,Federal Agency,Consumer Product Safety Commission,Bethesda,MD,ACTIVE
+POOLSAFELY.GOV,Federal Agency,Consumer Product Safety Commission,Bethesda,MD,ACTIVE
+POOLSAFETY.GOV,Federal Agency,Consumer Product Safety Commission,Bethesda,MD,ACTIVE
+RECALLS.GOV,Federal Agency,Consumer Product Safety Commission,Bethesda,MD,ACTIVE
+SAFERPRODUCT.GOV,Federal Agency,Consumer Product Safety Commission,Bethesda,MD,ACTIVE
+SAFERPRODUCTS.GOV,Federal Agency,Consumer Product Safety Commission,Bethesda,MD,ACTIVE
+SEGURIDADCONSUMIDOR.GOV,Federal Agency,Consumer Product Safety Commission,Bethesda,MD,ACTIVE
+AMERICORE.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC,ACTIVE
+AMERICORP.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC,ACTIVE
+AMERICORPS.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC,ACTIVE
+AMERICORPSCONNECT.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC,ACTIVE
+AMERICORPSWEEK.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC,ACTIVE
+CNCS.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC,ACTIVE
+CNCSOIG.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC,ACTIVE
+CNS.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC,ACTIVE
+FEDERALMENTORINGCOUNCIL.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC,ACTIVE
+GETINVOLVED.GOV,Federal Agency,Corporation for National & Community Service,Washington ,DC,ACTIVE
+LEARNANDSERVE.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC,ACTIVE
+MENTOR.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC,ACTIVE
+MLKDAY.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC,ACTIVE
+NATIONALSERVICE.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC,ACTIVE
+NATIONALSERVICEGEAR.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC,ACTIVE
+NATIONALSERVICERESOURCES.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC,ACTIVE
+PRESIDENTIALSERVICEAWARDS.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC,ACTIVE
+SENIORCORPS.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC,ACTIVE
+SERVE.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC,ACTIVE
+SERVICE.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC,ACTIVE
+SERVICELEARNING.GOV,Federal Agency,Corporation for National & Community Service,Washington ,DC,ACTIVE
+SERVIR.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC,ACTIVE
+VISTA.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC,ACTIVE
+VISTACAMPUS.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC,ACTIVE
+VOLUNTEERINGINAMERICA.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC,ACTIVE
+CIGIE.GOV,Federal Agency,Council of Inspector General on Integrity and Efficiency,WASHINGTON,DC,ACTIVE
+IGNET.GOV,Federal Agency,Council of Inspector General on Integrity and Efficiency,Washington,DC,ACTIVE
+OVERSIGHT.GOV,Federal Agency,Council of Inspector General on Integrity and Efficiency,Washington,DC,ACTIVE
+CSOSA.FED.US,Federal Agency,Court Services and Offender Supervision,Washington,DC,ACTIVE
+CSOSA.GOV,Federal Agency,Court Services and Offender Supervision,Washington,DC,ACTIVE
+PRETRIALSERVICES.GOV,Federal Agency,Court Services and Offender Supervision,Washington,DC,ACTIVE
+PSA.GOV,Federal Agency,Court Services and Offender Supervision,Washington,DC,ACTIVE
+DNFSB.GOV,Federal Agency,Defense Nuclear Facilities Safety Board,Washington,DC,ACTIVE
+DRA.GOV,Federal Agency,Delta Regional Authority,Clarksdale,MS,ACTIVE
+DENALI.GOV,Federal Agency,Denali Commission,Anchorage,AK,ACTIVE
+FEA.GOV,Federal Agency,Denali Commission,Anchorage,AK,ACTIVE
+AFF.GOV,Federal Agency,Department of Agriculture,Boise,ID,ACTIVE
+AG.GOV,Federal Agency,Department of Agriculture,Fort Collins,CO,ACTIVE
+ARS-GRIN.GOV,Federal Agency,Department of Agriculture,Beltsville,MD,ACTIVE
+ARSUSDA.GOV,Federal Agency,Department of Agriculture,Beltsville,MD,ACTIVE
+ASKKAREN.GOV,Federal Agency,Department of Agriculture,Washington,DC,ACTIVE
+BEFOODSAFE.GOV,Federal Agency,Department of Agriculture,Washington,DC,ACTIVE
+BIOPREFERRED.GOV,Federal Agency,Department of Agriculture,Washington,DC,ACTIVE
+BOSQUE.GOV,Federal Agency,Department of Agriculture,Albuquerque,NM,ACTIVE
+CHOOSEMYPLATE.GOV,Federal Agency,Department of Agriculture,Alexandria,VA,ACTIVE
+COASTALAMERICA.GOV,Federal Agency,Department of Agriculture,Washington,DC,ACTIVE
+DIETARYGUIDELINES.GOV,Federal Agency,Department of Agriculture,Alexandria,VA,ACTIVE
+EMPOWHR.GOV,Federal Agency,Department of Agriculture,New Orleans,LA,ACTIVE
+EXECSEC.GOV,Federal Agency,Department of Agriculture,Washington,DC,ACTIVE
+FARMERCLAIMS.GOV,Federal Agency,Department of Agriculture,St. Louis,MO,ACTIVE
+FEMALEFARMERCLAIMS.GOV,Federal Agency,Department of Agriculture,St. Louis,MO,ACTIVE
+FIREINSTITUTE.GOV,Federal Agency,Department of Agriculture,Tucson,AZ,ACTIVE
+FOODSAFETYJOBS.GOV,Federal Agency,Department of Agriculture,Washington,DC,ACTIVE
+FOODSAFETYWORKINGGROUP.GOV,Federal Agency,Department of Agriculture,Washington,DC,ACTIVE
+FORESTSANDRANGELANDS.GOV,Federal Agency,Department of Agriculture,Washington,DC,ACTIVE
+FS.FED.US,Federal Agency,Department of Agriculture,Washington,DC,ACTIVE
+GREEN.GOV,Federal Agency,Department of Agriculture,Washington,DC,ACTIVE
+HISPANICFARMERCLAIMS.GOV,Federal Agency,Department of Agriculture,St. Louis,MO,ACTIVE
+ICBEMP.GOV,Federal Agency,Department of Agriculture,Portland,OR,ACTIVE
+IIOG.GOV,Federal Agency,Department of Agriculture,Meridian,ID,ACTIVE
+INVASIVESPECIESINFO.GOV,Federal Agency,Department of Agriculture,Beltsville,MD,ACTIVE
+IPM.GOV,Federal Agency,Department of Agriculture,Washington,DC,ACTIVE
+ISITDONEYET.GOV,Federal Agency,Department of Agriculture,Washington,DC,ACTIVE
+ITAP.GOV,Federal Agency,Department of Agriculture,Beltsville,MD,ACTIVE
+JUNIORFORESTRANGER.GOV,Federal Agency,Department of Agriculture,Washington,DC,ACTIVE
+LATINOFARMERCLAIMS.GOV,Federal Agency,Department of Agriculture,St. Louis,MO,ACTIVE
+LCACOMMONS.GOV,Federal Agency,Department of Agriculture,Beltsville,MD,ACTIVE
+MTBS.GOV,Federal Agency,Department of Agriculture,Salt Lake City,UT,ACTIVE
+NAFRI.GOV,Federal Agency,Department of Agriculture,Tucson,AZ,ACTIVE
+NEL.GOV,Federal Agency,Department of Agriculture,Alexandria,VA,ACTIVE
+NUTRITION.GOV,Federal Agency,Department of Agriculture,Washington,DC,ACTIVE
+NUTRITIONEVIDENCELIBRARY.GOV,Federal Agency,Department of Agriculture,Alexandria,VA,ACTIVE
+NWCG.GOV,Federal Agency,Department of Agriculture,Boise,ID,ACTIVE
+PREGUNTELEAKAREN.GOV,Federal Agency,Department of Agriculture,Washington,DC,ACTIVE
+RECREATION.GOV,Federal Agency,Department of Agriculture,Ogden,UT,ACTIVE
+REO.GOV,Federal Agency,Department of Agriculture,Portland,OR,ACTIVE
+SMOKEYBEAR.GOV,Federal Agency,Department of Agriculture,Washington,DC,ACTIVE
+START2FARM.GOV,Federal Agency,Department of Agriculture,Beltsville,MD,ACTIVE
+SYMBOLS.GOV,Federal Agency,Department of Agriculture,Washington,DC,ACTIVE
+THEPEOPLESGARDEN.GOV,Federal Agency,Department of Agriculture,Wahington,DC,ACTIVE
+USDA.GOV,Federal Agency,Department of Agriculture,Ft. Collins,CO,ACTIVE
+USDAPII.GOV,Federal Agency,Department of Agriculture,Washington,DC,ACTIVE
+WILDFIRE.GOV,Federal Agency,Department of Agriculture,Boise,ID,ACTIVE
+WOMENFARMERCLAIMS.GOV,Federal Agency,Department of Agriculture,St. Louis,MO,ACTIVE
+WOODSY.GOV,Federal Agency,Department of Agriculture,Washington,DC,ACTIVE
+WOODSYOWL.GOV,Federal Agency,Department of Agriculture,Washington,DC,ACTIVE
+AP.GOV,Federal Agency,Department of Commerce,Washington,DC,ACTIVE
+AVIATIONWEATHER.GOV,Federal Agency,Department of Commerce,Silver Spring,MD,ACTIVE
+BEA.GOV,Federal Agency,Department of Commerce,Washington,DC,ACTIVE
+BLDRDOC.GOV,Federal Agency,Department of Commerce,Boulder,CO,ACTIVE
+BUYUSA.GOV,Federal Agency,Department of Commerce,Washington,DC,ACTIVE
+CBP.GOV,Federal Agency,Department of Commerce,Alexandria,VA,ACTIVE
+CENSUS.GOV,Federal Agency,Department of Commerce,Suitland,MD,ACTIVE
+CIVILRIGHTSUSA.GOV,Federal Agency,Department of Commerce,Alexandria,VA,ACTIVE
+CLIMATE.GOV,Federal Agency,Department of Commerce,Silver Spring,MD,ACTIVE
+CLIMATECHANGE.GOV,Federal Agency,Department of Commerce,Oak Ridge,TN,ACTIVE
+COMMERCE.GOV,Federal Agency,Department of Commerce,Washington,DC,ACTIVE
+COOP-USPTO.GOV,Federal Agency,Department of Commerce,Arlington,VA,ACTIVE
+DIGITALLITERACY.GOV,Federal Agency,Department of Commerce,Washington,DC,ACTIVE
+DNSOPS.GOV,Federal Agency,Department of Commerce,Gaithersburg,MD,ACTIVE
+DOC.GOV,Federal Agency,Department of Commerce,Washington,DC,ACTIVE
+DROUGHT.GOV,Federal Agency,Department of Commerce,Asheville,NC,ACTIVE
+EDA.GOV,Federal Agency,Department of Commerce,Washington,DC,ACTIVE
+ESA.GOV,Federal Agency,Department of Commerce,Washington,DC,ACTIVE
+EXPORT.GOV,Federal Agency,Department of Commerce,Washington,DC,ACTIVE
+FCSM.GOV,Federal Agency,Department of Commerce,Suitland,MD,SERVER-HOLD
+FIRSTNET.GOV,Federal Agency,Department of Commerce,Washington,DC,ACTIVE
+FISHWATCH.GOV,Federal Agency,Department of Commerce,Silver Spring,MD,ACTIVE
+GETYOUHOME.GOV,Federal Agency,Department of Commerce,Alexandria,VA,ACTIVE
+GLOBALENTRY.GOV,Federal Agency,Department of Commerce,Alexandria,VA,ACTIVE
+GOES-R.GOV,Federal Agency,Department of Commerce,Greenbelt,MD,ACTIVE
+GPS.GOV,Federal Agency,Department of Commerce,Washington,DC,ACTIVE
+HURRICANES.GOV,Federal Agency,Department of Commerce,Miami,FL,ACTIVE
+ITDS.GOV,Federal Agency,Department of Commerce,Springfield,VA,ACTIVE
+MANUFACTURING.GOV,Federal Agency,Department of Commerce,Washington,DC,ACTIVE
+MAPSTATS.GOV,Federal Agency,Department of Commerce,Washington,DC,SERVER-HOLD
+MARINECADASTRE.GOV,Federal Agency,Department of Commerce,Charleston,SC,ACTIVE
+MBDA.GOV,Federal Agency,Department of Commerce,Washington,DC,ACTIVE
+MGI.GOV,Federal Agency,Department of Commerce,Gaithersburg,MD,ACTIVE
+NEHRP.GOV,Federal Agency,Department of Commerce,Gaithersburg,MD,ACTIVE
+NIST.GOV,Federal Agency,Department of Commerce,Gaithersburg,MD,ACTIVE
+NOAA.GOV,Federal Agency,Department of Commerce,Silver Spring,MD,ACTIVE
+NTIS.GOV,Federal Agency,Department of Commerce,Alexandria,VA,ACTIVE
+OFCM.GOV,Federal Agency,Department of Commerce,Silver Spring,MD,ACTIVE
+PAPAHANAUMOKUAKEA.GOV,Federal Agency,Department of Commerce,Silver Spring,MD,ACTIVE
+PRIVACYSHIELD.GOV,Federal Agency,Department of Commerce,Washington,DC,ACTIVE
+PSCR.GOV,Federal Agency,Department of Commerce,Boulder,CO,ACTIVE
+SDR.GOV,Federal Agency,Department of Commerce,Washington,DC,ACTIVE
+SELECTUSA.GOV,Federal Agency,Department of Commerce,Washington,DC,ACTIVE
+SPACEWEATHER.GOV,Federal Agency,Department of Commerce,Boulder,CO,ACTIVE
+SPECTRUM.GOV,Federal Agency,Department of Commerce,Washington,DC,ACTIVE
+STANDARDS.GOV,Federal Agency,Department of Commerce,Gaithersburg,MD,ACTIVE
+TIME.GOV,Federal Agency,Department of Commerce,Boulder,CO,ACTIVE
+TRADE.GOV,Federal Agency,Department of Commerce,Washington,DC,ACTIVE
+TSUNAMI.GOV,Federal Agency,Department of Commerce,Palmer,AK,ACTIVE
+USPTO.GOV,Federal Agency,Department of Commerce,Washington,DC,ACTIVE
+WDOL.GOV,Federal Agency,Department of Commerce,Alexandria,VA,ACTIVE
+WEATHER.GOV,Federal Agency,Department of Commerce,Silver Spring,MD,ACTIVE
+ADLNET.GOV,Federal Agency,Department of Defense,Washington,DC,ACTIVE
+AFTAC.GOV,Federal Agency,Department of Defense,Patrick AFB,FL,ACTIVE
+ALTUSANDC.GOV,Federal Agency,Department of Defense,"patrick, afb",FL,ACTIVE
+BRAC.GOV,Federal Agency,Department of Defense,Alexandria,VA,ACTIVE
+CMTS.GOV,Federal Agency,Department of Defense,Mobile,AL,ACTIVE
+CNSS.GOV,Federal Agency,Department of Defense,Ft George G. Meade,MD,ACTIVE
+CTOC.GOV,Federal Agency,Department of Defense,Starke,FL,ACTIVE
+CTTSO.GOV,Federal Agency,Department of Defense,Arlington,VA,ACTIVE
+DC3ON.GOV,Federal Agency,Department of Defense,Linthicum,MD,ACTIVE
+DEFENSE.GOV,Federal Agency,Department of Defense,Fort Meade,MD,ACTIVE
+DOD.GOV,Federal Agency,Department of Defense,Fort Meade,MD,ACTIVE
+EACLEARINGHOUSE.GOV,Federal Agency,Department of Defense,Arlington,VA,ACTIVE
+ERDC.GOV,Federal Agency,Department of Defense,Vicksburg,MS,ACTIVE
+FVAP.GOV,Federal Agency,Department of Defense,Alexandria,VA,ACTIVE
+IAD.GOV,Federal Agency,Department of Defense,Ft Meade,MD,ACTIVE
+IOSS.GOV,Federal Agency,Department of Defense,Greenbelt,MD,ACTIVE
+ITC.GOV,Federal Agency,Department of Defense,Ft. Washington,MD,ACTIVE
+JCCS.GOV,Federal Agency,Department of Defense,Alexandria,VA,ACTIVE
+MCRMC.GOV,Federal Agency,Department of Defense,Arlington,VA,ACTIVE
+MOJAVEDATA.GOV,Federal Agency,Department of Defense,Barstow,CA,ACTIVE
+MTMC.GOV,Federal Agency,Department of Defense,Alexandria,VA,ACTIVE
+MYPAY.GOV,Federal Agency,Department of Defense,Pensacola,FL,ACTIVE
+NCR.GOV,Federal Agency,Department of Defense,Washington,DC,ACTIVE
+NRO.GOV,Federal Agency,Department of Defense,Chantilly,VA,ACTIVE
+NROJR.GOV,Federal Agency,Department of Defense,Chantilly,VA,ACTIVE
+NSA.GOV,Federal Agency,Department of Defense,Ft. Meade,MD,ACTIVE
+NSEP.GOV,Federal Agency,Department of Defense,Arlington,VA,ACTIVE
+OEA.GOV,Federal Agency,Department of Defense,Arlington,VA,ACTIVE
+OSDBU.GOV,Federal Agency,Department of Defense,Washington,DC,ACTIVE
+PENTAGON.GOV,Federal Agency,Department of Defense,Fort Meade,MD,ACTIVE
+SITEIDIQ.GOV,Federal Agency,Department of Defense,Arlington,VA,ACTIVE
+TSWG.GOV,Federal Agency,Department of Defense,Arlington,VA,ACTIVE
+USANDC.GOV,Federal Agency,Department of Defense,Patrick AFB,FL,ACTIVE
+AAPI.GOV,Federal Agency,Department of Education,Washington,DC,ACTIVE
+BFELOB.GOV,Federal Agency,Department of Education,Washington,DC,ACTIVE
+CHILDSTATS.GOV,Federal Agency,Department of Education,Washington,DC,ACTIVE
+COLLEGENAVIGATOR.GOV,Federal Agency,Department of Education,Washington,DC,ACTIVE
+ED.GOV,Federal Agency,Department of Education,Washington,DC,ACTIVE
+EDPUBS.GOV,Federal Agency,Department of Education,Washington ,DC,ACTIVE
+EDUCATION.GOV,Federal Agency,Department of Education,Washington,DC,ACTIVE
+FAFSA.GOV,Federal Agency,Department of Education,Washington,DC,ACTIVE
+FSAPUBS.GOV,Federal Agency,Department of Education,Washington,DC,ACTIVE
+G5.GOV,Federal Agency,Department of Education,Washington,DC,ACTIVE
+NAGB.GOV,Federal Agency,Department of Education,Washington,DC,ACTIVE
+NATIONSREPORTCARD.GOV,Federal Agency,Department of Education,Washington,DC,ACTIVE
+STUDENTAID.GOV,Federal Agency,Department of Education,Washington,DC,ACTIVE
+STUDENTLOANS.GOV,Federal Agency,Department of Education,Washington,DC,ACTIVE
+AMESLAB.GOV,Federal Agency,Department of Energy,Ames,IA,ACTIVE
+ANL.GOV,Federal Agency,Department of Energy,Argonne,IL,ACTIVE
+ARM.GOV,Federal Agency,Department of Energy,Richland,WA,ACTIVE
+BIOMASSBOARD.GOV,Federal Agency,Department of Energy,Washington,DC,ACTIVE
+BNL.GOV,Federal Agency,Department of Energy,Upton,NY,ACTIVE
+BPA.GOV,Federal Agency,Department of Energy,Portland,OR,ACTIVE
+BRC.GOV,Federal Agency,Department of Energy,Washington,DC,ACTIVE
+BUILDINGAMERICA.GOV,Federal Agency,Department of Energy,Golden,CO,ACTIVE
+CASL.GOV,Federal Agency,Department of Energy,Oak Ridge,TN,ACTIVE
+CEBAF.GOV,Federal Agency,Department of Energy,Newport News,VA,ACTIVE
+CENDI.GOV,Federal Agency,Department of Energy,Oak Ridge,TN,ACTIVE
+CRT2014-2024REVIEW.GOV,Federal Agency,Department of Energy,Portland,OR,ACTIVE
+DOE.GOV,Federal Agency,Department of Energy,Washington,DC,ACTIVE
+DOEAL.GOV,Federal Agency,Department of Energy,Albuquerque,NM,ACTIVE
+EIA.GOV,Federal Agency,Department of Energy,Washington,DC,ACTIVE
+ENERGY.GOV,Federal Agency,Department of Energy,Washington,DC,ACTIVE
+ENERGYCODES.GOV,Federal Agency,Department of Energy,Richland,WA,ACTIVE
+ENERGYPLUS.GOV,Federal Agency,Department of Energy,Washington,DC,ACTIVE
+ENERGYSAVER.GOV,Federal Agency,Department of Energy,Washington,DC,ACTIVE
+ENERGYSAVERS.GOV,Federal Agency,Department of Energy,Washington,DC,ACTIVE
+FNAL.GOV,Federal Agency,Department of Energy,Batavia,IL,ACTIVE
+FUELECONOMY.GOV,Federal Agency,Department of Energy,Oak Ridge,TN,ACTIVE
+HANFORD.GOV,Federal Agency,Department of Energy,Richland,WA,ACTIVE
+HIGHPERFORMANCEBUILDINGS.GOV,Federal Agency,Department of Energy,Golden,CO,ACTIVE
+HOMEENERGYSCORE.GOV,Federal Agency,Department of Energy,Washington,DC,ACTIVE
+HYDROGEN.GOV,Federal Agency,Department of Energy,Washington,DC,ACTIVE
+INEL.GOV,Federal Agency,Department of Energy,Idaho Falls,ID,ACTIVE
+INL.GOV,Federal Agency,Department of Energy,Idaho Falls,ID,ACTIVE
+ISOTOPE.GOV,Federal Agency,Department of Energy,Oak Ridge,TN,ACTIVE
+ISOTOPES.GOV,Federal Agency,Department of Energy,Oak Ridge,TN,ACTIVE
+KAPL.GOV,Federal Agency,Department of Energy,Schenectady,NY,ACTIVE
+LANL.GOV,Federal Agency,Department of Energy,Los Alamos,NM,ACTIVE
+LBL.GOV,Federal Agency,Department of Energy,Berkeley,CA,ACTIVE
+LLNL.GOV,Federal Agency,Department of Energy,Livermore,CA,ACTIVE
+NCCRC.GOV,Federal Agency,Department of Energy,Oak Ridge,TN,ACTIVE
+NCCS.GOV,Federal Agency,Department of Energy,Oak Ridge,TN,ACTIVE
+NCRC.GOV,Federal Agency,Department of Energy,Oak Ridge,TN,ACTIVE
+NERSC.GOV,Federal Agency,Department of Energy,Berkeley,CA,ACTIVE
+NEUP.GOV,Federal Agency,Department of Energy,Washington,DC,ACTIVE
+NREL.GOV,Federal Agency,Department of Energy,Golden,CO,ACTIVE
+NRELHUB.GOV,Federal Agency,Department of Energy,Golden,CO,ACTIVE
+NTRC.GOV,Federal Agency,Department of Energy,Knoxville,TN,ACTIVE
+NUCLEAR.GOV,Federal Agency,Department of Energy,Washington,DC,ACTIVE
+ORAU.GOV,Federal Agency,Department of Energy,Oak Ridge,TN,ACTIVE
+ORNL.GOV,Federal Agency,Department of Energy,Oak Ridge,TN,ACTIVE
+OSTI.GOV,Federal Agency,Department of Energy,Oak Ridge,TN,ACTIVE
+PNL.GOV,Federal Agency,Department of Energy,Richland,WA,ACTIVE
+PNNL.GOV,Federal Agency,Department of Energy,Richland,WA,ACTIVE
+RL.GOV,Federal Agency,Department of Energy,Richland,WA,ACTIVE
+SALMONRECOVERY.GOV,Federal Agency,Department of Energy,Portland,OR,ACTIVE
+SANDIA.GOV,Federal Agency,Department of Energy,Albuquerque,NM,ACTIVE
+SCIDAC.GOV,Federal Agency,Department of Energy,Oak Ridge,TN,ACTIVE
+SCIENCE.GOV,Federal Agency,Department of Energy,Oak Ridge,TN,ACTIVE
+SCIENCEACCELERATOR.GOV,Federal Agency,Department of Energy,Oak Ridge,TN,ACTIVE
+SMARTGRID.GOV,Federal Agency,Department of Energy,Washington,DC,ACTIVE
+SNS.GOV,Federal Agency,Department of Energy,Oak Ridge,TN,ACTIVE
+SOLARDECATHLON.GOV,Federal Agency,Department of Energy,Golden,CO,ACTIVE
+SRS.GOV,Federal Agency,Department of Energy,Aiken,SC,ACTIVE
+SWPA.GOV,Federal Agency,Department of Energy,Tulsa,OK,ACTIVE
+UNNPP.GOV,Federal Agency,Department of Energy,West Mifflin,PA,ACTIVE
+UNRPNET.GOV,Federal Agency,Department of Energy,Washington,DC,ACTIVE
+WAPA.GOV,Federal Agency,Department of Energy,Lakewood,CO,ACTIVE
+WINDPOWERINGAMERICA.GOV,Federal Agency,Department of Energy,Golden,CO,ACTIVE
+YMP.GOV,Federal Agency,Department of Energy,Las Vegas,NV,ACTIVE
+ACF.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+ACL.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+AFTERSCHOOL.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+AGING.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+AGINGSTATS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+AHCPR.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE
+AHRQ.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE
+AIDS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+ALZHEIMERS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+AOA.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+BAM.GOV,Federal Agency,Department of Health And Human Services,Atlanta,GA,ACTIVE
+BESTBONESFOREVER.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+BETOBACCOFREE.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+BIOETHICS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+BIOSECURITYBOARD.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+BRAINHEALTH.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+CANCER.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE
+CANCERNET.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE
+CDC.GOV,Federal Agency,Department of Health And Human Services,Atlanta,GA,ACTIVE
+CHILDWELFARE.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+CLINICALTRIAL.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE
+CLINICALTRIALS.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE
+CLUBDRUGS.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE
+CMS.GOV,Federal Agency,Department of Health And Human Services,Baltimore,MD,ACTIVE
+COLLEGEDRINKINGPREVENTION.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE
+CUIDADODESALUD.GOV,Federal Agency,Department of Health And Human Services,Baltimore,MD,ACTIVE
+DHHS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+DIABETESCOMMITTEE.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+DOCLINE.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE
+DONACIONDEORGANOS.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE
+DRUGABUSE.GOV,Federal Agency,Department of Health And Human Services,Baltimore,MD,ACTIVE
+DRUGFREEWORKPLACE.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE
+EDISON.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE
+ELDERCARE.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+ENDINGTHEDOCUMENTGAME.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+ERRP.GOV,Federal Agency,Department of Health And Human Services,Baltimore,MD,ACTIVE
+FATHERHOOD.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+FDA.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE
+FINDYOUTHINFO.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE
+FITNESS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+FLU.GOV,Federal Agency,Department of Health And Human Services,Washington ,DC,ACTIVE
+FOODSAFETY.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+FRESHEMPIRE.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+FRUITSANDVEGGIESMATTER.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+GENBANK.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE
+GENOME.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE
+GIRLSHEALTH.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+GLOBALHEALTH.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE
+GRANTS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+GRANTSOLUTIONS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+GUIDELINE.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE
+GUIDELINES.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE
+HCQUALITYCOMMISSION.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE
+HEALTH.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+HEALTHCARE.GOV,Federal Agency,Department of Health And Human Services,Baltimore,MD,ACTIVE
+HEALTHDATA.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+HEALTHFINDER.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+HEALTHINDICATORS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+HEALTHIT.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+HEALTHREFORM.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+HEALTHYPEOPLE.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+HEARTTRUTH.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE
+HHS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+HHSOIG.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+HHSOPS.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE
+HIV.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+HRSA.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE
+IDEALAB.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+IEDISON.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE
+IHS.GOV,Federal Agency,Department of Health And Human Services,Albuquerque,NM,ACTIVE
+INSUREKIDSNOW.GOV,Federal Agency,Department of Health And Human Services,Baltimore,MD,ACTIVE
+KNOWTHEFACTSFIRST.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+LOCATORPLUS.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE
+LONGTERMCARE.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+MEDICAID.GOV,Federal Agency,Department of Health And Human Services,Baltimore,MD,ACTIVE
+MEDICALCOUNTERMEASURES.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+MEDICALRESERVECORPS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+MEDICARE.GOV,Federal Agency,Department of Health And Human Services,Baltimore,MD,ACTIVE
+MEDLINE.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE
+MEDLINEPLUS.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE
+MENTALHEALTH.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE
+MESH.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE
+MIMEDICARE.GOV,Federal Agency,Department of Health And Human Services,Baltimore,MD,ACTIVE
+MYMEDICARE.GOV,Federal Agency,Department of Health And Human Services,Baltimore,MD,ACTIVE
+NATIONALCHILDRENSSTUDY.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE
+NCIFCRF.GOV,Federal Agency,Department of Health And Human Services,Frederick,MD,ACTIVE
+NGC.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE
+NIH.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE
+NIHSENIORHEALTH.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE
+NIOSH.GOV,Federal Agency,Department of Health And Human Services,Atlanta,GA,ACTIVE
+NLM.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE
+NNLM.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE
+ORGANDONOR.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE
+PANDEMICFLU.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+PHE.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+PSC.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE
+PUBMED.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE
+PUBMEDCENTRAL.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE
+QUIC.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE
+QUICK.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE
+RECOVERYMONTH.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE
+SAFEYOUTH.GOV,Federal Agency,Department of Health And Human Services,Atlanta,GA,ACTIVE
+SAMHSA.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE
+SELECTAGENTS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+SMOKEFREE.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE
+STEROIDABUSE.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE
+STOPALCOHOLABUSE.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+STOPBULLYING.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+STOPMEDICAREFRAUD.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+SURGEONGENERAL.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+THECOOLSPOT.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE
+THEREALCOST.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+THISFREELIFE.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+TISSUEENGINEERING.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE
+TOBACCO.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+USABILITY.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+USBM.GOV,Federal Agency,Department of Health And Human Services,Atlanta,GA,ACTIVE
+USPHS.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE
+VACCINES.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+WHAGING.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+WHITEHOUSECONFERENCEONAGING.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+WOMENSHEALTH.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+YOUTH.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+BIOMETRICS.GOV,Federal Agency,Department of Homeland Security,Arlington,VA,ACTIVE
+CITIZENCORPS.GOV,Federal Agency,Department of Homeland Security,Washington,DC,ACTIVE
+CPNIREPORTING.GOV,Federal Agency,Department of Homeland Security,Washington,DC,ACTIVE
+DHS.GOV,Federal Agency,Department of Homeland Security,Washington,DC,ACTIVE
+DISASTERASSISTANCE.GOV,Federal Agency,Department of Homeland Security,Bluemont,VA,ACTIVE
+FEMA.GOV,Federal Agency,Department of Homeland Security,Washington,DC,ACTIVE
+FIRSTRESPONDER.GOV,Federal Agency,Department of Homeland Security,Washington,DC,ACTIVE
+FIRSTRESPONDERTRAINING.GOV,Federal Agency,Department of Homeland Security,Washington,DC,ACTIVE
+FLETA.GOV,Federal Agency,Department of Homeland Security,Glynco,GA,ACTIVE
+FLETC.GOV,Federal Agency,Department of Homeland Security,Glynco,GA,ACTIVE
+FLIGHTSCHOOLCANDIDATES.GOV,Federal Agency,Department of Homeland Security,Rockville,MD,ACTIVE
+FLOODSMART.GOV,Federal Agency,Department of Homeland Security,Bluemont,VA,ACTIVE
+HOMELANDSECURITY.GOV,Federal Agency,Department of Homeland Security,Washington,DC,ACTIVE
+ICE.GOV,Federal Agency,Department of Homeland Security,Washington,DC,ACTIVE
+LISTO.GOV,Federal Agency,Department of Homeland Security,Washington,DC,ACTIVE
+LLIS.GOV,Federal Agency,Department of Homeland Security,Washington,DC,ACTIVE
+NMSC.GOV,Federal Agency,Department of Homeland Security,St Augustine,FL,ACTIVE
+READY.GOV,Federal Agency,Department of Homeland Security,Washington,DC,ACTIVE
+READYBUSINESS.GOV,Federal Agency,Department of Homeland Security,Washington,DC,ACTIVE
+SAFECOMPROGRAM.GOV,Federal Agency,Department of Homeland Security,Washington,DC,ACTIVE
+SAFETYACT.GOV,Federal Agency,Department of Homeland Security,Washington,DC,ACTIVE
+SECRETSERVICE.GOV,Federal Agency,Department of Homeland Security,Washington D.C.,DC,ACTIVE
+TSA.GOV,Federal Agency,Department of Homeland Security,Arlington,VA,ACTIVE
+US-CERT.GOV,Federal Agency,Department of Homeland Security,Washington,DC,ACTIVE
+USCG.GOV,Federal Agency,Department of Homeland Security,Alexandria,VA,ACTIVE
+USCIS.GOV,Federal Agency,Department of Homeland Security,Washington,DC,ACTIVE
+USSS.GOV,Federal Agency,Department of Homeland Security,Washington,DC,ACTIVE
+DISASTERHOUSING.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC,ACTIVE
+FHA.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC,ACTIVE
+GINNIEMAE.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC,ACTIVE
+HOMESALES.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC,ACTIVE
+HUD.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC,ACTIVE
+HUDOIG.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC,ACTIVE
+HUDUSER.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC,ACTIVE
+NATIONALHOUSING.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC,ACTIVE
+NATIONALHOUSINGLOCATOR.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC,ACTIVE
+NHL.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC,ACTIVE
+NLS.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC,ACTIVE
+ADA.GOV,Federal Agency,Department of Justice,Rockville,MD,ACTIVE
+ADR.GOV,Federal Agency,Department of Justice,Rockville,MD,ACTIVE
+AMBERALERT.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+ATF.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE
+ATFONLINE.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE
+BATS.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+BIOMETRICCOE.GOV,Federal Agency,Department of Justice,Clarksburg,WV,ACTIVE
+BJA.GOV,Federal Agency,Department of Justice,Washington ,DC,ACTIVE
+BJS.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE
+BOP.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE
+CJIS.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE
+CRIMESOLUTIONS.GOV,Federal Agency,Department of Justice,Washinton ,DC,ACTIVE
+CRIMEVICTIMS.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+CYBERCRIME.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE
+DEA.GOV,Federal Agency,Department of Justice,Rockville,MD,ACTIVE
+DEADIVERSION.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+DEAECOM.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+DEALS.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE
+DNA.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+DOJ.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+DSAC.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+EGUARDIAN.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE
+EPIC.GOV,Federal Agency,Department of Justice,Rockville,MD,ACTIVE
+EPIC2.GOV,Federal Agency,Department of Justice,Arlington ,VA,ACTIVE
+ESP.GOV,Federal Agency,Department of Justice,Falls Church,VA,ACTIVE
+ESPANOLFORLAWENFORCEMENT.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+FARA.GOV,Federal Agency,Department of Justice,potomac,MD,ACTIVE
+FBI.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE
+FBIJOBS.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE
+FIRSTFREEDOM.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+FOIA.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE
+FORENSICSCIENCE.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE
+FORFEITURE.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+FPI.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE
+GETSMARTABOUTDRUGS.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+HELPINGAMERICASYOUTH.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+IC3.GOV,Federal Agency,Department of Justice,Fairmont,WV,ACTIVE
+INTERPOL.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+IPRCENTER.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE
+JUSTICE.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE
+JUSTTHINKTWICE.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+JUVENILECOUNCIL.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+LEARNATF.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE
+LEARNDOJ.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE
+LEO.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+LEP.GOV,Federal Agency,Department of Justice,Rockville,MD,ACTIVE
+LOOKSTOOGOOD.GOV,Federal Agency,Department of Justice,Fairmont,WV,ACTIVE
+LOOKSTOOGOODTOBETRUE.GOV,Federal Agency,Department of Justice,Fairmont,WV,ACTIVE
+MALWAREINVESTIGATOR.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE
+MEDALOFVALOR.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+METHRESOURCES.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+NAMUS.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+NATIONALGANGCENTER.GOV,Federal Agency,Department of Justice,Tallahassee,FL,ACTIVE
+NCIRC.GOV,Federal Agency,Department of Justice,Tallahassee,FL,ACTIVE
+NCJRS.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+NIBIN.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE
+NICIC.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE
+NICSEZCHECKFBI.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE
+NIEM.GOV,Federal Agency,Department of Justice,Tallahassee,FL,ACTIVE
+NIJ.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE
+NMVTIS.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE
+NSOPR.GOV,Federal Agency,Department of Justice,Tallahassee,FL,ACTIVE
+NSOPW.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE
+NVTC.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE
+OJJDP.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+OJP.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE
+OVC.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+OVCTTAC.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+PROJECTSAFECHILDHOOD.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+PROJECTSAFENEIGHBORHOODS.GOV,Federal Agency,Department of Justice,Rockville,MD,ACTIVE
+PSN.GOV,Federal Agency,Department of Justice,Rocckville,MD,ACTIVE
+PSOB.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+RCFL.GOV,Federal Agency,Department of Justice,McLean,VA,ACTIVE
+REENTRY.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+SCRA.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+SERVICEMEMBERS.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+SMART.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE
+STOPFRAUD.GOV,Federal Agency,Department of Justice,Rockville,MD,ACTIVE
+TECHTRACK.GOV,Federal Agency,Department of Justice,Arlington,VA,ACTIVE
+TRIBALJUSTICEANDSAFETY.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+UCRDATATOOL.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE
+UNICOR.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE
+USDOJ.GOV,Federal Agency,Department of Justice,Rockville,MD,ACTIVE
+USERRA.GOV,Federal Agency,Department of Justice,Potpmac,MD,ACTIVE
+USMARSHALS.GOV,Federal Agency,Department of Justice,Rockville,MD,ACTIVE
+VCF.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE
+VEHICLEHISTORY.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+AMERICASHEROESATWORK.GOV,Federal Agency,Department of Labor,Washington,DC,ACTIVE
+BENEFITS.GOV,Federal Agency,Department of Labor,Washington,DC,ACTIVE
+BLS.GOV,Federal Agency,Department of Labor,Washington,DC,ACTIVE
+DISABILITY.GOV,Federal Agency,Department of Labor,Washington,DC,ACTIVE
+DOL-ESA.GOV,Federal Agency,Department of Labor,Washington,DC,ACTIVE
+DOL.GOV,Federal Agency,Department of Labor,Washington,DC,ACTIVE
+DOLETA.GOV,Federal Agency,Department of Labor,Washington,DC,ACTIVE
+GOVBENEFITS.GOV,Federal Agency,Department of Labor,Washington,DC,ACTIVE
+GOVLOANS.GOV,Federal Agency,Department of Labor,Washington,DC,ACTIVE
+JOBCORPS.GOV,Federal Agency,Department of Labor,Austin,TX,ACTIVE
+LABOR.GOV,Federal Agency,Department of Labor,Washington,DC,ACTIVE
+MSHA.GOV,Federal Agency,Department of Labor,Arlington,VA,ACTIVE
+MYNEXTMOVE.GOV,Federal Agency,Department of Labor,Washington,DC,ACTIVE
+OSHA.GOV,Federal Agency,Department of Labor,Washington,DC,ACTIVE
+UNIONREPORTS.GOV,Federal Agency,Department of Labor,Washington,DC,ACTIVE
+VETERANS.GOV,Federal Agency,Department of Labor,Washington,DC,ACTIVE
+WHISTLEBLOWERS.GOV,Federal Agency,Department of Labor,Washington,DC,ACTIVE
+WRP.GOV,Federal Agency,Department of Labor,Washington,DC,ACTIVE
+YOUTHRULES.GOV,Federal Agency,Department of Labor,Washington,DC,ACTIVE
+AMERICA.GOV,Federal Agency,Department of State,Washington,DC,ACTIVE
+CONTINENTALSHELF.GOV,Federal Agency,Department of State,Washington,DC,ACTIVE
+CWC.GOV,Federal Agency,Department of State,Washington,DC,ACTIVE
+ECOPARTNERSHIPS.GOV,Federal Agency,Department of State,Washington,DC,ACTIVE
+FAN.GOV,Federal Agency,Department of State,Washington,DC,ACTIVE
+FOREIGNASSISTANCE.GOV,Federal Agency,Department of State,Washington,DC,ACTIVE
+FSGB.GOV,Federal Agency,Department of State,Washington,DC,ACTIVE
+GHI.GOV,Federal Agency,Department of State,Washington,DC,ACTIVE
+HUMANRIGHTS.GOV,Federal Agency,Department of State,Washington ,DC,ACTIVE
+IAWG.GOV,Federal Agency,Department of State,Washington,DC,ACTIVE
+IBWC.GOV,Federal Agency,Department of State,El Paso,TX,ACTIVE
+ICASS.GOV,Federal Agency,Department of State,Washington,DC,ACTIVE
+OSAC.GOV,Federal Agency,Department of State,Washington,DC,ACTIVE
+PEPFAR.GOV,Federal Agency,Department of State,Washington,DC,ACTIVE
+STATE.GOV,Federal Agency,Department of State,Washington,DC,ACTIVE
+USCONSULATE.GOV,Federal Agency,Department of State,Washington,DC,ACTIVE
+USEMBASSY-MEXICO.GOV,Federal Agency,Department of State,Mexico City,11,ACTIVE
+USEMBASSY.GOV,Federal Agency,Department of State,Washington,DC,ACTIVE
+USINT.GOV,Federal Agency,Department of State,Washington,DC,ACTIVE
+USMISSION.GOV,Federal Agency,Department of State,Washington,DC,ACTIVE
+USVPP.GOV,Federal Agency,Department of State,Washington,DC,ACTIVE
+STATEOIG.GOV,Federal Agency,Department of State OIG,Arlington,VA,ACTIVE
+ABANDONEDMINES.GOV,Federal Agency,Department of the Interior,Washington,DC,ACTIVE
+ACWI.GOV,Federal Agency,Department of the Interior,Reston,VA,ACTIVE
+ALASKACENTERS.GOV,Federal Agency,Department of the Interior,Washington,DC,ACTIVE
+AMERICANLATINOMUSEUM.GOV,Federal Agency,Department of the Interior,Washington,WV,ACTIVE
+AMERICASGREATOUTDOORS.GOV,Federal Agency,Department of the Interior,Washington,DC,ACTIVE
+ANSTASKFORCE.GOV,Federal Agency,Department of the Interior,Arlington,VA,ACTIVE
+BIA.GOV,Federal Agency,Department of the Interior,Reston,VA,ACTIVE
+BIOECO.GOV,Federal Agency,Department of the Interior,Denver,CO,ACTIVE
+BLM.GOV,Federal Agency,Department of the Interior,Denver,CO,ACTIVE
+BLMNTL.GOV,Federal Agency,Department of the Interior,Denver,CO,ACTIVE
+BOEM.GOV,Federal Agency,Department of the Interior,Herndon,VA,ACTIVE
+BOEMRE.GOV,Federal Agency,Department of the Interior,Herndon,VA,ACTIVE
+BOR.GOV,Federal Agency,Department of the Interior,Denver,CO,ACTIVE
+BSEE.GOV,Federal Agency,Department of the Interior,Herndon,VA,ACTIVE
+CORALREEF.GOV,Federal Agency,Department of the Interior,Denver,CO,ACTIVE
+CUPCAO.GOV,Federal Agency,Department of the Interior,Denver,CO,ACTIVE
+DOI.GOV,Federal Agency,Department of the Interior,Washington,DC,ACTIVE
+DOIOIG.GOV,Federal Agency,Department of the Interior,RESTON,VA,ACTIVE
+EARTHQUAKE.GOV,Federal Agency,Department of the Interior,Menlo Park,CA,ACTIVE
+EVERGLADESRESTORATION.GOV,Federal Agency,Department of the Interior,Davie,FL,ACTIVE
+FCG.GOV,Federal Agency,Department of the Interior,Denver,CO,ACTIVE
+FGDC.GOV,Federal Agency,Department of the Interior,Reston,VA,ACTIVE
+FIRECODE.GOV,Federal Agency,Department of the Interior,Boise,ID,ACTIVE
+FIRELEADERSHIP.GOV,Federal Agency,Department of the Interior,Boise,ID,ACTIVE
+FIRENET.GOV,Federal Agency,Department of the Interior,Boise,ID,ACTIVE
+FIRESCIENCE.GOV,Federal Agency,Department of the Interior,Boise,ID,ACTIVE
+FWS.GOV,Federal Agency,Department of the Interior,Lakewood,CO,ACTIVE
+GCDAMP.GOV,Federal Agency,Department of the Interior,Denver,CO,ACTIVE
+GCMRC.GOV,Federal Agency,Department of the Interior,Flagstaff,AZ,ACTIVE
+GEOCOMMUNICATOR.GOV,Federal Agency,Department of the Interior,Denver,CO,ACTIVE
+GEOMAC.GOV,Federal Agency,Department of the Interior,Denver,CO,ACTIVE
+GEOPLATFORM.GOV,Federal Agency,Department of the Interior,Washington,DC,ACTIVE
+IAT.GOV,Federal Agency,Department of the Interior,Boise,ID,ACTIVE
+INDIANAFFAIRS.GOV,Federal Agency,Department of the Interior,Reston,VA,ACTIVE
+INTERIOR.GOV,Federal Agency,Department of the Interior,Washington,DC,ACTIVE
+INVASIVESPECIES.GOV,Federal Agency,Department of the Interior,Washington,DC,ACTIVE
+JEM.GOV,Federal Agency,Department of the Interior,Lafayett,LA,ACTIVE
+KLAMATHRESTORATION.GOV,Federal Agency,Department of the Interior,Yreka,CA,ACTIVE
+LACOAST.GOV,Federal Agency,Department of the Interior,Lafayette,LA,ACTIVE
+LANDFIRE.GOV,Federal Agency,Department of the Interior,Sioux Falls,SD,ACTIVE
+LANDIMAGING.GOV,Federal Agency,Department of the Interior,Reston,VA,ACTIVE
+LCA.GOV,Federal Agency,Department of the Interior,Lafayette,LA,ACTIVE
+LCRMSCP.GOV,Federal Agency,Department of the Interior,Denver,CO,ACTIVE
+LMVSCI.GOV,Federal Agency,Department of the Interior,Lafayette,LA,ACTIVE
+LOWERMISSISSIPPIVALLEYSCIENCE.GOV,Federal Agency,Department of the Interior,Lafayette,LA,ACTIVE
+MARINE.GOV,Federal Agency,Department of the Interior,Camarillo,CA,ACTIVE
+MITIGATIONCOMMISSION.GOV,Federal Agency,Department of the Interior,Denver,CO,ACTIVE
+MMS.GOV,Federal Agency,Department of the Interior,Herndon,VA,ACTIVE
+MRLC.GOV,Federal Agency,Department of the Interior,Sioux Falls,SD,ACTIVE
+NATIONALATLAS.GOV,Federal Agency,Department of the Interior,Reston,VA,ACTIVE
+NATIONALMAP.GOV,Federal Agency,Department of the Interior,Reston,VA,ACTIVE
+NATIVEONESTOP.GOV,Federal Agency,Department of the Interior,Reston,VA,ACTIVE
+NBC.GOV,Federal Agency,Department of the Interior,Denver,CO,ACTIVE
+NDEP.GOV,Federal Agency,Department of the Interior,Reston,VA,ACTIVE
+NDOP.GOV,Federal Agency,Department of the Interior,Reston,VA,ACTIVE
+NEMI.GOV,Federal Agency,Department of the Interior,Middleton,WI,ACTIVE
+NFPORS.GOV,Federal Agency,Department of the Interior,Washington,DC,ACTIVE
+NIFC.GOV,Federal Agency,Department of the Interior,Boise,ID,ACTIVE
+NOLAENVIRONMENTAL.GOV,Federal Agency,Department of the Interior,Lafayette,LA,ACTIVE
+NPS.GOV,Federal Agency,Department of the Interior,WASHINGTON DC,DC,ACTIVE
+ONHIR.GOV,Federal Agency,Department of the Interior,Flagstaff,AZ,ACTIVE
+ONRR.GOV,Federal Agency,Department of the Interior,Herndon,VA,ACTIVE
+OSM.GOV,Federal Agency,Department of the Interior,Washington,DC,ACTIVE
+OSMRE.GOV,Federal Agency,Department of the Interior,Washington,DC,ACTIVE
+PIEDRASBLANCAS.GOV,Federal Agency,Department of the Interior,Sacramento,CA,ACTIVE
+REPORTBAND.GOV,Federal Agency,Department of the Interior,Laurel,MD,ACTIVE
+RIVERS.GOV,Federal Agency,Department of the Interior,Burbank,WA,ACTIVE
+SAFECOM.GOV,Federal Agency,Department of the Interior,Boise,ID,ACTIVE
+SCIENCEBASE.GOV,Federal Agency,Department of the Interior,Denver,CO,ACTIVE
+SIERRAWILD.GOV,Federal Agency,Department of the Interior,Yosemite,CA,ACTIVE
+SNAP.GOV,Federal Agency,Department of the Interior,Washington,DC,ACTIVE
+USBR.GOV,Federal Agency,Department of the Interior,Denver,CO,ACTIVE
+USGS.GOV,Federal Agency,Department of the Interior,Reston,VA,ACTIVE
+UTAHFIREINFO.GOV,Federal Agency,Department of the Interior,Denver,CO,ACTIVE
+VOLCANO.GOV,Federal Agency,Department of the Interior,Anchorage,AK,ACTIVE
+VOLUNTEER.GOV,Federal Agency,Department of the Interior,Reston,VA,ACTIVE
+WATERMONITOR.GOV,Federal Agency,Department of the Interior,Reston,VA,ACTIVE
+WILDLIFEADAPTATIONSTRATEGY.GOV,Federal Agency,Department of the Interior,Arlington,VA,ACTIVE
+WLCI.GOV,Federal Agency,Department of the Interior,Denver,CO,ACTIVE
+YOUTHGO.GOV,Federal Agency,Department of the Interior,Shepherdstown,WV,ACTIVE
+AMA.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+AMERICATHEBEAUTIFULQUARTERS.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+ASAP.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+AYUDACONMIBANCO.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+BANKANSWERS.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+BANKCUSTOMER.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+BANKCUSTOMERASSISTANCE.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+BANKHELP.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+BANKNET.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+BEP.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+BFEM.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+BONDPRO.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+CCAC.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+CDFIFUND.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+COMPLAINTREFERRALEXPRESS.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+COMPTROLLEROFTHECURRENCY.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+DIRECTOASUCUENTA.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+EAGLECASH.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+EFTPS.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+ETA-FIND.GOV,Federal Agency,Department of the Treasury,DALLAS,TX,ACTIVE
+ETHICSBURG.GOV,Federal Agency,Department of the Treasury,Parkersburg,WV,ACTIVE
+EYENOTE.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+FEDERALINVESTMENTS.GOV,Federal Agency,Department of the Treasury,Pakersburg,WV,ACTIVE
+FEDERALSPENDING.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+FEDINVEST.GOV,Federal Agency,Department of the Treasury,Parkersburg,WV,ACTIVE
+FEDSPENDING.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+FINANCIALRESEARCH.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+FINANCIALSTABILITY.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+FINCEN.GOV,Federal Agency,Department of the Treasury,Vienna,VA,ACTIVE
+FSOC.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+FTTESTTWAI.GOV,Federal Agency,Department of the Treasury,Hyattsville,MD,ACTIVE
+GODIRECT.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+GWA.GOV,Federal Agency,Department of the Treasury,Hyattsville,MD,ACTIVE
+HELPWITHMYBANK.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+HELPWITHMYCHECKINGACCOUNT.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+HELPWITHMYCREDITCARD.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+HELPWITHMYCREDITCARDBANK.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+HELPWITHMYMORTGAGE.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+HELPWITHMYMORTGAGEBANK.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+IPAC.GOV,Federal Agency,Department of the Treasury,Boston,MA,ACTIVE
+IPP.GOV,Federal Agency,Department of the Treasury,McLean,VA,ACTIVE
+IRS.GOV,Federal Agency,Department of the Treasury,McLean,VA,ACTIVE
+IRSAUCTIONS.GOV,Federal Agency,Department of the Treasury,McLean,VA,ACTIVE
+IRSNET.GOV,Federal Agency,Department of the Treasury,McLean,VA,ACTIVE
+IRSSALES.GOV,Federal Agency,Department of the Treasury,McLean,VA,ACTIVE
+IRSVIDEOS.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+ITS.GOV,Federal Agency,Department of the Treasury,McLean,VA,ACTIVE
+MAKINGHOMEAFFORDABLE.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+MHA.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+MONEYFACTORY.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+MONEYFACTORYSTORE.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+MSB.GOV,Federal Agency,Department of the Treasury,Vienna,VA,ACTIVE
+MYIRA.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+MYMONEY.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+MYRA.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+NATIONALBANK.GOV,Federal Agency,Department of the Treasury,McLean,VA,ACTIVE
+NATIONALBANKHELP.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+NATIONALBANKNET.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+NAVYCASH.GOV,Federal Agency,Department of the Treasury,McLean,VA,ACTIVE
+OCC.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+OCCHELPS.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+OCCNET.GOV,Federal Agency,Department of the Treasury,Landover,MD,ACTIVE
+OTS.GOV,Federal Agency,Department of the Treasury,McLean,VA,ACTIVE
+PATRIOTBONDS.GOV,Federal Agency,Department of the Treasury,Parkersburg,WV,ACTIVE
+PAY.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+PRACOMMENT.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+QATESTTWAI.GOV,Federal Agency,Department of the Treasury,Hyattsville,MD,ACTIVE
+SAVINGSBOND.GOV,Federal Agency,Department of the Treasury,Mclean,VA,ACTIVE
+SAVINGSBONDS.GOV,Federal Agency,Department of the Treasury,McLean,VA,ACTIVE
+SAVINGSBONDWIZARD.GOV,Federal Agency,Department of the Treasury,Mclean,VA,ACTIVE
+SIGTARP.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+SLGS.GOV,Federal Agency,Department of the Treasury,Mclean,VA,ACTIVE
+TAAPS.GOV,Federal Agency,Department of the Treasury,Mclean,VA,ACTIVE
+TAX.GOV,Federal Agency,Department of the Treasury,McLean,VA,ACTIVE
+TCIS.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+TIGTA.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+TIGTANET.GOV,Federal Agency,Department of the Treasury,McLean,VA,ACTIVE
+TRANSPARENCY.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+TREAS.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+TREASLOCKBOX.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+TREASURY.FED.US,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+TREASURY.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+TREASURYAUCTION.GOV,Federal Agency,Department of the Treasury,Parkersburg,WV,ACTIVE
+TREASURYAUCTIONS.GOV,Federal Agency,Department of the Treasury,Mclean,VA,ACTIVE
+TREASURYDIRECT.GOV,Federal Agency,Department of the Treasury,McLean,VA,ACTIVE
+TREASURYECM.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+TREASURYHUNT.GOV,Federal Agency,Department of the Treasury,Parkersburg,WV,ACTIVE
+TREASURYSCAMS.GOV,Federal Agency,Department of the Treasury,Mclean,VA,ACTIVE
+TRS.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+TTB.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+TTBONLINE.GOV,Federal Agency,Department of the Treasury,McLean,VA,ACTIVE
+TTLPLUS.GOV,Federal Agency,Department of the Treasury,St. Louis,MO,ACTIVE
+TWAI.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+USASPENDING.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+USDEBITCARD.GOV,Federal Agency,Department of the Treasury,Mclean,VA,ACTIVE
+USMINT.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+USTREAS.GOV,Federal Agency,Department of the Treasury,McLean,VA,ACTIVE
+VERIFYPAYMENT.GOV,Federal Agency,Department of the Treasury,Parkersburg,WV,ACTIVE
+WIZARD.GOV,Federal Agency,Department of the Treasury,Mclean,VA,ACTIVE
+WORKPLACE.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+911.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE
+BTS.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE
+CFLHD.GOV,Federal Agency,Department of Transportation,Lakewood,CO,ACTIVE
+DISTRACTEDDRIVING.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE
+DISTRACTION.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE
+DOT.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE
+DOTIDEAHUB.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE
+DOTTRAFFICRECORDS.GOV,Federal Agency,Department of Transportation,Room 2202,DC,ACTIVE
+EMS.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE
+ESC.GOV,Federal Agency,Department of Transportation,Oklahoma City,OK,ACTIVE
+FAA.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE
+FAASAFETY.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE
+JCCBI.GOV,Federal Agency,Department of Transportation,Oklahoma City,OK,ACTIVE
+MDA.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE
+NHTSA.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE
+NTDPROGRAM.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE
+PLAINLANGUAGE.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE
+PROTECTYOURMOVE.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE
+SAFEOCS.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE
+SAFERCAR.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE
+SAFERTRUCK.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE
+SHARETHEROADSAFELY.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE
+STRONGPORTS.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE
+SUSTAINABLECOMMUNITIES.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE
+TFHRC.GOV,Federal Agency,Department of Transportation,Mclean,VA,ACTIVE
+TRAFFICSAFETYMARKETING.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE
+TRANSPORTATION.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE
+CDCO.GOV,Federal Agency,Department of Veterans Affairs,Austin,TX,ACTIVE
+NATIONALRESOURCEDIRECTORY.GOV,Federal Agency,Department of Veterans Affairs,Washington,DC,ACTIVE
+NRD.GOV,Federal Agency,Department of Veterans Affairs,Washington,DC,ACTIVE
+VA.GOV,Federal Agency,Department of Veterans Affairs,Washington,DC,ACTIVE
+VETBIZ.GOV,Federal Agency,Department of Veterans Affairs,Washington,DC,ACTIVE
+VETS.GOV,Federal Agency,Department of Veterans Affairs,Washington,DC,ACTIVE
+DNI.GOV,Federal Agency,Director of National Intelligence,McLean,VA,ACTIVE
+IARPA-IDEAS.GOV,Federal Agency,Director of National Intelligence,Washington,DC,ACTIVE
+IARPA.GOV,Federal Agency,Director of National Intelligence,College Park,MD,ACTIVE
+ICJOINTDUTY.GOV,Federal Agency,Director of National Intelligence,Washington,DC,ACTIVE
+INTELINK.GOV,Federal Agency,Director of National Intelligence,Ft. George G. Meade,MD,ACTIVE
+INTELLIGENCE.GOV,Federal Agency,Director of National Intelligence,Washington,DC,ACTIVE
+ISE.GOV,Federal Agency,Director of National Intelligence,Washington ,DC,ACTIVE
+NCIX.GOV,Federal Agency,Director of National Intelligence,Washington,DC,ACTIVE
+NCSC.GOV,Federal Agency,Director of National Intelligence,Bethesda,MD,ACTIVE
+NMIC.GOV,Federal Agency,Director of National Intelligence,Washington,DC,SERVER-HOLD
+ODNI.GOV,Federal Agency,Director of National Intelligence,Washington,DC,ACTIVE
+OSIS.GOV,Federal Agency,Director of National Intelligence,Fort George G. Meade,MD,ACTIVE
+PIX.GOV,Federal Agency,Director of National Intelligence,Washington,DC,ACTIVE
+QART.GOV,Federal Agency,Director of National Intelligence,Washington,DC,ACTIVE
+UGOV.GOV,Federal Agency,Director of National Intelligence,Fort George G Meade,MD,ACTIVE
+AIRNOW.GOV,Federal Agency,Environmental Protection Agency,Durham,NC,ACTIVE
+CBI-EPA.GOV,Federal Agency,Environmental Protection Agency,Durham,NC,ACTIVE
+ENERGYSTAR.GOV,Federal Agency,Environmental Protection Agency,Washington,DC,ACTIVE
+EPA.GOV,Federal Agency,Environmental Protection Agency,Research Triangle Park,NC,ACTIVE
+FDMS.GOV,Federal Agency,Environmental Protection Agency,Washington,DC,ACTIVE
+FEDCENTER.GOV,Federal Agency,Environmental Protection Agency,Champaign,IL,ACTIVE
+FRTR.GOV,Federal Agency,Environmental Protection Agency,Omaha,NE,ACTIVE
+GREENGOV.GOV,Federal Agency,Environmental Protection Agency, Washington,DC,ACTIVE
+OFEE.GOV,Federal Agency,Environmental Protection Agency,Washington,DC,ACTIVE
+REGULATIONS.GOV,Federal Agency,Environmental Protection Agency,Washington,DC,ACTIVE
+RELOCATEFEDS.GOV,Federal Agency,Environmental Protection Agency,Cincinnati,OH,ACTIVE
+SUSTAINABILITY.GOV,Federal Agency,Environmental Protection Agency,Washington,DC,ACTIVE
+URBANWATERS.GOV,Federal Agency,Environmental Protection Agency,Washington,DC,ACTIVE
+EEOC.GOV,Federal Agency,Equal Employment Opportunity Commission,Washington,DC,ACTIVE
+AIDREFUGEES.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE
+ASTRONGMIDDLECLASS.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE
+BUDGET.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE
+CHANGE.GOV,Federal Agency,Executive Office of the President,Arlington,VA,ACTIVE
+EARMARKS.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE
+EGOV.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE
+EOP.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE
+ETHICS.GOV,Federal Agency,Executive Office of the President,Washington ,DC,ACTIVE
+EXRWH.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE
+FISCALCOMMISSION.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE
+HC.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE
+ITDASHBOARD.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE
+JOININGFORCES.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE
+LETSMOVE.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE
+MAX.GOV,Federal Agency,Executive Office of the President,NW,WA,ACTIVE
+NEPA.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE
+NOTALONE.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE
+NSTIC.GOV,Federal Agency,Executive Office of the President,Gaithersburg,MD,ACTIVE
+OMB.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE
+OMBLOG.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE
+ONDCP.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE
+OSTP.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE
+PAYMENTACCURACY.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE
+PCI.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE
+PRESIDIO.GOV,Federal Agency,Executive Office of the President,San Francisco,CA,ACTIVE
+PRESIDIOTRUST.GOV,Federal Agency,Executive Office of the President,San Francisco,CA,ACTIVE
+REACHHIGHER.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE
+SAVE.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE
+SAVEAWARD.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE
+STRONGMIDDLECLASS.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE
+USDIGITALSERVICE.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE
+USDS.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE
+USTR.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE
+WH.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE
+WHITEHOUSE.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE
+WHITEHOUSEDRUGPOLICY.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE
+EXIM.GOV,Federal Agency,Export/Import Bank of the U.S.,Washington,DC,ACTIVE
+EXIMCOOP.GOV,Federal Agency,Export/Import Bank of the U.S.,Washington,DC,ACTIVE
+FCA.GOV,Federal Agency,Farm Credit Administration,McLean,VA,ACTIVE
+FCSIC.GOV,Federal Agency,Farm Credit Administration,McLean,VA,ACTIVE
+BROADBAND.GOV,Federal Agency,Federal Communications Commission,Washington,DC,ACTIVE
+BROADBANDMAP.GOV,Federal Agency,Federal Communications Commission,Washington,DC,ACTIVE
+DTV.GOV,Federal Agency,Federal Communications Commission,Washington,DC,ACTIVE
+FCC.GOV,Federal Agency,Federal Communications Commission,Washington,DC,ACTIVE
+FCCUNIVERSITY.GOV,Federal Agency,Federal Communications Commission,Washington,DC,ACTIVE
+LIFELINE.GOV,Federal Agency,Federal Communications Commission,Washington,DC,ACTIVE
+NBM.GOV,Federal Agency,Federal Communications Commission,Washington,DC,ACTIVE
+OPENINTERNET.GOV,Federal Agency,Federal Communications Commission,Washington,DC,ACTIVE
+ECONOMICINCLUSION.GOV,Federal Agency,Federal Deposit Insurance Corporation,Arlington,VA,ACTIVE
+FDIC.GOV,Federal Agency,Federal Deposit Insurance Corporation,Arlington,VA,ACTIVE
+FDICCONNECT.GOV,Federal Agency,Federal Deposit Insurance Corporation,Arlington,VA,ACTIVE
+FDICIG.GOV,Federal Agency,Federal Deposit Insurance Corporation,Arlington,VA,ACTIVE
+FDICOIG.GOV,Federal Agency,Federal Deposit Insurance Corporation,Washington,DC,ACTIVE
+FDICSALES.GOV,Federal Agency,Federal Deposit Insurance Corporation,Arlington,VA,ACTIVE
+FDICSEGURO.GOV,Federal Agency,Federal Deposit Insurance Corporation,Arlington,VA,ACTIVE
+MYFDIC.GOV,Federal Agency,Federal Deposit Insurance Corporation,Arlington,VA,ACTIVE
+MYFDICINSURANCE.GOV,Federal Agency,Federal Deposit Insurance Corporation,Arlington,VA,ACTIVE
+FEC.GOV,Federal Agency,Federal Elections Commission,Washington,DC,ACTIVE
+FERC.GOV,Federal Agency,Federal Energy Regulatory Commission,Washington,DC,ACTIVE
+FERCALT.GOV,Federal Agency,Federal Energy Regulatory Commission,Washington,DC,ACTIVE
+FHFA.GOV,Federal Agency,Federal Housing Finance Agency,Washington,DC,ACTIVE
+FHFB.GOV,Federal Agency,Federal Housing Finance Agency,Washington,DC,ACTIVE
+HARP.GOV,Federal Agency,Federal Housing Finance Agency,Washington,DC,ACTIVE
+OFHEO.GOV,Federal Agency,Federal Housing Finance Agency,Washington,DC,ACTIVE
+FHFAOIG.GOV,Federal Agency,Federal Housing Finance Agency Office of Inspector General,Washington,DC,ACTIVE
+FLRA.GOV,Federal Agency,Federal Labor Relations Authority,Washington,DC,ACTIVE
+FMC.GOV,Federal Agency,Federal Maritime Commission,Washington,DC,ACTIVE
+FMCS.GOV,Federal Agency,Federal Mediation and Conciliation Service,Washington,DC,ACTIVE
+FBIIC.GOV,Federal Agency,Federal Reserve System,Washington,DC,ACTIVE
+FEDCENTENNIAL.GOV,Federal Agency,Federal Reserve System,Washington,DC,ACTIVE
+FEDERALRESERVE.GOV,Federal Agency,Federal Reserve System,Washington,DC,ACTIVE
+FEDERALRESERVE100.GOV,Federal Agency,Federal Reserve System,Washington ,DC,ACTIVE
+FEDERALRESERVE2013.GOV,Federal Agency,Federal Reserve System,Washington,DC,ACTIVE
+FEDERALRESERVECENTENNIAL.GOV,Federal Agency,Federal Reserve System,Washington ,DC,ACTIVE
+FEDERALRESERVECENTENNIALCELEBRATION.GOV,Federal Agency,Federal Reserve System,Washington,DC,ACTIVE
+FEDERALRESERVECONSUMERHELP.GOV,Federal Agency,Federal Reserve System,Washington,DC,ACTIVE
+FEDPARTNERSHIP.GOV,Federal Agency,Federal Reserve System,Washington,DC,ACTIVE
+FFIEC.GOV,Federal Agency,Federal Reserve System,Washington,DC,ACTIVE
+FRB.FED.US,Federal Agency,Federal Reserve System,Washington,DC,ACTIVE
+FRB.GOV,Federal Agency,Federal Reserve System,Washington,DC,ACTIVE
+FRS.GOV,Federal Agency,Federal Reserve System,Washington,DC,ACTIVE
+NEWMONEY.GOV,Federal Agency,Federal Reserve System,Washington,DC,ACTIVE
+USCURRENCY.GOV,Federal Agency,Federal Reserve System,Washington,DC,ACTIVE
+EXPLORETSP.GOV,Federal Agency,Federal Retirement Thrift Investment Board,Washington,DC,ACTIVE
+FRTIB.GOV,Federal Agency,Federal Retirement Thrift Investment Board,Washington,DC,ACTIVE
+FRTIBTEST.GOV,Federal Agency,Federal Retirement Thrift Investment Board,Washigton,DC,ACTIVE
+TSP.GOV,Federal Agency,Federal Retirement Thrift Investment Board,Washington,DC,ACTIVE
+TSPTEST.GOV,Federal Agency,Federal Retirement Thrift Investment Board,Washington,DC,ACTIVE
+ADMONGO.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE
+ALERTAENLINEA.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE
+ANNUALCREDITREPORT.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE
+CONSUMER.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE
+CONSUMERSENTINEL.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE
+CONSUMERSENTINELNETWORK.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE
+CONSUMIDOR.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE
+DONOTCALL.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE
+DONTSERVETEENS.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE
+ECONSUMER.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE
+FREECREDITREPORT.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE
+FTC.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE
+FTCCOMPLAINTASSISTANT.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE
+FTCEFILE.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE
+HSR.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE
+IDENTITYTHEFT.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE
+IDTHEFT.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE
+NCPW.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE
+ONGUARDONLINE.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE
+ONLINEONGUARD.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE
+PROTECCIONDELCONSUMIDOR.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE
+ROBODEIDENTIDAD.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE
+SENTINEL.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE
+UCE.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE
+USICN.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE
+18F.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+ACQUISITION.GOV,Federal Agency,General Services Administration,Arlington,VA,ACTIVE
+AFADVANTAGE.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+APP.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+APPS.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+BUSINESSUSA.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+BUYACCESSIBLE.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+CAO.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+CBCA.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+CFDA.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+CFO.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+CFOC.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+CHALLENGE.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+CHALLENGES.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+CIO.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+CITIZENSCIENCE.GOV,Federal Agency,General Services Administration,NW,DC,ACTIVE
+CLOUD.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+COMPUTERS4LEARNING.GOV,Federal Agency,General Services Administration,Arlington,VA,ACTIVE
+COMPUTERSFORLEARNING.GOV,Federal Agency,General Services Administration,Arlington,VA,ACTIVE
+CONNECT.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+CONSUMERACTION.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+CONTRACTDIRECTORY.GOV,Federal Agency,General Services Administration,Arlington,VA,ACTIVE
+CPARS.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+DATA.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+DIGITALGOV.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+DOTGOV.GOV,Federal Agency,General Services Administration,Fairfax,VA,ACTIVE
+EAC.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+ECPIC.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+EISENHOWERMEMORIAL.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+EPLS.GOV,Federal Agency,General Services Administration,Arlington,VA,ACTIVE
+ESRS.GOV,Federal Agency,General Services Administration,arlington,VA,ACTIVE
+EVERYKID.GOV,Federal Agency,General Services Administration,Washington DC,DC,ACTIVE
+EVERYKIDINAPARK.GOV,Federal Agency,General Services Administration,Washington DC,DC,ACTIVE
+FACA.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+FACADATABASE.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+FAI.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+FAPIIS.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+FAQ.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+FBO.GOV,Federal Agency,General Services Administration,Arlington,VA,ACTIVE
+FED.US,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+FEDBIZOPPS.GOV,Federal Agency,General Services Administration,Arlington,VA,ACTIVE
+FEDIDCARD.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+FEDINFO.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+FEDRAMP.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+FEDROOMS.GOV,Federal Agency,General Services Administration,Arlington,VA,ACTIVE
+FIDO.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+FIRSTGOV.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+FMI.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+FORMS.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+FPDS.GOV,Federal Agency,General Services Administration,Arlington,VA,ACTIVE
+FPKI-LAB.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+FPKI.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+FRPG.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+FRPP-PA.GOV,Federal Agency,General Services Administration,WASHINGTON,DC,ACTIVE
+FSD.GOV,Federal Agency,General Services Administration,Arlington,VA,ACTIVE
+FSRS.GOV,Federal Agency,General Services Administration,Crystal City,VA,ACTIVE
+GOBIERNO.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+GOBIERNOUSA.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+GOVSALES.GOV,Federal Agency,General Services Administration,Arlington,VA,ACTIVE
+GSA.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+GSAADVANTAGE.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+GSAAUCTIONS.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+GSAIG.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+GSAXCESS.GOV,Federal Agency,General Services Administration,Arlington,VA,ACTIVE
+HOWTO.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+IDMANAGEMENT.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+INFO.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+KIDS.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+LEARNPERFORMANCE.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+LOGIN.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+MYUSA.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+NBRC.GOV,Federal Agency,General Services Administration,Bangor,ME,ACTIVE
+NETWORX.GOV,Federal Agency,General Services Administration,Fairfax,VA,ACTIVE
+NIC.GOV,Federal Agency,General Services Administration,Fairfax,VA,ACTIVE
+PARTNER4SOLUTIONS.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+PCLOB.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+PERFORMANCE.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+PIC.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+PIF.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+PPIRS.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+PRESIDENTIALINNOVATIONFELLOWS.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+PTT.GOV,Federal Agency,General Services Administration,Washington D.C.,DC,ACTIVE
+REALESTATESALES.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+REALPROPERTYPROFILE.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+REGINFO.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+ROCIS.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+SAM.GOV,Federal Agency,General Services Administration,Arlington,VA,ACTIVE
+SANDBOX.GOV,Federal Agency,General Services Administration,Washinton,DC,ACTIVE
+SBST.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+SECTION508.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+SFTOOL.GOV,Federal Agency,General Services Administration,Chicago,IL,ACTIVE
+STRATEGICSOURCING.GOV,Federal Agency,General Services Administration,Arlington,VA,ACTIVE
+SUPPORTTHEVOTER.GOV,Federal Agency,General Services Administration,WASHINGTON,DC,ACTIVE
+UNITEDSTATES.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+US.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+USA.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+USAGOV.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+USAPERFORMANCE.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+USCIRF.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+USGOVERNMENT.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+USIP.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+USSM.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+VEF.GOV,Federal Agency,General Services Administration,Arlington,VA,ACTIVE
+VITM.GOV,Federal Agency,General Services Administration,Arlington,VA,ACTIVE
+VOTE.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+VOTEBYMAIL.GOV,Federal Agency,General Services Administration,SILVER SPRING,MD,ACTIVE
+CONGRESSIONALDIRECTORY.GOV,Federal Agency,Government Printing Office,Washington,DC,ACTIVE
+CONGRESSIONALRECORD.GOV,Federal Agency,Government Printing Office,Washington,DC,ACTIVE
+ECFR.GOV,Federal Agency,Government Printing Office,Washington,DC,ACTIVE
+FDLP.GOV,Federal Agency,Government Printing Office,Washington,DC,ACTIVE
+FDSYS.GOV,Federal Agency,Government Printing Office,Washington,DC,ACTIVE
+FEDERALREGISTER.GOV,Federal Agency,Government Printing Office,Washington,DC,ACTIVE
+FEDREG.GOV,Federal Agency,Government Printing Office,Washington,DC,ACTIVE
+FMSHRC.GOV,Federal Agency,Government Printing Office,Washington,DC,ACTIVE
+GOVINFO.GOV,Federal Agency,Government Printing Office,Washington,DC,ACTIVE
+GPO.GOV,Federal Agency,Government Printing Office,Washington,DC,ACTIVE
+HOUSECALENDAR.GOV,Federal Agency,Government Printing Office,Washington,DC,ACTIVE
+OFR.GOV,Federal Agency,Government Printing Office,Washington,DC,ACTIVE
+OPENWORLD.GOV,Federal Agency,Government Printing Office,Washington,DC,ACTIVE
+PRESIDENTIALDOCUMENTS.GOV,Federal Agency,Government Printing Office,Washington,DC,ACTIVE
+SENATECALENDAR.GOV,Federal Agency,Government Printing Office,Washington,DC,ACTIVE
+STOPFAKES.GOV,Federal Agency,Government Printing Office,Washington,DC,ACTIVE
+USCAPITOLPOLICE.GOV,Federal Agency,Government Printing Office,Washington,DC,ACTIVE
+USCC.GOV,Federal Agency,Government Printing Office,Washington,DC,ACTIVE
+USCODE.GOV,Federal Agency,Government Printing Office,Washington,DC,ACTIVE
+USGOVERNMENTMANUAL.GOV,Federal Agency,Government Printing Office,College Park,MD,ACTIVE
+WELCOMETOUSA.GOV,Federal Agency,Government Printing Office,Washington,DC,ACTIVE
+RESTORETHEGULF.GOV,Federal Agency,Gulf Coast Ecosystem Restoration Council (GCERC),Silver Spring,MD,ACTIVE
+TRUMAN.GOV,Federal Agency,Harry S. Truman Scholarship Foundation,Washington,DC,ACTIVE
+IMLS.GOV,Federal Agency,Institute of Museum and Library Services,Washington,DC,ACTIVE
+IAF.GOV,Federal Agency,Inter-American Foundation,Washington,DC,ACTIVE
+BBG.GOV,Federal Agency,International Broadcasting Bureau,Washington,DC,ACTIVE
+IBB.GOV,Federal Agency,International Broadcasting Bureau,Washington,DC,ACTIVE
+VOA.GOV,Federal Agency,International Broadcasting Bureau,Washington,DC,ACTIVE
+JAMESMADISON.GOV,Federal Agency,James Madison Memorial Fellowship Foundation,Alexandria,VA,ACTIVE
+LSC.GOV,Federal Agency,Legal Services Corporation,Washington,DC,ACTIVE
+AFRICANAMERICANHISTORYMONTH.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+AMERICANMEMORY.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+AMERICASLIBRARY.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+AMERICASSTORY.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+AMERICASTORY.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+ASIANPACIFICHERITAGE.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+COMMISSION.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+CONGRESS.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+COPYRIGHT.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+CRS.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+DIGITALPRESERVATION.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+DIGITIZATIONGUIDELINES.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+HISPANICHERITAGEMONTH.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+JEWISHHERITAGE.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+JEWISHHERITAGEMONTH.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+LAW.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+LCTL.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+LIBRARYOFCONGRESS.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+LIS.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+LITERACY.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+LOC.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+LOCTPS.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+NATIVEAMERICANHERITAGEMONTH.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+PRIMARYSOURCES.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+READ.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+SECTION108.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+TEACHINGPRIMARYSOURCES.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+TEACHINGWITHPRIMARYSOURCES.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+THOMAS.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+TPS.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+UNITEDSTATESCONGRESS.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+USCONGRESS.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+WDL.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+WOMENSHISTORYMONTH.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+MMC.GOV,Federal Agency,Marine Mammal Commission,Bethesda,MD,ACTIVE
+MACPAC.GOV,Federal Agency,Medicaid and CHIP Payment and Access Commission,Washington,DC,ACTIVE
+MEDPAC.GOV,Federal Agency,Medical Payment Advisory Commission,Washington,DC,ACTIVE
+MSPB.GOV,Federal Agency,Merit Systems Protection Board,Washington,DC,ACTIVE
+MCC.GOV,Federal Agency,Millennium Challenge Corporation,Washington,DC,ACTIVE
+ECR.GOV,Federal Agency,Morris K. Udall Foundation,Tucson,AZ,ACTIVE
+UDALL.GOV,Federal Agency,Morris K. Udall Foundation,Tucson,AZ,ACTIVE
+GLOBE.GOV,Federal Agency,National Aeronautics and Space Administration,Greenbelt,MD,ACTIVE
+NASA.GOV,Federal Agency,National Aeronautics and Space Administration,MSFC,AL,ACTIVE
+NSWP.GOV,Federal Agency,National Aeronautics and Space Administration,MSFC,AL,ACTIVE
+SCIJINKS.GOV,Federal Agency,National Aeronautics and Space Administration,MSFC,AL,ACTIVE
+USGEO.GOV,Federal Agency,National Aeronautics and Space Administration,MSFC,AL,ACTIVE
+9-11COMMISSION.GOV,Federal Agency,National Archives and Records Administration,College Park,MD,ACTIVE
+911COMMISSION.GOV,Federal Agency,National Archives and Records Administration,College Park,MD,ACTIVE
+ARCHIVES.GOV,Federal Agency,National Archives and Records Administration,College Park,MD,ACTIVE
+CLINTONLIBRARY.GOV,Federal Agency,National Archives and Records Administration,Little Rock,AR,ACTIVE
+EMERGENCY-FEDERAL-REGISTER.GOV,Federal Agency,National Archives and Records Administration,College Park,MD,ACTIVE
+FCIC.GOV,Federal Agency,National Archives and Records Administration,College Park,MD,ACTIVE
+FORDLIBRARYMUSEUM.GOV,Federal Agency,National Archives and Records Administration,College Park,MD,ACTIVE
+FRC.GOV,Federal Agency,National Archives and Records Administration,College Park,MD,ACTIVE
+GEORGEWBUSHLIBRARY.GOV,Federal Agency,National Archives and Records Administration,College Park,MD,ACTIVE
+HISTORY.GOV,Federal Agency,National Archives and Records Administration,College Park,MD,ACTIVE
+JIMMYCARTERLIBRARY.GOV,Federal Agency,National Archives and Records Administration,College,MD,ACTIVE
+NARA-AT-WORK.GOV,Federal Agency,National Archives and Records Administration,College Park,MD,ACTIVE
+NARA.GOV,Federal Agency,National Archives and Records Administration,College Park,MD,ACTIVE
+NIXONLIBRARY.GOV,Federal Agency,National Archives and Records Administration,College Park,MD,ACTIVE
+OGIS.GOV,Federal Agency,National Archives and Records Administration,College Park,MD,ACTIVE
+OURDOCUMENTS.GOV,Federal Agency,National Archives and Records Administration,College Park,MD,ACTIVE
+REAGANLIBRARY.GOV,Federal Agency,National Archives and Records Administration,College Park,MD,ACTIVE
+RECORDSMANAGEMENT.GOV,Federal Agency,National Archives and Records Administration,College Park,MD,ACTIVE
+WARTIMECONTRACTING.GOV,Federal Agency,National Archives and Records Administration,College Park,MD,ACTIVE
+WEBHARVEST.GOV,Federal Agency,National Archives and Records Administration,College Park,MD,ACTIVE
+NCPC.GOV,Federal Agency,National Capital Planning Commission,Washington,DC,ACTIVE
+NCD.GOV,Federal Agency,National Council on Disability,Washington,DC,ACTIVE
+MYCREDITUNION.GOV,Federal Agency,National Credit Union Administration,Alexandria,VA,ACTIVE
+NCUA.GOV,Federal Agency,National Credit Union Administration,Alexandria,VA,ACTIVE
+ARTS.GOV,Federal Agency,National Endowment for the Arts,Washington,DC,ACTIVE
+NEA.GOV,Federal Agency,National Endowment for the Arts,Washington,DC,ACTIVE
+HUMANITIES.GOV,Federal Agency,National Endowment for the Humanities,Washington,DC,ACTIVE
+NEH.GOV,Federal Agency,National Endowment for the Humanities,Washington,DC,ACTIVE
+PCAH.GOV,Federal Agency,National Endowment for the Humanities,Washington,DC,ACTIVE
+WETHEPEOPLE.GOV,Federal Agency,National Endowment for the Humanities,Washington,DC,ACTIVE
+NGA.GOV,Federal Agency,National Gallery of Art,Washington,DC,ACTIVE
+NIGC.GOV,Federal Agency,National Indian Gaming Commission,Washington,DC,ACTIVE
+NLRB.GOV,Federal Agency,National Labor Relations Board,Washington,DC,ACTIVE
+NMB.GOV,Federal Agency,National Mediation Board,Washington,DC,ACTIVE
+NANO.GOV,Federal Agency,National Nanotechnology Coordination Office,Arlington,VA,ACTIVE
+ARCTIC.GOV,Federal Agency,National Science Foundation,Arlington,VA,ACTIVE
+NSF.GOV,Federal Agency,National Science Foundation,Arlington,VA,ACTIVE
+RESEARCH.GOV,Federal Agency,National Science Foundation,Arlington,VA,ACTIVE
+SAC.GOV,Federal Agency,National Science Foundation,Arlington,VA,ACTIVE
+SCIENCE360.GOV,Federal Agency,National Science Foundation,Arlington,VA,ACTIVE
+USAP.GOV,Federal Agency,National Science Foundation,Arlington,VA,ACTIVE
+INTELLIGENCECAREERS.GOV,Federal Agency,National Security Agency,Ft. Meade,MD,ACTIVE
+LPS.GOV,Federal Agency,National Security Agency,College Park,MD,ACTIVE
+NTSB.GOV,Federal Agency,National Transportation Safety Board,Washington,DC,ACTIVE
+ITRD.GOV,Federal Agency,Networking Information Technology Research and Development (NITRD),Arlington,VA,ACTIVE
+NITRD.GOV,Federal Agency,Networking Information Technology Research and Development (NITRD),Arlington,VA,ACTIVE
+HERITAGEABROAD.GOV,Federal Agency,Non-Federal Agency,Washington,DC,ACTIVE
+IAB.GOV,Federal Agency,Non-Federal Agency,Quantico,VA,ACTIVE
+JUSFC.GOV,Federal Agency,Non-Federal Agency,Washington,DC,ACTIVE
+NWTRB.GOV,Federal Agency,Non-Federal Agency,Arlington,VA,ACTIVE
+PPPL.GOV,Federal Agency,Non-Federal Agency,Princeton,NJ,ACTIVE
+SERVEINDIANA.GOV,Federal Agency,Non-Federal Agency,Indianapolis,IN,ACTIVE
+SJI.GOV,Federal Agency,Non-Federal Agency,Reston,VA,ACTIVE
+WMATC.GOV,Federal Agency,Non-Federal Agency,Silver Spring,MD,ACTIVE
+NRC-GATEWAY.GOV,Federal Agency,Nuclear Regulatory Commission,Rockville,MD,ACTIVE
+NRC.GOV,Federal Agency,Nuclear Regulatory Commission,Rockville,MD,ACTIVE
+OSHRC.GOV,Federal Agency,Occupational Safety & Health Review Commission,Washington,DC,ACTIVE
+INTEGRITY.GOV,Federal Agency,Office of Government Ethics,Washington,DC,ACTIVE
+APPLICATIONMANAGER.GOV,Federal Agency,Office of Personnel Management,Macon,GA,ACTIVE
+CHCOC.GOV,Federal Agency,Office of Personnel Management,Washington,DC,ACTIVE
+E-QIP.GOV,Federal Agency,Office of Personnel Management,Washington,DC,ACTIVE
+EMPLOYEEEXPRESS.GOV,Federal Agency,Office of Personnel Management,Macon,GA,ACTIVE
+FEB.GOV,Federal Agency,Office of Personnel Management,Washington,DC,ACTIVE
+FEDERALJOBS.GOV,Federal Agency,Office of Personnel Management,Macon,GA,ACTIVE
+FEDJOBS.GOV,Federal Agency,Office of Personnel Management,Macon,GA,ACTIVE
+FEDSHIREVETS.GOV,Federal Agency,Office of Personnel Management,Washington,DC,ACTIVE
+FEGLI.GOV,Federal Agency,Office of Personnel Management,Washington,DC,ACTIVE
+FSAFEDS.GOV,Federal Agency,Office of Personnel Management,Washington,DC,ACTIVE
+GOLEARN.GOV,Federal Agency,Office of Personnel Management,Washington,DC,ACTIVE
+GOVERNMENTJOBS.GOV,Federal Agency,Office of Personnel Management,Macon,GA,ACTIVE
+HRU.GOV,Federal Agency,Office of Personnel Management,Washington,DC,ACTIVE
+LMRCOUNCIL.GOV,Federal Agency,Office of Personnel Management,Washington,DC,ACTIVE
+OPM.GOV,Federal Agency,Office of Personnel Management,Macon,GA,ACTIVE
+PAC.GOV,Federal Agency,Office of Personnel Management,Washington,DC,ACTIVE
+PMF.GOV,Federal Agency,Office of Personnel Management,Washington,DC,ACTIVE
+TELEWORK.GOV,Federal Agency,Office of Personnel Management,Washington,DC,ACTIVE
+UNLOCKTALENT.GOV,Federal Agency,Office of Personnel Management,Washington,DC,ACTIVE
+USAJOBS.GOV,Federal Agency,Office of Personnel Management,Washington,DC,ACTIVE
+USALEARNING.GOV,Federal Agency,Office of Personnel Management,Washington,DC,ACTIVE
+USASTAFFING.GOV,Federal Agency,Office of Personnel Management,Macon,GA,ACTIVE
+OPIC.GOV,Federal Agency,Overseas Private Investment Corporation,Washington,DC,ACTIVE
+PBGC.GOV,Federal Agency,Pension Benefit Guaranty Corporation,Washington,DC,ACTIVE
+PRC.GOV,Federal Agency,Postal Rate Commission,Washington,DC,ACTIVE
+RRB.GOV,Federal Agency,Railroad Retirement Board,Chicago,IL,ACTIVE
+INVESTOR.GOV,Federal Agency,Securities and Exchange Commission,Alexandria,VA,ACTIVE
+SEC.GOV,Federal Agency,Securities and Exchange Commission,Alexandria,VA,ACTIVE
+SSS.GOV,Federal Agency,Selective Service System,Arlington,VA,ACTIVE
+BUSINESS.GOV,Federal Agency,Small Business Administration,Washington,DC,ACTIVE
+HSA.GOV,Federal Agency,Small Business Administration,Washington,DC,ACTIVE
+NWBC.GOV,Federal Agency,Small Business Administration,Washington,DC,ACTIVE
+ONLINEWBC.GOV,Federal Agency,Small Business Administration,Washington,DC,ACTIVE
+SBA.GOV,Federal Agency,Small Business Administration,Washington,DC,ACTIVE
+SBIR.GOV,Federal Agency,Small Business Administration,Arlington,VA,ACTIVE
+WOMENBIZ.GOV,Federal Agency,Small Business Administration,Washington,DC,ACTIVE
+ITIS.GOV,Federal Agency,Smithsonian Institution,Washington,DC,ACTIVE
+SEGUROSOCIAL.GOV,Federal Agency,Social Security Administration,Baltimore,MD,ACTIVE
+SOCIALSECURITY.GOV,Federal Agency,Social Security Administration,Baltimore,MD,ACTIVE
+SSA.GOV,Federal Agency,Social Security Administration,Baltimore,MD,ACTIVE
+SSAB.GOV,Federal Agency,Social Security Advisory Board,WASHINGTON,DC,ACTIVE
+STENNIS.GOV,Federal Agency,Stennis Center for Public Service,Starkville,MS,ACTIVE
+STB.GOV,Federal Agency,Surface Transportation Board (STB),Washington,DC,ACTIVE
+TVA.GOV,Federal Agency,Tennessee Valley Authority,Knoxville,TN,ACTIVE
+TVAOIG.GOV,Federal Agency,Tennessee Valley Authority,Knoxville,TN,ACTIVE
+TSC.GOV,Federal Agency,Terrorist Screening Center,Washington,DC,ACTIVE
+PTF.GOV,Federal Agency,The Intelligence Community,Washington,DC,ACTIVE
+AOC.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+CAPITAL.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+CAPITOL.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+CAPITOLFLAGS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+CBO.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+CBONEWS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+CECC.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+CHINA-COMMISSION.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+CHINACOMMISSION.GOV,Federal Agency,The Legislative Branch (Congress),Washington,MD,ACTIVE
+CITIZENCOSPONSORS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+CITIZENS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+COSPONSOR.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+CSCE.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+DEMOCRATICLEADER.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+DEMOCRATICWHIP.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+DEMOCRATS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+DEMS.GOV,Federal Agency,The Legislative Branch (Congress),Washington DC,DC,ACTIVE
+ESECLAB.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+FASAB.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+GAO.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+GAONET.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+GOP.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+GOPCONFERENCE.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,SERVER-HOLD
+GOPLEADER.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+HOUSE.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+HOUSECOMMUNICATIONS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+HOUSEDEMOCRATS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+HOUSEDEMS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+HOUSELIVE.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+HOUSENEWSLETTERS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+JCT.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+LISTENSTOYOU.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+MAJORITYLEADER.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+MAJORITYWHIP.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+PDBCECC.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+PPDCECC.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+REPUBLICANS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+SEN.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+SENATE.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+SENATERESTAURANTS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+SPEAKER.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+TAXREFORM.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+USBG.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+USCAPITAL.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+USCAPITOL.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+USCAPITOLVISITORCENTER.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,SERVER-HOLD
+USCVC.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,SERVER-HOLD
+USHOUSE.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+USHR.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+VISITTHECAPITAL.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+VISITTHECAPITOL.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+SC-US.GOV,Federal Agency,The Supreme Court,Washington,DC,ACTIVE
+SCINET-TEST.GOV,Federal Agency,The Supreme Court,Washington,DC,ACTIVE
+SCINET.GOV,Federal Agency,The Supreme Court,Washington,DC,ACTIVE
+SCUS.GOV,Federal Agency,The Supreme Court,WASHINGTON,DC,ACTIVE
+SUPREME-COURT.GOV,Federal Agency,The Supreme Court,Washington,DC,ACTIVE
+SUPREMECOURT.GOV,Federal Agency,The Supreme Court,Washington,DC,ACTIVE
+SUPREMECOURTUS.GOV,Federal Agency,The Supreme Court,Washington,DC,ACTIVE
+WORLDWAR1CENTENNIAL.GOV,Federal Agency,The United States World War One Centennial Commission,Washington,DC,ACTIVE
+ACCESS-BOARD.GOV,Federal Agency,U. S. Access Board,Washington,DC,ACTIVE
+USHMM.GOV,Federal Agency,U. S. Holocaust Memorial Museum,Washington,DC,ACTIVE
+USITC.GOV,Federal Agency,U. S. International Trade Commission,Washington,DC,ACTIVE
+OSC.GOV,Federal Agency,U. S. Office of Special Counsel,Washington,DC,ACTIVE
+OSCNET.GOV,Federal Agency,U. S. Office of Special Counsel,Washington,DC,ACTIVE
+PEACECORE.GOV,Federal Agency,U. S. Peace Corps,Washington,DC,ACTIVE
+PEACECORP.GOV,Federal Agency,U. S. Peace Corps,Washington,DC,ACTIVE
+PEACECORPS.GOV,Federal Agency,U. S. Peace Corps,Washington,DC,ACTIVE
+CHANGEOFADDRESS.GOV,Federal Agency,U. S. Postal Service,Washington,DC,ACTIVE
+MAIL.GOV,Federal Agency,U. S. Postal Service,Raleigh,NC,ACTIVE
+POSTOFFICE.GOV,Federal Agency,U. S. Postal Service,Raleigh,NC,ACTIVE
+PURCHASING.GOV,Federal Agency,U. S. Postal Service,Raleigh,NC,ACTIVE
+USPIS.GOV,Federal Agency,U. S. Postal Service,Arlington,VA,ACTIVE
+USPS.GOV,Federal Agency,U. S. Postal Service,Raleigh,NC,ACTIVE
+BANKRUPTCY.GOV,Federal Agency,U.S Courts,Washington,DC,ACTIVE
+CAVC.GOV,Federal Agency,U.S Courts,Washington,DC,ACTIVE
+DCSC.GOV,Federal Agency,U.S Courts,Washington,DC,ACTIVE
+FEDCIR.GOV,Federal Agency,U.S Courts,Washington,DC,SERVER-HOLD
+FEDERALCOURTS.GOV,Federal Agency,U.S Courts,Washington,DC,ACTIVE
+FEDERALPROBATION.GOV,Federal Agency,U.S Courts,Washington,DC,ACTIVE
+FEDERALRULES.GOV,Federal Agency,U.S Courts,Washington,DC,ACTIVE
+FJC.GOV,Federal Agency,U.S Courts,Washington,DC,ACTIVE
+JUDICIALCONFERENCE.GOV,Federal Agency,U.S Courts,Washington,DC,ACTIVE
+NMCOURT.FED.US,Federal Agency,U.S Courts,Albuquerque,NM,ACTIVE
+PACER.GOV,Federal Agency,U.S Courts,Washington,DC,ACTIVE
+USBANKRUPTCY.GOV,Federal Agency,U.S Courts,Washington,DC,ACTIVE
+USC.GOV,Federal Agency,U.S Courts,Washington,DC,ACTIVE
+USCAVC.GOV,Federal Agency,U.S Courts,Washington,DC,SERVER-HOLD
+USCOURTS.GOV,Federal Agency,U.S Courts,Washington,DC,ACTIVE
+USCVA.GOV,Federal Agency,U.S Courts,Washington,DC,SERVER-HOLD
+USPROBATION.GOV,Federal Agency,U.S Courts,Washington,DC,ACTIVE
+USSC.GOV,Federal Agency,U.S Courts,Washington,DC,ACTIVE
+USTAXCOURT.GOV,Federal Agency,U.S Courts,Washington,DC,ACTIVE
+VETAPP.GOV,Federal Agency,U.S Courts,Washington,DC,SERVER-HOLD
+CHILDRENINADVERSITY.GOV,Federal Agency,U.S. Agency for International Development,Washington,DC,ACTIVE
+DFAFACTS.GOV,Federal Agency,U.S. Agency for International Development,Washington,DC,ACTIVE
+FEEDTHEFUTURE.GOV,Federal Agency,U.S. Agency for International Development,Washington,DC,ACTIVE
+LETGIRLSLEARN.GOV,Federal Agency,U.S. Agency for International Development,Washington,DC,ACTIVE
+NEGLECTEDDISEASES.GOV,Federal Agency,U.S. Agency for International Development,Washington,DC,ACTIVE
+OFDA.GOV,Federal Agency,U.S. Agency for International Development,Washington,DC,ACTIVE
+PMI.GOV,Federal Agency,U.S. Agency for International Development,Washington,DC,ACTIVE
+USAID.GOV,Federal Agency,U.S. Agency for International Development,Washington,DC,ACTIVE
+USAIDALLNET.GOV,Federal Agency,U.S. Agency for International Development,Arlington,VA,ACTIVE
+USCP.GOV,Federal Agency,U.S. Capitol Police,Washington,DC,ACTIVE
+CHEMSAFETY.GOV,Federal Agency,U.S. Chemical Safety and Hazard Investigation Board,Washington,DC,ACTIVE
+CSB.GOV,Federal Agency,U.S. Chemical Safety and Hazard Investigation Board,Washington,DC,ACTIVE
+SAFETYVIDEOS.GOV,Federal Agency,U.S. Chemical Safety and Hazard Investigation Board,Washington,DC,ACTIVE
+CFA.GOV,Federal Agency,U.S. Commission of Fine Arts,Washington,DC,ACTIVE
+USCCR.GOV,Federal Agency,U.S. Commission on Civil Rights,Washington,DC,ACTIVE
+PEACECORPSOIG.GOV,Federal Agency,"U.S. Postal Service, Office of Inspector General",Washington,DC,ACTIVE
+USPSOIG.GOV,Federal Agency,"U.S. Postal Service, Office of Inspector General",Arlington,VA,ACTIVE
+USTDA.GOV,Federal Agency,U.S. Trade and Development Agency,Arlington,VA,ACTIVE
+CARBONCYCLESCIENCE.GOV,Federal Agency,United Stated Global Change Research Program,Washington,DC,SERVER-HOLD
+GLOBALCHANGE.GOV,Federal Agency,United Stated Global Change Research Program,Washington,DC,ACTIVE
+IPCC-WG2.GOV,Federal Agency,United Stated Global Change Research Program,Stanford,CA,ACTIVE
+USGCRP.GOV,Federal Agency,United Stated Global Change Research Program,Washington,DC,ACTIVE
+OGE.GOV,Federal Agency,United States Office of Government Ethics,Washington,DC,ACTIVE
+ICH.GOV,Federal Agency,US Interagency Council on Homelessness,washington,DC,ACTIVE
+USICH.GOV,Federal Agency,US Interagency Council on Homelessness,Washington,DC,ACTIVE
+29PALMSBOMI-NSN.GOV,Native Sovereign Nation,Indian Affairs,Coachella,CA,ACTIVE
+ABSENTEESHAWNEETRIBE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Shawnee,OK,ACTIVE
+AGUACALIENTE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Palm Springs,CA,ACTIVE
+AHA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Hogansburg,NY,ACTIVE
+AK-CHIN-NSN.GOV,Native Sovereign Nation,Indian Affairs,Maricopa,AZ,ACTIVE
+BADRIVER-NSN.GOV,Native Sovereign Nation,Indian Affairs,Odanah,WI,ACTIVE
+BARONA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Lakeside,CA,ACTIVE
+BEARRIVER-NSN.GOV,Native Sovereign Nation,Indian Affairs,Loleta,CA,ACTIVE
+BIHASITKA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Sitka,AK,ACTIVE
+BLUELAKERANCHERIA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Blue Lake,CA,ACTIVE
+BOISFORTE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Nett Lake,MN,ACTIVE
+BRB-NSN.GOV,Native Sovereign Nation,Indian Affairs,LOLETA,CA,ACTIVE
+BURNSPAIUTE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Burns,OR,ACTIVE
+CABAZONINDIANS-NSN.GOV,Native Sovereign Nation,Indian Affairs,Indio,CA,ACTIVE
+CADDONATION-NSN.GOV,Native Sovereign Nation,Indian Affairs,Binger,OK,ACTIVE
+CAHTOTRIBE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Laytonville,CA,ACTIVE
+CAMPO-NSN.GOV,Native Sovereign Nation,Indian Affairs,Campo,CA,ACTIVE
+CAYUGANATION-NSN.GOV,Native Sovereign Nation,Indian Affairs,Seneca Falls ,NY,ACTIVE
+CCTHITA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Juneau,AK,ACTIVE
+CDATRIBE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Plummer,ID,ACTIVE
+CHEROKEE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Tahlequah,OK,ACTIVE
+CHICKASAW-GOVERNMENT-NSN.GOV,Native Sovereign Nation,Indian Affairs,Ada,OK,ACTIVE
+CHICKASAW-NSN.GOV,Native Sovereign Nation,Indian Affairs,Ada,OK,ACTIVE
+CHICKASAWARTISANS-NSN.GOV,Native Sovereign Nation,Indian Affairs,Ada,OK,ACTIVE
+CHICKASAWGOVERNMENT-NSN.GOV,Native Sovereign Nation,Indian Affairs,Ada,OK,ACTIVE
+CHICKASAWJUDICIAL-NSN.GOV,Native Sovereign Nation,Indian Affairs,Ada,OK,ACTIVE
+CHICKASAWLEGISLATURE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Ada,OK,ACTIVE
+CHICKASAWNATION-NSN.GOV,Native Sovereign Nation,Indian Affairs,Ada,OK,ACTIVE
+CHICKASAWTRIBE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Ada,OK,ACTIVE
+CHILKOOT-NSN.GOV,Native Sovereign Nation,Indian Affairs,Haines,AK,ACTIVE
+CHITIMACHA.GOV,Native Sovereign Nation,Indian Affairs,Charenton,LA,ACTIVE
+CHUKCHANSI-NSN.GOV,Native Sovereign Nation,Indian Affairs,Fresno,CA,ACTIVE
+CIT-NSN.GOV,Native Sovereign Nation,Indian Affairs,Havasu Lake,CA,ACTIVE
+COLUSA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Colusa,CA,ACTIVE
+COYOTEVALLEY-NSN.GOV,Native Sovereign Nation,Indian Affairs,Redwood valley,CA,ACTIVE
+CRHC-NSN.GOV,Native Sovereign Nation,Indian Affairs,Chico,CA,ACTIVE
+CRIT-NSN.GOV,Native Sovereign Nation,Indian Affairs,Parker,AZ,ACTIVE
+CROW-NSN.GOV,Native Sovereign Nation,Indian Affairs,Crow Agency,MT,ACTIVE
+CRST-NSN.GOV,Native Sovereign Nation,Indian Affairs,EAGLE BUTTE,SD,ACTIVE
+EKLUTNA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Chugiak,AK,ACTIVE
+ELYSHOSHONETRIBE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Ely,NV,ACTIVE
+ESTOO-NSN.GOV,Native Sovereign Nation,Indian Affairs,Wyandotte,OK,ACTIVE
+EWIIAAPAAYP-NSN.GOV,Native Sovereign Nation,Indian Affairs,Alpine,CA,ACTIVE
+EYAK-NSN.GOV,Native Sovereign Nation,Indian Affairs,Cordova,AK,ACTIVE
+FCP-NSN.GOV,Native Sovereign Nation,Indian Affairs,Crandon,WI,ACTIVE
+FCPOTAWATOMI-NSN.GOV,Native Sovereign Nation,Indian Affairs,Crandon,WI,ACTIVE
+FORTSILLAPACHE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Apache,OK,ACTIVE
+GILARIVER-NSN.GOV,Native Sovereign Nation,Indian Affairs,Sacaton,AZ,ACTIVE
+GLT-NSN.GOV,Native Sovereign Nation,Indian Affairs,Dorr,MI,ACTIVE
+GUNLAKETRIBE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Dorr,MI,ACTIVE
+HANNAHVILLEPOTAWATOMI-NSN.GOV,Native Sovereign Nation,Indian Affairs,Wilson,MI,ACTIVE
+HAVASUPAI-NSN.GOV,Native Sovereign Nation,Indian Affairs,Supai,AZ,ACTIVE
+HOOPA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Hoopa,CA,ACTIVE
+HOPI-NSN.GOV,Native Sovereign Nation,Indian Affairs,Kykotsmovi,AZ,ACTIVE
+HPULTRIBE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Upper Lake,CA,ACTIVE
+HUALAPAI-NSN.GOV,Native Sovereign Nation,Indian Affairs,Peach Springs,AZ,ACTIVE
+IIPAYNATION-NSN.GOV,Native Sovereign Nation,Indian Affairs,santa ysabel,CA,ACTIVE
+ISLETAPUEBLO-NSN.GOV,Native Sovereign Nation,Indian Affairs,Isleta,NM,ACTIVE
+JACKSONRANCHERIA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Jackson,CA,ACTIVE
+KAIBABPAIUTE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Fredonia,AZ,ACTIVE
+KAWAIKA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Laguna,NM,ACTIVE
+KAYENTATOWNSHIP-NSN.GOV,Native Sovereign Nation,Indian Affairs,Kayenta,AZ,ACTIVE
+KBIC-NSN.GOV,Native Sovereign Nation,Indian Affairs,Baraga,MI,ACTIVE
+KENAITZE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Kenai,AK,ACTIVE
+KEWEENAWBAY-NSN.GOV,Native Sovereign Nation,Indian Affairs,Baraga,MI,ACTIVE
+KTIK-NSN.GOV,Native Sovereign Nation,Indian Affairs,Horton,KS,ACTIVE
+LAGUNA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Laguna,NM,ACTIVE
+LAGUNAPUEBLO-NSN.GOV,Native Sovereign Nation,Indian Affairs,Laguna,NM,ACTIVE
+LAJOLLA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Pauma Valley,CA,ACTIVE
+LCO-NSN.GOV,Native Sovereign Nation,Indian Affairs,Hayward,WI,ACTIVE
+LTBBODAWA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Harbor Springs,MI,ACTIVE
+LUMMI-NSN.GOV,Native Sovereign Nation,Indian Affairs,Bellingham,WA,ACTIVE
+MASHANTUCKET-NSN.GOV,Native Sovereign Nation,Indian Affairs,Mashantucket,CT,ACTIVE
+MASHANTUCKETPEQUOT-NSN.GOV,Native Sovereign Nation,Indian Affairs,Mashantucket,CT,ACTIVE
+MASHANTUCKETWESTERNPEQUOT-NSN.GOV,Native Sovereign Nation,Indian Affairs,Mashantucket,CT,ACTIVE
+MCN-NSN.GOV,Native Sovereign Nation,Indian Affairs,Okmulgee,OK,ACTIVE
+MECHOOPDA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Chico,CA,ACTIVE
+MENOMINEE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Keshena,WI,ACTIVE
+MESAGRANDEBAND-NSN.GOV,Native Sovereign Nation,Indian Affairs,SantaYsabel,CA,ACTIVE
+MESKWAKI-NSN.GOV,Native Sovereign Nation,Indian Affairs,Tama,IA,ACTIVE
+MICCOSUKEE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Miami,FL,ACTIVE
+MICMAC-NSN.GOV,Native Sovereign Nation,Indian Affairs,Presque Isle,ME,ACTIVE
+MIDDLETOWNRANCHERIA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Middletown,CA,ACTIVE
+MILLELACSBAND-NSN.GOV,Native Sovereign Nation,Indian Affairs,Onamia,MN,ACTIVE
+MOAPABANDOFPAIUTES-NSN.GOV,Native Sovereign Nation,Indian Affairs,Moapa,NV,SERVER-HOLD
+MOHICAN-NSN.GOV,Native Sovereign Nation,Indian Affairs,Bowler,WI,ACTIVE
+MORONGO-NSN.GOV,Native Sovereign Nation,Indian Affairs,Banning,CA,ACTIVE
+MPGE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Mashantucket,CT,ACTIVE
+MPTN-NSN.GOV,Native Sovereign Nation,Indian Affairs,Mashantucket,CT,ACTIVE
+MUSCOGEENATION-NSN.GOV,Native Sovereign Nation,Indian Affairs,Okmulgee,OK,ACTIVE
+NCIHA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Ukiah,CA,ACTIVE
+NFR-NSN.GOV,Native Sovereign Nation,Indian Affairs,North Fork,CA,ACTIVE
+NFRIHA-NSN.GOV,Native Sovereign Nation,Indian Affairs,North Fork,CA,ACTIVE
+NINILCHIKTRIBE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Ninilchik,AK,ACTIVE
+NISQUALLY-NSN.GOV,Native Sovereign Nation,Indian Affairs,Olympia,WA,ACTIVE
+NOOKSACK-NSN.GOV,Native Sovereign Nation,Indian Affairs,Deming,WA,ACTIVE
+NORTHFORKRANCHERIA-NSN.GOV,Native Sovereign Nation,Indian Affairs,North Fork ,CA,ACTIVE
+NVB-NSN.GOV,Native Sovereign Nation,Indian Affairs,Barrow,AK,ACTIVE
+OHKAYOWINGEH-NSN.GOV,Native Sovereign Nation,Indian Affairs,San Juan Pueblo,NM,ACTIVE
+OMAHA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Macy,NE,ACTIVE
+ONEIDA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Oneida,WI,ACTIVE
+OSAGECONGRESS-NSN.GOV,Native Sovereign Nation,Indian Affairs,Pawhuska,OK,ACTIVE
+OSAGENATION-NSN.GOV,Native Sovereign Nation,Indian Affairs,Pawhuska,OK,ACTIVE
+PASCUAYAQUI-NSN.GOV,Native Sovereign Nation,Indian Affairs,Tucson,AZ,ACTIVE
+PASKENTA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Corning,CA,ACTIVE
+PAUMA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Pauma Valley,CA,ACTIVE
+PCI-NSN.GOV,Native Sovereign Nation,Indian Affairs,Atmore,AL,ACTIVE
+PECHANGA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Temecula,CA,ACTIVE
+PEQUOT-NSN.GOV,Native Sovereign Nation,Indian Affairs,Mashantucket,CT,ACTIVE
+PHC-NSN.GOV,Native Sovereign Nation,Indian Affairs,Princeton,ME,ACTIVE
+POARCHCREEKINDIANS-NSN.GOV,Native Sovereign Nation,Indian Affairs,ATMORE,AL,ACTIVE
+POKAGONBAND-NSN.GOV,Native Sovereign Nation,Indian Affairs,DOWAGIAC,MI,ACTIVE
+POL-NSN.GOV,Native Sovereign Nation,Indian Affairs,Laguna,NM,ACTIVE
+PUYALLUPTRIBE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Tacoma,WA,ACTIVE
+QVIR-NSN.GOV,Native Sovereign Nation,Indian Affairs,Fort jones,CA,ACTIVE
+RAMONA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Anza,CA,ACTIVE
+REDCLIFF-NSN.GOV,Native Sovereign Nation,Indian Affairs,Bayfield,WI,ACTIVE
+ROSEBUDSIOUXTRIBE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Rosebud,SD,ACTIVE
+RST-NSN.GOV,Native Sovereign Nation,Indian Affairs,Rosebud,SD,ACTIVE
+RSTWATER-NSN.GOV,Native Sovereign Nation,Indian Affairs,Rosebud,SD,ACTIVE
+SACANDFOXNATION-NSN.GOV,Native Sovereign Nation,Indian Affairs,Stroud,OK,ACTIVE
+SANMANUEL-NSN.GOV,Native Sovereign Nation,Indian Affairs,Highland,CA,ACTIVE
+SANTAANA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Santa Ana,NM,ACTIVE
+SANTAROSACAHUILLA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Anza,CA,ACTIVE
+SCAT-NSN.GOV,Native Sovereign Nation,Indian Affairs,Peridot,AZ,ACTIVE
+SCC-NSN.GOV,Native Sovereign Nation,Indian Affairs,Crandon,WI,ACTIVE
+SEMINOLENATION-NSN.GOV,Native Sovereign Nation,Indian Affairs,Wewoka,OK,ACTIVE
+SHOALWATERBAY-NSN.GOV,Native Sovereign Nation,Indian Affairs,Tokeland,WA,ACTIVE
+SIR-NSN.GOV,Native Sovereign Nation,Indian Affairs,Susanville,CA,ACTIVE
+SITKATRIBE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Sitka,AK,ACTIVE
+SNO-NSN.GOV,Native Sovereign Nation,Indian Affairs,Wewoka,OK,ACTIVE
+SOBOBA-NSN.GOV,Native Sovereign Nation,Indian Affairs,San Jacinto,CA,ACTIVE
+SOUTHERNUTE-NSN.GOV,Native Sovereign Nation,Indian Affairs,IGNACIO,CO,ACTIVE
+SRMT-NSN.GOV,Native Sovereign Nation,Indian Affairs,Akwesasne,NY,ACTIVE
+SRPMIC-NSN.GOV,Native Sovereign Nation,Indian Affairs,Scottsdale,AZ,ACTIVE
+SUSANVILLEINDIANRANCHERIA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Susanville,CA,ACTIVE
+SWINOMISH-NSN.GOV,Native Sovereign Nation,Indian Affairs,La Conner,WA,ACTIVE
+SWO-NSN.GOV,Native Sovereign Nation,Indian Affairs,Agency Village,SD,ACTIVE
+SYCUAN-NSN.GOV,Native Sovereign Nation,Indian Affairs,El Cajon,CA,ACTIVE
+TACHI-YOKUT-NSN.GOV,Native Sovereign Nation,Indian Affairs,Lemoore,CA,ACTIVE
+TAMAYA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Santa Ana,NM,ACTIVE
+TEJONINDIANTRIBE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Bakersfield,CA,ACTIVE
+TMDCI-NSN.GOV,Native Sovereign Nation,Indian Affairs,Thermal,CA,ACTIVE
+TOLOWA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Smith River,CA,ACTIVE
+TONATION-NSN.GOV,Native Sovereign Nation,Indian Affairs,Sells,AZ,ACTIVE
+TORRESMARTINEZ-NSN.GOV,Native Sovereign Nation,Indian Affairs,Thermal,CA,ACTIVE
+TULALIP-NSN.GOV,Native Sovereign Nation,Indian Affairs,Tulalip,WA,ACTIVE
+TULALIPAIR-NSN.GOV,Native Sovereign Nation,Indian Affairs,Tulalip,WA,ACTIVE
+TULALIPTRIBES-NSN.GOV,Native Sovereign Nation,Indian Affairs,Tulalip,WA,ACTIVE
+TULERIVERTRIBE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Porterville,CA,ACTIVE
+TWENTYNINEPALMSBOMI-NSN.GOV,Native Sovereign Nation,Indian Affairs,Coachella,CA,ACTIVE
+UKB-NSN.GOV,Native Sovereign Nation,Indian Affairs,Tahlequah,OK,ACTIVE
+UPPERSIOUXCOMMUNITY-NSN.GOV,Native Sovereign Nation,Indian Affairs,Granite Falls,MN,ACTIVE
+VIEJAS-NSN.GOV,Native Sovereign Nation,Indian Affairs,Alpine,CA,ACTIVE
+WARMSPRINGS-NSN.GOV,Native Sovereign Nation,Indian Affairs,Warm Springs,OR,ACTIVE
+WESTERNPEQUOT-NSN.GOV,Native Sovereign Nation,Indian Affairs,Mashantucket,CT,ACTIVE
+WHITEEARTH-NSN.GOV,Native Sovereign Nation,Indian Affairs,Ogema,MN,ACTIVE
+WILTONRANCHERIA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Elk Grove,CA,ACTIVE
+WINNEMUCCAINDIANCOLONYOFNEVADA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Winnemucca,NV,ACTIVE
+WYANDOTTE-NATION-NSN.GOV,Native Sovereign Nation,Indian Affairs,Wyandotte,OK,ACTIVE
+YAKAMAFISH-NSN.GOV,Native Sovereign Nation,Indian Affairs,Toppenish,WA,ACTIVE
+YAKAMANATION-NSN.GOV,Native Sovereign Nation,Indian Affairs,Toppenish,WA,ACTIVE
+YOCHADEHE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Brooks,CA,ACTIVE
+YPT-NSN.GOV,Native Sovereign Nation,Indian Affairs,Yerington,NV,ACTIVE
+CHILKAT-NSN.GOV,Native Sovereign Nation,Non-Federal Agency,Haines,AK,ACTIVE
+DINEH-NSN.GOV,Native Sovereign Nation,Non-Federal Agency,Window Rock,AZ,ACTIVE
+LRBOI-NSN.GOV,Native Sovereign Nation,Non-Federal Agency,Manistee,MI,ACTIVE
+NAVAJO-NSN.GOV,Native Sovereign Nation,Non-Federal Agency,Window Rock,AZ,ACTIVE
+YDSP-NSN.GOV,Native Sovereign Nation,Non-Federal Agency,El Pas,TX,ACTIVE
+MTC.GOV,State/Local Govt,Multistate Tax Commission,Washington,DC,ACTIVE
+IUS.GOV,State/Local Govt,National Gallery of Art,Boise,ID,ACTIVE
+511MAINE.GOV,State/Local Govt,Non-Federal Agency,Augusta,ME,ACTIVE
+511NY.GOV,State/Local Govt,Non-Federal Agency,Albany,NY,ACTIVE
+511TX.GOV,State/Local Govt,Non-Federal Agency,Austin,TX,ACTIVE
+511WI.GOV,State/Local Govt,Non-Federal Agency,Madison,WI,ACTIVE
+ABLETN.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE
+ACCESSTN.GOV,State/Local Govt,Non-Federal Agency,NASHVILLE,TN,ACTIVE
+ADRCNJ.GOV,State/Local Govt,Non-Federal Agency,Mercerville,NJ,ACTIVE
+AGAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AGUTAH.GOV,State/Local Govt,Non-Federal Agency,Salt Lake City,UT,ACTIVE
+AK.GOV,State/Local Govt,Non-Federal Agency,Juneau,AK,ACTIVE
+AKAEROSPACE.GOV,State/Local Govt,Non-Federal Agency,Anchorage,AK,ACTIVE
+AKLEG.GOV,State/Local Govt,Non-Federal Agency,Juneau,AK,ACTIVE
+AL-LEGISLATURE.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE
+AL.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE
+ALABAMA.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE
+ALABAMAAGELINE.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE
+ALABAMACONNECT.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE
+ALABAMADA.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE
+ALABAMADEMENTIA.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE
+ALABAMAHOUSEPHOTOS.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE
+ALABAMASMP.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE
+ALABAMAVOTES.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE
+ALABPP.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE
+ALACOP.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE
+ALACOURT.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE
+ALADA.GOV,State/Local Govt,Non-Federal Agency,Mongomery,AL,ACTIVE
+ALADNA.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE
+ALAPPEALS.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE
+ALASAFE.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE
+ALASKA.GOV,State/Local Govt,Non-Federal Agency,Juneau,AK,ACTIVE
+ALASKACARE.GOV,State/Local Govt,Non-Federal Agency,Juneau,AK,ACTIVE
+ALDOI.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE
+ALEA.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE
+ALHOUSE.GOV,State/Local Govt,Non-Federal Agency,Montgomery ,AL,ACTIVE
+ALPHARETTA-GA.GOV,State/Local Govt,Non-Federal Agency,Alpharetta,GA,ACTIVE
+ALSENATE.GOV,State/Local Govt,Non-Federal Agency,Montgomery ,AL,ACTIVE
+AMERICANSAMOA.GOV,State/Local Govt,Non-Federal Agency,Pago Pago,AS,ACTIVE
+AMESBURYMA.GOV,State/Local Govt,Non-Federal Agency,Amesbury,MA,ACTIVE
+ANNAPOLIS.GOV,State/Local Govt,Non-Federal Agency,Annapolis,MD,ACTIVE
+ANNAPOLISMD.GOV,State/Local Govt,Non-Federal Agency,Annapolis,MD,ACTIVE
+AQMD.GOV,State/Local Govt,Non-Federal Agency,Diamond Bar,CA,ACTIVE
+AR.GOV,State/Local Govt,Non-Federal Agency,Little Rock,AR,ACTIVE
+ARCOURTS.GOV,State/Local Govt,Non-Federal Agency,Little Rock,AR,ACTIVE
+ARIZONA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+ARIZONAJOBCONNECTION.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+ARIZONATURBOCOURT.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+ARKANSAS.GOV,State/Local Govt,Non-Federal Agency,Little Rock,AR,ACTIVE
+ARKANSASAG.GOV,State/Local Govt,Non-Federal Agency,Little Rock,AR,ACTIVE
+ARKANSASED.GOV,State/Local Govt,Non-Federal Agency,Little Rock,AR,ACTIVE
+ARKLEGAUDIT.GOV,State/Local Govt,Non-Federal Agency,Little Rock,AR,ACTIVE
+ARTREASURY.GOV,State/Local Govt,Non-Federal Agency,Litlte Rock,AR,ACTIVE
+ARTRS.GOV,State/Local Govt,Non-Federal Agency,Little Rock,AR,ACTIVE
+AS.GOV,State/Local Govt,Non-Federal Agency,Pago Pago,AS,ACTIVE
+ASAFERFLORIDA.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+ASEPA.GOV,State/Local Govt,Non-Federal Agency,Pago Pago,AS,ACTIVE
+ATHOMEILLINOIS.GOV,State/Local Govt,Non-Federal Agency,Chicago,IL,ACTIVE
+ATLASALABAMA.GOV,State/Local Govt,Non-Federal Agency,TUSCALOOSA,AL,ACTIVE
+ATTORNEYGENERAL.GOV,State/Local Govt,Non-Federal Agency,Harrisburg,PA,ACTIVE
+AUGUSTAGA.GOV,State/Local Govt,Non-Federal Agency,Augusta,GA,ACTIVE
+AVON-MA.GOV,State/Local Govt,Non-Federal Agency,Avon,MA,ACTIVE
+AZ-ACOIHC.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZ-FHSD.GOV,State/Local Govt,Non-Federal Agency,Fountain Hills,AZ,ACTIVE
+AZ.GOV,State/Local Govt,Non-Federal Agency,Phoeniz,AZ,ACTIVE
+AZ511.GOV,State/Local Govt,Non-Federal Agency,Pheonix,AZ,ACTIVE
+AZ529.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZ911.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZABRC.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZACCOUNTANCY.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZACTIC.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZAFIS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZAG.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZAHCCCS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZARTS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZASRS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZAUDITOR.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZBN.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZBNP.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZBOA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZBOC.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZBOEC.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZBOF.GOV,State/Local Govt,Non-Federal Agency,PHOENIX,AZ,ACTIVE
+AZBORDERTRASH.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZBOTA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZBOXINGANDMMA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZBROADBAND.GOV,State/Local Govt,Non-Federal Agency,PHOENIX,AZ,ACTIVE
+AZBTR.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZCAAA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZCANCERCONTROL.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZCC.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZCIA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZCJC.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZCLEANELECTIONS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZCLIMATECHANGE.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZCOOP.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZCORPCOM.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZCORPCOMM.GOV,State/Local Govt,Non-Federal Agency,Phoenxi,AZ,ACTIVE
+AZCORRECTIONS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZCOURTDOCS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZCOURTS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZCVD.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZDA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZDAARS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZDCS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZDDPC.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZDEMA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZDEQ.GOV,State/Local Govt,Non-Federal Agency,Phx,AZ,ACTIVE
+AZDES.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZDFI.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZDHS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZDIABETES.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZDJC.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZDO.GOV,State/Local Govt,Non-Federal Agency,Scottsdale,AZ,ACTIVE
+AZDOA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZDOC.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZDOH.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZDOHS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZDOR.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZDOSH.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZDOT.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZDPS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZDVS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZECDH.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZED.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZEIN.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZENVIROKIDS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZEPIP.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZFIRSTTHINGSFIRST.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZFTF.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZGADA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZGAMING.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZGFD.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZGITA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZGOHS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZGOVERNOR.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZGRANTS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZGU.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZGUARD.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZHC.GOV,State/Local Govt,Non-Federal Agency,Pheonix,AZ,ACTIVE
+AZHEALTH.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZHIGHERED.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZHOUSE.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZHOUSING.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZHS.GOV,State/Local Govt,Non-Federal Agency,Tempe,AZ,ACTIVE
+AZICA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZINSURANCE.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZINVESTOR.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZJOBCONNECTION.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZJUVED.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZKIDSCARE.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZKIDSNEEDU.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZLAND.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZLEG.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZLGMA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZLIBRARY.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZLINKS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZLIQUOR.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZLOTTERY.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZMAG.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZMD.GOV,State/Local Govt,Non-Federal Agency,Scottsdale,AZ,ACTIVE
+AZMINORITYHEALTH.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZMORTGAGERESOURCE.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZMYFAMILYBENEFITS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZND.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZNET.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZOCA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZOSPB.GOV,State/Local Govt,Non-Federal Agency,phoenix,AZ,ACTIVE
+AZOT.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZPA.GOV,State/Local Govt,Non-Federal Agency,Scottsdale,AZ,ACTIVE
+AZPARKS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZPCRPD.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZPH.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZPHARMACY.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZPOST.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZPPSE.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZPSIC.GOV,State/Local Govt,Non-Federal Agency,PHOENIX,AZ,ACTIVE
+AZQUALITYFIRST.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZRACING.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZRE.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZRECYCLES.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZREPORTCARD.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZROC.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZRRA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZRUCO.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZSAL.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZSENATE.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZSF.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZSFB.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZSHARE.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZSOS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZSTATEJOBS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZSTATEPARKS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZSTATS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZSTEPSUP.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZSUMMERFOOD.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZSURPLUS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZTAXES.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZTRANSPORTATIONBOARD.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZTREASURER.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZTREASURY.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZTURBOCOURT.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZUI.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZUITAX.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZUNCLAIMED.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZVOICES.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZWATER.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZWATERBANK.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZWIC.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZWIFA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZWPF.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZYES.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+B4WV.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE
+BAAQMD.GOV,State/Local Govt,Non-Federal Agency,San Francisco,CA,ACTIVE
+BABYARIZONA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+BARHARBORMAINE.GOV,State/Local Govt,Non-Federal Agency,Bar Harbor,ME,ACTIVE
+BART.GOV,State/Local Govt,Non-Federal Agency,Oakland,CA,ACTIVE
+BATONROUGELA.GOV,State/Local Govt,Non-Federal Agency,Baton Rouge,LA,ACTIVE
+BEGA-DC.GOV,State/Local Govt,Non-Federal Agency,Washington,DC,ACTIVE
+BEREADYUTAH.GOV,State/Local Govt,Non-Federal Agency,Salt Lake City,UT,ACTIVE
+BETSYLEHMANCENTERMA.GOV,State/Local Govt,Non-Federal Agency,Boston,MA,ACTIVE
+BLNC.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+BOATIDAHO.GOV,State/Local Govt,Non-Federal Agency,Boise,ID,ACTIVE
+BOIMI.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI,ACTIVE
+BOULDERCOUNTY-CO.GOV,State/Local Govt,Non-Federal Agency,Boulder,CO,ACTIVE
+BRAINTREEMA.GOV,State/Local Govt,Non-Federal Agency,Braintree,MA,ACTIVE
+BRANDCOLORADO.GOV,State/Local Govt,Non-Federal Agency,Boulder,CO,ACTIVE
+BREWERMAINE.GOV,State/Local Govt,Non-Federal Agency,Brewer,ME,ACTIVE
+BROCKTON-MA.GOV,State/Local Govt,Non-Federal Agency,Brockton,MA,ACTIVE
+BRUNSWICKMD.GOV,State/Local Govt,Non-Federal Agency,Brunswick,MD,ACTIVE
+BURKECOUNTY-GA.GOV,State/Local Govt,Non-Federal Agency,Waynesboro,GA,ACTIVE
+BUSINESS4WV.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE
+BUYNJBONDS.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+CA.GOV,State/Local Govt,Non-Federal Agency,Rancho Cordova,CA,ACTIVE
+CAHWNET.GOV,State/Local Govt,Non-Federal Agency,Sacramento,CA,ACTIVE
+CALIFORNIA.GOV,State/Local Govt,Non-Federal Agency,Rancho Cordova,CA,ACTIVE
+CALIFORNIADESERT.GOV,State/Local Govt,Non-Federal Agency,Barstow,CA,ACTIVE
+CAMBRIDGERETIREMENTMA.GOV,State/Local Govt,Non-Federal Agency,Cambridge,MA,ACTIVE
+CAMDENCOUNTYGA.GOV,State/Local Govt,Non-Federal Agency,Woodbine,GA,ACTIVE
+CANBYOREGON.GOV,State/Local Govt,Non-Federal Agency,Canby,OR,ACTIVE
+CAPITALREGIONUPDATES.GOV,State/Local Govt,Non-Federal Agency,Fairfax,VA,ACTIVE
+CASAAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+CHIAMASS.GOV,State/Local Govt,Non-Federal Agency,Boston,MA,ACTIVE
+CHOOSEIDAHO.GOV,State/Local Govt,Non-Federal Agency,Boise,ID,ACTIVE
+CITYOFBOSTON.GOV,State/Local Govt,Non-Federal Agency,Boston,MA,ACTIVE
+CLAIMITTN.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE
+CLAYCOUNTYIN.GOV,State/Local Govt,Non-Federal Agency,Brazil,IN,ACTIVE
+CLEARSPRINGMD.GOV,State/Local Govt,Non-Federal Agency,Clear Spring,MD,ACTIVE
+CMSPLANFLORIDA.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL,ACTIVE
+CO.GOV,State/Local Govt,Non-Federal Agency,Lakewood,CO,ACTIVE
+COAG.GOV,State/Local Govt,Non-Federal Agency,Denver,CO,ACTIVE
+COBBCOUNTYGA.GOV,State/Local Govt,Non-Federal Agency,Marietta,GA,ACTIVE
+COBERTURAMEDICAILLINOIS.GOV,State/Local Govt,Non-Federal Agency,Chicago,IL,ACTIVE
+COCICJIS.GOV,State/Local Govt,Non-Federal Agency,Golden,CO,ACTIVE
+CODOT.GOV,State/Local Govt,Non-Federal Agency,Denver,CO,ACTIVE
+COLLEGEGOALARIZONA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+COLLEGEGOALOREGON.GOV,State/Local Govt,Non-Federal Agency,Eugene,OR,ACTIVE
+COLLIERCOUNTYFL.GOV,State/Local Govt,Non-Federal Agency,Naples,FL,ACTIVE
+COLORADO.GOV,State/Local Govt,Non-Federal Agency,Lakewood,CO,ACTIVE
+COLORADOATTORNEYGENERAL.GOV,State/Local Govt,Non-Federal Agency,Denver,CO,ACTIVE
+COLORADOJUDICIAL.GOV,State/Local Govt,Non-Federal Agency,Denver,CO,ACTIVE
+COLORADOJUDICIALPERFORMANCE.GOV,State/Local Govt,Non-Federal Agency,Denver,CO,ACTIVE
+COLORADOLABORLAW.GOV,State/Local Govt,Non-Federal Agency,Denver,CO,ACTIVE
+COLORADOPOST.GOV,State/Local Govt,Non-Federal Agency,Denver,CO,ACTIVE
+COLORADOPOSTGRANTS.GOV,State/Local Govt,Non-Federal Agency,Denver,CO,ACTIVE
+COLORADORCJC.GOV,State/Local Govt,Non-Federal Agency,Denver,CO,ACTIVE
+COLORADOUI.GOV,State/Local Govt,Non-Federal Agency,Denver,CO,ACTIVE
+COLORADOWORKS.GOV,State/Local Govt,Non-Federal Agency,Denver,CO,ACTIVE
+COMPARECAREWV.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE
+CONCORD-MA.GOV,State/Local Govt,Non-Federal Agency,Concord,MA,ACTIVE
+CONNECTND.GOV,State/Local Govt,Non-Federal Agency,Bisamarck,ND,ACTIVE
+CONSERVEALABAMA.GOV,State/Local Govt,Non-Federal Agency,MONTGOMERY,AL,ACTIVE
+CONSHOHOCKENPA.GOV,State/Local Govt,Non-Federal Agency,Conshohocken,PA,ACTIVE
+COSIPA.GOV,State/Local Govt,Non-Federal Agency,Denver,CO,ACTIVE
+COUNCILBLUFFS-IA.GOV,State/Local Govt,Non-Federal Agency,Council Bluffs,IA,ACTIVE
+COURTNEWSOHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+COURTSWV.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE
+COVERTENNESSEE.GOV,State/Local Govt,Non-Federal Agency,NASHVILLE,TN,ACTIVE
+COVERTN.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE
+COWORKFORCE.GOV,State/Local Govt,Non-Federal Agency,Denver,CO,ACTIVE
+CRESTEDBUTTE-CO.GOV,State/Local Govt,Non-Federal Agency,Crested Butte,CO,ACTIVE
+CSIMT.GOV,State/Local Govt,Non-Federal Agency,Helena,MT,ACTIVE
+CSTX.GOV,State/Local Govt,Non-Federal Agency,College Station,TX,ACTIVE
+CT.GOV,State/Local Govt,Non-Federal Agency,Hartford,CT,ACTIVE
+CTALERT.GOV,State/Local Govt,Non-Federal Agency,Middletown,CT,ACTIVE
+CTBROWNFIELDS.GOV,State/Local Govt,Non-Federal Agency,Hartford,CT,ACTIVE
+CTGROWN.GOV,State/Local Govt,Non-Federal Agency,Hartford,CT,ACTIVE
+CTPROBATE.GOV,State/Local Govt,Non-Federal Agency,West Hartford,CT,ACTIVE
+DA16CO.GOV,State/Local Govt,Non-Federal Agency,LA JUNTA,CO,ACTIVE
+DC.GOV,State/Local Govt,Non-Federal Agency,Washington,DC,ACTIVE
+DCAPPEALS.GOV,State/Local Govt,Non-Federal Agency,Washington,DC,ACTIVE
+DCCODE.GOV,State/Local Govt,Non-Federal Agency,Washington,DC,ACTIVE
+DCCOUNCIL.GOV,State/Local Govt,Non-Federal Agency,Washington,DC,ACTIVE
+DCCOURT.GOV,State/Local Govt,Non-Federal Agency,Washington,DC,ACTIVE
+DCCOURTS.GOV,State/Local Govt,Non-Federal Agency,Washington,DC,ACTIVE
+DCCOURTSNEWS.GOV,State/Local Govt,Non-Federal Agency,Washington,DC,ACTIVE
+DE.GOV,State/Local Govt,Non-Federal Agency,Dover,DE,ACTIVE
+DEBTREPORTINGIOWA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+DEL.GOV,State/Local Govt,Non-Federal Agency,Dover,DE,ACTIVE
+DELAWARE.GOV,State/Local Govt,Non-Federal Agency,Dover,DE,ACTIVE
+DELAWAREINSURANCE.GOV,State/Local Govt,Non-Federal Agency,Dover,DE,ACTIVE
+DELDOT.GOV,State/Local Govt,Non-Federal Agency,Dover,DE,ACTIVE
+DEVAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+DIGITALARIZONA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+DIGITALAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+DMG.GOV,State/Local Govt,Non-Federal Agency,Barstow,CA,ACTIVE
+DNSSECOHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+DNSTESTOHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+DOJMT.GOV,State/Local Govt,Non-Federal Agency,Helena,MT,ACTIVE
+DOSEOFREALITYWI.GOV,State/Local Govt,Non-Federal Agency,Madison,WI,ACTIVE
+DOUBLECHECKIOWA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+DRACUTMA.GOV,State/Local Govt,Non-Federal Agency,Dracut,MA,ACTIVE
+DRIVENC.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+DUDLEYMA.GOV,State/Local Govt,Non-Federal Agency,Dudley,MA,ACTIVE
+DWGPA.GOV,State/Local Govt,Non-Federal Agency,Delaware Water Gap,PA,ACTIVE
+EASTHAM-MA.GOV,State/Local Govt,Non-Federal Agency,Eastham,MA,ACTIVE
+EASTVALLEYFUSIONCENTERAZ.GOV,State/Local Govt,Non-Federal Agency,Mesa,AZ,ACTIVE
+EDGEWOODKY.GOV,State/Local Govt,Non-Federal Agency,Edgewood,KY,ACTIVE
+EDUCATEIOWA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+EFILETEXAS.GOV,State/Local Govt,Non-Federal Agency,Austin,TX,ACTIVE
+EGREMONT-MA.GOV,State/Local Govt,Non-Federal Agency,Egremont,MA,ACTIVE
+EHAWAII.GOV,State/Local Govt,Non-Federal Agency,Honolulu,HI,ACTIVE
+EISGATEWAYPACIFICWA.GOV,State/Local Govt,Non-Federal Agency,Lacey,WA,ACTIVE
+ELEARNINGNC.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+ELIZABETHTOWNKY.GOV,State/Local Govt,Non-Federal Agency,Elizabethtown,KY,ACTIVE
+EVFCAZ.GOV,State/Local Govt,Non-Federal Agency,Mesa,AZ,ACTIVE
+EVFUSIONCENTERAZ.GOV,State/Local Govt,Non-Federal Agency,Mesa,AZ,ACTIVE
+EWYOMING.GOV,State/Local Govt,Non-Federal Agency,Cheyenne,WY,ACTIVE
+EXPLOREMAINE.GOV,State/Local Govt,Non-Federal Agency,Augusta,ME,ACTIVE
+FAIRHAVEN-MA.GOV,State/Local Govt,Non-Federal Agency,Fairhaven,MA,ACTIVE
+FAMILYRESOURCEAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+FAYETTECOUNTYGA.GOV,State/Local Govt,Non-Federal Agency,Fayetteville,GA,ACTIVE
+FAYETTEVILLE-GA.GOV,State/Local Govt,Non-Federal Agency,Fayetteville,GA,ACTIVE
+FILELOCAL-WA.GOV,State/Local Govt,Non-Federal Agency,Seattle,WA,ACTIVE
+FIRSTNETME.GOV,State/Local Govt,Non-Federal Agency,Augusta,ME,ACTIVE
+FIRSTTHINGSFIRSTAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+FL.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+FLBOARDOFMEDICINE.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL,ACTIVE
+FLCENSUS.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+FLCOURTS1.GOV,State/Local Govt,Non-Federal Agency,Pensacola,FL,ACTIVE
+FLCRC.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+FLDOI.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+FLDOT.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+FLHEALTH.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+FLHEALTHCOMPLAINT.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+FLHEALTHSOURCE.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+FLHISTORICCAPITOL.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+FLHOUSE.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+FLHSMV.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+FLLEG.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+FLLEGISLATIVEMAILINGS.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+FLORIDA.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+FLORIDAABUSEHOTLINE.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+FLORIDAHEALTH.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+FLORIDAHEALTHFINDER.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+FLORIDALOBBYIST.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+FLORIDANET.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+FLORIDAOPC.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+FLORIDAPACE.GOV,State/Local Govt,Non-Federal Agency,Kissimmee,FL,ACTIVE
+FLORIDAREDISTRICTING.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+FLORIDASACUPUNCTURE.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL,ACTIVE
+FLORIDASATHLETICTRAINING.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL,ACTIVE
+FLORIDASCHIROPRACTICMEDICINE.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL,ACTIVE
+FLORIDASCHOOLBUSSAFETY.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+FLORIDASCLINICALLABS.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL,ACTIVE
+FLORIDASDENTISTRY.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL,ACTIVE
+FLORIDASENATE.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+FLORIDASHEALTH.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+FLORIDASHEARINGAIDSPECIALISTS.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL,ACTIVE
+FLORIDASMASSAGETHERAPY.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL,ACTIVE
+FLORIDASMENTALHEALTHPROFESSIONS.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL,ACTIVE
+FLORIDASNURSING.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL,ACTIVE
+FLORIDASNURSINGHOMEADMIN.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL,ACTIVE
+FLORIDASOCCUPATIONALTHERAPY.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL,ACTIVE
+FLORIDASOPTICIANRY.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL,ACTIVE
+FLORIDASOPTOMETRY.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL,ACTIVE
+FLORIDASORTHOTISTSPROSTHETISTS.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL,ACTIVE
+FLORIDASOSTEOPATHICMEDICINE.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL,ACTIVE
+FLORIDASPHARMACY.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL,ACTIVE
+FLORIDASPHYSICALTHERAPY.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL,ACTIVE
+FLORIDASPODIATRICMEDICINE.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL,ACTIVE
+FLORIDASPSYCHOLOGY.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL,ACTIVE
+FLORIDASRESPIRATORYCARE.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL,ACTIVE
+FLORIDASSPEECHAUDIOLOGY.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL,ACTIVE
+FLORIDASUNSETREVIEWS.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+FLORIDASUNSHINE.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+FLRCM.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+FLSENATE.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+FLSUNSHINE.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+FLWG.GOV,State/Local Govt,Non-Federal Agency,Opa Locka,FL,ACTIVE
+FOIA-DC.GOV,State/Local Govt,Non-Federal Agency,Washington,DC,ACTIVE
+FOIAXPRESS-DC.GOV,State/Local Govt,Non-Federal Agency,Washington,DC,ACTIVE
+FORTLAUDERDALE.GOV,State/Local Govt,Non-Federal Agency,Fort Lauderdale,FL,ACTIVE
+FRAMES.GOV,State/Local Govt,Non-Federal Agency,Moscow,ID,ACTIVE
+FREEPORTFLORIDA.GOV,State/Local Govt,Non-Federal Agency,Freeport,FL,ACTIVE
+FUTUREREADYIOWA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+GA.GOV,State/Local Govt,Non-Federal Agency,Atlanta,GA,ACTIVE
+GACOURTS.GOV,State/Local Govt,Non-Federal Agency,Atlanta,GA,ACTIVE
+GADOL.GOV,State/Local Govt,Non-Federal Agency,Atlanta,GA,ACTIVE
+GAITHERSBURGMD.GOV,State/Local Govt,Non-Federal Agency,Gaithersburg,MD,ACTIVE
+GAPROBATE.GOV,State/Local Govt,Non-Federal Agency,Atlanta,GA,ACTIVE
+GARDNER-MA.GOV,State/Local Govt,Non-Federal Agency,GARDNER,MA,ACTIVE
+GATREES.GOV,State/Local Govt,Non-Federal Agency,Dry Branch,GA,ACTIVE
+GEARUPIOWA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+GEARUPTN.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE
+GEORGETOWNMA.GOV,State/Local Govt,Non-Federal Agency,Georgetown,MA,ACTIVE
+GEORGIA.GOV,State/Local Govt,Non-Federal Agency,Atlanta,GA,ACTIVE
+GEORGIACOURTS.GOV,State/Local Govt,Non-Federal Agency,Atlanta,GA,ACTIVE
+GEORGIAHEALTHINFO.GOV,State/Local Govt,Non-Federal Agency,Atlanta,GA,ACTIVE
+GETCOVEREDILLINOIS.GOV,State/Local Govt,Non-Federal Agency,Chicago,IL,ACTIVE
+GETKANSASBENEFITS.GOV,State/Local Govt,Non-Federal Agency,Topeka,KS,ACTIVE
+GETREADYHAWAII.GOV,State/Local Govt,Non-Federal Agency,Honolulu,HI,ACTIVE
+GETTYSBURGPA.GOV,State/Local Govt,Non-Federal Agency,Gettysburg,PA,ACTIVE
+GIS10SERVICEMT.GOV,State/Local Govt,Non-Federal Agency,Helena,MT,ACTIVE
+GISSERVICEMT.GOV,State/Local Govt,Non-Federal Agency,Helena,MT,ACTIVE
+GISTESTSERVICEMT.GOV,State/Local Govt,Non-Federal Agency,Helena,MT,ACTIVE
+GLYNNCOUNTY-GA.GOV,State/Local Govt,Non-Federal Agency,Brunswick,GA,ACTIVE
+GOLFMANOROH.GOV,State/Local Govt,Non-Federal Agency,Golf Manor,OH,ACTIVE
+GOVOTEVERMONT.GOV,State/Local Govt,Non-Federal Agency,Montpelier,VT,ACTIVE
+GRAFTONTWP-OH.GOV,State/Local Govt,Non-Federal Agency,Grafton Township,OH,ACTIVE
+GREATIOWATREASUREHUNT.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+GRFDAZ.GOV,State/Local Govt,Non-Federal Agency,Tucson,AZ,ACTIVE
+GRINNELLIOWA.GOV,State/Local Govt,Non-Federal Agency,Grinnell,IA,ACTIVE
+GUAM.GOV,State/Local Govt,Non-Federal Agency,Agana,GU,ACTIVE
+HAMILTONMA.GOV,State/Local Govt,Non-Federal Agency,So. Hamilton,MA,ACTIVE
+HARFORDCOUNTYMD.GOV,State/Local Govt,Non-Federal Agency,Bel Air,MD,ACTIVE
+HAWAII.GOV,State/Local Govt,Non-Federal Agency,Honolulu,HI,ACTIVE
+HEALTH-E-ARIZONA-PLUS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+HEALTH-E-ARIZONAPLUS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+HEALTHCAREHELPMASS.GOV,State/Local Govt,Non-Federal Agency,Boston,MA,ACTIVE
+HEALTHEARIZONA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+HEALTHEARIZONAPLUS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+HEALTHVERMONT.GOV,State/Local Govt,Non-Federal Agency,Burlington,VT,ACTIVE
+HEALTHYIOWA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+HEALTHYSD.GOV,State/Local Govt,Non-Federal Agency,Pierre,SD,ACTIVE
+HEALTHYTEETHAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+HI.GOV,State/Local Govt,Non-Federal Agency,Honolulu,HI,ACTIVE
+HIJOSSALUDABLESOREGON.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE
+HINSDALEMA.GOV,State/Local Govt,Non-Federal Agency,Hinsdale,MA,ACTIVE
+HIREACOLORADOVET.GOV,State/Local Govt,Non-Federal Agency,Denver,CO,ACTIVE
+HOMEAGAINNEVADA.GOV,State/Local Govt,Non-Federal Agency,Las Vegas,NV,ACTIVE
+HOMEBASEIOWA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+HOMEMEANSNEVADA.GOV,State/Local Govt,Non-Federal Agency,Las Vegas,NV,ACTIVE
+HONOLULU.GOV,State/Local Govt,Non-Federal Agency,Honolulu,HI,ACTIVE
+IA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IAABATEDOC.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IAHEALTHLINK.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IASHP.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IASIMPLEABATE.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IAVOTERS.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+ID.GOV,State/Local Govt,Non-Federal Agency,Boise,ID,ACTIVE
+IDAHO.GOV,State/Local Govt,Non-Federal Agency,Boise,ID,ACTIVE
+IDAHOBYWAYS.GOV,State/Local Govt,Non-Federal Agency,Boise,ID,ACTIVE
+IDAHOPREPARES.GOV,State/Local Govt,Non-Federal Agency,Boise,ID,ACTIVE
+IDAHOVOTES.GOV,State/Local Govt,Non-Federal Agency,Boise,ID,ACTIVE
+IDAHOWORKS.GOV,State/Local Govt,Non-Federal Agency,Boise,ID,ACTIVE
+IHAVEAPLANIOWA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IJOBSIOWA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IL.GOV,State/Local Govt,Non-Federal Agency,Springfield,IL,ACTIVE
+ILATTORNEYGENERAL.GOV,State/Local Govt,Non-Federal Agency,Chicago,IL,ACTIVE
+ILGA.GOV,State/Local Govt,Non-Federal Agency,Springfield,IL,ACTIVE
+ILLINOIS-HISTORY.GOV,State/Local Govt,Non-Federal Agency,Springfield,IL,ACTIVE
+ILLINOIS.GOV,State/Local Govt,Non-Federal Agency,Springfield,IL,ACTIVE
+ILLINOISATTORNEYGENERAL.GOV,State/Local Govt,Non-Federal Agency,Chicago,IL,ACTIVE
+ILLINOISCOMPTROLLER.GOV,State/Local Govt,Non-Federal Agency,Springfield,IL,ACTIVE
+ILLINOISCOURTS.GOV,State/Local Govt,Non-Federal Agency,Springfield,IL,ACTIVE
+ILLINOISHISTORY.GOV,State/Local Govt,Non-Federal Agency,Springfield,IL,ACTIVE
+ILLINOISRETIREMENT.GOV,State/Local Govt,Non-Federal Agency,Springfield,IL,ACTIVE
+ILLINOISTREASURER.GOV,State/Local Govt,Non-Federal Agency,Springfield,IL,ACTIVE
+ILSOS.GOV,State/Local Govt,Non-Federal Agency,Springfield,IL,ACTIVE
+IN.GOV,State/Local Govt,Non-Federal Agency,Indianapolis,IN,ACTIVE
+INCOURTS.GOV,State/Local Govt,Non-Federal Agency,Indianapolis,IN,ACTIVE
+INDIANA.GOV,State/Local Govt,Non-Federal Agency,Indianapolis,IN,ACTIVE
+INDIANAMOTORSPORTS.GOV,State/Local Govt,Non-Federal Agency,Indianapolis,IN,ACTIVE
+INDIANAUNCLAIMED.GOV,State/Local Govt,Non-Federal Agency,Indianapolis,IN,ACTIVE
+INNOCENCECOMMISSION-NC.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+INTEGRATEAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+INVESTINIOWA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWAAGING.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWAAGRICULTURE.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWAATTORNEYGENERAL.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWACHILDSUPPORT.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWACLEANAIR.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWACOLLEGEAID.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWACOLLEGEAIDDATACENTER.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWACORE.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWACOURTS.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWACULTURE.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWADIVISIONOFLABOR.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWADNR.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWADOT.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWAELECTRICAL.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWAELEVATORS.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWAFINANCEAUTHORITY.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWAFINANCIALAIDAPPLICATION.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWAFORMS.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWAFRAUDFIGHTERS.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWAGRANTS.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWAGREATPLACES.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWAJNC.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWAJQC.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWALIFT.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWALMI.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWAMORTGAGEHELP.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWANEXT.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWAOSHA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWAPIB.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWAPMA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWASMOKEFREEAIR.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWASTEM.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWATAXANDTAGS.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWATEST.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWATITLEGUARANTY.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWATREASURER.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWAWDB.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWAWORKCOMP.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWAWORKFORCE.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWAWORKFORCEDEVELOPMENT.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+JASPERINDIANA.GOV,State/Local Govt,Non-Federal Agency,Jasper,IN,ACTIVE
+JOBS4TN.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE
+JOBSFORTN.GOV,State/Local Govt,Non-Federal Agency,38401,TN,ACTIVE
+JUDNJ.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+KANSAS.GOV,State/Local Govt,Non-Federal Agency,Topeka,KS,ACTIVE
+KANSASEMPLOYER.GOV,State/Local Govt,Non-Federal Agency,Topeka,KS,ACTIVE
+KANSASMONEY.GOV,State/Local Govt,Non-Federal Agency,Topeka,KS,ACTIVE
+KANSASREADY.GOV,State/Local Govt,Non-Federal Agency,Topeka,KS,ACTIVE
+KANSASTAG.GOV,State/Local Govt,Non-Federal Agency,Topeka,KS,ACTIVE
+KDHEKS.GOV,State/Local Govt,Non-Federal Agency,Topeka,KS,ACTIVE
+KENTUCKY.GOV,State/Local Govt,Non-Federal Agency,Frankfort,KY,ACTIVE
+KIDCENTRALTENNESSEE.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE
+KIDCENTRALTN.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE
+KPL.GOV,State/Local Govt,Non-Federal Agency,KALAMAZOO,MI,ACTIVE
+KS.GOV,State/Local Govt,Non-Federal Agency,Topeka,KS,ACTIVE
+KSCAREERNAV.GOV,State/Local Govt,Non-Federal Agency,Topeka,KS,ACTIVE
+KSDA.GOV,State/Local Govt,Non-Federal Agency,Topeka,KS,ACTIVE
+KSHOUSINGCORP.GOV,State/Local Govt,Non-Federal Agency,Topeka,KS,ACTIVE
+KSREADY.GOV,State/Local Govt,Non-Federal Agency,Topeka,KS,ACTIVE
+KY.GOV,State/Local Govt,Non-Federal Agency,Frankfort,KY,ACTIVE
+LA.GOV,State/Local Govt,Non-Federal Agency,Baton Rouge,LA,ACTIVE
+LAFASTSTART.GOV,State/Local Govt,Non-Federal Agency,Baton Rouge,LA,ACTIVE
+LAFAYETTELA.GOV,State/Local Govt,Non-Federal Agency,Lafayette,LA,ACTIVE
+LAJUDICIAL.GOV,State/Local Govt,Non-Federal Agency,New Orleans,LA,ACTIVE
+LAKECOUNTYFL.GOV,State/Local Govt,Non-Federal Agency,Tavares,FL,ACTIVE
+LAKEPARK-FL.GOV,State/Local Govt,Non-Federal Agency,Lake Park,FL,ACTIVE
+LAKEPARKFLORIDA.GOV,State/Local Govt,Non-Federal Agency,Lake Park,FL,ACTIVE
+LAMOINE-ME.GOV,State/Local Govt,Non-Federal Agency,Lamoine,ME,ACTIVE
+LEADERSHIPAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+LEGMT.GOV,State/Local Govt,Non-Federal Agency,Helena,MT,ACTIVE
+LEXINGTON-MA.GOV,State/Local Govt,Non-Federal Agency,Lexington,MA,ACTIVE
+LEXINGTONMA.GOV,State/Local Govt,Non-Federal Agency,Lexington,MA,ACTIVE
+LGADMI.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI,ACTIVE
+LGO-VI.GOV,State/Local Govt,Non-Federal Agency,St. Thomas,VI,ACTIVE
+LICENSEDINIOWA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+LISTOVIRGINIA.GOV,State/Local Govt,Non-Federal Agency,Richmond,VA,ACTIVE
+LIVEHEALTHYNEVADA.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV,ACTIVE
+LOUISIANA.GOV,State/Local Govt,Non-Federal Agency,Baton Rouge,LA,ACTIVE
+LOUISIANAENTERTAINMENT.GOV,State/Local Govt,Non-Federal Agency,Baton Rouge,LA,ACTIVE
+LOUISIANAFASTSTART.GOV,State/Local Govt,Non-Federal Agency,Baton Rouge,LA,ACTIVE
+LOUISIANAMAP.GOV,State/Local Govt,Non-Federal Agency,Baton Rouge,LA,ACTIVE
+LOUISIANAMUSIC.GOV,State/Local Govt,Non-Federal Agency,Baton Rouge,LA,ACTIVE
+LOWELLMA.GOV,State/Local Govt,Non-Federal Agency,Lowell,MA,ACTIVE
+LOXAHATCHEEGROVESFL.GOV,State/Local Govt,Non-Federal Agency,Loxahatchee Groves,FL,ACTIVE
+MA.GOV,State/Local Govt,Non-Federal Agency,Boston,MA,ACTIVE
+MAHOUSE.GOV,State/Local Govt,Non-Federal Agency,Boston,MA,ACTIVE
+MAINE.GOV,State/Local Govt,Non-Federal Agency,Augusta,ME,ACTIVE
+MAINEDOT.GOV,State/Local Govt,Non-Federal Agency,Augusta,ME,ACTIVE
+MAINEFLU.GOV,State/Local Govt,Non-Federal Agency,Augusta,ME,ACTIVE
+MAINEFORESTSERVICE.GOV,State/Local Govt,Non-Federal Agency,AUGUSTA,ME,ACTIVE
+MAINEPUBLICHEALTH.GOV,State/Local Govt,Non-Federal Agency,Augusta,ME,ACTIVE
+MAINEQUALITYFORUM.GOV,State/Local Govt,Non-Federal Agency,Augusta,ME,ACTIVE
+MAINESERVICECOMMISSION.GOV,State/Local Govt,Non-Federal Agency,Augusta,ME,ACTIVE
+MAJURY.GOV,State/Local Govt,Non-Federal Agency,Boston,MA,ACTIVE
+MAKINGCOLORADO.GOV,State/Local Govt,Non-Federal Agency,Boulder,CO,ACTIVE
+MALEGISLATURE.GOV,State/Local Govt,Non-Federal Agency,Boston,MA,ACTIVE
+MAPWV.GOV,State/Local Govt,Non-Federal Agency,Morgantown,WV,ACTIVE
+MARIETTAGA.GOV,State/Local Govt,Non-Federal Agency,Marietta,GA,ACTIVE
+MARIETTAGEORGIA.GOV,State/Local Govt,Non-Federal Agency,Marietta,GA,ACTIVE
+MARSHFIELD-MA.GOV,State/Local Govt,Non-Federal Agency,Marshfield,MA,ACTIVE
+MARYLAND.GOV,State/Local Govt,Non-Federal Agency,Annapolis,MD,ACTIVE
+MARYLANDCOURTS.GOV,State/Local Govt,Non-Federal Agency,Annapolis,MD,ACTIVE
+MARYLANDHEALTHCONNECTION.GOV,State/Local Govt,Non-Federal Agency,Baltimore,MD,ACTIVE
+MARYLANDSOS.GOV,State/Local Govt,Non-Federal Agency,ANNAPOLIS,MD,ACTIVE
+MASENATE.GOV,State/Local Govt,Non-Federal Agency,Boston,MA,ACTIVE
+MASS.GOV,State/Local Govt,Non-Federal Agency,Boston,MA,ACTIVE
+MASSACHUSETTS.GOV,State/Local Govt,Non-Federal Agency,Boston,MA,ACTIVE
+MCAC-MD.GOV,State/Local Govt,Non-Federal Agency,Calverton ,MD,ACTIVE
+MD.GOV,State/Local Govt,Non-Federal Agency,Annapolis,MD,ACTIVE
+MDCAC.GOV,State/Local Govt,Non-Federal Agency,Woodlawn,MD,ACTIVE
+MDCACDOM.GOV,State/Local Govt,Non-Federal Agency,Woodlawn,MD,ACTIVE
+MDCOURTS.GOV,State/Local Govt,Non-Federal Agency,Annapolis,MD,ACTIVE
+ME.GOV,State/Local Govt,Non-Federal Agency,Augusta,ME,ACTIVE
+MEASURETN.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE
+MEDCMI.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI,ACTIVE
+MENTORMICHIGAN.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI,ACTIVE
+MGCBMI.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI,ACTIVE
+MHB.GOV,State/Local Govt,Non-Federal Agency,Mobile,AL,ACTIVE
+MI.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI,ACTIVE
+MI365.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI,ACTIVE
+MIAMI-FL.GOV,State/Local Govt,Non-Federal Agency,Miami,FL,ACTIVE
+MIBUSINESS1STOP.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI,ACTIVE
+MIBUSINESSONESTOP.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI,ACTIVE
+MICH.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI,ACTIVE
+MICHIGAN.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI,ACTIVE
+MICHIGANIDC.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI,ACTIVE
+MILLENNIUMBULKEISWA.GOV,State/Local Govt,Non-Federal Agency,Lacey,WA,ACTIVE
+MILLERSBURGKY.GOV,State/Local Govt,Non-Federal Agency,Millersburg,KY,ACTIVE
+MILTON-FREEWATER-OR.GOV,State/Local Govt,Non-Federal Agency,Milton-Freewater,OR,ACTIVE
+MINNESOTA.GOV,State/Local Govt,Non-Federal Agency,St. Paul,MN,ACTIVE
+MIRAMAR-FL.GOV,State/Local Govt,Non-Federal Agency,Miramar,FL,ACTIVE
+MISSISSIPPI.GOV,State/Local Govt,Non-Federal Agency,Jackson,MS,ACTIVE
+MISSOURI.GOV,State/Local Govt,Non-Federal Agency,Jefferson City,MO,ACTIVE
+MISSOURIINVESTORPROTECTION.GOV,State/Local Govt,Non-Federal Agency,Jefferson City,MO,ACTIVE
+MN.GOV,State/Local Govt,Non-Federal Agency,St. Paul,MN,ACTIVE
+MNCOURTS.GOV,State/Local Govt,Non-Federal Agency,St. Paul,MN,ACTIVE
+MNDISABILITY.GOV,State/Local Govt,Non-Federal Agency,St. Paul,MN,ACTIVE
+MNDNR.GOV,State/Local Govt,Non-Federal Agency,St. Paul,MN,ACTIVE
+MNDOT.GOV,State/Local Govt,Non-Federal Agency,St. Paul,MN,ACTIVE
+MNHOUSING.GOV,State/Local Govt,Non-Federal Agency,St. Paul,MN,ACTIVE
+MO.GOV,State/Local Govt,Non-Federal Agency,Jefferson City,MO,ACTIVE
+MOAPPED.GOV,State/Local Govt,Non-Federal Agency,St. Louis,MO,ACTIVE
+MODOT.GOV,State/Local Govt,Non-Federal Agency,Jefferson City,MO,ACTIVE
+MONSON-MA.GOV,State/Local Govt,Non-Federal Agency,Monson,MA,ACTIVE
+MONTANA.GOV,State/Local Govt,Non-Federal Agency,Helena,MT,ACTIVE
+MOPROSECUTORS.GOV,State/Local Govt,Non-Federal Agency,Jefferson City,MO,ACTIVE
+MRCOG-NM.GOV,State/Local Govt,Non-Federal Agency,Albuquerque,NM,ACTIVE
+MS.GOV,State/Local Govt,Non-Federal Agency,Jackson,MS,ACTIVE
+MSLMI.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI,ACTIVE
+MSPADMI.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI,ACTIVE
+MT.GOV,State/Local Govt,Non-Federal Agency,Helena,MT,ACTIVE
+MTCOUNTYRESULTS.GOV,State/Local Govt,Non-Federal Agency,Helena,MT,ACTIVE
+MTELECTIONRESULTS.GOV,State/Local Govt,Non-Federal Agency,Helena,MT,ACTIVE
+MTSOSFILINGS.GOV,State/Local Govt,Non-Federal Agency,Helena,MT,ACTIVE
+MURRAYCOUNTYGA.GOV,State/Local Govt,Non-Federal Agency,Chatsworth,GA,ACTIVE
+MYALABAMA.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE
+MYALASKA.GOV,State/Local Govt,Non-Federal Agency,Juneau,AK,ACTIVE
+MYFLORIDA.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+MYFLORIDACENSUS.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+MYFLORIDAHOUSE.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+MYHAWAII.GOV,State/Local Govt,Non-Federal Agency,Honolulu,HI,ACTIVE
+MYIN.GOV,State/Local Govt,Non-Federal Agency,Indianapolis,IN,ACTIVE
+MYINDIANA.GOV,State/Local Govt,Non-Federal Agency,Indianapolis,IN,ACTIVE
+MYNCRETIREMENT.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+MYNEVADA.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV,ACTIVE
+MYOHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+MYSC.GOV,State/Local Govt,Non-Federal Agency,Cloumbia,SC,ACTIVE
+MYTENNESSEE.GOV,State/Local Govt,Non-Federal Agency,Smyrna,TN,ACTIVE
+NATICKMA.GOV,State/Local Govt,Non-Federal Agency,Natick,MA,ACTIVE
+NC.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCAGR.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCBAR.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCBROADBAND.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCCARELINK.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCCERTIFIEDPARALEGAL.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCCIVILWAR150.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCCOB.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCCOURTS.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCCPABOARD.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCCRIMELAB.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCDCI.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCDCR.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCDENR.GOV,State/Local Govt,Non-Federal Agency,RALEIGH,NC,ACTIVE
+NCDHHS.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCDOI.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCDOJ.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCDOR.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCDOT.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCDPS.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCESC.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCFAST.GOV,State/Local Govt,Non-Federal Agency,RTP,NC,ACTIVE
+NCFINDOFFENDER.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCFORECLOSUREPREVENTION.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCFORESTPRODUCTS.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCFORESTSERVICE.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCGRANTS.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCICAC.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCISAAC.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCLAMP.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCLAP.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCLAWSPECIALISTS.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCMORTGAGEHELP.GOV,State/Local Govt,Non-Federal Agency,27609,NC,ACTIVE
+NCONEMAP.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCOPENBOOK.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCPARKS.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCPUBLICSCHOOLS.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCREC.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCRETIREMENT.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCSBE.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCSBI.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCSTATE.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCSTATEBAR.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCTREASURER.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCVISION25.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCWORKS.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+ND.GOV,State/Local Govt,Non-Federal Agency,Bismarck,ND,ACTIVE
+NDCENSUS.GOV,State/Local Govt,Non-Federal Agency,Bismarck,ND,ACTIVE
+NDCLOUD.GOV,State/Local Govt,Non-Federal Agency,Bismarck,North Dakota,ACTIVE
+NDCOURTS.GOV,State/Local Govt,Non-Federal Agency,Bismarck,ND,ACTIVE
+NDDATACENTER.GOV,State/Local Govt,Non-Federal Agency,Bismarck,ND,ACTIVE
+NDDOHPRESSROOM.GOV,State/Local Govt,Non-Federal Agency,Bismarck,ND,ACTIVE
+NDHAN.GOV,State/Local Govt,Non-Federal Agency,Bismarck,ND,ACTIVE
+NDHEALTH.GOV,State/Local Govt,Non-Federal Agency,Bismarck,ND,ACTIVE
+NDSTUDIES.GOV,State/Local Govt,Non-Federal Agency,Bismarck,ND,ACTIVE
+NE.GOV,State/Local Govt,Non-Federal Agency,Lincoln,NE,ACTIVE
+NEBRASKA.GOV,State/Local Govt,Non-Federal Agency,Lincoln,NE,ACTIVE
+NEBRASKACORN.GOV,State/Local Govt,Non-Federal Agency,Lincoln,NE,ACTIVE
+NEBRASKALEGISLATURE.GOV,State/Local Govt,Non-Federal Agency,Lincoln,NE,ACTIVE
+NEBRASKAMAP.GOV,State/Local Govt,Non-Federal Agency,Lincoln,NE,ACTIVE
+NEBRASKASPENDING.GOV,State/Local Govt,Non-Federal Agency,Lincoln,NE,ACTIVE
+NEBRASKAUNICAMERAL.GOV,State/Local Govt,Non-Federal Agency,Lincoln,NE,ACTIVE
+NEHEALTHINSURANCEINFO.GOV,State/Local Govt,Non-Federal Agency,Lincoln,NE,ACTIVE
+NETWORKMARYLAND.GOV,State/Local Govt,Non-Federal Agency,Annapolis,MD,ACTIVE
+NETWORKNEBRASKA.GOV,State/Local Govt,Non-Federal Agency,Lincoln,NE,ACTIVE
+NEVADA.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV,ACTIVE
+NEVADAGUARD.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV,ACTIVE
+NEVADAHOMEAGAIN.GOV,State/Local Govt,Non-Federal Agency,Las Vegas,NV,ACTIVE
+NEVADAREADY.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV,ACTIVE
+NEVADATREASURER.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV,ACTIVE
+NEWENGLAND511.GOV,State/Local Govt,Non-Federal Agency,Montpelier,VT,ACTIVE
+NEWHAMPSHIRE.GOV,State/Local Govt,Non-Federal Agency,Concord,NH,ACTIVE
+NEWJERSEY.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+NEWJERSEYBUSINESS.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+NEWJERSEYHOMEKEEPER.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+NEWMEXICO.GOV,State/Local Govt,Non-Federal Agency,Santa Fe,NM,ACTIVE
+NEWTONMA.GOV,State/Local Govt,Non-Federal Agency,Newton,MA,ACTIVE
+NEWYORKHEALTH.GOV,State/Local Govt,Non-Federal Agency,Albany,NY,ACTIVE
+NEXTCHAPTERTN.GOV,State/Local Govt,Non-Federal Agency,Smyrna,TN,ACTIVE
+NH.GOV,State/Local Govt,Non-Federal Agency,Concord,NH,ACTIVE
+NJ.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+NJALERT.GOV,State/Local Govt,Non-Federal Agency,Hamilton,NJ,ACTIVE
+NJCANCER.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+NJCCC.GOV,State/Local Govt,Non-Federal Agency,Atlantic City,NJ,ACTIVE
+NJCCR.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+NJCIVILRIGHTS.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+NJCONSUMERAFFAIRS.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+NJCOURTS.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+NJDOC.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+NJFLUPANDEMIC.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+NJHAS.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+NJHMFA.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+NJHOMEKEEPER.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+NJHOMELANDSECURITY.GOV,State/Local Govt,Non-Federal Agency,Hamilton,NJ,ACTIVE
+NJHOUSING.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+NJHOUSINGRESOURCECENTER.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+NJHRC.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+NJHUMANTRAFFICKING.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+NJJUD.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+NJMEADOWLANDS.GOV,State/Local Govt,Non-Federal Agency,Lyndhurst,NJ,ACTIVE
+NJMEDICALBOARD.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+NJMVC.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+NJMVCONLINE.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+NJOHSP.GOV,State/Local Govt,Non-Federal Agency,Hamilton,NJ,ACTIVE
+NJPAAD.GOV,State/Local Govt,Non-Federal Agency,Mercerville,NJ,ACTIVE
+NJSDA.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+NJSECURITIES.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+NJSENIORGOLD.GOV,State/Local Govt,Non-Federal Agency,Mercerville,NJ,ACTIVE
+NJSHC.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+NJSNAP.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+NJSPEAKUP.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+NJSRGOLD.GOV,State/Local Govt,Non-Federal Agency,Mercerville,NJ,ACTIVE
+NJSTART.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+NM.GOV,State/Local Govt,Non-Federal Agency,Santa Fe,NM,ACTIVE
+NMAG.GOV,State/Local Govt,Non-Federal Agency,Santa Fe,NM,ACTIVE
+NMCOURTS.GOV,State/Local Govt,Non-Federal Agency,Santa Fe,NM,ACTIVE
+NMLEGIS.GOV,State/Local Govt,Non-Federal Agency,Santa Fe,NM,ACTIVE
+NMSTO.GOV,State/Local Govt,Non-Federal Agency,Santa Fe,NM,ACTIVE
+NORTH-DAKOTA.GOV,State/Local Govt,Non-Federal Agency,Bismarck,ND,ACTIVE
+NORTHCAROLINA.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NORTHDAKOTA.GOV,State/Local Govt,Non-Federal Agency,Bismarck,ND,ACTIVE
+NORTHMIAMIFL.GOV,State/Local Govt,Non-Federal Agency,North Miami,FL,ACTIVE
+NOSCAMNC.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NV.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV,ACTIVE
+NVCOURTS.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV,ACTIVE
+NVDOW.GOV,State/Local Govt,Non-Federal Agency,Reno,NV,ACTIVE
+NVDPSPUB.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV,ACTIVE
+NVEASE.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV,ACTIVE
+NVGGMS.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV,ACTIVE
+NVPREPAID.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV,ACTIVE
+NVSEXOFFENDERS.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV,ACTIVE
+NVSILVERFLUME.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV,ACTIVE
+NVSOS.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV,ACTIVE
+NY.GOV,State/Local Govt,Non-Federal Agency,Albany,NY,ACTIVE
+NYALERT.GOV,State/Local Govt,Non-Federal Agency,Albany,NY,ACTIVE
+NYASSEMBLY.GOV,State/Local Govt,Non-Federal Agency,Albany,NY,ACTIVE
+NYCOURTHELP.GOV,State/Local Govt,Non-Federal Agency,Troy,NY,ACTIVE
+NYCOURTS.GOV,State/Local Govt,Non-Federal Agency,Troy,NY,ACTIVE
+NYGOVOFFICE.GOV,State/Local Govt,Non-Federal Agency,Albany,NY,ACTIVE
+NYHALLOFGOVERNORS.GOV,State/Local Govt,Non-Federal Agency,Albany,NY,ACTIVE
+NYHEALTH.GOV,State/Local Govt,Non-Federal Agency,Albany,NY,ACTIVE
+NYHOUSINGSEARCH.GOV,State/Local Govt,Non-Federal Agency,Albany,NY,ACTIVE
+NYJUROR.GOV,State/Local Govt,Non-Federal Agency,New York,NY,ACTIVE
+NYOPENFORBUSINESS.GOV,State/Local Govt,Non-Federal Agency,Albany,NY,ACTIVE
+NYPA.GOV,State/Local Govt,Non-Federal Agency,WHITE PLAINS,NY,ACTIVE
+NYPREPARE.GOV,State/Local Govt,Non-Federal Agency,Albany,NY,ACTIVE
+NYSCANALS.GOV,State/Local Govt,Non-Federal Agency,Albany,NY,ACTIVE
+NYSDOT.GOV,State/Local Govt,Non-Federal Agency,Albany,NY,ACTIVE
+NYSED.GOV,State/Local Govt,Non-Federal Agency,Albany,NY,ACTIVE
+NYSENATE.GOV,State/Local Govt,Non-Federal Agency,Albany,NY,ACTIVE
+NYSTAX.GOV,State/Local Govt,Non-Federal Agency,Albany,NY,ACTIVE
+NYSTHRUWAY.GOV,State/Local Govt,Non-Federal Agency,Albany,NY,ACTIVE
+OCFODC.GOV,State/Local Govt,Non-Federal Agency,Washington,DC,ACTIVE
+OCPR.GOV,State/Local Govt,Non-Federal Agency,San Juan,PR,ACTIVE
+OH.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOAGRICULTURE.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOANALYTICS.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOATTORNEYGENERAL.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOAUDITOR.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOBMV.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOCENTERFORNURSING.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOCHECKBOOK.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOCOURTOFCLAIMS.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOCOURTS.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIODNR.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOHERETOHELP.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOHOUSE.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOHOUSINGLOCATOR.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOJOBS.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOJUDICIALCENTER.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOMEANSACCESSIBILITY.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOMEANSJOBS.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOMEANSTRAINING.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOMEANSVETERANSJOBS.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIONOSMOKELAW.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOPMP.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIORED.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIORESPONDS.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOSAFEID.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOSECRETARYOFSTATE.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOSENATE.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOSUPREMECOURT.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOTHIRDFRONTIER.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOTPES.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOTREASURER.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOVALUESVETERANS.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOVALUESVETS.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOVET.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOVETERANSHOME.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOVETHOF.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOVETS.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOVETSHOF.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOWOMENVETS.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OK.GOV,State/Local Govt,Non-Federal Agency,Oklahoma City,OK,ACTIVE
+OKBENEFITS.GOV,State/Local Govt,Non-Federal Agency,Oklahoma City,OK,ACTIVE
+OKC.GOV,State/Local Govt,Non-Federal Agency,Oklahoma City,OK,ACTIVE
+OKCOMMERCE.GOV,State/Local Govt,Non-Federal Agency,Oklahoma city,OK,ACTIVE
+OKDHS.GOV,State/Local Govt,Non-Federal Agency,Oklahoma City,OK,ACTIVE
+OKDRS.GOV,State/Local Govt,Non-Federal Agency,Oklahoma City,OK,ACTIVE
+OKGEOSURVEY1.GOV,State/Local Govt,Non-Federal Agency,Norman,OK,ACTIVE
+OKHOUSE.GOV,State/Local Govt,Non-Federal Agency,Oklahoma City,OK,ACTIVE
+OKLAHOMA.GOV,State/Local Govt,Non-Federal Agency,Oklahoma City,OK,ACTIVE
+OKLAHOMABENEFITS.GOV,State/Local Govt,Non-Federal Agency,Oklahoma City,OK,ACTIVE
+OKLAHOMAWORKS.GOV,State/Local Govt,Non-Federal Agency,Oklahoma City,OK,ACTIVE
+OKLEGISLATURE.GOV,State/Local Govt,Non-Federal Agency,Oklahoma City,OK,ACTIVE
+OKSENATE.GOV,State/Local Govt,Non-Federal Agency,Oklahoma City,OK,ACTIVE
+OLATHEKS.GOV,State/Local Govt,Non-Federal Agency,Olathe,KS,ACTIVE
+ONESTOPFLORIDA.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,SERVER-HOLD
+ONSLOWCOUNTYNC.GOV,State/Local Govt,Non-Federal Agency,Jacksonville,NC,ACTIVE
+OPC-DC.GOV,State/Local Govt,Non-Federal Agency,Washington,DC,ACTIVE
+OPEN-DC.GOV,State/Local Govt,Non-Federal Agency,Washington,DC,ACTIVE
+OPENMYFLORIDABUSINESS.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+OPENOHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OR-MEDICAID.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE
+OR.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE
+ORCLIMATECHANGE.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE
+OREGON.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE
+OREGONATTORNEYGENERAL.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE
+OREGONBENEFITSONLINE.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE
+OREGONBUDGET.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE
+OREGONBUYS.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE
+OREGONCHILDSUPPORT.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE
+OREGONCONSUMER.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE
+OREGONFORESTRY.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE
+OREGONHEALTHCARE.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE
+OREGONHEALTHYKIDS.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE
+OREGONHOMEOWNERSUPPORT.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE
+OREGONLEGISLATURE.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE
+OREGONMARINERESERVES.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE
+OREGONMETRO.GOV,State/Local Govt,Non-Federal Agency,Portland,OR,ACTIVE
+OREGONMOTORVOTER.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE
+OREGONRX.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE
+OREGONSTUDENTAID.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE
+OREGONUSF.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE
+OREGONVOTES.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE
+ORHEALTHCARE.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE
+OSE-CT.GOV,State/Local Govt,Non-Federal Agency,Hartford,CT,ACTIVE
+OUTDOORNEBRASKA.GOV,State/Local Govt,Non-Federal Agency,Lincoln,NE,ACTIVE
+OVERLANDPARKKS.GOV,State/Local Govt,Non-Federal Agency,Overland Park,KS,ACTIVE
+PA.GOV,State/Local Govt,Non-Federal Agency,Harrisburg,PA,ACTIVE
+PA529.GOV,State/Local Govt,Non-Federal Agency,Harrisburg,PA,ACTIVE
+PA529ABLE.GOV,State/Local Govt,Non-Federal Agency,Harrisburg,PA,ACTIVE
+PAABLE.GOV,State/Local Govt,Non-Federal Agency,Harrisburg,PA,ACTIVE
+PAACPAMMMI.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI,ACTIVE
+PAAUDITOR.GOV,State/Local Govt,Non-Federal Agency,Harrisburg,PA,ACTIVE
+PACIFICFLYWAY.GOV,State/Local Govt,Non-Federal Agency,Vancouver,WA,ACTIVE
+PADILLABAY.GOV,State/Local Govt,Non-Federal Agency,MOUNT VERNON,WA,ACTIVE
+PAHOUSE.GOV,State/Local Govt,Non-Federal Agency,Harrisburg,PA,ACTIVE
+PAINVEST.GOV,State/Local Govt,Non-Federal Agency,Harrisburg,PA,ACTIVE
+PALMBEACHCOUNTYTAXCOLLECTOR-FL.GOV,State/Local Govt,Non-Federal Agency,West Palm Beach,FL,ACTIVE
+PANYNJ.GOV,State/Local Govt,Non-Federal Agency,New York,NY,ACTIVE
+PAOPENFORBUSINESS.GOV,State/Local Govt,Non-Federal Agency,Harrisburg,PA,ACTIVE
+PARTNERSFORHEALTHTN.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE
+PASEN.GOV,State/Local Govt,Non-Federal Agency,Harrisburg,PA,ACTIVE
+PASENATE.GOV,State/Local Govt,Non-Federal Agency,Harrisburg,PA,ACTIVE
+PATREASURY.GOV,State/Local Govt,Non-Federal Agency,Harrisburg,PA,ACTIVE
+PAULDING.GOV,State/Local Govt,Non-Federal Agency,Dallas,GA,ACTIVE
+PAYIOWA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+PAYMAINE.GOV,State/Local Govt,Non-Federal Agency,Augusta,ME,ACTIVE
+PEACHTREECORNERSGA.GOV,State/Local Govt,Non-Federal Agency,PEACHTREE CORNERS,GA,ACTIVE
+PENNDOT.GOV,State/Local Govt,Non-Federal Agency,Harrisburg,PA,ACTIVE
+PENNSYLVANIA.GOV,State/Local Govt,Non-Federal Agency,Harrisburg,PA,ACTIVE
+PERRY-GA.GOV,State/Local Govt,Non-Federal Agency,Perry,GA,ACTIVE
+PINECREST-FL.GOV,State/Local Govt,Non-Federal Agency,Pinecrest,FL,ACTIVE
+PINELLASCOUNTY-FL.GOV,State/Local Govt,Non-Federal Agency,Clearwater,FL,ACTIVE
+PINELLASCOUNTYFL.GOV,State/Local Govt,Non-Federal Agency,Clearwater,FL,ACTIVE
+PLAINVILLE-CT.GOV,State/Local Govt,Non-Federal Agency,Plainville,CT,ACTIVE
+PPA-OR.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE
+PR.GOV,State/Local Govt,Non-Federal Agency,San Juan,PR,ACTIVE
+PREVENTHAIAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+PROVINCETOWN-MA.GOV,State/Local Govt,Non-Federal Agency,Provincetown,MA,ACTIVE
+PUERTORICO.GOV,State/Local Govt,Non-Federal Agency,San Juan,PR,ACTIVE
+QAAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+QUALITYFIRSTAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+READYALABAMA.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE
+READYNH.GOV,State/Local Govt,Non-Federal Agency,Concord,NH,ACTIVE
+READYVIRGINIA.GOV,State/Local Govt,Non-Federal Agency,Richmond,VA,ACTIVE
+READYWV.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE
+RECYCLEOHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+REDISTRICTINGFLORIDA.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+REGISTERTOVOTENV.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV,ACTIVE
+RELAYUTAH.GOV,State/Local Govt,Non-Federal Agency,Salt Lake City,UT,ACTIVE
+REPORTITTN.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE
+RETIREREADYTN.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE
+RHODEISLAND.GOV,State/Local Govt,Non-Federal Agency,Providence,RI,ACTIVE
+RI.GOV,State/Local Govt,Non-Federal Agency,Providence,RI,ACTIVE
+RIDESHAREWI.GOV,State/Local Govt,Non-Federal Agency,Madison,WI,ACTIVE
+RIDESHAREWISCONSIN.GOV,State/Local Govt,Non-Federal Agency,Madison,WI,ACTIVE
+RILEGISLATURE.GOV,State/Local Govt,Non-Federal Agency,Providence,RI,ACTIVE
+RIPSGA.GOV,State/Local Govt,Non-Federal Agency,North Scituate,RI,ACTIVE
+RISP.GOV,State/Local Govt,Non-Federal Agency,North Scituate,RI,ACTIVE
+ROCKISLANDTOWNSHIPIL.GOV,State/Local Govt,Non-Federal Agency,Rock Island,IL,ACTIVE
+ROWANCOUNTYNC.GOV,State/Local Govt,Non-Federal Agency,Salisbury,NC,ACTIVE
+RSA-AL.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE
+RULEWATCHOHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+SACOMAINE.GOV,State/Local Govt,Non-Federal Agency,Saco,ME,ACTIVE
+SAFEHOMEALABAMA.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE
+SAFERFLORIDAHIGHWAYS.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+SAFERFLORIDAROADS.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+SAFESD.GOV,State/Local Govt,Non-Federal Agency,Pierre,SD,ACTIVE
+SALINA-KS.GOV,State/Local Govt,Non-Federal Agency,Salina,KS,ACTIVE
+SANDPOINTIDAHO.GOV,State/Local Govt,Non-Federal Agency,Sandpoint,ID,ACTIVE
+SAOMT.GOV,State/Local Govt,Non-Federal Agency,Helena,MT,ACTIVE
+SAVEMYHOMEAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+SAVEOURHOMEAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+SC.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC,ACTIVE
+SCAG.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC,ACTIVE
+SCCONSUMER.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC,ACTIVE
+SCDEW.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC,ACTIVE
+SCDHEC.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC,ACTIVE
+SCDHHS.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC,ACTIVE
+SCDPS.GOV,State/Local Govt,Non-Federal Agency,Blythewood,SC,ACTIVE
+SCFC.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC,ACTIVE
+SCHELP.GOV,State/Local Govt,Non-Federal Agency,Columbia`,SC,ACTIVE
+SCHOUSE.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC,ACTIVE
+SCNEWHIRE.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC,ACTIVE
+SCOH.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+SCOHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+SCOTTCOUNTYIOWA.GOV,State/Local Govt,Non-Federal Agency,Davenport,IA,ACTIVE
+SCSENATE.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC,ACTIVE
+SCSERV.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC,ACTIVE
+SCSTATEHOUSE.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC,ACTIVE
+SD.GOV,State/Local Govt,Non-Federal Agency,Pierre,SD,ACTIVE
+SDAUDITOR.GOV,State/Local Govt,Non-Federal Agency,Pierre,SD,ACTIVE
+SDBMOE.GOV,State/Local Govt,Non-Federal Agency,Pierre,SD,ACTIVE
+SDLEGISLATURE.GOV,State/Local Govt,Non-Federal Agency,pierre,SD,ACTIVE
+SDSOS.GOV,State/Local Govt,Non-Federal Agency,Pierre,SD,ACTIVE
+SDTREASURER.GOV,State/Local Govt,Non-Federal Agency,Pierre,SD,ACTIVE
+SEDGWICK.GOV,State/Local Govt,Non-Federal Agency,Wichita,KS,ACTIVE
+SEELYVILLE-IN.GOV,State/Local Govt,Non-Federal Agency,Seelyville,IN,ACTIVE
+SEMINOLECOUNTYFL.GOV,State/Local Govt,Non-Federal Agency,Sanford,FL,ACTIVE
+SERVEALABAMA.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE
+SERVEIDAHO.GOV,State/Local Govt,Non-Federal Agency,Boise,ID,ACTIVE
+SERVEOHIO.GOV,State/Local Govt,Non-Federal Agency,Columb us,OH,ACTIVE
+SERVGA.GOV,State/Local Govt,Non-Federal Agency,Atlanta,GA,ACTIVE
+SFWMD.GOV,State/Local Govt,Non-Federal Agency,West Palm Beach,FL,ACTIVE
+SHAPINGNEWJERSEY.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+SHAPINGNJ.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+SHAREOHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+SHREWSBURY-MA.GOV,State/Local Govt,Non-Federal Agency,Shrewsbury,MA,ACTIVE
+SOSNC.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+SOUTHCAROLINA.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC,ACTIVE
+SOUTHERNSHORES-NC.GOV,State/Local Govt,Non-Federal Agency,Southern Shores,NC,ACTIVE
+SPACEFLORIDA.GOV,State/Local Govt,Non-Federal Agency,Cape Canaveral,FL,ACTIVE
+STAGINGAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+STATEOFSOUTHCAROLINA.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC,ACTIVE
+STATEOFWV.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE
+STILLWATERCOUNTYMT.GOV,State/Local Govt,Non-Federal Agency,Columbus,MT,ACTIVE
+STOPFRAUDCOLORADO.GOV,State/Local Govt,Non-Federal Agency,Denver,CO,ACTIVE
+STOUGHTON-MA.GOV,State/Local Govt,Non-Federal Agency,Stoughton,MA,ACTIVE
+STOW-MA.GOV,State/Local Govt,Non-Federal Agency,Stow,MA,ACTIVE
+STPAULSNC.GOV,State/Local Govt,Non-Federal Agency,St. Pauls,NC,ACTIVE
+SUNRISEFL.GOV,State/Local Govt,Non-Federal Agency,Sunrise,FL,ACTIVE
+SUNRISEFLORIDA.GOV,State/Local Govt,Non-Federal Agency,Sunrise,FL,ACTIVE
+SUPREMECOURTOFOHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+SURFCITYNC.GOV,State/Local Govt,Non-Federal Agency,Surf City,NC,ACTIVE
+SWEETHOMEALABAMA.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE
+TAKOMAPARKMD.GOV,State/Local Govt,Non-Federal Agency,Takoma Park,MD,ACTIVE
+TEACHIOWA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+TEAMGA.GOV,State/Local Govt,Non-Federal Agency,Atlanta,GA,ACTIVE
+TEAMGEORGIA.GOV,State/Local Govt,Non-Federal Agency,Atlanta,GA,ACTIVE
+TEAMTN.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE
+TENNESSEE.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE
+TENNESSEECOLLEGEADVISER.GOV,State/Local Govt,Non-Federal Agency,Smyrna,TN,ACTIVE
+TENNESSEECOLLEGEADVISOR.GOV,State/Local Govt,Non-Federal Agency,Smyrna,TN,ACTIVE
+TENNESSEEIIS.GOV,State/Local Govt,Non-Federal Agency,Smyrna,TN,ACTIVE
+TENNESSEEPROMISE.GOV,State/Local Govt,Non-Federal Agency,Smyrna,TN,ACTIVE
+TENNESSEERECONNECT.GOV,State/Local Govt,Non-Federal Agency,Smyrna,TN,ACTIVE
+TESTOHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+TEWKSBURY-MA.GOV,State/Local Govt,Non-Federal Agency,Tewksbury,MA,ACTIVE
+TEXAS.GOV,State/Local Govt,Non-Federal Agency,Austin,TX,ACTIVE
+TEXAS511.GOV,State/Local Govt,Non-Federal Agency,Austin,TX,ACTIVE
+TEXASAGRICULTURE.GOV,State/Local Govt,Non-Federal Agency,Austin,TX,ACTIVE
+TEXASATTORNEYGENERAL.GOV,State/Local Govt,Non-Federal Agency,Austin,TX,ACTIVE
+TEXASCHILDRENSCOMMISSION.GOV,State/Local Govt,Non-Federal Agency,Austin,TX,ACTIVE
+TEXASFIGHTSIDTHEFT.GOV,State/Local Govt,Non-Federal Agency,Austin,TX,ACTIVE
+TEXASONLINE.GOV,State/Local Govt,Non-Federal Agency,Austin,TX,ACTIVE
+TEXASSTATEPARKS.GOV,State/Local Govt,Non-Federal Agency,Austin,TX,ACTIVE
+TEXASSUPREMECOURTCOMMISSION.GOV,State/Local Govt,Non-Federal Agency,Austin,TX,ACTIVE
+THA.GOV,State/Local Govt,Non-Federal Agency,Topeka,KS,ACTIVE
+THEFTAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+THERIGHTCALLIOWA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+THESTATEOFSOUTHCAROLINA.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC,ACTIVE
+TN.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE
+TNAG.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE
+TNCOLLATERALMANAGEMENT.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE
+TNCOLLEGEADVISER.GOV,State/Local Govt,Non-Federal Agency,Smyrna,TN,ACTIVE
+TNCOLLEGEADVISOR.GOV,State/Local Govt,Non-Federal Agency,Smyrna,TN,ACTIVE
+TNCOURTS.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE
+TNECD.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE
+TNEDU.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE
+TNFAFSAFRENZY.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE
+TNIIS.GOV,State/Local Govt,Non-Federal Agency,Smyrna,TN,ACTIVE
+TNK12.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE
+TNPROMISE.GOV,State/Local Govt,Non-Federal Agency,Smyrna,TN,ACTIVE
+TNQUITLINE.GOV,State/Local Govt,Non-Federal Agency,Smyrna,TN,ACTIVE
+TNREADY.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE
+TNRECONNECT.GOV,State/Local Govt,Non-Federal Agency,Smyrna,TN,ACTIVE
+TNTOOLKIT.GOV,State/Local Govt,Non-Federal Agency,Smyrna,TN,ACTIVE
+TNTREASURY.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE
+TNVACATION.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE
+TOURISMOHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+TOWNOFGOLDENMEADOW-LA.GOV,State/Local Govt,Non-Federal Agency,Golden Meadow,LA,ACTIVE
+TOWNOFWINGATENC.GOV,State/Local Govt,Non-Federal Agency,Wingate,NC,ACTIVE
+TRANSPARENCYFLORIDA.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+TRANSPARENCYWV.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE
+TRAVELWYOMING.GOV,State/Local Govt,Non-Federal Agency,Cheyenne,WY,ACTIVE
+TRUSTTENNESSEE.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE
+TRUSTTN.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE
+TTD.GOV,State/Local Govt,Non-Federal Agency,East Norwalk,CT,ACTIVE
+TX.GOV,State/Local Govt,Non-Federal Agency,Austin,TX,ACTIVE
+TX511.GOV,State/Local Govt,Non-Federal Agency,Austin,TX,ACTIVE
+TXAG.GOV,State/Local Govt,Non-Federal Agency,Austin,TX,ACTIVE
+TXCOURTS.GOV,State/Local Govt,Non-Federal Agency,Austin,TX,ACTIVE
+TXDMV.GOV,State/Local Govt,Non-Federal Agency,Austin,TX,ACTIVE
+TXDOT.GOV,State/Local Govt,Non-Federal Agency,Austin,TX,ACTIVE
+TXDPS.GOV,State/Local Govt,Non-Federal Agency,Austin,TX,ACTIVE
+TXMAP.GOV,State/Local Govt,Non-Federal Agency,Austin,TX,ACTIVE
+TXOAG.GOV,State/Local Govt,Non-Federal Agency,Austin,TX,ACTIVE
+US41WISCONSIN.GOV,State/Local Govt,Non-Federal Agency,Madison,WI,ACTIVE
+UTAH.GOV,State/Local Govt,Non-Federal Agency,Salt Lake City,UT,ACTIVE
+UTAHLAKE.GOV,State/Local Govt,Non-Federal Agency,Salt Lake City,UT,ACTIVE
+UTAHTRUST.GOV,State/Local Govt,Non-Federal Agency,North Salt Lake,UT,ACTIVE
+UTCOURTS.GOV,State/Local Govt,Non-Federal Agency,Salt Lake City,UT,ACTIVE
+VACOURTS.GOV,State/Local Govt,Non-Federal Agency,Richmond,VA,ACTIVE
+VAEMERGENCY.GOV,State/Local Govt,Non-Federal Agency,Richmond,VA,ACTIVE
+VERMONT.GOV,State/Local Govt,Non-Federal Agency,Montpelier,VT,ACTIVE
+VERMONTHEALTHCONNECT.GOV,State/Local Govt,Non-Federal Agency,Montpelier,VT,ACTIVE
+VERMONTTAXAMNESTY.GOV,State/Local Govt,Non-Federal Agency,Montpelier,VT,ACTIVE
+VERMONTTREASURER.GOV,State/Local Govt,Non-Federal Agency,Montpelier,VT,ACTIVE
+VERMONTVOTESFORKIDS.GOV,State/Local Govt,Non-Federal Agency,Montpelier,VT,ACTIVE
+VI.GOV,State/Local Govt,Non-Federal Agency,St. Thomas,VI,ACTIVE
+VIALERT.GOV,State/Local Govt,Non-Federal Agency,St. Thomas,VI,ACTIVE
+VIBIR.GOV,State/Local Govt,Non-Federal Agency,St. Thomas,VI,ACTIVE
+VIDOL.GOV,State/Local Govt,Non-Federal Agency,St. Thomas,VI,ACTIVE
+VIHFA.GOV,State/Local Govt,Non-Federal Agency,St. Thomas,VI,ACTIVE
+VILLAGEOFPENINSULA-OH.GOV,State/Local Govt,Non-Federal Agency,Peninsula,OH,ACTIVE
+VIRGINIA.GOV,State/Local Govt,Non-Federal Agency,Chester,VA,ACTIVE
+VIRGINIACAPITAL.GOV,State/Local Govt,Non-Federal Agency,Richmond,VA,ACTIVE
+VIRGINIACAPITOL.GOV,State/Local Govt,Non-Federal Agency,Richmond,VA,ACTIVE
+VIRGINIAGENERALASSEMBLY.GOV,State/Local Govt,Non-Federal Agency,Richmond,VA,ACTIVE
+VIRGINIARESOURCES.GOV,State/Local Govt,Non-Federal Agency,Richmond,VA,ACTIVE
+VIRGINIASTATEPARKS.GOV,State/Local Govt,Non-Federal Agency,Richmond,VA,ACTIVE
+VISITIDAHO.GOV,State/Local Govt,Non-Federal Agency,Boise,ID,ACTIVE
+VISITNEBRASKA.GOV,State/Local Govt,Non-Federal Agency,Lincoln,NE,ACTIVE
+VISITNH.GOV,State/Local Govt,Non-Federal Agency,Concord,NH,ACTIVE
+VISITWYO.GOV,State/Local Govt,Non-Federal Agency,Cheyenne,WY,ACTIVE
+VISITWYOMING.GOV,State/Local Govt,Non-Federal Agency,Cheyenne,WY,ACTIVE
+VITEMA.GOV,State/Local Govt,Non-Federal Agency,St. Thomas,VI,ACTIVE
+VIVOTE.GOV,State/Local Govt,Non-Federal Agency,St Croix,VI,ACTIVE
+VOLUNTEERLOUISIANA.GOV,State/Local Govt,Non-Federal Agency,Baton Rouge,LA,ACTIVE
+VOTETEXAS.GOV,State/Local Govt,Non-Federal Agency,Austin,TX,ACTIVE
+VT.GOV,State/Local Govt,Non-Federal Agency,Montpelier,VT,ACTIVE
+VTALERT.GOV,State/Local Govt,Non-Federal Agency,Montpelier,VT,ACTIVE
+WA.GOV,State/Local Govt,Non-Federal Agency,Olympia,WA,ACTIVE
+WAKECOUNTYNC.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+WALDOCOUNTYME.GOV,State/Local Govt,Non-Federal Agency,Belfast,ME,ACTIVE
+WALPOLE-MA.GOV,State/Local Govt,Non-Federal Agency,Walpole,MA,ACTIVE
+WALTONCOUNTYGA.GOV,State/Local Govt,Non-Federal Agency,Monroe,GA,ACTIVE
+WASHINGTON-NC.GOV,State/Local Govt,Non-Federal Agency,Washington,NC,ACTIVE
+WASHINGTON.GOV,State/Local Govt,Non-Federal Agency,Olympia,WA,ACTIVE
+WASHINGTONDC.GOV,State/Local Govt,Non-Federal Agency,"Washington,",DC,ACTIVE
+WASHINGTONNC.GOV,State/Local Govt,Non-Federal Agency,Washington,NC,ACTIVE
+WASHINGTONSTATE.GOV,State/Local Govt,Non-Federal Agency,Olympia,WA,ACTIVE
+WATAUGACOUNTYNC.GOV,State/Local Govt,Non-Federal Agency,Boone,NC,ACTIVE
+WCNYH.GOV,State/Local Govt,Non-Federal Agency,New YOrk,NY,ACTIVE
+WENHAMMA.GOV,State/Local Govt,Non-Federal Agency,Wenham,MA,ACTIVE
+WESTVIRGINIA.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE
+WHITMAN-MA.GOV,State/Local Govt,Non-Federal Agency,Whitman,MA,ACTIVE
+WHYNEVADA.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV,ACTIVE
+WI-TIME.GOV,State/Local Govt,Non-Federal Agency,Madison,WI,ACTIVE
+WI-WORCS.GOV,State/Local Govt,Non-Federal Agency,Madison,WI,ACTIVE
+WI.GOV,State/Local Govt,Non-Federal Agency,Madison,WI,ACTIVE
+WIBADGERTRACS.GOV,State/Local Govt,Non-Federal Agency,Madison,WI,ACTIVE
+WICONNECTIONS2030.GOV,State/Local Govt,Non-Federal Agency,Madison,WI,ACTIVE
+WICOURTS.GOV,State/Local Govt,Non-Federal Agency,MADISON,WI,ACTIVE
+WIDOC.GOV,State/Local Govt,Non-Federal Agency,Madison,WI,ACTIVE
+WIGRANTS.GOV,State/Local Govt,Non-Federal Agency,Madison,WI,ACTIVE
+WILAWLIBRARY.GOV,State/Local Govt,Non-Federal Agency,Madison,WI,ACTIVE
+WILDOHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+WILMINGTON-NC.GOV,State/Local Govt,Non-Federal Agency,Wilmington,NC,ACTIVE
+WILMINGTONNC.GOV,State/Local Govt,Non-Federal Agency,Wilmington,NC,ACTIVE
+WINTERGARDEN-FL.GOV,State/Local Govt,Non-Federal Agency,Winter Garden,FL,ACTIVE
+WINTERPORTMAINE.GOV,State/Local Govt,Non-Federal Agency,Winterport,ME,ACTIVE
+WINTERSPRINGSFL.GOV,State/Local Govt,Non-Federal Agency,Winter Springs,FL,ACTIVE
+WISC.GOV,State/Local Govt,Non-Federal Agency,Madison,WI,ACTIVE
+WISCONSIN.GOV,State/Local Govt,Non-Federal Agency,Madison,WI,ACTIVE
+WISCONSINCRIMEALERT.GOV,State/Local Govt,Non-Federal Agency,Madison,WI,ACTIVE
+WISCONSINDMV.GOV,State/Local Govt,Non-Federal Agency,Madison,WI,ACTIVE
+WISCONSINDOT.GOV,State/Local Govt,Non-Federal Agency,Madison,WI,ACTIVE
+WISCONSINFREIGHTPLAN.GOV,State/Local Govt,Non-Federal Agency,Madison,WI,ACTIVE
+WISCONSINRAILPLAN.GOV,State/Local Govt,Non-Federal Agency,Madison,WI,ACTIVE
+WISCONSINROUNDABOUTS.GOV,State/Local Govt,Non-Federal Agency,Madison,WI,ACTIVE
+WMATA.GOV,State/Local Govt,Non-Federal Agency,Washington,DC,ACTIVE
+WORKFORCEONETOUCHTN.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE
+WORKFORNC.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+WSDOT.GOV,State/Local Govt,Non-Federal Agency,Olympia,WA,ACTIVE
+WV.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE
+WV457.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE
+WVAGO.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE
+WVCOMMERCE.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE
+WVCONSUMERPROTECTION.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE
+WVCSI.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE
+WVDHSEM.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE
+WVDNR.GOV,State/Local Govt,Non-Federal Agency,South Charleston,WV,ACTIVE
+WVHOUSE.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE
+WVINSURANCE.GOV,State/Local Govt,Non-Federal Agency,Charleson,WV,ACTIVE
+WVLEGISLATURE.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE
+WVOASIS.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE
+WVOT.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE
+WVOTA.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE
+WVPRESIDENT.GOV,State/Local Govt,Non-Federal Agency,Morgantown,WV,ACTIVE
+WVPURCHASING.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE
+WVREVENUE.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE
+WVSAO.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE
+WVSENATE.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE
+WVSENIORSERVICES.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE
+WVSP.GOV,State/Local Govt,Non-Federal Agency,South Charleston,WV,ACTIVE
+WVSPEAKER.GOV,State/Local Govt,Non-Federal Agency,Morgantown,WV,ACTIVE
+WVSTO.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE
+WVSURPLUS.GOV,State/Local Govt,Non-Federal Agency,Dunbar,WV,ACTIVE
+WVTAX.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE
+WY.GOV,State/Local Govt,Non-Federal Agency,Cheyenne,WY,ACTIVE
+WYCAMPAIGNFINANCE.GOV,State/Local Govt,Non-Federal Agency,Cheyenne,WY,ACTIVE
+WYO.GOV,State/Local Govt,Non-Federal Agency,Cheyenne,WY,ACTIVE
+WYOBOARDS.GOV,State/Local Govt,Non-Federal Agency,Cheyenne,WY,ACTIVE
+WYOLEG.GOV,State/Local Govt,Non-Federal Agency,Cheyenne,WY,ACTIVE
+WYOMING.GOV,State/Local Govt,Non-Federal Agency,Cheyenne,WY,ACTIVE
+WYOMINGAGCARE.GOV,State/Local Govt,Non-Federal Agency,Cheyenne,WY,ACTIVE
+WYOMINGLMI.GOV,State/Local Govt,Non-Federal Agency,cheyenne,WY,ACTIVE
+WYOMINGOFFICEOFTOURISM.GOV,State/Local Govt,Non-Federal Agency,Cheyenne,WY,ACTIVE
+WYOREG.GOV,State/Local Govt,Non-Federal Agency,cheyenne,WY,ACTIVE
+WYWINDFALL.GOV,State/Local Govt,Non-Federal Agency,cheyenne,WY,ACTIVE
+YADKINCOUNTY.GOV,State/Local Govt,Non-Federal Agency,Yadkinville,NC,ACTIVE
+YADKINCOUNTYNC.GOV,State/Local Govt,Non-Federal Agency,Yadkinville,NC,ACTIVE
+YANCEYVILLENC.GOV,State/Local Govt,Non-Federal Agency,Roxboro,NC,ACTIVE
+ZEROINWISCONSIN.GOV,State/Local Govt,Non-Federal Agency,Madison,WI,ACTIVE
+ZIONSVILLE-IN.GOV,State/Local Govt,Non-Federal Agency,Zionsville,IN,ACTIVE

--- a/dotgov-domains/2016-06-30-native.csv
+++ b/dotgov-domains/2016-06-30-native.csv
@@ -1,0 +1,170 @@
+Domain Name,Domain Type,Agency,City,State,Status
+29PALMSBOMI-NSN.GOV,Native Sovereign Nation,Indian Affairs,Coachella,CA,ACTIVE
+ABSENTEESHAWNEETRIBE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Shawnee,OK,ACTIVE
+AGUACALIENTE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Palm Springs,CA,ACTIVE
+AHA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Hogansburg,NY,ACTIVE
+AK-CHIN-NSN.GOV,Native Sovereign Nation,Indian Affairs,Maricopa,AZ,ACTIVE
+BADRIVER-NSN.GOV,Native Sovereign Nation,Indian Affairs,Odanah,WI,ACTIVE
+BARONA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Lakeside,CA,ACTIVE
+BEARRIVER-NSN.GOV,Native Sovereign Nation,Indian Affairs,Loleta,CA,ACTIVE
+BIHASITKA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Sitka,AK,ACTIVE
+BLUELAKERANCHERIA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Blue Lake,CA,ACTIVE
+BOISFORTE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Nett Lake,MN,ACTIVE
+BRB-NSN.GOV,Native Sovereign Nation,Indian Affairs,LOLETA,CA,ACTIVE
+BURNSPAIUTE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Burns,OR,ACTIVE
+CABAZONINDIANS-NSN.GOV,Native Sovereign Nation,Indian Affairs,Indio,CA,ACTIVE
+CADDONATION-NSN.GOV,Native Sovereign Nation,Indian Affairs,Binger,OK,ACTIVE
+CAHTOTRIBE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Laytonville,CA,ACTIVE
+CAMPO-NSN.GOV,Native Sovereign Nation,Indian Affairs,Campo,CA,ACTIVE
+CAYUGANATION-NSN.GOV,Native Sovereign Nation,Indian Affairs,Seneca Falls ,NY,ACTIVE
+CCTHITA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Juneau,AK,ACTIVE
+CDATRIBE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Plummer,ID,ACTIVE
+CHEROKEE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Tahlequah,OK,ACTIVE
+CHICKASAW-GOVERNMENT-NSN.GOV,Native Sovereign Nation,Indian Affairs,Ada,OK,ACTIVE
+CHICKASAW-NSN.GOV,Native Sovereign Nation,Indian Affairs,Ada,OK,ACTIVE
+CHICKASAWARTISANS-NSN.GOV,Native Sovereign Nation,Indian Affairs,Ada,OK,ACTIVE
+CHICKASAWGOVERNMENT-NSN.GOV,Native Sovereign Nation,Indian Affairs,Ada,OK,ACTIVE
+CHICKASAWJUDICIAL-NSN.GOV,Native Sovereign Nation,Indian Affairs,Ada,OK,ACTIVE
+CHICKASAWLEGISLATURE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Ada,OK,ACTIVE
+CHICKASAWNATION-NSN.GOV,Native Sovereign Nation,Indian Affairs,Ada,OK,ACTIVE
+CHICKASAWTRIBE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Ada,OK,ACTIVE
+CHILKOOT-NSN.GOV,Native Sovereign Nation,Indian Affairs,Haines,AK,ACTIVE
+CHITIMACHA.GOV,Native Sovereign Nation,Indian Affairs,Charenton,LA,ACTIVE
+CHUKCHANSI-NSN.GOV,Native Sovereign Nation,Indian Affairs,Fresno,CA,ACTIVE
+CIT-NSN.GOV,Native Sovereign Nation,Indian Affairs,Havasu Lake,CA,ACTIVE
+COLUSA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Colusa,CA,ACTIVE
+COYOTEVALLEY-NSN.GOV,Native Sovereign Nation,Indian Affairs,Redwood valley,CA,ACTIVE
+CRHC-NSN.GOV,Native Sovereign Nation,Indian Affairs,Chico,CA,ACTIVE
+CRIT-NSN.GOV,Native Sovereign Nation,Indian Affairs,Parker,AZ,ACTIVE
+CROW-NSN.GOV,Native Sovereign Nation,Indian Affairs,Crow Agency,MT,ACTIVE
+CRST-NSN.GOV,Native Sovereign Nation,Indian Affairs,EAGLE BUTTE,SD,ACTIVE
+EKLUTNA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Chugiak,AK,ACTIVE
+ELYSHOSHONETRIBE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Ely,NV,ACTIVE
+ESTOO-NSN.GOV,Native Sovereign Nation,Indian Affairs,Wyandotte,OK,ACTIVE
+EWIIAAPAAYP-NSN.GOV,Native Sovereign Nation,Indian Affairs,Alpine,CA,ACTIVE
+EYAK-NSN.GOV,Native Sovereign Nation,Indian Affairs,Cordova,AK,ACTIVE
+FCP-NSN.GOV,Native Sovereign Nation,Indian Affairs,Crandon,WI,ACTIVE
+FCPOTAWATOMI-NSN.GOV,Native Sovereign Nation,Indian Affairs,Crandon,WI,ACTIVE
+FORTSILLAPACHE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Apache,OK,ACTIVE
+GILARIVER-NSN.GOV,Native Sovereign Nation,Indian Affairs,Sacaton,AZ,ACTIVE
+GLT-NSN.GOV,Native Sovereign Nation,Indian Affairs,Dorr,MI,ACTIVE
+GUNLAKETRIBE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Dorr,MI,ACTIVE
+HANNAHVILLEPOTAWATOMI-NSN.GOV,Native Sovereign Nation,Indian Affairs,Wilson,MI,ACTIVE
+HAVASUPAI-NSN.GOV,Native Sovereign Nation,Indian Affairs,Supai,AZ,ACTIVE
+HOOPA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Hoopa,CA,ACTIVE
+HOPI-NSN.GOV,Native Sovereign Nation,Indian Affairs,Kykotsmovi,AZ,ACTIVE
+HPULTRIBE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Upper Lake,CA,ACTIVE
+HUALAPAI-NSN.GOV,Native Sovereign Nation,Indian Affairs,Peach Springs,AZ,ACTIVE
+IIPAYNATION-NSN.GOV,Native Sovereign Nation,Indian Affairs,santa ysabel,CA,ACTIVE
+ISLETAPUEBLO-NSN.GOV,Native Sovereign Nation,Indian Affairs,Isleta,NM,ACTIVE
+JACKSONRANCHERIA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Jackson,CA,ACTIVE
+KAIBABPAIUTE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Fredonia,AZ,ACTIVE
+KAWAIKA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Laguna,NM,ACTIVE
+KAYENTATOWNSHIP-NSN.GOV,Native Sovereign Nation,Indian Affairs,Kayenta,AZ,ACTIVE
+KBIC-NSN.GOV,Native Sovereign Nation,Indian Affairs,Baraga,MI,ACTIVE
+KENAITZE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Kenai,AK,ACTIVE
+KEWEENAWBAY-NSN.GOV,Native Sovereign Nation,Indian Affairs,Baraga,MI,ACTIVE
+KTIK-NSN.GOV,Native Sovereign Nation,Indian Affairs,Horton,KS,ACTIVE
+LAGUNA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Laguna,NM,ACTIVE
+LAGUNAPUEBLO-NSN.GOV,Native Sovereign Nation,Indian Affairs,Laguna,NM,ACTIVE
+LAJOLLA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Pauma Valley,CA,ACTIVE
+LCO-NSN.GOV,Native Sovereign Nation,Indian Affairs,Hayward,WI,ACTIVE
+LTBBODAWA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Harbor Springs,MI,ACTIVE
+LUMMI-NSN.GOV,Native Sovereign Nation,Indian Affairs,Bellingham,WA,ACTIVE
+MASHANTUCKET-NSN.GOV,Native Sovereign Nation,Indian Affairs,Mashantucket,CT,ACTIVE
+MASHANTUCKETPEQUOT-NSN.GOV,Native Sovereign Nation,Indian Affairs,Mashantucket,CT,ACTIVE
+MASHANTUCKETWESTERNPEQUOT-NSN.GOV,Native Sovereign Nation,Indian Affairs,Mashantucket,CT,ACTIVE
+MCN-NSN.GOV,Native Sovereign Nation,Indian Affairs,Okmulgee,OK,ACTIVE
+MECHOOPDA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Chico,CA,ACTIVE
+MENOMINEE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Keshena,WI,ACTIVE
+MESAGRANDEBAND-NSN.GOV,Native Sovereign Nation,Indian Affairs,SantaYsabel,CA,ACTIVE
+MESKWAKI-NSN.GOV,Native Sovereign Nation,Indian Affairs,Tama,IA,ACTIVE
+MICCOSUKEE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Miami,FL,ACTIVE
+MICMAC-NSN.GOV,Native Sovereign Nation,Indian Affairs,Presque Isle,ME,ACTIVE
+MIDDLETOWNRANCHERIA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Middletown,CA,ACTIVE
+MILLELACSBAND-NSN.GOV,Native Sovereign Nation,Indian Affairs,Onamia,MN,ACTIVE
+MOAPABANDOFPAIUTES-NSN.GOV,Native Sovereign Nation,Indian Affairs,Moapa,NV,SERVER-HOLD
+MOHICAN-NSN.GOV,Native Sovereign Nation,Indian Affairs,Bowler,WI,ACTIVE
+MORONGO-NSN.GOV,Native Sovereign Nation,Indian Affairs,Banning,CA,ACTIVE
+MPGE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Mashantucket,CT,ACTIVE
+MPTN-NSN.GOV,Native Sovereign Nation,Indian Affairs,Mashantucket,CT,ACTIVE
+MUSCOGEENATION-NSN.GOV,Native Sovereign Nation,Indian Affairs,Okmulgee,OK,ACTIVE
+NCIHA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Ukiah,CA,ACTIVE
+NFR-NSN.GOV,Native Sovereign Nation,Indian Affairs,North Fork,CA,ACTIVE
+NFRIHA-NSN.GOV,Native Sovereign Nation,Indian Affairs,North Fork,CA,ACTIVE
+NINILCHIKTRIBE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Ninilchik,AK,ACTIVE
+NISQUALLY-NSN.GOV,Native Sovereign Nation,Indian Affairs,Olympia,WA,ACTIVE
+NOOKSACK-NSN.GOV,Native Sovereign Nation,Indian Affairs,Deming,WA,ACTIVE
+NORTHFORKRANCHERIA-NSN.GOV,Native Sovereign Nation,Indian Affairs,North Fork ,CA,ACTIVE
+NVB-NSN.GOV,Native Sovereign Nation,Indian Affairs,Barrow,AK,ACTIVE
+OHKAYOWINGEH-NSN.GOV,Native Sovereign Nation,Indian Affairs,San Juan Pueblo,NM,ACTIVE
+OMAHA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Macy,NE,ACTIVE
+ONEIDA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Oneida,WI,ACTIVE
+OSAGECONGRESS-NSN.GOV,Native Sovereign Nation,Indian Affairs,Pawhuska,OK,ACTIVE
+OSAGENATION-NSN.GOV,Native Sovereign Nation,Indian Affairs,Pawhuska,OK,ACTIVE
+PASCUAYAQUI-NSN.GOV,Native Sovereign Nation,Indian Affairs,Tucson,AZ,ACTIVE
+PASKENTA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Corning,CA,ACTIVE
+PAUMA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Pauma Valley,CA,ACTIVE
+PCI-NSN.GOV,Native Sovereign Nation,Indian Affairs,Atmore,AL,ACTIVE
+PECHANGA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Temecula,CA,ACTIVE
+PEQUOT-NSN.GOV,Native Sovereign Nation,Indian Affairs,Mashantucket,CT,ACTIVE
+PHC-NSN.GOV,Native Sovereign Nation,Indian Affairs,Princeton,ME,ACTIVE
+POARCHCREEKINDIANS-NSN.GOV,Native Sovereign Nation,Indian Affairs,ATMORE,AL,ACTIVE
+POKAGONBAND-NSN.GOV,Native Sovereign Nation,Indian Affairs,DOWAGIAC,MI,ACTIVE
+POL-NSN.GOV,Native Sovereign Nation,Indian Affairs,Laguna,NM,ACTIVE
+PUYALLUPTRIBE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Tacoma,WA,ACTIVE
+QVIR-NSN.GOV,Native Sovereign Nation,Indian Affairs,Fort jones,CA,ACTIVE
+RAMONA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Anza,CA,ACTIVE
+REDCLIFF-NSN.GOV,Native Sovereign Nation,Indian Affairs,Bayfield,WI,ACTIVE
+ROSEBUDSIOUXTRIBE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Rosebud,SD,ACTIVE
+RST-NSN.GOV,Native Sovereign Nation,Indian Affairs,Rosebud,SD,ACTIVE
+RSTWATER-NSN.GOV,Native Sovereign Nation,Indian Affairs,Rosebud,SD,ACTIVE
+SACANDFOXNATION-NSN.GOV,Native Sovereign Nation,Indian Affairs,Stroud,OK,ACTIVE
+SANMANUEL-NSN.GOV,Native Sovereign Nation,Indian Affairs,Highland,CA,ACTIVE
+SANTAANA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Santa Ana,NM,ACTIVE
+SANTAROSACAHUILLA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Anza,CA,ACTIVE
+SCAT-NSN.GOV,Native Sovereign Nation,Indian Affairs,Peridot,AZ,ACTIVE
+SCC-NSN.GOV,Native Sovereign Nation,Indian Affairs,Crandon,WI,ACTIVE
+SEMINOLENATION-NSN.GOV,Native Sovereign Nation,Indian Affairs,Wewoka,OK,ACTIVE
+SHOALWATERBAY-NSN.GOV,Native Sovereign Nation,Indian Affairs,Tokeland,WA,ACTIVE
+SIR-NSN.GOV,Native Sovereign Nation,Indian Affairs,Susanville,CA,ACTIVE
+SITKATRIBE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Sitka,AK,ACTIVE
+SNO-NSN.GOV,Native Sovereign Nation,Indian Affairs,Wewoka,OK,ACTIVE
+SOBOBA-NSN.GOV,Native Sovereign Nation,Indian Affairs,San Jacinto,CA,ACTIVE
+SOUTHERNUTE-NSN.GOV,Native Sovereign Nation,Indian Affairs,IGNACIO,CO,ACTIVE
+SRMT-NSN.GOV,Native Sovereign Nation,Indian Affairs,Akwesasne,NY,ACTIVE
+SRPMIC-NSN.GOV,Native Sovereign Nation,Indian Affairs,Scottsdale,AZ,ACTIVE
+SUSANVILLEINDIANRANCHERIA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Susanville,CA,ACTIVE
+SWINOMISH-NSN.GOV,Native Sovereign Nation,Indian Affairs,La Conner,WA,ACTIVE
+SWO-NSN.GOV,Native Sovereign Nation,Indian Affairs,Agency Village,SD,ACTIVE
+SYCUAN-NSN.GOV,Native Sovereign Nation,Indian Affairs,El Cajon,CA,ACTIVE
+TACHI-YOKUT-NSN.GOV,Native Sovereign Nation,Indian Affairs,Lemoore,CA,ACTIVE
+TAMAYA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Santa Ana,NM,ACTIVE
+TEJONINDIANTRIBE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Bakersfield,CA,ACTIVE
+TMDCI-NSN.GOV,Native Sovereign Nation,Indian Affairs,Thermal,CA,ACTIVE
+TOLOWA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Smith River,CA,ACTIVE
+TONATION-NSN.GOV,Native Sovereign Nation,Indian Affairs,Sells,AZ,ACTIVE
+TORRESMARTINEZ-NSN.GOV,Native Sovereign Nation,Indian Affairs,Thermal,CA,ACTIVE
+TULALIP-NSN.GOV,Native Sovereign Nation,Indian Affairs,Tulalip,WA,ACTIVE
+TULALIPAIR-NSN.GOV,Native Sovereign Nation,Indian Affairs,Tulalip,WA,ACTIVE
+TULALIPTRIBES-NSN.GOV,Native Sovereign Nation,Indian Affairs,Tulalip,WA,ACTIVE
+TULERIVERTRIBE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Porterville,CA,ACTIVE
+TWENTYNINEPALMSBOMI-NSN.GOV,Native Sovereign Nation,Indian Affairs,Coachella,CA,ACTIVE
+UKB-NSN.GOV,Native Sovereign Nation,Indian Affairs,Tahlequah,OK,ACTIVE
+UPPERSIOUXCOMMUNITY-NSN.GOV,Native Sovereign Nation,Indian Affairs,Granite Falls,MN,ACTIVE
+VIEJAS-NSN.GOV,Native Sovereign Nation,Indian Affairs,Alpine,CA,ACTIVE
+WARMSPRINGS-NSN.GOV,Native Sovereign Nation,Indian Affairs,Warm Springs,OR,ACTIVE
+WESTERNPEQUOT-NSN.GOV,Native Sovereign Nation,Indian Affairs,Mashantucket,CT,ACTIVE
+WHITEEARTH-NSN.GOV,Native Sovereign Nation,Indian Affairs,Ogema,MN,ACTIVE
+WILTONRANCHERIA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Elk Grove,CA,ACTIVE
+WINNEMUCCAINDIANCOLONYOFNEVADA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Winnemucca,NV,ACTIVE
+WYANDOTTE-NATION-NSN.GOV,Native Sovereign Nation,Indian Affairs,Wyandotte,OK,ACTIVE
+YAKAMAFISH-NSN.GOV,Native Sovereign Nation,Indian Affairs,Toppenish,WA,ACTIVE
+YAKAMANATION-NSN.GOV,Native Sovereign Nation,Indian Affairs,Toppenish,WA,ACTIVE
+YOCHADEHE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Brooks,CA,ACTIVE
+YPT-NSN.GOV,Native Sovereign Nation,Indian Affairs,Yerington,NV,ACTIVE
+CHILKAT-NSN.GOV,Native Sovereign Nation,Non-Federal Agency,Haines,AK,ACTIVE
+DINEH-NSN.GOV,Native Sovereign Nation,Non-Federal Agency,Window Rock,AZ,ACTIVE
+LRBOI-NSN.GOV,Native Sovereign Nation,Non-Federal Agency,Manistee,MI,ACTIVE
+NAVAJO-NSN.GOV,Native Sovereign Nation,Non-Federal Agency,Window Rock,AZ,ACTIVE
+YDSP-NSN.GOV,Native Sovereign Nation,Non-Federal Agency,El Pas,TX,ACTIVE

--- a/dotgov-domains/2016-06-30-state-local.csv
+++ b/dotgov-domains/2016-06-30-state-local.csv
@@ -1,0 +1,1188 @@
+Domain Name,Domain Type,Agency,City,State,Status
+MTC.GOV,State/Local Govt,Multistate Tax Commission,Washington,DC,ACTIVE
+IUS.GOV,State/Local Govt,National Gallery of Art,Boise,ID,ACTIVE
+511MAINE.GOV,State/Local Govt,Non-Federal Agency,Augusta,ME,ACTIVE
+511NY.GOV,State/Local Govt,Non-Federal Agency,Albany,NY,ACTIVE
+511TX.GOV,State/Local Govt,Non-Federal Agency,Austin,TX,ACTIVE
+511WI.GOV,State/Local Govt,Non-Federal Agency,Madison,WI,ACTIVE
+ABLETN.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE
+ACCESSTN.GOV,State/Local Govt,Non-Federal Agency,NASHVILLE,TN,ACTIVE
+ADRCNJ.GOV,State/Local Govt,Non-Federal Agency,Mercerville,NJ,ACTIVE
+AGAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AGUTAH.GOV,State/Local Govt,Non-Federal Agency,Salt Lake City,UT,ACTIVE
+AK.GOV,State/Local Govt,Non-Federal Agency,Juneau,AK,ACTIVE
+AKAEROSPACE.GOV,State/Local Govt,Non-Federal Agency,Anchorage,AK,ACTIVE
+AKLEG.GOV,State/Local Govt,Non-Federal Agency,Juneau,AK,ACTIVE
+AL-LEGISLATURE.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE
+AL.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE
+ALABAMA.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE
+ALABAMAAGELINE.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE
+ALABAMACONNECT.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE
+ALABAMADA.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE
+ALABAMADEMENTIA.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE
+ALABAMAHOUSEPHOTOS.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE
+ALABAMASMP.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE
+ALABAMAVOTES.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE
+ALABPP.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE
+ALACOP.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE
+ALACOURT.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE
+ALADA.GOV,State/Local Govt,Non-Federal Agency,Mongomery,AL,ACTIVE
+ALADNA.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE
+ALAPPEALS.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE
+ALASAFE.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE
+ALASKA.GOV,State/Local Govt,Non-Federal Agency,Juneau,AK,ACTIVE
+ALASKACARE.GOV,State/Local Govt,Non-Federal Agency,Juneau,AK,ACTIVE
+ALDOI.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE
+ALEA.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE
+ALHOUSE.GOV,State/Local Govt,Non-Federal Agency,Montgomery ,AL,ACTIVE
+ALPHARETTA-GA.GOV,State/Local Govt,Non-Federal Agency,Alpharetta,GA,ACTIVE
+ALSENATE.GOV,State/Local Govt,Non-Federal Agency,Montgomery ,AL,ACTIVE
+AMERICANSAMOA.GOV,State/Local Govt,Non-Federal Agency,Pago Pago,AS,ACTIVE
+AMESBURYMA.GOV,State/Local Govt,Non-Federal Agency,Amesbury,MA,ACTIVE
+ANNAPOLIS.GOV,State/Local Govt,Non-Federal Agency,Annapolis,MD,ACTIVE
+ANNAPOLISMD.GOV,State/Local Govt,Non-Federal Agency,Annapolis,MD,ACTIVE
+AQMD.GOV,State/Local Govt,Non-Federal Agency,Diamond Bar,CA,ACTIVE
+AR.GOV,State/Local Govt,Non-Federal Agency,Little Rock,AR,ACTIVE
+ARCOURTS.GOV,State/Local Govt,Non-Federal Agency,Little Rock,AR,ACTIVE
+ARIZONA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+ARIZONAJOBCONNECTION.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+ARIZONATURBOCOURT.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+ARKANSAS.GOV,State/Local Govt,Non-Federal Agency,Little Rock,AR,ACTIVE
+ARKANSASAG.GOV,State/Local Govt,Non-Federal Agency,Little Rock,AR,ACTIVE
+ARKANSASED.GOV,State/Local Govt,Non-Federal Agency,Little Rock,AR,ACTIVE
+ARKLEGAUDIT.GOV,State/Local Govt,Non-Federal Agency,Little Rock,AR,ACTIVE
+ARTREASURY.GOV,State/Local Govt,Non-Federal Agency,Litlte Rock,AR,ACTIVE
+ARTRS.GOV,State/Local Govt,Non-Federal Agency,Little Rock,AR,ACTIVE
+AS.GOV,State/Local Govt,Non-Federal Agency,Pago Pago,AS,ACTIVE
+ASAFERFLORIDA.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+ASEPA.GOV,State/Local Govt,Non-Federal Agency,Pago Pago,AS,ACTIVE
+ATHOMEILLINOIS.GOV,State/Local Govt,Non-Federal Agency,Chicago,IL,ACTIVE
+ATLASALABAMA.GOV,State/Local Govt,Non-Federal Agency,TUSCALOOSA,AL,ACTIVE
+ATTORNEYGENERAL.GOV,State/Local Govt,Non-Federal Agency,Harrisburg,PA,ACTIVE
+AUGUSTAGA.GOV,State/Local Govt,Non-Federal Agency,Augusta,GA,ACTIVE
+AVON-MA.GOV,State/Local Govt,Non-Federal Agency,Avon,MA,ACTIVE
+AZ-ACOIHC.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZ-FHSD.GOV,State/Local Govt,Non-Federal Agency,Fountain Hills,AZ,ACTIVE
+AZ.GOV,State/Local Govt,Non-Federal Agency,Phoeniz,AZ,ACTIVE
+AZ511.GOV,State/Local Govt,Non-Federal Agency,Pheonix,AZ,ACTIVE
+AZ529.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZ911.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZABRC.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZACCOUNTANCY.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZACTIC.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZAFIS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZAG.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZAHCCCS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZARTS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZASRS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZAUDITOR.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZBN.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZBNP.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZBOA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZBOC.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZBOEC.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZBOF.GOV,State/Local Govt,Non-Federal Agency,PHOENIX,AZ,ACTIVE
+AZBORDERTRASH.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZBOTA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZBOXINGANDMMA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZBROADBAND.GOV,State/Local Govt,Non-Federal Agency,PHOENIX,AZ,ACTIVE
+AZBTR.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZCAAA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZCANCERCONTROL.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZCC.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZCIA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZCJC.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZCLEANELECTIONS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZCLIMATECHANGE.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZCOOP.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZCORPCOM.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZCORPCOMM.GOV,State/Local Govt,Non-Federal Agency,Phoenxi,AZ,ACTIVE
+AZCORRECTIONS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZCOURTDOCS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZCOURTS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZCVD.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZDA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZDAARS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZDCS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZDDPC.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZDEMA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZDEQ.GOV,State/Local Govt,Non-Federal Agency,Phx,AZ,ACTIVE
+AZDES.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZDFI.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZDHS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZDIABETES.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZDJC.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZDO.GOV,State/Local Govt,Non-Federal Agency,Scottsdale,AZ,ACTIVE
+AZDOA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZDOC.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZDOH.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZDOHS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZDOR.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZDOSH.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZDOT.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZDPS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZDVS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZECDH.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZED.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZEIN.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZENVIROKIDS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZEPIP.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZFIRSTTHINGSFIRST.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZFTF.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZGADA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZGAMING.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZGFD.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZGITA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZGOHS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZGOVERNOR.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZGRANTS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZGU.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZGUARD.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZHC.GOV,State/Local Govt,Non-Federal Agency,Pheonix,AZ,ACTIVE
+AZHEALTH.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZHIGHERED.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZHOUSE.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZHOUSING.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZHS.GOV,State/Local Govt,Non-Federal Agency,Tempe,AZ,ACTIVE
+AZICA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZINSURANCE.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZINVESTOR.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZJOBCONNECTION.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZJUVED.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZKIDSCARE.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZKIDSNEEDU.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZLAND.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZLEG.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZLGMA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZLIBRARY.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZLINKS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZLIQUOR.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZLOTTERY.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZMAG.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZMD.GOV,State/Local Govt,Non-Federal Agency,Scottsdale,AZ,ACTIVE
+AZMINORITYHEALTH.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZMORTGAGERESOURCE.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZMYFAMILYBENEFITS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZND.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZNET.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZOCA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZOSPB.GOV,State/Local Govt,Non-Federal Agency,phoenix,AZ,ACTIVE
+AZOT.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZPA.GOV,State/Local Govt,Non-Federal Agency,Scottsdale,AZ,ACTIVE
+AZPARKS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZPCRPD.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZPH.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZPHARMACY.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZPOST.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZPPSE.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZPSIC.GOV,State/Local Govt,Non-Federal Agency,PHOENIX,AZ,ACTIVE
+AZQUALITYFIRST.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZRACING.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZRE.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZRECYCLES.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZREPORTCARD.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZROC.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZRRA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZRUCO.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZSAL.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZSENATE.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZSF.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZSFB.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZSHARE.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZSOS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZSTATEJOBS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZSTATEPARKS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZSTATS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZSTEPSUP.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZSUMMERFOOD.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZSURPLUS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZTAXES.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZTRANSPORTATIONBOARD.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZTREASURER.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZTREASURY.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZTURBOCOURT.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZUI.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZUITAX.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZUNCLAIMED.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZVOICES.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZWATER.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZWATERBANK.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZWIC.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZWIFA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZWPF.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZYES.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+B4WV.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE
+BAAQMD.GOV,State/Local Govt,Non-Federal Agency,San Francisco,CA,ACTIVE
+BABYARIZONA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+BARHARBORMAINE.GOV,State/Local Govt,Non-Federal Agency,Bar Harbor,ME,ACTIVE
+BART.GOV,State/Local Govt,Non-Federal Agency,Oakland,CA,ACTIVE
+BATONROUGELA.GOV,State/Local Govt,Non-Federal Agency,Baton Rouge,LA,ACTIVE
+BEGA-DC.GOV,State/Local Govt,Non-Federal Agency,Washington,DC,ACTIVE
+BEREADYUTAH.GOV,State/Local Govt,Non-Federal Agency,Salt Lake City,UT,ACTIVE
+BETSYLEHMANCENTERMA.GOV,State/Local Govt,Non-Federal Agency,Boston,MA,ACTIVE
+BLNC.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+BOATIDAHO.GOV,State/Local Govt,Non-Federal Agency,Boise,ID,ACTIVE
+BOIMI.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI,ACTIVE
+BOULDERCOUNTY-CO.GOV,State/Local Govt,Non-Federal Agency,Boulder,CO,ACTIVE
+BRAINTREEMA.GOV,State/Local Govt,Non-Federal Agency,Braintree,MA,ACTIVE
+BRANDCOLORADO.GOV,State/Local Govt,Non-Federal Agency,Boulder,CO,ACTIVE
+BREWERMAINE.GOV,State/Local Govt,Non-Federal Agency,Brewer,ME,ACTIVE
+BROCKTON-MA.GOV,State/Local Govt,Non-Federal Agency,Brockton,MA,ACTIVE
+BRUNSWICKMD.GOV,State/Local Govt,Non-Federal Agency,Brunswick,MD,ACTIVE
+BURKECOUNTY-GA.GOV,State/Local Govt,Non-Federal Agency,Waynesboro,GA,ACTIVE
+BUSINESS4WV.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE
+BUYNJBONDS.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+CA.GOV,State/Local Govt,Non-Federal Agency,Rancho Cordova,CA,ACTIVE
+CAHWNET.GOV,State/Local Govt,Non-Federal Agency,Sacramento,CA,ACTIVE
+CALIFORNIA.GOV,State/Local Govt,Non-Federal Agency,Rancho Cordova,CA,ACTIVE
+CALIFORNIADESERT.GOV,State/Local Govt,Non-Federal Agency,Barstow,CA,ACTIVE
+CAMBRIDGERETIREMENTMA.GOV,State/Local Govt,Non-Federal Agency,Cambridge,MA,ACTIVE
+CAMDENCOUNTYGA.GOV,State/Local Govt,Non-Federal Agency,Woodbine,GA,ACTIVE
+CANBYOREGON.GOV,State/Local Govt,Non-Federal Agency,Canby,OR,ACTIVE
+CAPITALREGIONUPDATES.GOV,State/Local Govt,Non-Federal Agency,Fairfax,VA,ACTIVE
+CASAAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+CHIAMASS.GOV,State/Local Govt,Non-Federal Agency,Boston,MA,ACTIVE
+CHOOSEIDAHO.GOV,State/Local Govt,Non-Federal Agency,Boise,ID,ACTIVE
+CITYOFBOSTON.GOV,State/Local Govt,Non-Federal Agency,Boston,MA,ACTIVE
+CLAIMITTN.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE
+CLAYCOUNTYIN.GOV,State/Local Govt,Non-Federal Agency,Brazil,IN,ACTIVE
+CLEARSPRINGMD.GOV,State/Local Govt,Non-Federal Agency,Clear Spring,MD,ACTIVE
+CMSPLANFLORIDA.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL,ACTIVE
+CO.GOV,State/Local Govt,Non-Federal Agency,Lakewood,CO,ACTIVE
+COAG.GOV,State/Local Govt,Non-Federal Agency,Denver,CO,ACTIVE
+COBBCOUNTYGA.GOV,State/Local Govt,Non-Federal Agency,Marietta,GA,ACTIVE
+COBERTURAMEDICAILLINOIS.GOV,State/Local Govt,Non-Federal Agency,Chicago,IL,ACTIVE
+COCICJIS.GOV,State/Local Govt,Non-Federal Agency,Golden,CO,ACTIVE
+CODOT.GOV,State/Local Govt,Non-Federal Agency,Denver,CO,ACTIVE
+COLLEGEGOALARIZONA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+COLLEGEGOALOREGON.GOV,State/Local Govt,Non-Federal Agency,Eugene,OR,ACTIVE
+COLLIERCOUNTYFL.GOV,State/Local Govt,Non-Federal Agency,Naples,FL,ACTIVE
+COLORADO.GOV,State/Local Govt,Non-Federal Agency,Lakewood,CO,ACTIVE
+COLORADOATTORNEYGENERAL.GOV,State/Local Govt,Non-Federal Agency,Denver,CO,ACTIVE
+COLORADOJUDICIAL.GOV,State/Local Govt,Non-Federal Agency,Denver,CO,ACTIVE
+COLORADOJUDICIALPERFORMANCE.GOV,State/Local Govt,Non-Federal Agency,Denver,CO,ACTIVE
+COLORADOLABORLAW.GOV,State/Local Govt,Non-Federal Agency,Denver,CO,ACTIVE
+COLORADOPOST.GOV,State/Local Govt,Non-Federal Agency,Denver,CO,ACTIVE
+COLORADOPOSTGRANTS.GOV,State/Local Govt,Non-Federal Agency,Denver,CO,ACTIVE
+COLORADORCJC.GOV,State/Local Govt,Non-Federal Agency,Denver,CO,ACTIVE
+COLORADOUI.GOV,State/Local Govt,Non-Federal Agency,Denver,CO,ACTIVE
+COLORADOWORKS.GOV,State/Local Govt,Non-Federal Agency,Denver,CO,ACTIVE
+COMPARECAREWV.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE
+CONCORD-MA.GOV,State/Local Govt,Non-Federal Agency,Concord,MA,ACTIVE
+CONNECTND.GOV,State/Local Govt,Non-Federal Agency,Bisamarck,ND,ACTIVE
+CONSERVEALABAMA.GOV,State/Local Govt,Non-Federal Agency,MONTGOMERY,AL,ACTIVE
+CONSHOHOCKENPA.GOV,State/Local Govt,Non-Federal Agency,Conshohocken,PA,ACTIVE
+COSIPA.GOV,State/Local Govt,Non-Federal Agency,Denver,CO,ACTIVE
+COUNCILBLUFFS-IA.GOV,State/Local Govt,Non-Federal Agency,Council Bluffs,IA,ACTIVE
+COURTNEWSOHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+COURTSWV.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE
+COVERTENNESSEE.GOV,State/Local Govt,Non-Federal Agency,NASHVILLE,TN,ACTIVE
+COVERTN.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE
+COWORKFORCE.GOV,State/Local Govt,Non-Federal Agency,Denver,CO,ACTIVE
+CRESTEDBUTTE-CO.GOV,State/Local Govt,Non-Federal Agency,Crested Butte,CO,ACTIVE
+CSIMT.GOV,State/Local Govt,Non-Federal Agency,Helena,MT,ACTIVE
+CSTX.GOV,State/Local Govt,Non-Federal Agency,College Station,TX,ACTIVE
+CT.GOV,State/Local Govt,Non-Federal Agency,Hartford,CT,ACTIVE
+CTALERT.GOV,State/Local Govt,Non-Federal Agency,Middletown,CT,ACTIVE
+CTBROWNFIELDS.GOV,State/Local Govt,Non-Federal Agency,Hartford,CT,ACTIVE
+CTGROWN.GOV,State/Local Govt,Non-Federal Agency,Hartford,CT,ACTIVE
+CTPROBATE.GOV,State/Local Govt,Non-Federal Agency,West Hartford,CT,ACTIVE
+DA16CO.GOV,State/Local Govt,Non-Federal Agency,LA JUNTA,CO,ACTIVE
+DC.GOV,State/Local Govt,Non-Federal Agency,Washington,DC,ACTIVE
+DCAPPEALS.GOV,State/Local Govt,Non-Federal Agency,Washington,DC,ACTIVE
+DCCODE.GOV,State/Local Govt,Non-Federal Agency,Washington,DC,ACTIVE
+DCCOUNCIL.GOV,State/Local Govt,Non-Federal Agency,Washington,DC,ACTIVE
+DCCOURT.GOV,State/Local Govt,Non-Federal Agency,Washington,DC,ACTIVE
+DCCOURTS.GOV,State/Local Govt,Non-Federal Agency,Washington,DC,ACTIVE
+DCCOURTSNEWS.GOV,State/Local Govt,Non-Federal Agency,Washington,DC,ACTIVE
+DE.GOV,State/Local Govt,Non-Federal Agency,Dover,DE,ACTIVE
+DEBTREPORTINGIOWA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+DEL.GOV,State/Local Govt,Non-Federal Agency,Dover,DE,ACTIVE
+DELAWARE.GOV,State/Local Govt,Non-Federal Agency,Dover,DE,ACTIVE
+DELAWAREINSURANCE.GOV,State/Local Govt,Non-Federal Agency,Dover,DE,ACTIVE
+DELDOT.GOV,State/Local Govt,Non-Federal Agency,Dover,DE,ACTIVE
+DEVAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+DIGITALARIZONA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+DIGITALAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+DMG.GOV,State/Local Govt,Non-Federal Agency,Barstow,CA,ACTIVE
+DNSSECOHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+DNSTESTOHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+DOJMT.GOV,State/Local Govt,Non-Federal Agency,Helena,MT,ACTIVE
+DOSEOFREALITYWI.GOV,State/Local Govt,Non-Federal Agency,Madison,WI,ACTIVE
+DOUBLECHECKIOWA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+DRACUTMA.GOV,State/Local Govt,Non-Federal Agency,Dracut,MA,ACTIVE
+DRIVENC.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+DUDLEYMA.GOV,State/Local Govt,Non-Federal Agency,Dudley,MA,ACTIVE
+DWGPA.GOV,State/Local Govt,Non-Federal Agency,Delaware Water Gap,PA,ACTIVE
+EASTHAM-MA.GOV,State/Local Govt,Non-Federal Agency,Eastham,MA,ACTIVE
+EASTVALLEYFUSIONCENTERAZ.GOV,State/Local Govt,Non-Federal Agency,Mesa,AZ,ACTIVE
+EDGEWOODKY.GOV,State/Local Govt,Non-Federal Agency,Edgewood,KY,ACTIVE
+EDUCATEIOWA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+EFILETEXAS.GOV,State/Local Govt,Non-Federal Agency,Austin,TX,ACTIVE
+EGREMONT-MA.GOV,State/Local Govt,Non-Federal Agency,Egremont,MA,ACTIVE
+EHAWAII.GOV,State/Local Govt,Non-Federal Agency,Honolulu,HI,ACTIVE
+EISGATEWAYPACIFICWA.GOV,State/Local Govt,Non-Federal Agency,Lacey,WA,ACTIVE
+ELEARNINGNC.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+ELIZABETHTOWNKY.GOV,State/Local Govt,Non-Federal Agency,Elizabethtown,KY,ACTIVE
+EVFCAZ.GOV,State/Local Govt,Non-Federal Agency,Mesa,AZ,ACTIVE
+EVFUSIONCENTERAZ.GOV,State/Local Govt,Non-Federal Agency,Mesa,AZ,ACTIVE
+EWYOMING.GOV,State/Local Govt,Non-Federal Agency,Cheyenne,WY,ACTIVE
+EXPLOREMAINE.GOV,State/Local Govt,Non-Federal Agency,Augusta,ME,ACTIVE
+FAIRHAVEN-MA.GOV,State/Local Govt,Non-Federal Agency,Fairhaven,MA,ACTIVE
+FAMILYRESOURCEAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+FAYETTECOUNTYGA.GOV,State/Local Govt,Non-Federal Agency,Fayetteville,GA,ACTIVE
+FAYETTEVILLE-GA.GOV,State/Local Govt,Non-Federal Agency,Fayetteville,GA,ACTIVE
+FILELOCAL-WA.GOV,State/Local Govt,Non-Federal Agency,Seattle,WA,ACTIVE
+FIRSTNETME.GOV,State/Local Govt,Non-Federal Agency,Augusta,ME,ACTIVE
+FIRSTTHINGSFIRSTAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+FL.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+FLBOARDOFMEDICINE.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL,ACTIVE
+FLCENSUS.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+FLCOURTS1.GOV,State/Local Govt,Non-Federal Agency,Pensacola,FL,ACTIVE
+FLCRC.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+FLDOI.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+FLDOT.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+FLHEALTH.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+FLHEALTHCOMPLAINT.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+FLHEALTHSOURCE.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+FLHISTORICCAPITOL.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+FLHOUSE.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+FLHSMV.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+FLLEG.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+FLLEGISLATIVEMAILINGS.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+FLORIDA.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+FLORIDAABUSEHOTLINE.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+FLORIDAHEALTH.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+FLORIDAHEALTHFINDER.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+FLORIDALOBBYIST.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+FLORIDANET.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+FLORIDAOPC.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+FLORIDAPACE.GOV,State/Local Govt,Non-Federal Agency,Kissimmee,FL,ACTIVE
+FLORIDAREDISTRICTING.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+FLORIDASACUPUNCTURE.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL,ACTIVE
+FLORIDASATHLETICTRAINING.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL,ACTIVE
+FLORIDASCHIROPRACTICMEDICINE.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL,ACTIVE
+FLORIDASCHOOLBUSSAFETY.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+FLORIDASCLINICALLABS.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL,ACTIVE
+FLORIDASDENTISTRY.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL,ACTIVE
+FLORIDASENATE.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+FLORIDASHEALTH.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+FLORIDASHEARINGAIDSPECIALISTS.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL,ACTIVE
+FLORIDASMASSAGETHERAPY.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL,ACTIVE
+FLORIDASMENTALHEALTHPROFESSIONS.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL,ACTIVE
+FLORIDASNURSING.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL,ACTIVE
+FLORIDASNURSINGHOMEADMIN.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL,ACTIVE
+FLORIDASOCCUPATIONALTHERAPY.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL,ACTIVE
+FLORIDASOPTICIANRY.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL,ACTIVE
+FLORIDASOPTOMETRY.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL,ACTIVE
+FLORIDASORTHOTISTSPROSTHETISTS.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL,ACTIVE
+FLORIDASOSTEOPATHICMEDICINE.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL,ACTIVE
+FLORIDASPHARMACY.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL,ACTIVE
+FLORIDASPHYSICALTHERAPY.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL,ACTIVE
+FLORIDASPODIATRICMEDICINE.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL,ACTIVE
+FLORIDASPSYCHOLOGY.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL,ACTIVE
+FLORIDASRESPIRATORYCARE.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL,ACTIVE
+FLORIDASSPEECHAUDIOLOGY.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL,ACTIVE
+FLORIDASUNSETREVIEWS.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+FLORIDASUNSHINE.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+FLRCM.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+FLSENATE.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+FLSUNSHINE.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+FLWG.GOV,State/Local Govt,Non-Federal Agency,Opa Locka,FL,ACTIVE
+FOIA-DC.GOV,State/Local Govt,Non-Federal Agency,Washington,DC,ACTIVE
+FOIAXPRESS-DC.GOV,State/Local Govt,Non-Federal Agency,Washington,DC,ACTIVE
+FORTLAUDERDALE.GOV,State/Local Govt,Non-Federal Agency,Fort Lauderdale,FL,ACTIVE
+FRAMES.GOV,State/Local Govt,Non-Federal Agency,Moscow,ID,ACTIVE
+FREEPORTFLORIDA.GOV,State/Local Govt,Non-Federal Agency,Freeport,FL,ACTIVE
+FUTUREREADYIOWA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+GA.GOV,State/Local Govt,Non-Federal Agency,Atlanta,GA,ACTIVE
+GACOURTS.GOV,State/Local Govt,Non-Federal Agency,Atlanta,GA,ACTIVE
+GADOL.GOV,State/Local Govt,Non-Federal Agency,Atlanta,GA,ACTIVE
+GAITHERSBURGMD.GOV,State/Local Govt,Non-Federal Agency,Gaithersburg,MD,ACTIVE
+GAPROBATE.GOV,State/Local Govt,Non-Federal Agency,Atlanta,GA,ACTIVE
+GARDNER-MA.GOV,State/Local Govt,Non-Federal Agency,GARDNER,MA,ACTIVE
+GATREES.GOV,State/Local Govt,Non-Federal Agency,Dry Branch,GA,ACTIVE
+GEARUPIOWA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+GEARUPTN.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE
+GEORGETOWNMA.GOV,State/Local Govt,Non-Federal Agency,Georgetown,MA,ACTIVE
+GEORGIA.GOV,State/Local Govt,Non-Federal Agency,Atlanta,GA,ACTIVE
+GEORGIACOURTS.GOV,State/Local Govt,Non-Federal Agency,Atlanta,GA,ACTIVE
+GEORGIAHEALTHINFO.GOV,State/Local Govt,Non-Federal Agency,Atlanta,GA,ACTIVE
+GETCOVEREDILLINOIS.GOV,State/Local Govt,Non-Federal Agency,Chicago,IL,ACTIVE
+GETKANSASBENEFITS.GOV,State/Local Govt,Non-Federal Agency,Topeka,KS,ACTIVE
+GETREADYHAWAII.GOV,State/Local Govt,Non-Federal Agency,Honolulu,HI,ACTIVE
+GETTYSBURGPA.GOV,State/Local Govt,Non-Federal Agency,Gettysburg,PA,ACTIVE
+GIS10SERVICEMT.GOV,State/Local Govt,Non-Federal Agency,Helena,MT,ACTIVE
+GISSERVICEMT.GOV,State/Local Govt,Non-Federal Agency,Helena,MT,ACTIVE
+GISTESTSERVICEMT.GOV,State/Local Govt,Non-Federal Agency,Helena,MT,ACTIVE
+GLYNNCOUNTY-GA.GOV,State/Local Govt,Non-Federal Agency,Brunswick,GA,ACTIVE
+GOLFMANOROH.GOV,State/Local Govt,Non-Federal Agency,Golf Manor,OH,ACTIVE
+GOVOTEVERMONT.GOV,State/Local Govt,Non-Federal Agency,Montpelier,VT,ACTIVE
+GRAFTONTWP-OH.GOV,State/Local Govt,Non-Federal Agency,Grafton Township,OH,ACTIVE
+GREATIOWATREASUREHUNT.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+GRFDAZ.GOV,State/Local Govt,Non-Federal Agency,Tucson,AZ,ACTIVE
+GRINNELLIOWA.GOV,State/Local Govt,Non-Federal Agency,Grinnell,IA,ACTIVE
+GUAM.GOV,State/Local Govt,Non-Federal Agency,Agana,GU,ACTIVE
+HAMILTONMA.GOV,State/Local Govt,Non-Federal Agency,So. Hamilton,MA,ACTIVE
+HARFORDCOUNTYMD.GOV,State/Local Govt,Non-Federal Agency,Bel Air,MD,ACTIVE
+HAWAII.GOV,State/Local Govt,Non-Federal Agency,Honolulu,HI,ACTIVE
+HEALTH-E-ARIZONA-PLUS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+HEALTH-E-ARIZONAPLUS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+HEALTHCAREHELPMASS.GOV,State/Local Govt,Non-Federal Agency,Boston,MA,ACTIVE
+HEALTHEARIZONA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+HEALTHEARIZONAPLUS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+HEALTHVERMONT.GOV,State/Local Govt,Non-Federal Agency,Burlington,VT,ACTIVE
+HEALTHYIOWA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+HEALTHYSD.GOV,State/Local Govt,Non-Federal Agency,Pierre,SD,ACTIVE
+HEALTHYTEETHAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+HI.GOV,State/Local Govt,Non-Federal Agency,Honolulu,HI,ACTIVE
+HIJOSSALUDABLESOREGON.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE
+HINSDALEMA.GOV,State/Local Govt,Non-Federal Agency,Hinsdale,MA,ACTIVE
+HIREACOLORADOVET.GOV,State/Local Govt,Non-Federal Agency,Denver,CO,ACTIVE
+HOMEAGAINNEVADA.GOV,State/Local Govt,Non-Federal Agency,Las Vegas,NV,ACTIVE
+HOMEBASEIOWA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+HOMEMEANSNEVADA.GOV,State/Local Govt,Non-Federal Agency,Las Vegas,NV,ACTIVE
+HONOLULU.GOV,State/Local Govt,Non-Federal Agency,Honolulu,HI,ACTIVE
+IA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IAABATEDOC.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IAHEALTHLINK.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IASHP.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IASIMPLEABATE.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IAVOTERS.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+ID.GOV,State/Local Govt,Non-Federal Agency,Boise,ID,ACTIVE
+IDAHO.GOV,State/Local Govt,Non-Federal Agency,Boise,ID,ACTIVE
+IDAHOBYWAYS.GOV,State/Local Govt,Non-Federal Agency,Boise,ID,ACTIVE
+IDAHOPREPARES.GOV,State/Local Govt,Non-Federal Agency,Boise,ID,ACTIVE
+IDAHOVOTES.GOV,State/Local Govt,Non-Federal Agency,Boise,ID,ACTIVE
+IDAHOWORKS.GOV,State/Local Govt,Non-Federal Agency,Boise,ID,ACTIVE
+IHAVEAPLANIOWA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IJOBSIOWA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IL.GOV,State/Local Govt,Non-Federal Agency,Springfield,IL,ACTIVE
+ILATTORNEYGENERAL.GOV,State/Local Govt,Non-Federal Agency,Chicago,IL,ACTIVE
+ILGA.GOV,State/Local Govt,Non-Federal Agency,Springfield,IL,ACTIVE
+ILLINOIS-HISTORY.GOV,State/Local Govt,Non-Federal Agency,Springfield,IL,ACTIVE
+ILLINOIS.GOV,State/Local Govt,Non-Federal Agency,Springfield,IL,ACTIVE
+ILLINOISATTORNEYGENERAL.GOV,State/Local Govt,Non-Federal Agency,Chicago,IL,ACTIVE
+ILLINOISCOMPTROLLER.GOV,State/Local Govt,Non-Federal Agency,Springfield,IL,ACTIVE
+ILLINOISCOURTS.GOV,State/Local Govt,Non-Federal Agency,Springfield,IL,ACTIVE
+ILLINOISHISTORY.GOV,State/Local Govt,Non-Federal Agency,Springfield,IL,ACTIVE
+ILLINOISRETIREMENT.GOV,State/Local Govt,Non-Federal Agency,Springfield,IL,ACTIVE
+ILLINOISTREASURER.GOV,State/Local Govt,Non-Federal Agency,Springfield,IL,ACTIVE
+ILSOS.GOV,State/Local Govt,Non-Federal Agency,Springfield,IL,ACTIVE
+IN.GOV,State/Local Govt,Non-Federal Agency,Indianapolis,IN,ACTIVE
+INCOURTS.GOV,State/Local Govt,Non-Federal Agency,Indianapolis,IN,ACTIVE
+INDIANA.GOV,State/Local Govt,Non-Federal Agency,Indianapolis,IN,ACTIVE
+INDIANAMOTORSPORTS.GOV,State/Local Govt,Non-Federal Agency,Indianapolis,IN,ACTIVE
+INDIANAUNCLAIMED.GOV,State/Local Govt,Non-Federal Agency,Indianapolis,IN,ACTIVE
+INNOCENCECOMMISSION-NC.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+INTEGRATEAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+INVESTINIOWA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWAAGING.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWAAGRICULTURE.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWAATTORNEYGENERAL.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWACHILDSUPPORT.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWACLEANAIR.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWACOLLEGEAID.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWACOLLEGEAIDDATACENTER.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWACORE.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWACOURTS.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWACULTURE.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWADIVISIONOFLABOR.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWADNR.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWADOT.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWAELECTRICAL.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWAELEVATORS.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWAFINANCEAUTHORITY.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWAFINANCIALAIDAPPLICATION.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWAFORMS.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWAFRAUDFIGHTERS.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWAGRANTS.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWAGREATPLACES.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWAJNC.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWAJQC.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWALIFT.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWALMI.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWAMORTGAGEHELP.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWANEXT.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWAOSHA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWAPIB.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWAPMA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWASMOKEFREEAIR.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWASTEM.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWATAXANDTAGS.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWATEST.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWATITLEGUARANTY.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWATREASURER.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWAWDB.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWAWORKCOMP.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWAWORKFORCE.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWAWORKFORCEDEVELOPMENT.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+JASPERINDIANA.GOV,State/Local Govt,Non-Federal Agency,Jasper,IN,ACTIVE
+JOBS4TN.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE
+JOBSFORTN.GOV,State/Local Govt,Non-Federal Agency,38401,TN,ACTIVE
+JUDNJ.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+KANSAS.GOV,State/Local Govt,Non-Federal Agency,Topeka,KS,ACTIVE
+KANSASEMPLOYER.GOV,State/Local Govt,Non-Federal Agency,Topeka,KS,ACTIVE
+KANSASMONEY.GOV,State/Local Govt,Non-Federal Agency,Topeka,KS,ACTIVE
+KANSASREADY.GOV,State/Local Govt,Non-Federal Agency,Topeka,KS,ACTIVE
+KANSASTAG.GOV,State/Local Govt,Non-Federal Agency,Topeka,KS,ACTIVE
+KDHEKS.GOV,State/Local Govt,Non-Federal Agency,Topeka,KS,ACTIVE
+KENTUCKY.GOV,State/Local Govt,Non-Federal Agency,Frankfort,KY,ACTIVE
+KIDCENTRALTENNESSEE.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE
+KIDCENTRALTN.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE
+KPL.GOV,State/Local Govt,Non-Federal Agency,KALAMAZOO,MI,ACTIVE
+KS.GOV,State/Local Govt,Non-Federal Agency,Topeka,KS,ACTIVE
+KSCAREERNAV.GOV,State/Local Govt,Non-Federal Agency,Topeka,KS,ACTIVE
+KSDA.GOV,State/Local Govt,Non-Federal Agency,Topeka,KS,ACTIVE
+KSHOUSINGCORP.GOV,State/Local Govt,Non-Federal Agency,Topeka,KS,ACTIVE
+KSREADY.GOV,State/Local Govt,Non-Federal Agency,Topeka,KS,ACTIVE
+KY.GOV,State/Local Govt,Non-Federal Agency,Frankfort,KY,ACTIVE
+LA.GOV,State/Local Govt,Non-Federal Agency,Baton Rouge,LA,ACTIVE
+LAFASTSTART.GOV,State/Local Govt,Non-Federal Agency,Baton Rouge,LA,ACTIVE
+LAFAYETTELA.GOV,State/Local Govt,Non-Federal Agency,Lafayette,LA,ACTIVE
+LAJUDICIAL.GOV,State/Local Govt,Non-Federal Agency,New Orleans,LA,ACTIVE
+LAKECOUNTYFL.GOV,State/Local Govt,Non-Federal Agency,Tavares,FL,ACTIVE
+LAKEPARK-FL.GOV,State/Local Govt,Non-Federal Agency,Lake Park,FL,ACTIVE
+LAKEPARKFLORIDA.GOV,State/Local Govt,Non-Federal Agency,Lake Park,FL,ACTIVE
+LAMOINE-ME.GOV,State/Local Govt,Non-Federal Agency,Lamoine,ME,ACTIVE
+LEADERSHIPAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+LEGMT.GOV,State/Local Govt,Non-Federal Agency,Helena,MT,ACTIVE
+LEXINGTON-MA.GOV,State/Local Govt,Non-Federal Agency,Lexington,MA,ACTIVE
+LEXINGTONMA.GOV,State/Local Govt,Non-Federal Agency,Lexington,MA,ACTIVE
+LGADMI.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI,ACTIVE
+LGO-VI.GOV,State/Local Govt,Non-Federal Agency,St. Thomas,VI,ACTIVE
+LICENSEDINIOWA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+LISTOVIRGINIA.GOV,State/Local Govt,Non-Federal Agency,Richmond,VA,ACTIVE
+LIVEHEALTHYNEVADA.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV,ACTIVE
+LOUISIANA.GOV,State/Local Govt,Non-Federal Agency,Baton Rouge,LA,ACTIVE
+LOUISIANAENTERTAINMENT.GOV,State/Local Govt,Non-Federal Agency,Baton Rouge,LA,ACTIVE
+LOUISIANAFASTSTART.GOV,State/Local Govt,Non-Federal Agency,Baton Rouge,LA,ACTIVE
+LOUISIANAMAP.GOV,State/Local Govt,Non-Federal Agency,Baton Rouge,LA,ACTIVE
+LOUISIANAMUSIC.GOV,State/Local Govt,Non-Federal Agency,Baton Rouge,LA,ACTIVE
+LOWELLMA.GOV,State/Local Govt,Non-Federal Agency,Lowell,MA,ACTIVE
+LOXAHATCHEEGROVESFL.GOV,State/Local Govt,Non-Federal Agency,Loxahatchee Groves,FL,ACTIVE
+MA.GOV,State/Local Govt,Non-Federal Agency,Boston,MA,ACTIVE
+MAHOUSE.GOV,State/Local Govt,Non-Federal Agency,Boston,MA,ACTIVE
+MAINE.GOV,State/Local Govt,Non-Federal Agency,Augusta,ME,ACTIVE
+MAINEDOT.GOV,State/Local Govt,Non-Federal Agency,Augusta,ME,ACTIVE
+MAINEFLU.GOV,State/Local Govt,Non-Federal Agency,Augusta,ME,ACTIVE
+MAINEFORESTSERVICE.GOV,State/Local Govt,Non-Federal Agency,AUGUSTA,ME,ACTIVE
+MAINEPUBLICHEALTH.GOV,State/Local Govt,Non-Federal Agency,Augusta,ME,ACTIVE
+MAINEQUALITYFORUM.GOV,State/Local Govt,Non-Federal Agency,Augusta,ME,ACTIVE
+MAINESERVICECOMMISSION.GOV,State/Local Govt,Non-Federal Agency,Augusta,ME,ACTIVE
+MAJURY.GOV,State/Local Govt,Non-Federal Agency,Boston,MA,ACTIVE
+MAKINGCOLORADO.GOV,State/Local Govt,Non-Federal Agency,Boulder,CO,ACTIVE
+MALEGISLATURE.GOV,State/Local Govt,Non-Federal Agency,Boston,MA,ACTIVE
+MAPWV.GOV,State/Local Govt,Non-Federal Agency,Morgantown,WV,ACTIVE
+MARIETTAGA.GOV,State/Local Govt,Non-Federal Agency,Marietta,GA,ACTIVE
+MARIETTAGEORGIA.GOV,State/Local Govt,Non-Federal Agency,Marietta,GA,ACTIVE
+MARSHFIELD-MA.GOV,State/Local Govt,Non-Federal Agency,Marshfield,MA,ACTIVE
+MARYLAND.GOV,State/Local Govt,Non-Federal Agency,Annapolis,MD,ACTIVE
+MARYLANDCOURTS.GOV,State/Local Govt,Non-Federal Agency,Annapolis,MD,ACTIVE
+MARYLANDHEALTHCONNECTION.GOV,State/Local Govt,Non-Federal Agency,Baltimore,MD,ACTIVE
+MARYLANDSOS.GOV,State/Local Govt,Non-Federal Agency,ANNAPOLIS,MD,ACTIVE
+MASENATE.GOV,State/Local Govt,Non-Federal Agency,Boston,MA,ACTIVE
+MASS.GOV,State/Local Govt,Non-Federal Agency,Boston,MA,ACTIVE
+MASSACHUSETTS.GOV,State/Local Govt,Non-Federal Agency,Boston,MA,ACTIVE
+MCAC-MD.GOV,State/Local Govt,Non-Federal Agency,Calverton ,MD,ACTIVE
+MD.GOV,State/Local Govt,Non-Federal Agency,Annapolis,MD,ACTIVE
+MDCAC.GOV,State/Local Govt,Non-Federal Agency,Woodlawn,MD,ACTIVE
+MDCACDOM.GOV,State/Local Govt,Non-Federal Agency,Woodlawn,MD,ACTIVE
+MDCOURTS.GOV,State/Local Govt,Non-Federal Agency,Annapolis,MD,ACTIVE
+ME.GOV,State/Local Govt,Non-Federal Agency,Augusta,ME,ACTIVE
+MEASURETN.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE
+MEDCMI.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI,ACTIVE
+MENTORMICHIGAN.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI,ACTIVE
+MGCBMI.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI,ACTIVE
+MHB.GOV,State/Local Govt,Non-Federal Agency,Mobile,AL,ACTIVE
+MI.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI,ACTIVE
+MI365.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI,ACTIVE
+MIAMI-FL.GOV,State/Local Govt,Non-Federal Agency,Miami,FL,ACTIVE
+MIBUSINESS1STOP.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI,ACTIVE
+MIBUSINESSONESTOP.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI,ACTIVE
+MICH.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI,ACTIVE
+MICHIGAN.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI,ACTIVE
+MICHIGANIDC.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI,ACTIVE
+MILLENNIUMBULKEISWA.GOV,State/Local Govt,Non-Federal Agency,Lacey,WA,ACTIVE
+MILLERSBURGKY.GOV,State/Local Govt,Non-Federal Agency,Millersburg,KY,ACTIVE
+MILTON-FREEWATER-OR.GOV,State/Local Govt,Non-Federal Agency,Milton-Freewater,OR,ACTIVE
+MINNESOTA.GOV,State/Local Govt,Non-Federal Agency,St. Paul,MN,ACTIVE
+MIRAMAR-FL.GOV,State/Local Govt,Non-Federal Agency,Miramar,FL,ACTIVE
+MISSISSIPPI.GOV,State/Local Govt,Non-Federal Agency,Jackson,MS,ACTIVE
+MISSOURI.GOV,State/Local Govt,Non-Federal Agency,Jefferson City,MO,ACTIVE
+MISSOURIINVESTORPROTECTION.GOV,State/Local Govt,Non-Federal Agency,Jefferson City,MO,ACTIVE
+MN.GOV,State/Local Govt,Non-Federal Agency,St. Paul,MN,ACTIVE
+MNCOURTS.GOV,State/Local Govt,Non-Federal Agency,St. Paul,MN,ACTIVE
+MNDISABILITY.GOV,State/Local Govt,Non-Federal Agency,St. Paul,MN,ACTIVE
+MNDNR.GOV,State/Local Govt,Non-Federal Agency,St. Paul,MN,ACTIVE
+MNDOT.GOV,State/Local Govt,Non-Federal Agency,St. Paul,MN,ACTIVE
+MNHOUSING.GOV,State/Local Govt,Non-Federal Agency,St. Paul,MN,ACTIVE
+MO.GOV,State/Local Govt,Non-Federal Agency,Jefferson City,MO,ACTIVE
+MOAPPED.GOV,State/Local Govt,Non-Federal Agency,St. Louis,MO,ACTIVE
+MODOT.GOV,State/Local Govt,Non-Federal Agency,Jefferson City,MO,ACTIVE
+MONSON-MA.GOV,State/Local Govt,Non-Federal Agency,Monson,MA,ACTIVE
+MONTANA.GOV,State/Local Govt,Non-Federal Agency,Helena,MT,ACTIVE
+MOPROSECUTORS.GOV,State/Local Govt,Non-Federal Agency,Jefferson City,MO,ACTIVE
+MRCOG-NM.GOV,State/Local Govt,Non-Federal Agency,Albuquerque,NM,ACTIVE
+MS.GOV,State/Local Govt,Non-Federal Agency,Jackson,MS,ACTIVE
+MSLMI.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI,ACTIVE
+MSPADMI.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI,ACTIVE
+MT.GOV,State/Local Govt,Non-Federal Agency,Helena,MT,ACTIVE
+MTCOUNTYRESULTS.GOV,State/Local Govt,Non-Federal Agency,Helena,MT,ACTIVE
+MTELECTIONRESULTS.GOV,State/Local Govt,Non-Federal Agency,Helena,MT,ACTIVE
+MTSOSFILINGS.GOV,State/Local Govt,Non-Federal Agency,Helena,MT,ACTIVE
+MURRAYCOUNTYGA.GOV,State/Local Govt,Non-Federal Agency,Chatsworth,GA,ACTIVE
+MYALABAMA.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE
+MYALASKA.GOV,State/Local Govt,Non-Federal Agency,Juneau,AK,ACTIVE
+MYFLORIDA.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+MYFLORIDACENSUS.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+MYFLORIDAHOUSE.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+MYHAWAII.GOV,State/Local Govt,Non-Federal Agency,Honolulu,HI,ACTIVE
+MYIN.GOV,State/Local Govt,Non-Federal Agency,Indianapolis,IN,ACTIVE
+MYINDIANA.GOV,State/Local Govt,Non-Federal Agency,Indianapolis,IN,ACTIVE
+MYNCRETIREMENT.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+MYNEVADA.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV,ACTIVE
+MYOHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+MYSC.GOV,State/Local Govt,Non-Federal Agency,Cloumbia,SC,ACTIVE
+MYTENNESSEE.GOV,State/Local Govt,Non-Federal Agency,Smyrna,TN,ACTIVE
+NATICKMA.GOV,State/Local Govt,Non-Federal Agency,Natick,MA,ACTIVE
+NC.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCAGR.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCBAR.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCBROADBAND.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCCARELINK.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCCERTIFIEDPARALEGAL.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCCIVILWAR150.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCCOB.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCCOURTS.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCCPABOARD.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCCRIMELAB.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCDCI.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCDCR.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCDENR.GOV,State/Local Govt,Non-Federal Agency,RALEIGH,NC,ACTIVE
+NCDHHS.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCDOI.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCDOJ.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCDOR.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCDOT.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCDPS.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCESC.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCFAST.GOV,State/Local Govt,Non-Federal Agency,RTP,NC,ACTIVE
+NCFINDOFFENDER.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCFORECLOSUREPREVENTION.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCFORESTPRODUCTS.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCFORESTSERVICE.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCGRANTS.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCICAC.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCISAAC.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCLAMP.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCLAP.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCLAWSPECIALISTS.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCMORTGAGEHELP.GOV,State/Local Govt,Non-Federal Agency,27609,NC,ACTIVE
+NCONEMAP.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCOPENBOOK.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCPARKS.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCPUBLICSCHOOLS.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCREC.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCRETIREMENT.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCSBE.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCSBI.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCSTATE.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCSTATEBAR.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCTREASURER.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCVISION25.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCWORKS.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+ND.GOV,State/Local Govt,Non-Federal Agency,Bismarck,ND,ACTIVE
+NDCENSUS.GOV,State/Local Govt,Non-Federal Agency,Bismarck,ND,ACTIVE
+NDCLOUD.GOV,State/Local Govt,Non-Federal Agency,Bismarck,North Dakota,ACTIVE
+NDCOURTS.GOV,State/Local Govt,Non-Federal Agency,Bismarck,ND,ACTIVE
+NDDATACENTER.GOV,State/Local Govt,Non-Federal Agency,Bismarck,ND,ACTIVE
+NDDOHPRESSROOM.GOV,State/Local Govt,Non-Federal Agency,Bismarck,ND,ACTIVE
+NDHAN.GOV,State/Local Govt,Non-Federal Agency,Bismarck,ND,ACTIVE
+NDHEALTH.GOV,State/Local Govt,Non-Federal Agency,Bismarck,ND,ACTIVE
+NDSTUDIES.GOV,State/Local Govt,Non-Federal Agency,Bismarck,ND,ACTIVE
+NE.GOV,State/Local Govt,Non-Federal Agency,Lincoln,NE,ACTIVE
+NEBRASKA.GOV,State/Local Govt,Non-Federal Agency,Lincoln,NE,ACTIVE
+NEBRASKACORN.GOV,State/Local Govt,Non-Federal Agency,Lincoln,NE,ACTIVE
+NEBRASKALEGISLATURE.GOV,State/Local Govt,Non-Federal Agency,Lincoln,NE,ACTIVE
+NEBRASKAMAP.GOV,State/Local Govt,Non-Federal Agency,Lincoln,NE,ACTIVE
+NEBRASKASPENDING.GOV,State/Local Govt,Non-Federal Agency,Lincoln,NE,ACTIVE
+NEBRASKAUNICAMERAL.GOV,State/Local Govt,Non-Federal Agency,Lincoln,NE,ACTIVE
+NEHEALTHINSURANCEINFO.GOV,State/Local Govt,Non-Federal Agency,Lincoln,NE,ACTIVE
+NETWORKMARYLAND.GOV,State/Local Govt,Non-Federal Agency,Annapolis,MD,ACTIVE
+NETWORKNEBRASKA.GOV,State/Local Govt,Non-Federal Agency,Lincoln,NE,ACTIVE
+NEVADA.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV,ACTIVE
+NEVADAGUARD.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV,ACTIVE
+NEVADAHOMEAGAIN.GOV,State/Local Govt,Non-Federal Agency,Las Vegas,NV,ACTIVE
+NEVADAREADY.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV,ACTIVE
+NEVADATREASURER.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV,ACTIVE
+NEWENGLAND511.GOV,State/Local Govt,Non-Federal Agency,Montpelier,VT,ACTIVE
+NEWHAMPSHIRE.GOV,State/Local Govt,Non-Federal Agency,Concord,NH,ACTIVE
+NEWJERSEY.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+NEWJERSEYBUSINESS.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+NEWJERSEYHOMEKEEPER.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+NEWMEXICO.GOV,State/Local Govt,Non-Federal Agency,Santa Fe,NM,ACTIVE
+NEWTONMA.GOV,State/Local Govt,Non-Federal Agency,Newton,MA,ACTIVE
+NEWYORKHEALTH.GOV,State/Local Govt,Non-Federal Agency,Albany,NY,ACTIVE
+NEXTCHAPTERTN.GOV,State/Local Govt,Non-Federal Agency,Smyrna,TN,ACTIVE
+NH.GOV,State/Local Govt,Non-Federal Agency,Concord,NH,ACTIVE
+NJ.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+NJALERT.GOV,State/Local Govt,Non-Federal Agency,Hamilton,NJ,ACTIVE
+NJCANCER.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+NJCCC.GOV,State/Local Govt,Non-Federal Agency,Atlantic City,NJ,ACTIVE
+NJCCR.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+NJCIVILRIGHTS.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+NJCONSUMERAFFAIRS.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+NJCOURTS.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+NJDOC.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+NJFLUPANDEMIC.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+NJHAS.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+NJHMFA.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+NJHOMEKEEPER.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+NJHOMELANDSECURITY.GOV,State/Local Govt,Non-Federal Agency,Hamilton,NJ,ACTIVE
+NJHOUSING.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+NJHOUSINGRESOURCECENTER.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+NJHRC.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+NJHUMANTRAFFICKING.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+NJJUD.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+NJMEADOWLANDS.GOV,State/Local Govt,Non-Federal Agency,Lyndhurst,NJ,ACTIVE
+NJMEDICALBOARD.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+NJMVC.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+NJMVCONLINE.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+NJOHSP.GOV,State/Local Govt,Non-Federal Agency,Hamilton,NJ,ACTIVE
+NJPAAD.GOV,State/Local Govt,Non-Federal Agency,Mercerville,NJ,ACTIVE
+NJSDA.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+NJSECURITIES.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+NJSENIORGOLD.GOV,State/Local Govt,Non-Federal Agency,Mercerville,NJ,ACTIVE
+NJSHC.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+NJSNAP.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+NJSPEAKUP.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+NJSRGOLD.GOV,State/Local Govt,Non-Federal Agency,Mercerville,NJ,ACTIVE
+NJSTART.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+NM.GOV,State/Local Govt,Non-Federal Agency,Santa Fe,NM,ACTIVE
+NMAG.GOV,State/Local Govt,Non-Federal Agency,Santa Fe,NM,ACTIVE
+NMCOURTS.GOV,State/Local Govt,Non-Federal Agency,Santa Fe,NM,ACTIVE
+NMLEGIS.GOV,State/Local Govt,Non-Federal Agency,Santa Fe,NM,ACTIVE
+NMSTO.GOV,State/Local Govt,Non-Federal Agency,Santa Fe,NM,ACTIVE
+NORTH-DAKOTA.GOV,State/Local Govt,Non-Federal Agency,Bismarck,ND,ACTIVE
+NORTHCAROLINA.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NORTHDAKOTA.GOV,State/Local Govt,Non-Federal Agency,Bismarck,ND,ACTIVE
+NORTHMIAMIFL.GOV,State/Local Govt,Non-Federal Agency,North Miami,FL,ACTIVE
+NOSCAMNC.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NV.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV,ACTIVE
+NVCOURTS.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV,ACTIVE
+NVDOW.GOV,State/Local Govt,Non-Federal Agency,Reno,NV,ACTIVE
+NVDPSPUB.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV,ACTIVE
+NVEASE.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV,ACTIVE
+NVGGMS.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV,ACTIVE
+NVPREPAID.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV,ACTIVE
+NVSEXOFFENDERS.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV,ACTIVE
+NVSILVERFLUME.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV,ACTIVE
+NVSOS.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV,ACTIVE
+NY.GOV,State/Local Govt,Non-Federal Agency,Albany,NY,ACTIVE
+NYALERT.GOV,State/Local Govt,Non-Federal Agency,Albany,NY,ACTIVE
+NYASSEMBLY.GOV,State/Local Govt,Non-Federal Agency,Albany,NY,ACTIVE
+NYCOURTHELP.GOV,State/Local Govt,Non-Federal Agency,Troy,NY,ACTIVE
+NYCOURTS.GOV,State/Local Govt,Non-Federal Agency,Troy,NY,ACTIVE
+NYGOVOFFICE.GOV,State/Local Govt,Non-Federal Agency,Albany,NY,ACTIVE
+NYHALLOFGOVERNORS.GOV,State/Local Govt,Non-Federal Agency,Albany,NY,ACTIVE
+NYHEALTH.GOV,State/Local Govt,Non-Federal Agency,Albany,NY,ACTIVE
+NYHOUSINGSEARCH.GOV,State/Local Govt,Non-Federal Agency,Albany,NY,ACTIVE
+NYJUROR.GOV,State/Local Govt,Non-Federal Agency,New York,NY,ACTIVE
+NYOPENFORBUSINESS.GOV,State/Local Govt,Non-Federal Agency,Albany,NY,ACTIVE
+NYPA.GOV,State/Local Govt,Non-Federal Agency,WHITE PLAINS,NY,ACTIVE
+NYPREPARE.GOV,State/Local Govt,Non-Federal Agency,Albany,NY,ACTIVE
+NYSCANALS.GOV,State/Local Govt,Non-Federal Agency,Albany,NY,ACTIVE
+NYSDOT.GOV,State/Local Govt,Non-Federal Agency,Albany,NY,ACTIVE
+NYSED.GOV,State/Local Govt,Non-Federal Agency,Albany,NY,ACTIVE
+NYSENATE.GOV,State/Local Govt,Non-Federal Agency,Albany,NY,ACTIVE
+NYSTAX.GOV,State/Local Govt,Non-Federal Agency,Albany,NY,ACTIVE
+NYSTHRUWAY.GOV,State/Local Govt,Non-Federal Agency,Albany,NY,ACTIVE
+OCFODC.GOV,State/Local Govt,Non-Federal Agency,Washington,DC,ACTIVE
+OCPR.GOV,State/Local Govt,Non-Federal Agency,San Juan,PR,ACTIVE
+OH.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOAGRICULTURE.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOANALYTICS.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOATTORNEYGENERAL.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOAUDITOR.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOBMV.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOCENTERFORNURSING.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOCHECKBOOK.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOCOURTOFCLAIMS.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOCOURTS.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIODNR.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOHERETOHELP.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOHOUSE.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOHOUSINGLOCATOR.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOJOBS.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOJUDICIALCENTER.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOMEANSACCESSIBILITY.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOMEANSJOBS.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOMEANSTRAINING.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOMEANSVETERANSJOBS.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIONOSMOKELAW.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOPMP.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIORED.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIORESPONDS.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOSAFEID.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOSECRETARYOFSTATE.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOSENATE.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOSUPREMECOURT.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOTHIRDFRONTIER.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOTPES.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOTREASURER.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOVALUESVETERANS.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOVALUESVETS.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOVET.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOVETERANSHOME.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOVETHOF.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOVETS.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOVETSHOF.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOWOMENVETS.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OK.GOV,State/Local Govt,Non-Federal Agency,Oklahoma City,OK,ACTIVE
+OKBENEFITS.GOV,State/Local Govt,Non-Federal Agency,Oklahoma City,OK,ACTIVE
+OKC.GOV,State/Local Govt,Non-Federal Agency,Oklahoma City,OK,ACTIVE
+OKCOMMERCE.GOV,State/Local Govt,Non-Federal Agency,Oklahoma city,OK,ACTIVE
+OKDHS.GOV,State/Local Govt,Non-Federal Agency,Oklahoma City,OK,ACTIVE
+OKDRS.GOV,State/Local Govt,Non-Federal Agency,Oklahoma City,OK,ACTIVE
+OKGEOSURVEY1.GOV,State/Local Govt,Non-Federal Agency,Norman,OK,ACTIVE
+OKHOUSE.GOV,State/Local Govt,Non-Federal Agency,Oklahoma City,OK,ACTIVE
+OKLAHOMA.GOV,State/Local Govt,Non-Federal Agency,Oklahoma City,OK,ACTIVE
+OKLAHOMABENEFITS.GOV,State/Local Govt,Non-Federal Agency,Oklahoma City,OK,ACTIVE
+OKLAHOMAWORKS.GOV,State/Local Govt,Non-Federal Agency,Oklahoma City,OK,ACTIVE
+OKLEGISLATURE.GOV,State/Local Govt,Non-Federal Agency,Oklahoma City,OK,ACTIVE
+OKSENATE.GOV,State/Local Govt,Non-Federal Agency,Oklahoma City,OK,ACTIVE
+OLATHEKS.GOV,State/Local Govt,Non-Federal Agency,Olathe,KS,ACTIVE
+ONESTOPFLORIDA.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,SERVER-HOLD
+ONSLOWCOUNTYNC.GOV,State/Local Govt,Non-Federal Agency,Jacksonville,NC,ACTIVE
+OPC-DC.GOV,State/Local Govt,Non-Federal Agency,Washington,DC,ACTIVE
+OPEN-DC.GOV,State/Local Govt,Non-Federal Agency,Washington,DC,ACTIVE
+OPENMYFLORIDABUSINESS.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+OPENOHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OR-MEDICAID.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE
+OR.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE
+ORCLIMATECHANGE.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE
+OREGON.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE
+OREGONATTORNEYGENERAL.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE
+OREGONBENEFITSONLINE.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE
+OREGONBUDGET.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE
+OREGONBUYS.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE
+OREGONCHILDSUPPORT.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE
+OREGONCONSUMER.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE
+OREGONFORESTRY.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE
+OREGONHEALTHCARE.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE
+OREGONHEALTHYKIDS.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE
+OREGONHOMEOWNERSUPPORT.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE
+OREGONLEGISLATURE.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE
+OREGONMARINERESERVES.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE
+OREGONMETRO.GOV,State/Local Govt,Non-Federal Agency,Portland,OR,ACTIVE
+OREGONMOTORVOTER.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE
+OREGONRX.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE
+OREGONSTUDENTAID.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE
+OREGONUSF.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE
+OREGONVOTES.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE
+ORHEALTHCARE.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE
+OSE-CT.GOV,State/Local Govt,Non-Federal Agency,Hartford,CT,ACTIVE
+OUTDOORNEBRASKA.GOV,State/Local Govt,Non-Federal Agency,Lincoln,NE,ACTIVE
+OVERLANDPARKKS.GOV,State/Local Govt,Non-Federal Agency,Overland Park,KS,ACTIVE
+PA.GOV,State/Local Govt,Non-Federal Agency,Harrisburg,PA,ACTIVE
+PA529.GOV,State/Local Govt,Non-Federal Agency,Harrisburg,PA,ACTIVE
+PA529ABLE.GOV,State/Local Govt,Non-Federal Agency,Harrisburg,PA,ACTIVE
+PAABLE.GOV,State/Local Govt,Non-Federal Agency,Harrisburg,PA,ACTIVE
+PAACPAMMMI.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI,ACTIVE
+PAAUDITOR.GOV,State/Local Govt,Non-Federal Agency,Harrisburg,PA,ACTIVE
+PACIFICFLYWAY.GOV,State/Local Govt,Non-Federal Agency,Vancouver,WA,ACTIVE
+PADILLABAY.GOV,State/Local Govt,Non-Federal Agency,MOUNT VERNON,WA,ACTIVE
+PAHOUSE.GOV,State/Local Govt,Non-Federal Agency,Harrisburg,PA,ACTIVE
+PAINVEST.GOV,State/Local Govt,Non-Federal Agency,Harrisburg,PA,ACTIVE
+PALMBEACHCOUNTYTAXCOLLECTOR-FL.GOV,State/Local Govt,Non-Federal Agency,West Palm Beach,FL,ACTIVE
+PANYNJ.GOV,State/Local Govt,Non-Federal Agency,New York,NY,ACTIVE
+PAOPENFORBUSINESS.GOV,State/Local Govt,Non-Federal Agency,Harrisburg,PA,ACTIVE
+PARTNERSFORHEALTHTN.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE
+PASEN.GOV,State/Local Govt,Non-Federal Agency,Harrisburg,PA,ACTIVE
+PASENATE.GOV,State/Local Govt,Non-Federal Agency,Harrisburg,PA,ACTIVE
+PATREASURY.GOV,State/Local Govt,Non-Federal Agency,Harrisburg,PA,ACTIVE
+PAULDING.GOV,State/Local Govt,Non-Federal Agency,Dallas,GA,ACTIVE
+PAYIOWA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+PAYMAINE.GOV,State/Local Govt,Non-Federal Agency,Augusta,ME,ACTIVE
+PEACHTREECORNERSGA.GOV,State/Local Govt,Non-Federal Agency,PEACHTREE CORNERS,GA,ACTIVE
+PENNDOT.GOV,State/Local Govt,Non-Federal Agency,Harrisburg,PA,ACTIVE
+PENNSYLVANIA.GOV,State/Local Govt,Non-Federal Agency,Harrisburg,PA,ACTIVE
+PERRY-GA.GOV,State/Local Govt,Non-Federal Agency,Perry,GA,ACTIVE
+PINECREST-FL.GOV,State/Local Govt,Non-Federal Agency,Pinecrest,FL,ACTIVE
+PINELLASCOUNTY-FL.GOV,State/Local Govt,Non-Federal Agency,Clearwater,FL,ACTIVE
+PINELLASCOUNTYFL.GOV,State/Local Govt,Non-Federal Agency,Clearwater,FL,ACTIVE
+PLAINVILLE-CT.GOV,State/Local Govt,Non-Federal Agency,Plainville,CT,ACTIVE
+PPA-OR.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE
+PR.GOV,State/Local Govt,Non-Federal Agency,San Juan,PR,ACTIVE
+PREVENTHAIAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+PROVINCETOWN-MA.GOV,State/Local Govt,Non-Federal Agency,Provincetown,MA,ACTIVE
+PUERTORICO.GOV,State/Local Govt,Non-Federal Agency,San Juan,PR,ACTIVE
+QAAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+QUALITYFIRSTAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+READYALABAMA.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE
+READYNH.GOV,State/Local Govt,Non-Federal Agency,Concord,NH,ACTIVE
+READYVIRGINIA.GOV,State/Local Govt,Non-Federal Agency,Richmond,VA,ACTIVE
+READYWV.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE
+RECYCLEOHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+REDISTRICTINGFLORIDA.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+REGISTERTOVOTENV.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV,ACTIVE
+RELAYUTAH.GOV,State/Local Govt,Non-Federal Agency,Salt Lake City,UT,ACTIVE
+REPORTITTN.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE
+RETIREREADYTN.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE
+RHODEISLAND.GOV,State/Local Govt,Non-Federal Agency,Providence,RI,ACTIVE
+RI.GOV,State/Local Govt,Non-Federal Agency,Providence,RI,ACTIVE
+RIDESHAREWI.GOV,State/Local Govt,Non-Federal Agency,Madison,WI,ACTIVE
+RIDESHAREWISCONSIN.GOV,State/Local Govt,Non-Federal Agency,Madison,WI,ACTIVE
+RILEGISLATURE.GOV,State/Local Govt,Non-Federal Agency,Providence,RI,ACTIVE
+RIPSGA.GOV,State/Local Govt,Non-Federal Agency,North Scituate,RI,ACTIVE
+RISP.GOV,State/Local Govt,Non-Federal Agency,North Scituate,RI,ACTIVE
+ROCKISLANDTOWNSHIPIL.GOV,State/Local Govt,Non-Federal Agency,Rock Island,IL,ACTIVE
+ROWANCOUNTYNC.GOV,State/Local Govt,Non-Federal Agency,Salisbury,NC,ACTIVE
+RSA-AL.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE
+RULEWATCHOHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+SACOMAINE.GOV,State/Local Govt,Non-Federal Agency,Saco,ME,ACTIVE
+SAFEHOMEALABAMA.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE
+SAFERFLORIDAHIGHWAYS.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+SAFERFLORIDAROADS.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+SAFESD.GOV,State/Local Govt,Non-Federal Agency,Pierre,SD,ACTIVE
+SALINA-KS.GOV,State/Local Govt,Non-Federal Agency,Salina,KS,ACTIVE
+SANDPOINTIDAHO.GOV,State/Local Govt,Non-Federal Agency,Sandpoint,ID,ACTIVE
+SAOMT.GOV,State/Local Govt,Non-Federal Agency,Helena,MT,ACTIVE
+SAVEMYHOMEAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+SAVEOURHOMEAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+SC.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC,ACTIVE
+SCAG.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC,ACTIVE
+SCCONSUMER.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC,ACTIVE
+SCDEW.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC,ACTIVE
+SCDHEC.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC,ACTIVE
+SCDHHS.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC,ACTIVE
+SCDPS.GOV,State/Local Govt,Non-Federal Agency,Blythewood,SC,ACTIVE
+SCFC.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC,ACTIVE
+SCHELP.GOV,State/Local Govt,Non-Federal Agency,Columbia`,SC,ACTIVE
+SCHOUSE.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC,ACTIVE
+SCNEWHIRE.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC,ACTIVE
+SCOH.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+SCOHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+SCOTTCOUNTYIOWA.GOV,State/Local Govt,Non-Federal Agency,Davenport,IA,ACTIVE
+SCSENATE.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC,ACTIVE
+SCSERV.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC,ACTIVE
+SCSTATEHOUSE.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC,ACTIVE
+SD.GOV,State/Local Govt,Non-Federal Agency,Pierre,SD,ACTIVE
+SDAUDITOR.GOV,State/Local Govt,Non-Federal Agency,Pierre,SD,ACTIVE
+SDBMOE.GOV,State/Local Govt,Non-Federal Agency,Pierre,SD,ACTIVE
+SDLEGISLATURE.GOV,State/Local Govt,Non-Federal Agency,pierre,SD,ACTIVE
+SDSOS.GOV,State/Local Govt,Non-Federal Agency,Pierre,SD,ACTIVE
+SDTREASURER.GOV,State/Local Govt,Non-Federal Agency,Pierre,SD,ACTIVE
+SEDGWICK.GOV,State/Local Govt,Non-Federal Agency,Wichita,KS,ACTIVE
+SEELYVILLE-IN.GOV,State/Local Govt,Non-Federal Agency,Seelyville,IN,ACTIVE
+SEMINOLECOUNTYFL.GOV,State/Local Govt,Non-Federal Agency,Sanford,FL,ACTIVE
+SERVEALABAMA.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE
+SERVEIDAHO.GOV,State/Local Govt,Non-Federal Agency,Boise,ID,ACTIVE
+SERVEOHIO.GOV,State/Local Govt,Non-Federal Agency,Columb us,OH,ACTIVE
+SERVGA.GOV,State/Local Govt,Non-Federal Agency,Atlanta,GA,ACTIVE
+SFWMD.GOV,State/Local Govt,Non-Federal Agency,West Palm Beach,FL,ACTIVE
+SHAPINGNEWJERSEY.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+SHAPINGNJ.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+SHAREOHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+SHREWSBURY-MA.GOV,State/Local Govt,Non-Federal Agency,Shrewsbury,MA,ACTIVE
+SOSNC.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+SOUTHCAROLINA.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC,ACTIVE
+SOUTHERNSHORES-NC.GOV,State/Local Govt,Non-Federal Agency,Southern Shores,NC,ACTIVE
+SPACEFLORIDA.GOV,State/Local Govt,Non-Federal Agency,Cape Canaveral,FL,ACTIVE
+STAGINGAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+STATEOFSOUTHCAROLINA.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC,ACTIVE
+STATEOFWV.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE
+STILLWATERCOUNTYMT.GOV,State/Local Govt,Non-Federal Agency,Columbus,MT,ACTIVE
+STOPFRAUDCOLORADO.GOV,State/Local Govt,Non-Federal Agency,Denver,CO,ACTIVE
+STOUGHTON-MA.GOV,State/Local Govt,Non-Federal Agency,Stoughton,MA,ACTIVE
+STOW-MA.GOV,State/Local Govt,Non-Federal Agency,Stow,MA,ACTIVE
+STPAULSNC.GOV,State/Local Govt,Non-Federal Agency,St. Pauls,NC,ACTIVE
+SUNRISEFL.GOV,State/Local Govt,Non-Federal Agency,Sunrise,FL,ACTIVE
+SUNRISEFLORIDA.GOV,State/Local Govt,Non-Federal Agency,Sunrise,FL,ACTIVE
+SUPREMECOURTOFOHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+SURFCITYNC.GOV,State/Local Govt,Non-Federal Agency,Surf City,NC,ACTIVE
+SWEETHOMEALABAMA.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE
+TAKOMAPARKMD.GOV,State/Local Govt,Non-Federal Agency,Takoma Park,MD,ACTIVE
+TEACHIOWA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+TEAMGA.GOV,State/Local Govt,Non-Federal Agency,Atlanta,GA,ACTIVE
+TEAMGEORGIA.GOV,State/Local Govt,Non-Federal Agency,Atlanta,GA,ACTIVE
+TEAMTN.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE
+TENNESSEE.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE
+TENNESSEECOLLEGEADVISER.GOV,State/Local Govt,Non-Federal Agency,Smyrna,TN,ACTIVE
+TENNESSEECOLLEGEADVISOR.GOV,State/Local Govt,Non-Federal Agency,Smyrna,TN,ACTIVE
+TENNESSEEIIS.GOV,State/Local Govt,Non-Federal Agency,Smyrna,TN,ACTIVE
+TENNESSEEPROMISE.GOV,State/Local Govt,Non-Federal Agency,Smyrna,TN,ACTIVE
+TENNESSEERECONNECT.GOV,State/Local Govt,Non-Federal Agency,Smyrna,TN,ACTIVE
+TESTOHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+TEWKSBURY-MA.GOV,State/Local Govt,Non-Federal Agency,Tewksbury,MA,ACTIVE
+TEXAS.GOV,State/Local Govt,Non-Federal Agency,Austin,TX,ACTIVE
+TEXAS511.GOV,State/Local Govt,Non-Federal Agency,Austin,TX,ACTIVE
+TEXASAGRICULTURE.GOV,State/Local Govt,Non-Federal Agency,Austin,TX,ACTIVE
+TEXASATTORNEYGENERAL.GOV,State/Local Govt,Non-Federal Agency,Austin,TX,ACTIVE
+TEXASCHILDRENSCOMMISSION.GOV,State/Local Govt,Non-Federal Agency,Austin,TX,ACTIVE
+TEXASFIGHTSIDTHEFT.GOV,State/Local Govt,Non-Federal Agency,Austin,TX,ACTIVE
+TEXASONLINE.GOV,State/Local Govt,Non-Federal Agency,Austin,TX,ACTIVE
+TEXASSTATEPARKS.GOV,State/Local Govt,Non-Federal Agency,Austin,TX,ACTIVE
+TEXASSUPREMECOURTCOMMISSION.GOV,State/Local Govt,Non-Federal Agency,Austin,TX,ACTIVE
+THA.GOV,State/Local Govt,Non-Federal Agency,Topeka,KS,ACTIVE
+THEFTAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+THERIGHTCALLIOWA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+THESTATEOFSOUTHCAROLINA.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC,ACTIVE
+TN.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE
+TNAG.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE
+TNCOLLATERALMANAGEMENT.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE
+TNCOLLEGEADVISER.GOV,State/Local Govt,Non-Federal Agency,Smyrna,TN,ACTIVE
+TNCOLLEGEADVISOR.GOV,State/Local Govt,Non-Federal Agency,Smyrna,TN,ACTIVE
+TNCOURTS.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE
+TNECD.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE
+TNEDU.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE
+TNFAFSAFRENZY.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE
+TNIIS.GOV,State/Local Govt,Non-Federal Agency,Smyrna,TN,ACTIVE
+TNK12.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE
+TNPROMISE.GOV,State/Local Govt,Non-Federal Agency,Smyrna,TN,ACTIVE
+TNQUITLINE.GOV,State/Local Govt,Non-Federal Agency,Smyrna,TN,ACTIVE
+TNREADY.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE
+TNRECONNECT.GOV,State/Local Govt,Non-Federal Agency,Smyrna,TN,ACTIVE
+TNTOOLKIT.GOV,State/Local Govt,Non-Federal Agency,Smyrna,TN,ACTIVE
+TNTREASURY.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE
+TNVACATION.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE
+TOURISMOHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+TOWNOFGOLDENMEADOW-LA.GOV,State/Local Govt,Non-Federal Agency,Golden Meadow,LA,ACTIVE
+TOWNOFWINGATENC.GOV,State/Local Govt,Non-Federal Agency,Wingate,NC,ACTIVE
+TRANSPARENCYFLORIDA.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+TRANSPARENCYWV.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE
+TRAVELWYOMING.GOV,State/Local Govt,Non-Federal Agency,Cheyenne,WY,ACTIVE
+TRUSTTENNESSEE.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE
+TRUSTTN.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE
+TTD.GOV,State/Local Govt,Non-Federal Agency,East Norwalk,CT,ACTIVE
+TX.GOV,State/Local Govt,Non-Federal Agency,Austin,TX,ACTIVE
+TX511.GOV,State/Local Govt,Non-Federal Agency,Austin,TX,ACTIVE
+TXAG.GOV,State/Local Govt,Non-Federal Agency,Austin,TX,ACTIVE
+TXCOURTS.GOV,State/Local Govt,Non-Federal Agency,Austin,TX,ACTIVE
+TXDMV.GOV,State/Local Govt,Non-Federal Agency,Austin,TX,ACTIVE
+TXDOT.GOV,State/Local Govt,Non-Federal Agency,Austin,TX,ACTIVE
+TXDPS.GOV,State/Local Govt,Non-Federal Agency,Austin,TX,ACTIVE
+TXMAP.GOV,State/Local Govt,Non-Federal Agency,Austin,TX,ACTIVE
+TXOAG.GOV,State/Local Govt,Non-Federal Agency,Austin,TX,ACTIVE
+US41WISCONSIN.GOV,State/Local Govt,Non-Federal Agency,Madison,WI,ACTIVE
+UTAH.GOV,State/Local Govt,Non-Federal Agency,Salt Lake City,UT,ACTIVE
+UTAHLAKE.GOV,State/Local Govt,Non-Federal Agency,Salt Lake City,UT,ACTIVE
+UTAHTRUST.GOV,State/Local Govt,Non-Federal Agency,North Salt Lake,UT,ACTIVE
+UTCOURTS.GOV,State/Local Govt,Non-Federal Agency,Salt Lake City,UT,ACTIVE
+VACOURTS.GOV,State/Local Govt,Non-Federal Agency,Richmond,VA,ACTIVE
+VAEMERGENCY.GOV,State/Local Govt,Non-Federal Agency,Richmond,VA,ACTIVE
+VERMONT.GOV,State/Local Govt,Non-Federal Agency,Montpelier,VT,ACTIVE
+VERMONTHEALTHCONNECT.GOV,State/Local Govt,Non-Federal Agency,Montpelier,VT,ACTIVE
+VERMONTTAXAMNESTY.GOV,State/Local Govt,Non-Federal Agency,Montpelier,VT,ACTIVE
+VERMONTTREASURER.GOV,State/Local Govt,Non-Federal Agency,Montpelier,VT,ACTIVE
+VERMONTVOTESFORKIDS.GOV,State/Local Govt,Non-Federal Agency,Montpelier,VT,ACTIVE
+VI.GOV,State/Local Govt,Non-Federal Agency,St. Thomas,VI,ACTIVE
+VIALERT.GOV,State/Local Govt,Non-Federal Agency,St. Thomas,VI,ACTIVE
+VIBIR.GOV,State/Local Govt,Non-Federal Agency,St. Thomas,VI,ACTIVE
+VIDOL.GOV,State/Local Govt,Non-Federal Agency,St. Thomas,VI,ACTIVE
+VIHFA.GOV,State/Local Govt,Non-Federal Agency,St. Thomas,VI,ACTIVE
+VILLAGEOFPENINSULA-OH.GOV,State/Local Govt,Non-Federal Agency,Peninsula,OH,ACTIVE
+VIRGINIA.GOV,State/Local Govt,Non-Federal Agency,Chester,VA,ACTIVE
+VIRGINIACAPITAL.GOV,State/Local Govt,Non-Federal Agency,Richmond,VA,ACTIVE
+VIRGINIACAPITOL.GOV,State/Local Govt,Non-Federal Agency,Richmond,VA,ACTIVE
+VIRGINIAGENERALASSEMBLY.GOV,State/Local Govt,Non-Federal Agency,Richmond,VA,ACTIVE
+VIRGINIARESOURCES.GOV,State/Local Govt,Non-Federal Agency,Richmond,VA,ACTIVE
+VIRGINIASTATEPARKS.GOV,State/Local Govt,Non-Federal Agency,Richmond,VA,ACTIVE
+VISITIDAHO.GOV,State/Local Govt,Non-Federal Agency,Boise,ID,ACTIVE
+VISITNEBRASKA.GOV,State/Local Govt,Non-Federal Agency,Lincoln,NE,ACTIVE
+VISITNH.GOV,State/Local Govt,Non-Federal Agency,Concord,NH,ACTIVE
+VISITWYO.GOV,State/Local Govt,Non-Federal Agency,Cheyenne,WY,ACTIVE
+VISITWYOMING.GOV,State/Local Govt,Non-Federal Agency,Cheyenne,WY,ACTIVE
+VITEMA.GOV,State/Local Govt,Non-Federal Agency,St. Thomas,VI,ACTIVE
+VIVOTE.GOV,State/Local Govt,Non-Federal Agency,St Croix,VI,ACTIVE
+VOLUNTEERLOUISIANA.GOV,State/Local Govt,Non-Federal Agency,Baton Rouge,LA,ACTIVE
+VOTETEXAS.GOV,State/Local Govt,Non-Federal Agency,Austin,TX,ACTIVE
+VT.GOV,State/Local Govt,Non-Federal Agency,Montpelier,VT,ACTIVE
+VTALERT.GOV,State/Local Govt,Non-Federal Agency,Montpelier,VT,ACTIVE
+WA.GOV,State/Local Govt,Non-Federal Agency,Olympia,WA,ACTIVE
+WAKECOUNTYNC.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+WALDOCOUNTYME.GOV,State/Local Govt,Non-Federal Agency,Belfast,ME,ACTIVE
+WALPOLE-MA.GOV,State/Local Govt,Non-Federal Agency,Walpole,MA,ACTIVE
+WALTONCOUNTYGA.GOV,State/Local Govt,Non-Federal Agency,Monroe,GA,ACTIVE
+WASHINGTON-NC.GOV,State/Local Govt,Non-Federal Agency,Washington,NC,ACTIVE
+WASHINGTON.GOV,State/Local Govt,Non-Federal Agency,Olympia,WA,ACTIVE
+WASHINGTONDC.GOV,State/Local Govt,Non-Federal Agency,"Washington,",DC,ACTIVE
+WASHINGTONNC.GOV,State/Local Govt,Non-Federal Agency,Washington,NC,ACTIVE
+WASHINGTONSTATE.GOV,State/Local Govt,Non-Federal Agency,Olympia,WA,ACTIVE
+WATAUGACOUNTYNC.GOV,State/Local Govt,Non-Federal Agency,Boone,NC,ACTIVE
+WCNYH.GOV,State/Local Govt,Non-Federal Agency,New YOrk,NY,ACTIVE
+WENHAMMA.GOV,State/Local Govt,Non-Federal Agency,Wenham,MA,ACTIVE
+WESTVIRGINIA.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE
+WHITMAN-MA.GOV,State/Local Govt,Non-Federal Agency,Whitman,MA,ACTIVE
+WHYNEVADA.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV,ACTIVE
+WI-TIME.GOV,State/Local Govt,Non-Federal Agency,Madison,WI,ACTIVE
+WI-WORCS.GOV,State/Local Govt,Non-Federal Agency,Madison,WI,ACTIVE
+WI.GOV,State/Local Govt,Non-Federal Agency,Madison,WI,ACTIVE
+WIBADGERTRACS.GOV,State/Local Govt,Non-Federal Agency,Madison,WI,ACTIVE
+WICONNECTIONS2030.GOV,State/Local Govt,Non-Federal Agency,Madison,WI,ACTIVE
+WICOURTS.GOV,State/Local Govt,Non-Federal Agency,MADISON,WI,ACTIVE
+WIDOC.GOV,State/Local Govt,Non-Federal Agency,Madison,WI,ACTIVE
+WIGRANTS.GOV,State/Local Govt,Non-Federal Agency,Madison,WI,ACTIVE
+WILAWLIBRARY.GOV,State/Local Govt,Non-Federal Agency,Madison,WI,ACTIVE
+WILDOHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+WILMINGTON-NC.GOV,State/Local Govt,Non-Federal Agency,Wilmington,NC,ACTIVE
+WILMINGTONNC.GOV,State/Local Govt,Non-Federal Agency,Wilmington,NC,ACTIVE
+WINTERGARDEN-FL.GOV,State/Local Govt,Non-Federal Agency,Winter Garden,FL,ACTIVE
+WINTERPORTMAINE.GOV,State/Local Govt,Non-Federal Agency,Winterport,ME,ACTIVE
+WINTERSPRINGSFL.GOV,State/Local Govt,Non-Federal Agency,Winter Springs,FL,ACTIVE
+WISC.GOV,State/Local Govt,Non-Federal Agency,Madison,WI,ACTIVE
+WISCONSIN.GOV,State/Local Govt,Non-Federal Agency,Madison,WI,ACTIVE
+WISCONSINCRIMEALERT.GOV,State/Local Govt,Non-Federal Agency,Madison,WI,ACTIVE
+WISCONSINDMV.GOV,State/Local Govt,Non-Federal Agency,Madison,WI,ACTIVE
+WISCONSINDOT.GOV,State/Local Govt,Non-Federal Agency,Madison,WI,ACTIVE
+WISCONSINFREIGHTPLAN.GOV,State/Local Govt,Non-Federal Agency,Madison,WI,ACTIVE
+WISCONSINRAILPLAN.GOV,State/Local Govt,Non-Federal Agency,Madison,WI,ACTIVE
+WISCONSINROUNDABOUTS.GOV,State/Local Govt,Non-Federal Agency,Madison,WI,ACTIVE
+WMATA.GOV,State/Local Govt,Non-Federal Agency,Washington,DC,ACTIVE
+WORKFORCEONETOUCHTN.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE
+WORKFORNC.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+WSDOT.GOV,State/Local Govt,Non-Federal Agency,Olympia,WA,ACTIVE
+WV.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE
+WV457.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE
+WVAGO.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE
+WVCOMMERCE.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE
+WVCONSUMERPROTECTION.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE
+WVCSI.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE
+WVDHSEM.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE
+WVDNR.GOV,State/Local Govt,Non-Federal Agency,South Charleston,WV,ACTIVE
+WVHOUSE.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE
+WVINSURANCE.GOV,State/Local Govt,Non-Federal Agency,Charleson,WV,ACTIVE
+WVLEGISLATURE.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE
+WVOASIS.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE
+WVOT.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE
+WVOTA.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE
+WVPRESIDENT.GOV,State/Local Govt,Non-Federal Agency,Morgantown,WV,ACTIVE
+WVPURCHASING.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE
+WVREVENUE.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE
+WVSAO.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE
+WVSENATE.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE
+WVSENIORSERVICES.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE
+WVSP.GOV,State/Local Govt,Non-Federal Agency,South Charleston,WV,ACTIVE
+WVSPEAKER.GOV,State/Local Govt,Non-Federal Agency,Morgantown,WV,ACTIVE
+WVSTO.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE
+WVSURPLUS.GOV,State/Local Govt,Non-Federal Agency,Dunbar,WV,ACTIVE
+WVTAX.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE
+WY.GOV,State/Local Govt,Non-Federal Agency,Cheyenne,WY,ACTIVE
+WYCAMPAIGNFINANCE.GOV,State/Local Govt,Non-Federal Agency,Cheyenne,WY,ACTIVE
+WYO.GOV,State/Local Govt,Non-Federal Agency,Cheyenne,WY,ACTIVE
+WYOBOARDS.GOV,State/Local Govt,Non-Federal Agency,Cheyenne,WY,ACTIVE
+WYOLEG.GOV,State/Local Govt,Non-Federal Agency,Cheyenne,WY,ACTIVE
+WYOMING.GOV,State/Local Govt,Non-Federal Agency,Cheyenne,WY,ACTIVE
+WYOMINGAGCARE.GOV,State/Local Govt,Non-Federal Agency,Cheyenne,WY,ACTIVE
+WYOMINGLMI.GOV,State/Local Govt,Non-Federal Agency,cheyenne,WY,ACTIVE
+WYOMINGOFFICEOFTOURISM.GOV,State/Local Govt,Non-Federal Agency,Cheyenne,WY,ACTIVE
+WYOREG.GOV,State/Local Govt,Non-Federal Agency,cheyenne,WY,ACTIVE
+WYWINDFALL.GOV,State/Local Govt,Non-Federal Agency,cheyenne,WY,ACTIVE
+YADKINCOUNTY.GOV,State/Local Govt,Non-Federal Agency,Yadkinville,NC,ACTIVE
+YADKINCOUNTYNC.GOV,State/Local Govt,Non-Federal Agency,Yadkinville,NC,ACTIVE
+YANCEYVILLENC.GOV,State/Local Govt,Non-Federal Agency,Roxboro,NC,ACTIVE
+ZEROINWISCONSIN.GOV,State/Local Govt,Non-Federal Agency,Madison,WI,ACTIVE
+ZIONSVILLE-IN.GOV,State/Local Govt,Non-Federal Agency,Zionsville,IN,ACTIVE

--- a/dotgov-domains/current-full.csv
+++ b/dotgov-domains/current-full.csv
@@ -1,0 +1,5662 @@
+Domain Name,Domain Type,Agency,City,State,Status
+SANFRANCISCO.GOV,City,General Services Administration,San Francisco,CA,ACTIVE
+SF.GOV,City,General Services Administration,San Francisco,CA,ACTIVE
+ABERDEENMD.GOV,City,Non-Federal Agency,Aberdeen,MD,ACTIVE
+ABERDEENWA.GOV,City,Non-Federal Agency,Aberdeen,WA,ACTIVE
+ABINGDON-VA.GOV,City,Non-Federal Agency,Abingdon,VA,ACTIVE
+ABINGTONMA.GOV,City,Non-Federal Agency,Abington,MA,ACTIVE
+ABSECONNJ.GOV,City,Non-Federal Agency,Absecon,NJ,ACTIVE
+ACCESSPRINCETONNJ.GOV,City,Non-Federal Agency,Princeton,NJ,ACTIVE
+ACTON-MA.GOV,City,Non-Federal Agency,Acton,MA,ACTIVE
+ACTONMA.GOV,City,Non-Federal Agency,Acton,MA,ACTIVE
+ADAK-AK.GOV,City,Non-Federal Agency,Adak,AK,ACTIVE
+ADAMN.GOV,City,Non-Federal Agency,Ada,MN,ACTIVE
+ADDISONTX.GOV,City,Non-Federal Agency,Addison,TX,ACTIVE
+ADRIANMI.GOV,City,Non-Federal Agency,Adrian,MI,ACTIVE
+AFTONWYOMING.GOV,City,Non-Federal Agency,AFTON,WY,ACTIVE
+AKRONOHIO.GOV,City,Non-Federal Agency,Akron,OH,ACTIVE
+ALAMEDACA.GOV,City,Non-Federal Agency,Alameda,CA,ACTIVE
+ALAMOHEIGHTSTX.GOV,City,Non-Federal Agency,Alamo Heights,TX,ACTIVE
+ALBANYNY.GOV,City,Non-Federal Agency,Albany,NY,ACTIVE
+ALBEMARLENC.GOV,City,Non-Federal Agency,Albemarle,NC,ACTIVE
+ALBUQUERQUE-NM.GOV,City,Non-Federal Agency,Albuquerque,NM,ACTIVE
+ALEKNAGIKAK.GOV,City,Non-Federal Agency,Aleknagik,AK,ACTIVE
+ALEXANDERCITYAL.GOV,City,Non-Federal Agency,Alexander City,AL,ACTIVE
+ALEXANDRIANJ.GOV,City,Non-Federal Agency,Milford,NJ,ACTIVE
+ALEXANDRIAVA.GOV,City,Non-Federal Agency,Alexandria,VA,ACTIVE
+ALFREDME.GOV,City,Non-Federal Agency,Alfred,ME,ACTIVE
+ALGONAC-MI.GOV,City,Non-Federal Agency,Algonac,MI,ACTIVE
+ALGONAWA.GOV,City,Non-Federal Agency,Algona,WA,ACTIVE
+ALGOODTN.GOV,City,Non-Federal Agency,Algood,TN,ACTIVE
+ALIQUIPPAPA.GOV,City,Non-Federal Agency,Aliquippa,PA,ACTIVE
+ALLENDALENJ.GOV,City,Non-Federal Agency,Allendale,NJ,ACTIVE
+ALLENSTOWNNH.GOV,City,Non-Federal Agency,Allenstown,NH,ACTIVE
+ALLENTOWNPA.GOV,City,Non-Federal Agency,Allentown,PA,ACTIVE
+ALLIANCEOH.GOV,City,Non-Federal Agency,Alliance,OH,ACTIVE
+ALMONTMICHIGAN.GOV,City,Non-Federal Agency,Almont,MI,ACTIVE
+ALSTEADNH.GOV,City,Non-Federal Agency,Alstead,NH,ACTIVE
+ALTAVISTAVA.GOV,City,Non-Federal Agency,Altavista,VA,ACTIVE
+ALTON-TX.GOV,City,Non-Federal Agency,Alton,TX,ACTIVE
+ALTOONAPA.GOV,City,Non-Federal Agency,Altoona,PA,ACTIVE
+ALTUSOK.GOV,City,Non-Federal Agency,Altus,OK,ACTIVE
+ALVIN-TX.GOV,City,Non-Federal Agency,Alvin,TX,ACTIVE
+AMARILLO.GOV,City,Non-Federal Agency,Amarillo,TX,ACTIVE
+AMENIANY.GOV,City,Non-Federal Agency,Amenia,NY,ACTIVE
+AMERICUSGA.GOV,City,Non-Federal Agency,Americus,GA,ACTIVE
+AMERYWI.GOV,City,Non-Federal Agency,Amery,WI,ACTIVE
+AMHERSTMA.GOV,City,Non-Federal Agency,Amherst,MA,ACTIVE
+AMHERSTNH.GOV,City,Non-Federal Agency,Amherst,NH,ACTIVE
+AMHERSTVA.GOV,City,Non-Federal Agency,Amherst,VA,ACTIVE
+AMITYARKANSAS.GOV,City,Non-Federal Agency,Amity,AR,ACTIVE
+AMSTERDAMNY.GOV,City,Non-Federal Agency,Amsterdam,NY,ACTIVE
+ANCHORAGEAK.GOV,City,Non-Federal Agency,Anchorage,AK,ACTIVE
+ANDOVER-NH.GOV,City,Non-Federal Agency,Andover,NH,ACTIVE
+ANDOVERMA.GOV,City,Non-Federal Agency,Andover,MA,ACTIVE
+ANDOVERMN.GOV,City,Non-Federal Agency,Andover,MN,ACTIVE
+ANGELFIRENM.GOV,City,Non-Federal Agency,Angel Fire,NM,ACTIVE
+ANGELSCAMP.GOV,City,Non-Federal Agency,City of Angels Camp,CA,ACTIVE
+ANKENYIOWA.GOV,City,Non-Federal Agency,Ankeny,IA,ACTIVE
+ANNATEXAS.GOV,City,Non-Federal Agency,Anna,TX,ACTIVE
+ANNETTATX.GOV,City,Non-Federal Agency,Aledo,TX,ACTIVE
+ANNISTONAL.GOV,City,Non-Federal Agency,Anniston,AL,ACTIVE
+ANTIOCHTOWNSHIPIL.GOV,City,Non-Federal Agency,Lake Villa,IL,ACTIVE
+APPLEVALLEYCA.GOV,City,Non-Federal Agency,Apple Valley,CA,ACTIVE
+APPLEVALLEYUT.GOV,City,Non-Federal Agency,Apple Valley,UT,ACTIVE
+APPOMATTOXVA.GOV,City,Non-Federal Agency,Appomattox,VA,ACTIVE
+AQUINNAH-MA.GOV,City,Non-Federal Agency,Aquinnah,MA,ACTIVE
+ARANSASPASSTX.GOV,City,Non-Federal Agency,Aransas Pass,TX,ACTIVE
+ARCADIA-FL.GOV,City,Non-Federal Agency,Arcadia,FL,ACTIVE
+ARCADIACA.GOV,City,Non-Federal Agency,Arcadia,CA,ACTIVE
+ARCHBALDBOROUGHPA.GOV,City,Non-Federal Agency,Archbald,PA,ACTIVE
+ARCHDALE-NC.GOV,City,Non-Federal Agency,ARCHDALE,NC,ACTIVE
+ARKANSASCITYKS.GOV,City,Non-Federal Agency,Arkansas City,KS,ACTIVE
+ARLINGTON-TX.GOV,City,Non-Federal Agency,Arlington,TX,ACTIVE
+ARLINGTONMA.GOV,City,Non-Federal Agency,Arlington,MA,ACTIVE
+ARLINGTONTX.GOV,City,Non-Federal Agency,Arlington,TX,ACTIVE
+ARLINGTONWA.GOV,City,Non-Federal Agency,Arlington,WA,ACTIVE
+ARTESIANM.GOV,City,Non-Federal Agency,Artesia,NM,ACTIVE
+ARTHUR-IL.GOV,City,Non-Federal Agency,Arthur,IL,ACTIVE
+ASHBURNHAM-MA.GOV,City,Non-Federal Agency,Ashburnham,MA,ACTIVE
+ASHBYMA.GOV,City,Non-Federal Agency,Ashby,MA,ACTIVE
+ASHEBORONC.GOV,City,Non-Federal Agency,Asheboro,NC,ACTIVE
+ASHEVILLENC.GOV,City,Non-Federal Agency,Asheville,NC,ACTIVE
+ASHGROVEMO.GOV,City,Non-Federal Agency,Ash Grove,MO,ACTIVE
+ASHLANDCITYTN.GOV,City,Non-Federal Agency,Ashland City,TN,ACTIVE
+ASHLANDKY.GOV,City,Non-Federal Agency,Ashland,KY,ACTIVE
+ASHVILLEOHIO.GOV,City,Non-Federal Agency,Ashville,OH,ACTIVE
+ATHENSTX.GOV,City,Non-Federal Agency,Athens,TX,ACTIVE
+ATHOL-MA.GOV,City,Non-Federal Agency,Athol,MA,ACTIVE
+ATKINSON-NH.GOV,City,Non-Federal Agency,Atkinson,NH,ACTIVE
+ATLANTAGA.GOV,City,Non-Federal Agency,Atlanta,GA,ACTIVE
+ATLANTISFL.GOV,City,Non-Federal Agency,Atlantis,FL,ACTIVE
+ATRISCO-NM.GOV,City,Non-Federal Agency,Atrisco,NM,ACTIVE
+ATTICA-IN.GOV,City,Non-Federal Agency,Attica,IN,ACTIVE
+AUBREYTX.GOV,City,Non-Federal Agency,Aubrey,TX,ACTIVE
+AUBURNMAINE.GOV,City,Non-Federal Agency,Auburn,ME,ACTIVE
+AUBURNNY.GOV,City,Non-Federal Agency,Auburn,NY,ACTIVE
+AUBURNWA.GOV,City,Non-Federal Agency,Auburn,WA,ACTIVE
+AUGUSTAMAINE.GOV,City,Non-Federal Agency,Augusta,ME,ACTIVE
+AUGUSTAME.GOV,City,Non-Federal Agency,Augusta,ME,ACTIVE
+AURORATEXAS.GOV,City,Non-Federal Agency,Rhome,TX,ACTIVE
+AUSTELLGA.GOV,City,Non-Federal Agency,Austell,GA,ACTIVE
+AUSTINTEXAS.GOV,City,Non-Federal Agency,Austin,TX,ACTIVE
+AUSTINTX.GOV,City,Non-Federal Agency,Austin,TX,ACTIVE
+AVONCT.GOV,City,Non-Federal Agency,Avon,CT,ACTIVE
+AVONDALEAZ.GOV,City,Non-Federal Agency,Avondale,AZ,ACTIVE
+AZTECNM.GOV,City,Non-Federal Agency,Aztec,NM,ACTIVE
+BADENPA.GOV,City,Non-Federal Agency,Baden,PA,ACTIVE
+BAINBRIDGEWA.GOV,City,Non-Federal Agency,Bainbridge Island,WA,ACTIVE
+BAKERSFIELD-CA.GOV,City,Non-Federal Agency,Bakersfield,CA,ACTIVE
+BALHARBOURFL.GOV,City,Non-Federal Agency,Bal Harbour,FL,ACTIVE
+BALTIMORECITY.GOV,City,Non-Federal Agency,Baltimore,MD,ACTIVE
+BANGORMAINE.GOV,City,Non-Federal Agency,Bangor,ME,ACTIVE
+BARLINGAR.GOV,City,Non-Federal Agency,Barling,AR,ACTIVE
+BARRINGTON-IL.GOV,City,Non-Federal Agency,Barrington,IL,ACTIVE
+BARRINGTONHILLS-IL.GOV,City,Non-Federal Agency,Barrington Hills,IL,ACTIVE
+BASSLAKEWI.GOV,City,Non-Federal Agency,Hayward,WI,ACTIVE
+BASTROPTX.GOV,City,Non-Federal Agency,Bastrop,TX,ACTIVE
+BATTLECREEK-MI.GOV,City,Non-Federal Agency,Battle Creek,MI,ACTIVE
+BATTLECREEKMI.GOV,City,Non-Federal Agency,Battle Creek,MI,ACTIVE
+BATTLEFIELDMO.GOV,City,Non-Federal Agency,Battlefield,MO,ACTIVE
+BAXTERMN.GOV,City,Non-Federal Agency,Baxter,MN,ACTIVE
+BAYCOUNTY-MI.GOV,City,Non-Federal Agency,Bay City,MI,ACTIVE
+BAYSIDE-WI.GOV,City,Non-Federal Agency,Bayside,WI,ACTIVE
+BAYSTLOUIS-MS.GOV,City,Non-Federal Agency,Bay St. Louis,MS,ACTIVE
+BAYVILLENY.GOV,City,Non-Federal Agency,Bayville,NY,ACTIVE
+BEACHHAVEN-NJ.GOV,City,Non-Federal Agency,Beach Haven,NJ,ACTIVE
+BEAUMONT-CA.GOV,City,Non-Federal Agency,Beaumont,CA,ACTIVE
+BEAUMONTTEXAS.GOV,City,Non-Federal Agency,Beaumont,TX,ACTIVE
+BEAUXARTS-WA.GOV,City,Non-Federal Agency,Beaux Arts,WA,ACTIVE
+BEAVERCREEKOHIO.GOV,City,Non-Federal Agency,Beavercreek,OH,ACTIVE
+BEAVERPA.GOV,City,Non-Federal Agency,Beaver,PA,ACTIVE
+BEAVERTONOREGON.GOV,City,Non-Federal Agency,Beaverton,OR,ACTIVE
+BEAVERTWP-OH.GOV,City,Non-Federal Agency,North Lima,OH,ACTIVE
+BECKEMEYERIL.GOV,City,Non-Federal Agency,Beckemeyer,IL,ACTIVE
+BEDFORDHEIGHTS.GOV,City,Non-Federal Agency,Bedford Heights,OH,ACTIVE
+BEDFORDMA.GOV,City,Non-Federal Agency,Bedford,MA,ACTIVE
+BEDFORDNY.GOV,City,Non-Federal Agency,Bedford Hills,NY,ACTIVE
+BEDFORDOH.GOV,City,Non-Federal Agency,Bedford,OH,ACTIVE
+BEDFORDTX.GOV,City,Non-Federal Agency,Bedford,TX,ACTIVE
+BEDFORDVA.GOV,City,Non-Federal Agency,Bedford,VA,ACTIVE
+BEECAVETEXAS.GOV,City,Non-Federal Agency,Bee Cave,TX,ACTIVE
+BELAIREKS.GOV,City,Non-Federal Agency,Bel Aire,KS,ACTIVE
+BELEN-NM.GOV,City,Non-Federal Agency,Belen,NM,ACTIVE
+BELLAIRETX.GOV,City,Non-Federal Agency,Bellaire,TX,ACTIVE
+BELLAVISTAAR.GOV,City,Non-Federal Agency,Bella Vista,AR,ACTIVE
+BELLEAIRBLUFFS-FL.GOV,City,Non-Federal Agency,Belleair Bluffs,FL,ACTIVE
+BELLEFONTEPA.GOV,City,Non-Federal Agency,Bellefonte,PA,ACTIVE
+BELLEMEADE-KY.GOV,City,Non-Federal Agency,Louisville,KY,ACTIVE
+BELLERIVEACRESMO.GOV,City,Non-Federal Agency,Normandy,MO,ACTIVE
+BELLEVUEIA.GOV,City,Non-Federal Agency,Bellevue,IA,ACTIVE
+BELLEVUEWA.GOV,City,Non-Federal Agency,Bellevue,WA,ACTIVE
+BELMONT-MA.GOV,City,Non-Federal Agency,Belmont,MA,ACTIVE
+BELMONT.GOV,City,Non-Federal Agency,Belmont,CA,ACTIVE
+BELOITWI.GOV,City,Non-Federal Agency,Beloit,WI,ACTIVE
+BELTONPARKSMO.GOV,City,Non-Federal Agency,Belton,MO,ACTIVE
+BELTONTEXAS.GOV,City,Non-Federal Agency,Belton,TX,ACTIVE
+BENBROOK-TX.GOV,City,Non-Federal Agency,Benbrook,TX,ACTIVE
+BENDOREGON.GOV,City,Non-Federal Agency,Bend,OR,ACTIVE
+BENSALEMPA.GOV,City,Non-Federal Agency,Bensalem,PA,ACTIVE
+BENSONAZ.GOV,City,Non-Federal Agency,Benson,AZ,ACTIVE
+BENTONCHARTERTOWNSHIP-MI.GOV,City,Non-Federal Agency,Benton Harbor,MI,ACTIVE
+BENTONIL.GOV,City,Non-Federal Agency,Benton,IL,ACTIVE
+BEREAKY.GOV,City,Non-Federal Agency,Berea,KY,ACTIVE
+BERKELEYHEIGHTSTWPNJ.GOV,City,Non-Federal Agency,Berkeley Heights,NJ,ACTIVE
+BERLINMD.GOV,City,Non-Federal Agency,Berlin,MD,ACTIVE
+BERLINNH.GOV,City,Non-Federal Agency,Berlin,NH,ACTIVE
+BERNCO.GOV,City,Non-Federal Agency,Albuquerque,NM,ACTIVE
+BERRYVILLEVA.GOV,City,Non-Federal Agency,Berryville,VA,ACTIVE
+BERTHOLD-ND.GOV,City,Non-Federal Agency,Berthold,ND,ACTIVE
+BERWYN-IL.GOV,City,Non-Federal Agency,Berwyn,IL,ACTIVE
+BERWYNHEIGHTSMD.GOV,City,Non-Federal Agency,Berwyn Heights,MD,ACTIVE
+BETHANYBEACH-DE.GOV,City,Non-Federal Agency,Bethany Beach,DE,ACTIVE
+BETHEL-CT.GOV,City,Non-Federal Agency,Bethel,CT,ACTIVE
+BETHEL-OH.GOV,City,Non-Federal Agency,Bethel,OH,ACTIVE
+BETHLEHEM-PA.GOV,City,Non-Federal Agency,Bethlehem,PA,ACTIVE
+BEVERLYHILLS-CA.GOV,City,Non-Federal Agency,Beverly Hills,CA,ACTIVE
+BEVERLYHILLSCA.GOV,City,Non-Federal Agency,Beverly Hills,CA,ACTIVE
+BEVERLYMA.GOV,City,Non-Federal Agency,Beverly,MA,ACTIVE
+BHTX.GOV,City,Non-Federal Agency,Balcones Heights,TX,ACTIVE
+BIGFLATSNY.GOV,City,Non-Federal Agency,Big Flats,NY,ACTIVE
+BIGGS-CA.GOV,City,Non-Federal Agency,Biggs,CA,ACTIVE
+BIGSANDYTX.GOV,City,Non-Federal Agency,Big Sandy,TX,ACTIVE
+BINGHAMTON-NY.GOV,City,Non-Federal Agency,Binghamton,NY,ACTIVE
+BIRMINGHAMAL.GOV,City,Non-Federal Agency,Birmingham,AL,ACTIVE
+BISBEEAZ.GOV,City,Non-Federal Agency,Bisbee,AZ,ACTIVE
+BISCAYNEPARKFL.GOV,City,Non-Federal Agency,Biscayne Park,FL,ACTIVE
+BISMARCKND.GOV,City,Non-Federal Agency,Bismarck,ND,ACTIVE
+BIXBYOK.GOV,City,Non-Federal Agency,Bixby,OK,ACTIVE
+BLACKSBURG.GOV,City,Non-Federal Agency,Blacksburg,VA,ACTIVE
+BLAINEMN.GOV,City,Non-Federal Agency,Blaine,MN,ACTIVE
+BLAIRSVILLE-GA.GOV,City,Non-Federal Agency,Blairsville,GA,ACTIVE
+BLANDING-UT.GOV,City,Non-Federal Agency,Blanding,UT,ACTIVE
+BLENDONTOWNSHIP-MI.GOV,City,Non-Federal Agency,Hudsonville,MI,ACTIVE
+BLISSFIELDMICHIGAN.GOV,City,Non-Federal Agency,Blissfield,MI,ACTIVE
+BLOOMINGDALE-GA.GOV,City,Non-Federal Agency,Bloomingdale,GA,ACTIVE
+BLOOMINGTON-MN.GOV,City,Non-Federal Agency,Bloomington,MN,ACTIVE
+BLOOMINGTONMN.GOV,City,Non-Federal Agency,Bloomington,MN,ACTIVE
+BLUEASH-OH.GOV,City,Non-Federal Agency,Blue Ash,OH,ACTIVE
+BOCARATON-FL.GOV,City,Non-Federal Agency,Boca Raton,FL,ACTIVE
+BOERNE-TX.GOV,City,Non-Federal Agency,BOERNE,TX,ACTIVE
+BOISEIDAHO.GOV,City,Non-Federal Agency,Boise,ID,ACTIVE
+BOLTON-MA.GOV,City,Non-Federal Agency,Bolton,MA,ACTIVE
+BONNEYTEXAS.GOV,City,Non-Federal Agency,Bonney,TX,ACTIVE
+BOONEVILLE-MS.GOV,City,Non-Federal Agency,Booneville,MS,ACTIVE
+BORGERTX.GOV,City,Non-Federal Agency,Borger,TX,ACTIVE
+BOSQUEFARMSNM.GOV,City,Non-Federal Agency,Bosque Farms,NM,ACTIVE
+BOSTON.GOV,City,Non-Federal Agency,Boston,MA,ACTIVE
+BOTHELLWA.GOV,City,Non-Federal Agency,Bothell,WA,ACTIVE
+BOULDER-CO.GOV,City,Non-Federal Agency,Boulder,CO,ACTIVE
+BOULDERCITY-NV.GOV,City,Non-Federal Agency,Boulder City,NV,ACTIVE
+BOULDERCITYNV.GOV,City,Non-Federal Agency,Boulder City,NV,ACTIVE
+BOULDERCOLORADO.GOV,City,Non-Federal Agency,Boulder,CO,ACTIVE
+BOUNTIFULUTAH.GOV,City,Non-Federal Agency,Bountiful,UT,ACTIVE
+BOURBON-IN.GOV,City,Non-Federal Agency,Bremen,IN,ACTIVE
+BOW-NH.GOV,City,Non-Federal Agency,Bow,NH,ACTIVE
+BOWERSDE.GOV,City,Non-Federal Agency,"Frederica,",DE,ACTIVE
+BOWLINGGREEN-MO.GOV,City,Non-Federal Agency,Bowling Green,MO,ACTIVE
+BOWLINGGREENKY.GOV,City,Non-Federal Agency,Bowling Green,KY,ACTIVE
+BOWMAR.GOV,City,Non-Federal Agency,Bow Mar,CO,ACTIVE
+BOXBOROUGH-MA.GOV,City,Non-Federal Agency,Boxborough,MA,ACTIVE
+BOYCEVA.GOV,City,Non-Federal Agency,Boyce,VA,ACTIVE
+BOYLSTON-MA.GOV,City,Non-Federal Agency,Boylston,MA,ACTIVE
+BOZEMAN-MT.GOV,City,Non-Federal Agency,Bozeman,MT,ACTIVE
+BRADLEYBEACHNJ.GOV,City,Non-Federal Agency,Bradley Beach,NJ,ACTIVE
+BRANFORD-CT.GOV,City,Non-Federal Agency,Branford,CT,ACTIVE
+BRANSONMO.GOV,City,Non-Federal Agency,Branson,MO,ACTIVE
+BRASWELLGA.GOV,City,Non-Federal Agency,Rockmart,GA,ACTIVE
+BRAWLEY-CA.GOV,City,Non-Federal Agency,Brawley,CA,ACTIVE
+BRECKENRIDGETX.GOV,City,Non-Federal Agency,Breckenridge,TX,ACTIVE
+BREMENGA.GOV,City,Non-Federal Agency,Bremen,GA,ACTIVE
+BREMERTONWA.GOV,City,Non-Federal Agency,Bremerton,WA,ACTIVE
+BRENTWOOD-TN.GOV,City,Non-Federal Agency,Brentwood,TN,ACTIVE
+BRENTWOODCA.GOV,City,Non-Federal Agency,Brentwood,CA,ACTIVE
+BRENTWOODMD.GOV,City,Non-Federal Agency,Brentwood,MD,ACTIVE
+BRENTWOODNH.GOV,City,Non-Federal Agency,Brentwood,NH,ACTIVE
+BRENTWOODTN.GOV,City,Non-Federal Agency,Brentwood,TN,ACTIVE
+BREWSTER-MA.GOV,City,Non-Federal Agency,Brewster,MA,ACTIVE
+BREWSTERVILLAGE-NY.GOV,City,Non-Federal Agency,Brewster,NY,ACTIVE
+BRICKTOWNSHIP-NJ.GOV,City,Non-Federal Agency,Brick,NJ,ACTIVE
+BRIDGEPORTCT.GOV,City,Non-Federal Agency,Bridgeport,CT,ACTIVE
+BRIDGEPORTWV.GOV,City,Non-Federal Agency,Bridgeport,WV,ACTIVE
+BRIDGEVIEW-IL.GOV,City,Non-Federal Agency,Bridgeview,IL,ACTIVE
+BRIDGEWATERNJ.GOV,City,Non-Federal Agency,Bridgewater,NJ,ACTIVE
+BRIGHTONCO.GOV,City,Non-Federal Agency,Brighton,CO,ACTIVE
+BRIMFIELDOHIO.GOV,City,Non-Federal Agency,Kent,OH,ACTIVE
+BRISTOLCT.GOV,City,Non-Federal Agency,Bristol,CT,ACTIVE
+BRLA.GOV,City,Non-Federal Agency,Baton Rouge,LA,ACTIVE
+BROADVIEW-IL.GOV,City,Non-Federal Agency,Broadview,IL,ACTIVE
+BROKENARROWOK.GOV,City,Non-Federal Agency,Broken Arrow,OK,ACTIVE
+BROOKFIELD-WI.GOV,City,Non-Federal Agency,Brookfield,WI,ACTIVE
+BROOKFIELDCT.GOV,City,Non-Federal Agency,Brookfield,CT,ACTIVE
+BROOKFIELDIL.GOV,City,Non-Federal Agency,Brookfield ,IL,ACTIVE
+BROOKHAVENGA.GOV,City,Non-Federal Agency,Dunwoody,GA,ACTIVE
+BROOKLINEMA.GOV,City,Non-Federal Agency,Brookline,MA,ACTIVE
+BROOKLYNOHIO.GOV,City,Non-Federal Agency,Brooklyn,OH,ACTIVE
+BROOKLYNWI.GOV,City,Non-Federal Agency,Brooklyn,WI,ACTIVE
+BROOMFIELDCO.GOV,City,Non-Federal Agency,Broomfield,CO,ACTIVE
+BROWNSVILLETN.GOV,City,Non-Federal Agency,Brownsville,TN,ACTIVE
+BROWNWOODTEXAS.GOV,City,Non-Federal Agency,Brownwood,TX,ACTIVE
+BRYANTX.GOV,City,Non-Federal Agency,Bryan,TX,ACTIVE
+BRYCECANYONCITYUT.GOV,City,Non-Federal Agency,Bryce Canyon City,UT,ACTIVE
+BRYSONCITYNC.GOV,City,Non-Federal Agency,Bryson City,NC,ACTIVE
+BUCHANAN-VA.GOV,City,Non-Federal Agency,BUCHANAN,VA,ACTIVE
+BUCKEYEAZ.GOV,City,Non-Federal Agency,Buckeye,AZ,ACTIVE
+BUCKSPORTMAINE.GOV,City,Non-Federal Agency,Bucksport,ME,ACTIVE
+BUENAVISTACO.GOV,City,Non-Federal Agency,Buena Vista,CO,ACTIVE
+BULLHEADCITYAZ.GOV,City,Non-Federal Agency,Bullhead City,AZ,ACTIVE
+BULVERDETX.GOV,City,Non-Federal Agency,Bulverde,TX,ACTIVE
+BUNKERHILLTX.GOV,City,Non-Federal Agency,HOUSTON,TX,ACTIVE
+BURBANKCA.GOV,City,Non-Federal Agency,Burbank,CA,ACTIVE
+BURBANKIL.GOV,City,Non-Federal Agency,Burbank,IL,ACTIVE
+BURIENWA.GOV,City,Non-Federal Agency,Burien,WA,ACTIVE
+BURKITTSVILLE-MD.GOV,City,Non-Federal Agency,Burkittsville,MD,ACTIVE
+BURLINGTON-WI.GOV,City,Non-Federal Agency,Burlington,WI,ACTIVE
+BURLINGTONKANSAS.GOV,City,Non-Federal Agency,Burlington,KS,ACTIVE
+BURLINGTONNC.GOV,City,Non-Federal Agency,Burlington,NC,ACTIVE
+BURLINGTONND.GOV,City,Non-Federal Agency,Burlington,ND,ACTIVE
+BURLINGTONVT.GOV,City,Non-Federal Agency,Burlington,VT,ACTIVE
+BURLINGTONWA.GOV,City,Non-Federal Agency,Burlington,WA,ACTIVE
+BURNSHARBOR-IN.GOV,City,Non-Federal Agency,Burns Harbor,IN,ACTIVE
+BURNSVILLEMN.GOV,City,Non-Federal Agency,Burnsville,MN,ACTIVE
+BURR-RIDGE.GOV,City,Non-Federal Agency,Burr Ridge,IL,ACTIVE
+BURRILLVILLE-RI.GOV,City,Non-Federal Agency,Harrisville,RI,ACTIVE
+BURTONMI.GOV,City,Non-Federal Agency,Burton,MI,ACTIVE
+BUTLERWI.GOV,City,Non-Federal Agency,Butler,WI,ACTIVE
+BYESVILLEOH.GOV,City,Non-Federal Agency,Byesville,OH,ACTIVE
+CABOTAR.GOV,City,Non-Federal Agency,Cabot,AR,ACTIVE
+CABQ.GOV,City,Non-Federal Agency,Albuquerque,NM,ACTIVE
+CALAISVERMONT.GOV,City,Non-Federal Agency,East Calais,VT,ACTIVE
+CALDWELLTX.GOV,City,Non-Federal Agency,Caldwell,TX,ACTIVE
+CALEDONIAMN.GOV,City,Non-Federal Agency,Caledonia,MN,ACTIVE
+CALIFORNIACITY-CA.GOV,City,Non-Federal Agency,California City,CA,ACTIVE
+CALUMETTWP-IN.GOV,City,Non-Federal Agency,Gary,IN,ACTIVE
+CAMBRIDGEMA.GOV,City,Non-Federal Agency,Cambridge,MA,ACTIVE
+CAMBRIDGENY.GOV,City,Non-Federal Agency,Cambridge,NY,ACTIVE
+CAMDENMAINE.GOV,City,Non-Federal Agency,Camden,ME,ACTIVE
+CAMDENTN.GOV,City,Non-Federal Agency,Camden,TN,ACTIVE
+CAMPBELLCA.GOV,City,Non-Federal Agency,Campbell,CA,ACTIVE
+CAMPBELLOHIO.GOV,City,Non-Federal Agency,Campbell,OH,ACTIVE
+CANALWINCHESTEROHIO.GOV,City,Non-Federal Agency,Canal Winchester,OH,ACTIVE
+CANANDAIGUANEWYORK.GOV,City,Non-Federal Agency,Canandaigua,NY,ACTIVE
+CANNONFALLSMN.GOV,City,Non-Federal Agency,Cannon Falls,MN,ACTIVE
+CANTONOHIO.GOV,City,Non-Federal Agency,Canton,OH,ACTIVE
+CANTONTWP-OH.GOV,City,Non-Federal Agency,Canton,OH,ACTIVE
+CANTONTX.GOV,City,Non-Federal Agency,Canton,TX,ACTIVE
+CAPECORALFL.GOV,City,Non-Federal Agency,Cape Coral,FL,ACTIVE
+CARBONDALE-PA.GOV,City,Non-Federal Agency,Carbondale,PA,ACTIVE
+CARLISLE-IA.GOV,City,Non-Federal Agency,Carlisle,IA,ACTIVE
+CARLISLEMA.GOV,City,Non-Federal Agency,Carlisle,MA,ACTIVE
+CARLSBADCA.GOV,City,Non-Federal Agency,Carlsbad,CA,ACTIVE
+CARNATIONWA.GOV,City,Non-Federal Agency,Carnation,WA,ACTIVE
+CARNEGIEOK.GOV,City,Non-Federal Agency,Carnegie,OK,ACTIVE
+CARNEYSPOINTNJ.GOV,City,Non-Federal Agency,Carneys Point,NJ,ACTIVE
+CARRBORONC.GOV,City,Non-Federal Agency,Carrboro,NC,ACTIVE
+CARROLLTON-GA.GOV,City,Non-Federal Agency,Carrollton,GA,ACTIVE
+CARTERLAKE-IA.GOV,City,Non-Federal Agency,Carter Lake,IA,ACTIVE
+CARTERSVILLEGA.GOV,City,Non-Federal Agency,Cartersville,GA,ACTIVE
+CARTHAGEMO.GOV,City,Non-Federal Agency,Carthage,MO,ACTIVE
+CARVERMA.GOV,City,Non-Federal Agency,Carver,MA,ACTIVE
+CARYNC.GOV,City,Non-Federal Agency,Cary,NC,ACTIVE
+CASAGRANDEAZ.GOV,City,Non-Federal Agency,Casa Grande,AZ,ACTIVE
+CASPERWY.GOV,City,Non-Federal Agency,Casper,WY,ACTIVE
+CASTROVILLETX.GOV,City,Non-Federal Agency,Castroville,TX,ACTIVE
+CATHEDRALCITY.GOV,City,Non-Federal Agency,Cathedral City,CA,ACTIVE
+CAVESPRINGSAR.GOV,City,Non-Federal Agency,Cave Springs,AR,ACTIVE
+CECILTONMD.GOV,City,Non-Federal Agency,Cecilton ,MD,ACTIVE
+CECILTOWNSHIP-PA.GOV,City,Non-Federal Agency,Cecil,PA,ACTIVE
+CEDARHURST.GOV,City,Non-Federal Agency,cedarhurst,NY,ACTIVE
+CEDARPARKTEXAS.GOV,City,Non-Federal Agency,Cedar Park,TX,ACTIVE
+CEDARRAPIDS-IA.GOV,City,Non-Federal Agency,Cedar Rapids,IA,ACTIVE
+CEDARTOWNGEORGIA.GOV,City,Non-Federal Agency,Cedartown,GA,ACTIVE
+CELINA-TX.GOV,City,Non-Federal Agency,Celina,TX,ACTIVE
+CENTENNIALCO.GOV,City,Non-Federal Agency,Centennial,CO,ACTIVE
+CENTERCO.GOV,City,Non-Federal Agency,Center,CO,ACTIVE
+CENTERLINE.GOV,City,Non-Federal Agency,Center Line,MI,ACTIVE
+CENTERVILLEOHIO.GOV,City,Non-Federal Agency,Centerville,OH,ACTIVE
+CENTERVILLETX.GOV,City,Non-Federal Agency,College Station,TX,ACTIVE
+CENTRAL-LA.GOV,City,Non-Federal Agency,Central,LA,ACTIVE
+CENTRALPOINTOREGON.GOV,City,Non-Federal Agency,Central Point,OR,ACTIVE
+CENTREVILLE-MD.GOV,City,Non-Federal Agency,Centreville,MD,ACTIVE
+CGAZ.GOV,City,Non-Federal Agency,Casa Grande,AZ,ACTIVE
+CHADDSFORDPA.GOV,City,Non-Federal Agency,Chadds Ford,PA,ACTIVE
+CHAMBERSBURGPA.GOV,City,Non-Federal Agency,Chambersburg,PA,ACTIVE
+CHAMBLEEGA.GOV,City,Non-Federal Agency,Chamblee,GA,ACTIVE
+CHAMPAIGN-IL.GOV,City,Non-Federal Agency,Champaign,IL,ACTIVE
+CHAMPAIGNIL.GOV,City,Non-Federal Agency,Champaign,IL,ACTIVE
+CHANDLERAZ.GOV,City,Non-Federal Agency,Chandler,AZ,ACTIVE
+CHARLESTON-SC.GOV,City,Non-Federal Agency,Charleston,SC,ACTIVE
+CHARLESTONWV.GOV,City,Non-Federal Agency,Charleston,WV,ACTIVE
+CHARLESTOWN-NH.GOV,City,Non-Federal Agency,Charlestown,NH,ACTIVE
+CHARLOTTENC.GOV,City,Non-Federal Agency,Charlotte,NC,ACTIVE
+CHARLOTTESVILLEVA.GOV,City,Non-Federal Agency,Charlottesville,VA,ACTIVE
+CHATHAM-MA.GOV,City,Non-Federal Agency,Chatham,MA,ACTIVE
+CHATHAM-VA.GOV,City,Non-Federal Agency,Chatham,VA,ACTIVE
+CHATHAMTOWNSHIP-NJ.GOV,City,Non-Federal Agency,Chatham,NJ,ACTIVE
+CHATSWORTHGA.GOV,City,Non-Federal Agency,Chatsworth,GA,ACTIVE
+CHATTANOOGA.GOV,City,Non-Federal Agency,Chattanooga,TN,ACTIVE
+CHELSEAMA.GOV,City,Non-Federal Agency,Chelsea,MA,ACTIVE
+CHESAPEAKEBEACHMD.GOV,City,Non-Federal Agency,Chesapeake Beach,MD,ACTIVE
+CHESAPEAKECITY-MD.GOV,City,Non-Federal Agency,Chesapeake City,MD,ACTIVE
+CHESHIRE-MA.GOV,City,Non-Federal Agency,Cheshire,MA,ACTIVE
+CHESTER-NY.GOV,City,Non-Federal Agency,Chester,NY,ACTIVE
+CHESTERFIELD.GOV,City,Non-Federal Agency,Chesterfield,VA,ACTIVE
+CHESTERVT.GOV,City,Non-Federal Agency,Chester,VT,ACTIVE
+CHESTNUTHILLTWP-PA.GOV,City,Non-Federal Agency,Brodheadsville,PA,ACTIVE
+CHEVERLY-MD.GOV,City,Non-Federal Agency,Cheverly,MD,ACTIVE
+CHEVYCHASEVILLAGEMD.GOV,City,Non-Federal Agency,Chevy Chase,MD,ACTIVE
+CHICAGO-IL.GOV,City,Non-Federal Agency,Chicago,IL,ACTIVE
+CHICOCA.GOV,City,Non-Federal Agency,Chico,CA,ACTIVE
+CHICOPEEMA.GOV,City,Non-Federal Agency,Chicopee,MA,ACTIVE
+CHILLICOTHEOH.GOV,City,Non-Federal Agency,Chillicothe,OH,ACTIVE
+CHILMARKMA.GOV,City,Non-Federal Agency,Chilmark,MA,ACTIVE
+CHINAGROVENC.GOV,City,Non-Federal Agency,China Grove,NC,ACTIVE
+CHINCOTEAGUE-VA.GOV,City,Non-Federal Agency,Chincoteague,VA,ACTIVE
+CHIPPEWAFALLS-WI.GOV,City,Non-Federal Agency,Chippewa Falls,WI,ACTIVE
+CHOWANCOUNTY-NC.GOV,City,Non-Federal Agency,Edenton,NC,ACTIVE
+CHULAVISTACA.GOV,City,Non-Federal Agency,Chula Vista,CA,ACTIVE
+CHURCHHILLTN.GOV,City,Non-Federal Agency,Church Hill,TN,ACTIVE
+CIBOLOTX.GOV,City,Non-Federal Agency,Cibolo,TX,ACTIVE
+CINCINNATI-OH.GOV,City,Non-Federal Agency,Cincinnati,OH,ACTIVE
+CINCINNATIOHIO.GOV,City,Non-Federal Agency,Cincinnati,OH,ACTIVE
+CITYKANKAKEE-IL.GOV,City,Non-Federal Agency,KANKAKEE,IL,ACTIVE
+CITYOFADAMS-WI.GOV,City,Non-Federal Agency,Adams,WI,ACTIVE
+CITYOFAIKENSC.GOV,City,Non-Federal Agency,Aiken,SC,ACTIVE
+CITYOFALAMEDACA.GOV,City,Non-Federal Agency,Alameda,CA,ACTIVE
+CITYOFALBIONMI.GOV,City,Non-Federal Agency,albion,MI,ACTIVE
+CITYOFALCOA-TN.GOV,City,Non-Federal Agency,Alcoa,TN,ACTIVE
+CITYOFALGOODTN.GOV,City,Non-Federal Agency,Algood,TN,ACTIVE
+CITYOFALMAGA.GOV,City,Non-Federal Agency,Alma,GA,ACTIVE
+CITYOFAUBURNWA.GOV,City,Non-Federal Agency,Auburn,WA,ACTIVE
+CITYOFBAKERLA.GOV,City,Non-Federal Agency,Baker ,LA,ACTIVE
+CITYOFBELOITWI.GOV,City,Non-Federal Agency,Beloit,WI,ACTIVE
+CITYOFBENTONHARBORMI.GOV,City,Non-Federal Agency,Benton Harbor,MI,ACTIVE
+CITYOFBLUERIDGEGA.GOV,City,Non-Federal Agency,Blue Ridge,GA,ACTIVE
+CITYOFBOWIEMD.GOV,City,Non-Federal Agency,Bowie,MD,ACTIVE
+CITYOFBOWMANGA.GOV,City,Non-Federal Agency,Bowman,GA,ACTIVE
+CITYOFBRUNSWICK-GA.GOV,City,Non-Federal Agency,Brunswick,GA,ACTIVE
+CITYOFBURTON-TX.GOV,City,Non-Federal Agency,Burton,TX,ACTIVE
+CITYOFCANALFULTON-OH.GOV,City,Non-Federal Agency,Canal Fulton,OH,ACTIVE
+CITYOFCAYCE-SC.GOV,City,Non-Federal Agency,Cayce,SC,ACTIVE
+CITYOFCHAMPAIGN-IL.GOV,City,Non-Federal Agency,Champaign,IL,ACTIVE
+CITYOFCHAMPAIGNIL.GOV,City,Non-Federal Agency,Champaign,IL,ACTIVE
+CITYOFCHETEK-WI.GOV,City,Non-Federal Agency,Chetek,WI,ACTIVE
+CITYOFCHOTEAU-MT.GOV,City,Non-Federal Agency,Choteau,MT,ACTIVE
+CITYOFCLAYTONGA.GOV,City,Non-Federal Agency,Clayton,GA,ACTIVE
+CITYOFCODY-WY.GOV,City,Non-Federal Agency,Cody,WY,ACTIVE
+CITYOFCONWAY-AR.GOV,City,Non-Federal Agency,Conway,AR,ACTIVE
+CITYOFCOWETA-OK.GOV,City,Non-Federal Agency,Coweta,OK,ACTIVE
+CITYOFCRISFIELD-MD.GOV,City,Non-Federal Agency,Crisfield,MD,ACTIVE
+CITYOFCUDAHYCA.GOV,City,Non-Federal Agency,Cudahy,CA,ACTIVE
+CITYOFDALTON-GA.GOV,City,Non-Federal Agency,Dalton,GA,ACTIVE
+CITYOFDOUGLASGA.GOV,City,Non-Federal Agency,Douglas,GA,ACTIVE
+CITYOFDUNBARWV.GOV,City,Non-Federal Agency,Dunbar,WV,ACTIVE
+CITYOFDUPONTWA.GOV,City,Non-Federal Agency,DuPont,WA,ACTIVE
+CITYOFENGLEWOOD-NJ.GOV,City,Non-Federal Agency,Englewood,NJ,ACTIVE
+CITYOFEUDORAKS.GOV,City,Non-Federal Agency,Eudora,KS,ACTIVE
+CITYOFFAIRFAX-MN.GOV,City,Non-Federal Agency,Fairfax,MN,ACTIVE
+CITYOFFARGO-ND.GOV,City,Non-Federal Agency,Fargo,ND,ACTIVE
+CITYOFFARMERSVILLE-CA.GOV,City,Non-Federal Agency,Farmersville,CA,ACTIVE
+CITYOFFARMINGTON-AR.GOV,City,Non-Federal Agency,Farmington,AR,ACTIVE
+CITYOFFOLKSTON-GA.GOV,City,Non-Federal Agency,Folkston,GA,ACTIVE
+CITYOFFORTOGLETHORPEGA.GOV,City,Non-Federal Agency,FORT OGLETHORPE,GA,ACTIVE
+CITYOFGAFFNEY-SC.GOV,City,Non-Federal Agency,Gaffney,SC,ACTIVE
+CITYOFGALENAPARK-TX.GOV,City,Non-Federal Agency,Galena Park,TX,ACTIVE
+CITYOFGRAVETTE-AR.GOV,City,Non-Federal Agency,Gravette,AR,ACTIVE
+CITYOFGROTON-CT.GOV,City,Non-Federal Agency,Groton,CT,ACTIVE
+CITYOFGROVEOK.GOV,City,Non-Federal Agency,Grove,OK,ACTIVE
+CITYOFGUNNISON-CO.GOV,City,Non-Federal Agency,Gunnison,CO,ACTIVE
+CITYOFHAMPTON-GA.GOV,City,Non-Federal Agency,Hampton,GA,ACTIVE
+CITYOFHARRISON-MI.GOV,City,Non-Federal Agency,Harrison,MI,ACTIVE
+CITYOFHAYWARD-CA.GOV,City,Non-Federal Agency,Hayward,CA,ACTIVE
+CITYOFHAYWARDWI.GOV,City,Non-Federal Agency,Hayward,WI,ACTIVE
+CITYOFHIRAMGA.GOV,City,Non-Federal Agency,HIRAM,GA,ACTIVE
+CITYOFHOKAH-MN.GOV,City,Non-Federal Agency,Hokah,MN,ACTIVE
+CITYOFHOLYOKE-CO.GOV,City,Non-Federal Agency,Holyoke,CO,ACTIVE
+CITYOFHOMER-AK.GOV,City,Non-Federal Agency,Homer,AK,ACTIVE
+CITYOFHONDO-TX.GOV,City,Non-Federal Agency,Hondo,TX,ACTIVE
+CITYOFHOUSTON.GOV,City,Non-Federal Agency,Houston,TX,ACTIVE
+CITYOFHUMBLE-TX.GOV,City,Non-Federal Agency,Humble,TX,ACTIVE
+CITYOFHUMBLETX.GOV,City,Non-Federal Agency,Humble,TX,ACTIVE
+CITYOFHUNTSVILLETX.GOV,City,Non-Federal Agency,Huntsville,TX,ACTIVE
+CITYOFIRONDALEAL.GOV,City,Non-Federal Agency,Irondale,AL,ACTIVE
+CITYOFKEYWEST-FL.GOV,City,Non-Federal Agency,Key West,FL,ACTIVE
+CITYOFKINGMAN.GOV,City,Non-Federal Agency,Kingman,AZ,ACTIVE
+CITYOFKINGSBURG-CA.GOV,City,Non-Federal Agency,Kingsburg,CA,ACTIVE
+CITYOFLACRESCENT-MN.GOV,City,Non-Federal Agency,La Crescent,MN,ACTIVE
+CITYOFLADUE-MO.GOV,City,Non-Federal Agency,Ladue,MO,ACTIVE
+CITYOFLAGRANGEMO.GOV,City,Non-Federal Agency,LaGrange,MO,ACTIVE
+CITYOFLAHABRA-CA.GOV,City,Non-Federal Agency,LA HABRA,CA,ACTIVE
+CITYOFLENEXA-KS.GOV,City,Non-Federal Agency,Lenexa,KS,ACTIVE
+CITYOFLENEXAKS.GOV,City,Non-Federal Agency,Lenexa,KS,ACTIVE
+CITYOFLINDALETX.GOV,City,Non-Federal Agency,LINDALE,TX,ACTIVE
+CITYOFLISBON-IA.GOV,City,Non-Federal Agency,Lisbon,IA,ACTIVE
+CITYOFLUBBOCKTX.GOV,City,Non-Federal Agency,Lubbock,TX,ACTIVE
+CITYOFMACON-MO.GOV,City,Non-Federal Agency,Macon,MO,ACTIVE
+CITYOFMARIONIL.GOV,City,Non-Federal Agency,Marion,IL,ACTIVE
+CITYOFMARIONWI.GOV,City,Non-Federal Agency,MARION,WI,ACTIVE
+CITYOFMCCAYSVILLEGA.GOV,City,Non-Federal Agency,McCaysville,GA,ACTIVE
+CITYOFMENASHA-WI.GOV,City,Non-Federal Agency,Menasha,WI,ACTIVE
+CITYOFMIDLANDMI.GOV,City,Non-Federal Agency,Midland,MI,ACTIVE
+CITYOFMILLBROOK-AL.GOV,City,Non-Federal Agency,Millbrook,AL,ACTIVE
+CITYOFMILLENGA.GOV,City,Non-Federal Agency,Millen,GA,ACTIVE
+CITYOFMONONGAHELA-PA.GOV,City,Non-Federal Agency,Monongahela,PA,ACTIVE
+CITYOFMORROWGA.GOV,City,Non-Federal Agency,Morrow,GA,ACTIVE
+CITYOFMTVERNON-IA.GOV,City,Non-Federal Agency,Mount Vernon,IA,ACTIVE
+CITYOFNANTICOKE-PA.GOV,City,Non-Federal Agency,Nanticoke,PA,ACTIVE
+CITYOFNEWBURGH-NY.GOV,City,Non-Federal Agency,Newburgh,NY,ACTIVE
+CITYOFNEWULM-MN.GOV,City,Non-Federal Agency,New Ulm,MN,ACTIVE
+CITYOFNORMANDY.GOV,City,Non-Federal Agency,St. Louis,MO,ACTIVE
+CITYOFNOVI-MI.GOV,City,Non-Federal Agency,Novi,MI,ACTIVE
+CITYOFOLYMPIA-WA.GOV,City,Non-Federal Agency,Olympia,WA,ACTIVE
+CITYOFOLYMPIAWA.GOV,City,Non-Federal Agency,Olympia,WA,ACTIVE
+CITYOFOMAHA-NE.GOV,City,Non-Federal Agency,Omaha,NE,ACTIVE
+CITYOFPACIFICWA.GOV,City,Non-Federal Agency,Pacific,WA,ACTIVE
+CITYOFPALMVALLEY-TX.GOV,City,Non-Federal Agency,Harlingen,TX,ACTIVE
+CITYOFPARISTN.GOV,City,Non-Federal Agency,Paris,TN,ACTIVE
+CITYOFPARMA-OH.GOV,City,Non-Federal Agency,Parma,OH,ACTIVE
+CITYOFPASSAICNJ.GOV,City,Non-Federal Agency,Passaic,NJ,ACTIVE
+CITYOFPATASKALAOHIO.GOV,City,Non-Federal Agency,Pataskala,OH,ACTIVE
+CITYOFPATTERSONLA.GOV,City,Non-Federal Agency,Patterson,LA,ACTIVE
+CITYOFPEARLANDTX.GOV,City,Non-Federal Agency,Pearland,TX,ACTIVE
+CITYOFPHOENIX.GOV,City,Non-Federal Agency,Phoenix,AZ,ACTIVE
+CITYOFPIGEONFORGETN.GOV,City,Non-Federal Agency,Pigeon Forge,TN,ACTIVE
+CITYOFPLAINVILLE-KS.GOV,City,Non-Federal Agency,Plainville,KS,ACTIVE
+CITYOFPLATTSBURGH-NY.GOV,City,Non-Federal Agency,Plattsburgh,NY,ACTIVE
+CITYOFPLEASANTONCA.GOV,City,Non-Federal Agency,Pleasanton,CA,ACTIVE
+CITYOFPOCOMOKEMD.GOV,City,Non-Federal Agency,Pocomoke City,MD,ACTIVE
+CITYOFPORTLANDTN.GOV,City,Non-Federal Agency,Portland,TN,ACTIVE
+CITYOFREDMOND.GOV,City,Non-Federal Agency,Redmond,WA,ACTIVE
+CITYOFRENONV.GOV,City,Non-Federal Agency,Reno,NV,ACTIVE
+CITYOFROCHESTER.GOV,City,Non-Federal Agency,Rochester,NY,ACTIVE
+CITYOFROCKHILLSC.GOV,City,Non-Federal Agency,Rock Hill,SC,ACTIVE
+CITYOFROCKPORT-IN.GOV,City,Non-Federal Agency,Rockport,IN,ACTIVE
+CITYOFSAFFORD-AZ.GOV,City,Non-Federal Agency,Safford,AZ,ACTIVE
+CITYOFSAFFORDAZ.GOV,City,Non-Federal Agency,Safford,AZ,ACTIVE
+CITYOFSALEMNJ.GOV,City,Non-Federal Agency,Salem,NJ,ACTIVE
+CITYOFSANTAANA-CA.GOV,City,Non-Federal Agency,Santa Ana,CA,ACTIVE
+CITYOFSANTEECA.GOV,City,Non-Federal Agency,Santee,CA,ACTIVE
+CITYOFSEATTLE.GOV,City,Non-Federal Agency,Seattle,WA,ACTIVE
+CITYOFSPARTANBURG-SC.GOV,City,Non-Federal Agency,Spartanburg,SC,ACTIVE
+CITYOFSTMARYSPA.GOV,City,Non-Federal Agency,St. Marys,PA,ACTIVE
+CITYOFSTOCKBRIDGE-GA.GOV,City,Non-Federal Agency,Stockbridge,GA,ACTIVE
+CITYOFSUGAR-LANDTX.GOV,City,Non-Federal Agency,Sugar Land,TX,ACTIVE
+CITYOFSUGARLAND-TX.GOV,City,Non-Federal Agency,Sugar Land,TX,ACTIVE
+CITYOFSUGARLANDTX.GOV,City,Non-Federal Agency,Sugar Land,TX,ACTIVE
+CITYOFSUNRISEFL.GOV,City,Non-Federal Agency,Sunrise,FL,ACTIVE
+CITYOFSUNRISEFLORIDA.GOV,City,Non-Federal Agency,Sunrise,FL,ACTIVE
+CITYOFTITUSVILLEPA.GOV,City,Non-Federal Agency,Titusville,PA,ACTIVE
+CITYOFTORRANCECA.GOV,City,Non-Federal Agency,Torrance,CA,ACTIVE
+CITYOFTUKWILA-WA.GOV,City,Non-Federal Agency,Tukwila,WA,ACTIVE
+CITYOFTYLER-TX.GOV,City,Non-Federal Agency,Tyler,TX,ACTIVE
+CITYOFTYLERTX.GOV,City,Non-Federal Agency,Tyler,TX,ACTIVE
+CITYOFWARRENPA.GOV,City,Non-Federal Agency,Warren,PA,ACTIVE
+CITYOFWASHINGTONGA.GOV,City,Non-Federal Agency,Washington,GA,ACTIVE
+CITYOFWEATHERBYLAKE-MO.GOV,City,Non-Federal Agency,Weatherby Lake,MO,ACTIVE
+CITYOFWESTONLAKES-TX.GOV,City,Non-Federal Agency,Fulshear,TX,ACTIVE
+CITYOFWESTPALMBEACH-FL.GOV,City,Non-Federal Agency,West Palm Beach,FL,ACTIVE
+CITYOFWEYAUWEGA-WI.GOV,City,Non-Federal Agency,Weyauwega,WI,ACTIVE
+CITYOFWHEATON-IL.GOV,City,Non-Federal Agency,Wheaton,IL,ACTIVE
+CITYOFWOODBURYGA.GOV,City,Non-Federal Agency,Woodbury,GA,ACTIVE
+CITYOFWORLANDWY.GOV,City,Non-Federal Agency,Worland,WY,ACTIVE
+CITYOFYUKONOK.GOV,City,Non-Federal Agency,Yukon,OK,ACTIVE
+CITYOLYMPIA-WA.GOV,City,Non-Federal Agency,Olympia,WA,ACTIVE
+CITYOLYMPIAWA.GOV,City,Non-Federal Agency,Olympia,WA,ACTIVE
+CLAIRTON-PA.GOV,City,Non-Federal Agency,Clairton,PA,ACTIVE
+CLARKSTONGA.GOV,City,Non-Federal Agency,Clarkston,GA,ACTIVE
+CLARKSVILLEAR.GOV,City,Non-Federal Agency,Clarksville,AR,ACTIVE
+CLAYTONMO.GOV,City,Non-Federal Agency,Clayton,MO,ACTIVE
+CLEARLAKE-WI.GOV,City,Non-Federal Agency,Clear Lake,WI,ACTIVE
+CLEARLAKESHORES-TX.GOV,City,Non-Federal Agency,Clear Lake Shores,TX,ACTIVE
+CLERMONTFL.GOV,City,Non-Federal Agency,Clermont,FM,ACTIVE
+CLEVELAND-OH.GOV,City,Non-Federal Agency,Cleveland,OH,ACTIVE
+CLEVELANDOHIO.GOV,City,Non-Federal Agency,Cleveland,OH,ACTIVE
+CLEVELANDTN.GOV,City,Non-Federal Agency,Cleveland,TN,ACTIVE
+CLEVELANDWI.GOV,City,Non-Federal Agency,Cleveland,WI,ACTIVE
+CLEWISTON-FL.GOV,City,Non-Federal Agency,Clewiston,FL,ACTIVE
+CLIFFSIDEPARKNJ.GOV,City,Non-Federal Agency,Cliffside Park,NJ,ACTIVE
+CLIFTONAZ.GOV,City,Non-Federal Agency,Clifton,AZ,ACTIVE
+CLIFTONFORGEVA.GOV,City,Non-Federal Agency,Clifton Forge,VA,ACTIVE
+CLINTONMA.GOV,City,Non-Federal Agency,Clinton,MA,ACTIVE
+CLINTONNJ.GOV,City,Non-Federal Agency,New Jersey,NJ,ACTIVE
+CLINTONOK.GOV,City,Non-Federal Agency,Clinton,OK,ACTIVE
+CLINTONTOWNSHIP-MI.GOV,City,Non-Federal Agency,Clinton Township,MI,ACTIVE
+CMSDCA.GOV,City,Non-Federal Agency,Costa Mesa,CA,ACTIVE
+COALCITY-IL.GOV,City,Non-Federal Agency,Coal City,IL,ACTIVE
+COALRUNKY.GOV,City,Non-Federal Agency,Pikeville,KY,ACTIVE
+COHOES-NY.GOV,City,Non-Federal Agency,Cohoes,NY,ACTIVE
+COLCHESTERCT.GOV,City,Non-Federal Agency,Colchester,CT,ACTIVE
+COLCHESTERVT.GOV,City,Non-Federal Agency,Colchester,VT,ACTIVE
+COLDSPRINGKY.GOV,City,Non-Federal Agency,COLD SPRING,KY,ACTIVE
+COLDSPRINGNY.GOV,City,Non-Federal Agency,Cold Spring ,NY,ACTIVE
+COLFAX-CA.GOV,City,Non-Federal Agency,Colfax,CA,ACTIVE
+COLLEGEDALETN.GOV,City,Non-Federal Agency,Collegedale,TN,ACTIVE
+COLLEGEPARKMD.GOV,City,Non-Federal Agency,College Park,MD,ACTIVE
+COLLEGEVILLE-PA.GOV,City,Non-Federal Agency,Collegeville,PA,ACTIVE
+COLLIERVILLETN.GOV,City,Non-Federal Agency,Collierville,TN,ACTIVE
+COLLINCOUNTYTEXAS.GOV,City,Non-Federal Agency,Mckinney,TX,ACTIVE
+COLLINCOUNTYTX.GOV,City,Non-Federal Agency,McKinney,TX,ACTIVE
+COLONIALHEIGHTSVA.GOV,City,Non-Federal Agency,Colonial Heights,VA,ACTIVE
+COLONIE-NY.GOV,City,Non-Federal Agency,Newtonville,NY,ACTIVE
+COLORADOSPRINGS.GOV,City,Non-Federal Agency,Colorado Springs,CO,ACTIVE
+COLRAIN-MA.GOV,City,Non-Federal Agency,Colrain,MA,ACTIVE
+COLTONCA.GOV,City,Non-Federal Agency,Colton,CA,ACTIVE
+COLUMBIAHEIGHTSMN.GOV,City,Non-Federal Agency,Columbia Heights,MN,ACTIVE
+COLUMBIANAOHIO.GOV,City,Non-Federal Agency,Columbiana,OH,ACTIVE
+COLUMBIASC.GOV,City,Non-Federal Agency,Columbia,SC,ACTIVE
+COLUMBIATN.GOV,City,Non-Federal Agency,Columbia,TN,ACTIVE
+COLUMBIATWP-OH.GOV,City,Non-Federal Agency,Columbia Station,OH,ACTIVE
+COLUMBUS.GOV,City,Non-Federal Agency,Columbus,OH,ACTIVE
+COLUMBUSOH.GOV,City,Non-Federal Agency,Columbus,OH,ACTIVE
+COLUMBUSOHIO.GOV,City,Non-Federal Agency,Columbus,OH,ACTIVE
+COMMERCIALPOINTOHIO.GOV,City,Non-Federal Agency,Commercial Point,OH,ACTIVE
+COMO.GOV,City,Non-Federal Agency,Columbia,MO,ACTIVE
+COMSTOCKMI.GOV,City,Non-Federal Agency,Kalamazoo,MI,ACTIVE
+CONCORDMA.GOV,City,Non-Federal Agency,Concord,MA,ACTIVE
+CONCORDNC.GOV,City,Non-Federal Agency,Concord,NC,ACTIVE
+CONCORDNH.GOV,City,Non-Federal Agency,Concord,NH,ACTIVE
+CONCRETEWA.GOV,City,Non-Federal Agency,Concrete,WA,ACTIVE
+CONNEAUTOHIO.GOV,City,Non-Federal Agency,Conneaut,OH,ACTIVE
+CONNERSVILLEIN.GOV,City,Non-Federal Agency,Connersville,IN,ACTIVE
+CONOVERNC.GOV,City,Non-Federal Agency,Conover,NC,ACTIVE
+CONYERSGA.GOV,City,Non-Federal Agency,Conyers,GA,ACTIVE
+COOKEVILLE-TN.GOV,City,Non-Federal Agency,Cookeville,TN,ACTIVE
+COONRAPIDSMN.GOV,City,Non-Federal Agency,Coon Rapids,MN,ACTIVE
+COPPELLTX.GOV,City,Non-Federal Agency,Coppell,TX,ACTIVE
+COPPERASCOVETX.GOV,City,Non-Federal Agency,Copperas Cove,TX,ACTIVE
+COR.GOV,City,Non-Federal Agency,Richardson,TX,ACTIVE
+CORALGABLES-FL.GOV,City,Non-Federal Agency,Coral Gables,FL,ACTIVE
+CORALGABLESFL.GOV,City,Non-Federal Agency,Coral Gables,FL,ACTIVE
+CORBIN-KY.GOV,City,Non-Federal Agency,Corbin,KY,ACTIVE
+CORNINGAR.GOV,City,Non-Federal Agency,Corning,AR,ACTIVE
+CORNWALLNY.GOV,City,Non-Federal Agency,Cornwall,NY,ACTIVE
+CORPUSCHRISTI-TX.GOV,City,Non-Federal Agency,Corpus Christi,TX,ACTIVE
+CORRALESNM.GOV,City,Non-Federal Agency,Corales,NM,ACTIVE
+CORRYPA.GOV,City,Non-Federal Agency,Corry,PA,ACTIVE
+CORUNNA-MI.GOV,City,Non-Federal Agency,Corunna,MI,ACTIVE
+CORVALLISOREGON.GOV,City,Non-Federal Agency,Corvallis,OR,ACTIVE
+CORYDON-IN.GOV,City,Non-Federal Agency,Corydon,IN,ACTIVE
+COSMOPOLISWA.GOV,City,Non-Federal Agency,Cosmopolis,WA,ACTIVE
+COSPRINGS.GOV,City,Non-Federal Agency,Colorado Springs,CO,ACTIVE
+COSTAMESACA.GOV,City,Non-Federal Agency,Costa Mesa,CA,ACTIVE
+COTTAGECITYMD.GOV,City,Non-Federal Agency,Cottage City,MD,ACTIVE
+COTTONWOODAZ.GOV,City,Non-Federal Agency,Cottonwood,AZ,ACTIVE
+COUNTRYSIDE-IL.GOV,City,Non-Federal Agency,Countryside,IL,ACTIVE
+COVINACA.GOV,City,Non-Federal Agency,Covina,CA,ACTIVE
+COVINGTON-OH.GOV,City,Non-Federal Agency,COVINGTON ,OH,ACTIVE
+COVINGTONKY.GOV,City,Non-Federal Agency,Covington,KY,ACTIVE
+COVINGTONWA.GOV,City,Non-Federal Agency,Covington,WA,ACTIVE
+CRANBERRYISLES-ME.GOV,City,Non-Federal Agency,Islesford,ME,ACTIVE
+CRAWFORDSVILLE-IN.GOV,City,Non-Federal Agency,Crawfordsville,IN,ACTIVE
+CREDITRIVER-MN.GOV,City,Non-Federal Agency,Prior Lake,MN,ACTIVE
+CRESTONIOWA.GOV,City,Non-Federal Agency,Creston,IA,ACTIVE
+CRETE-NE.GOV,City,Non-Federal Agency,Crete,NE,ACTIVE
+CREVECOEURMO.GOV,City,Non-Federal Agency,Creve Coeur,MO,ACTIVE
+CROSSROADSTX.GOV,City,Non-Federal Agency,Crossroads,TX,ACTIVE
+CROSSVILLETN.GOV,City,Non-Federal Agency,Crossville,TN,ACTIVE
+CROTONONHUDSON-NY.GOV,City,Non-Federal Agency,Croton-On-Hudson,NY,ACTIVE
+CRYSTALMN.GOV,City,Non-Federal Agency,Crystal,MN,ACTIVE
+CUBAASSESSORIL.GOV,City,Non-Federal Agency,Barrington,IL,ACTIVE
+CUBATWPIL.GOV,City,Non-Federal Agency,Barrington,IL,ACTIVE
+CUDAHY-WI.GOV,City,Non-Federal Agency,Cudahy,WI,ACTIVE
+CULPEPERVA.GOV,City,Non-Federal Agency,Culpeper,VA,ACTIVE
+CUMBERLANDMD.GOV,City,Non-Federal Agency,Cumberland,MD,ACTIVE
+CUMMINGTON-MA.GOV,City,Non-Federal Agency,Cummington,MA,ACTIVE
+CUTLERBAY-FL.GOV,City,Non-Federal Agency,Cutler Bay,FL,ACTIVE
+DACULAGA.GOV,City,Non-Federal Agency,Dacula,GA,ACTIVE
+DAHLONEGA-GA.GOV,City,Non-Federal Agency,Dahlonega,GA,ACTIVE
+DALHARTTX.GOV,City,Non-Federal Agency,Dalhart,TX,ACTIVE
+DALLAS-GA.GOV,City,Non-Federal Agency,Dallas,GA,ACTIVE
+DALLASOR.GOV,City,Non-Federal Agency,Dallas,OR,ACTIVE
+DALLASOREGON.GOV,City,Non-Federal Agency,Dallas,OR,ACTIVE
+DALTON-MA.GOV,City,Non-Federal Agency,Dalton,MA,ACTIVE
+DAMASCUSOREGON.GOV,City,Non-Federal Agency,Damascus,OR,ACTIVE
+DANBURY-CT.GOV,City,Non-Federal Agency,Danbury,CT,ACTIVE
+DANDRIDGETN.GOV,City,Non-Federal Agency,Dandridge,TN,ACTIVE
+DANIABEACHFL.GOV,City,Non-Federal Agency,DANIA BEACH,FL,ACTIVE
+DANVERSMA.GOV,City,Non-Federal Agency,Danvers,MA,ACTIVE
+DANVILLE-VA.GOV,City,Non-Federal Agency,Danville,VA,ACTIVE
+DANVILLEVA.GOV,City,Non-Federal Agency,Danville,VA,ACTIVE
+DARIENCT.GOV,City,Non-Federal Agency,Darien,CT,ACTIVE
+DARIENIL.GOV,City,Non-Federal Agency,Darien,IL,ACTIVE
+DAUGHERTYTOWNSHIP-PA.GOV,City,Non-Federal Agency,New Brighton,PA,ACTIVE
+DAVIE-FL.GOV,City,Non-Federal Agency,Davie,FL,ACTIVE
+DAWSONVILLE-GA.GOV,City,Non-Federal Agency,Dawsonville,GA,ACTIVE
+DAYTON-ME.GOV,City,Non-Federal Agency,Dayton,ME,ACTIVE
+DAYTONOHIO.GOV,City,Non-Federal Agency,Dayton,OH,ACTIVE
+DECATUR-AL.GOV,City,Non-Federal Agency,Decatur,AL,ACTIVE
+DECATURIL.GOV,City,Non-Federal Agency,Decatur,IL,ACTIVE
+DECATURILLINOIS.GOV,City,Non-Federal Agency,Decatur,IL,ACTIVE
+DECATURTX.GOV,City,Non-Federal Agency,Decatur,TX,ACTIVE
+DEDHAM-MA.GOV,City,Non-Federal Agency,Dedham,MA,ACTIVE
+DEERFIELDMICHIGAN.GOV,City,Non-Federal Agency,Deerfield,MI,ACTIVE
+DEERPARK-OH.GOV,City,Non-Federal Agency,Deer Park,OH,ACTIVE
+DEERPARKTX.GOV,City,Non-Federal Agency,Deer Park,TX,ACTIVE
+DEKORRA-WI.GOV,City,Non-Federal Agency,Poynette,WI,ACTIVE
+DELAWARETOWNSHIPPA.GOV,City,Non-Federal Agency,Dingmans Ferry,PA,ACTIVE
+DELRAYBEACHFL.GOV,City,Non-Federal Agency,Delray Beach,FL,ACTIVE
+DELTA-CO.GOV,City,Non-Federal Agency,Delta,CO,ACTIVE
+DELTAMI.GOV,City,Non-Federal Agency,Lansing,MI,ACTIVE
+DELTONAFL.GOV,City,Non-Federal Agency,Deltona,FL,ACTIVE
+DEMOPOLISAL.GOV,City,Non-Federal Agency,Demopolis,AL,ACTIVE
+DENVERCO.GOV,City,Non-Federal Agency,Denver,CO,ACTIVE
+DERBYCT.GOV,City,Non-Federal Agency,Derby,CT,ACTIVE
+DESMOINESWA.GOV,City,Non-Federal Agency,Des Moines,WA,ACTIVE
+DESOTOTEXAS.GOV,City,Non-Federal Agency,DeSoto,TX,ACTIVE
+DETROITMI.GOV,City,Non-Federal Agency,Detroit,MI,ACTIVE
+DEXTERMI.GOV,City,Non-Federal Agency,Dexter,MI,ACTIVE
+DHAZ.GOV,City,Non-Federal Agency,Humboldt,AZ,ACTIVE
+DIAMONDBARCA.GOV,City,Non-Federal Agency,Diamond Bar,CA,ACTIVE
+DICKINSON-TX.GOV,City,Non-Federal Agency,Dickinson,TX,ACTIVE
+DICKINSONTEXAS.GOV,City,Non-Federal Agency,Dickinson,TX,ACTIVE
+DICKSONCITY-PA.GOV,City,Non-Federal Agency,Dickson City,PA,ACTIVE
+DIGHTON-MA.GOV,City,Non-Federal Agency,Dighton,MA,ACTIVE
+DISCOVERWAUKESHA-WI.GOV,City,Non-Federal Agency,Waukesha,WI,ACTIVE
+DONALDOREGON.GOV,City,Non-Federal Agency,Donald,OR,ACTIVE
+DONALDSONVILLE-LA.GOV,City,Non-Federal Agency,Donaldsonville,LA,ACTIVE
+DORAL-FL.GOV,City,Non-Federal Agency,Doral,FL,ACTIVE
+DORALPD-FL.GOV,City,Non-Federal Agency,Doral,FL,ACTIVE
+DOUGLASAZ.GOV,City,Non-Federal Agency,Douglas,AZ,ACTIVE
+DOUGLASVILLEGA.GOV,City,Non-Federal Agency,Douglasville,GA,ACTIVE
+DREW-MS.GOV,City,Non-Federal Agency,Drew,MS,ACTIVE
+DRUIDHILLSKY.GOV,City,Non-Federal Agency,Louisville,KY,ACTIVE
+DUBLIN-CA.GOV,City,Non-Federal Agency,Dublin,CA,ACTIVE
+DUBLINCA.GOV,City,Non-Federal Agency,Dublin,CA,ACTIVE
+DUBLINOHIOUSA.GOV,City,Non-Federal Agency,Dublin,OH,ACTIVE
+DUBOISPA.GOV,City,Non-Federal Agency,DuBois,PA,ACTIVE
+DULUTHMN.GOV,City,Non-Federal Agency,Duluth,MN,ACTIVE
+DUMASTX.GOV,City,Non-Federal Agency,Dumas,TX,ACTIVE
+DUMFRIESVA.GOV,City,Non-Federal Agency,Dumfries,VA,ACTIVE
+DUMONTNJ.GOV,City,Non-Federal Agency,Dumont,NJ,ACTIVE
+DUNCANOK.GOV,City,Non-Federal Agency,Duncan,OK,ACTIVE
+DUNCANVILLETX.GOV,City,Non-Federal Agency,Duncanville,TX,ACTIVE
+DUNDEEVILLAGEMI.GOV,City,Non-Federal Agency,Dundee,MI,ACTIVE
+DUNELLEN-NJ.GOV,City,Non-Federal Agency,Dunellen,NJ,ACTIVE
+DUNMOREPA.GOV,City,Non-Federal Agency,Dunmore,PA,ACTIVE
+DUNSTABLE-MA.GOV,City,Non-Federal Agency,Dunstable,MA,ACTIVE
+DUNWOODYGA.GOV,City,Non-Federal Agency,Dunwoody,GA,ACTIVE
+DUNWOODYGEORGIA.GOV,City,Non-Federal Agency,Dunwoody,GA,ACTIVE
+DUPONTWA.GOV,City,Non-Federal Agency,DuPont,WA,ACTIVE
+DURHAMNC.GOV,City,Non-Federal Agency,Durham,NC,ACTIVE
+DUSHOREPA.GOV,City,Non-Federal Agency,Dushore,PA,ACTIVE
+DUTCHESSNY.GOV,City,Non-Federal Agency,Poughkeepsie,NY,ACTIVE
+DUVALLWA.GOV,City,Non-Federal Agency,Duvall,WA,ACTIVE
+DYERSBURGTN.GOV,City,Non-Federal Agency,Dyersburg,TN,ACTIVE
+EAGARAZ.GOV,City,Non-Federal Agency,Eagar,AZ,ACTIVE
+EAGLE-WI.GOV,City,Non-Federal Agency,Eagle,WI,ACTIVE
+EAGLELAKE-TX.GOV,City,Non-Federal Agency,Eagle Lake,TX,ACTIVE
+EASTBOROUGH-KS.GOV,City,Non-Federal Agency,Eastborough,KS,ACTIVE
+EASTCOVENTRY-PA.GOV,City,Non-Federal Agency,Pottstown,PA,ACTIVE
+EASTHAMPTONCT.GOV,City,Non-Federal Agency,East Hampton,CT,ACTIVE
+EASTHAMPTONNY.GOV,City,Non-Federal Agency,Amagansett,NY,ACTIVE
+EASTHAMPTONVILLAGENY.GOV,City,Non-Federal Agency,East Hampton,NY,ACTIVE
+EASTHARTFORDCT.GOV,City,Non-Federal Agency,East Hartford,CT,ACTIVE
+EASTKINGSTONNH.GOV,City,Non-Federal Agency,East Kingston,NH,ACTIVE
+EASTLONGMEADOWMA.GOV,City,Non-Federal Agency,East Longmeadow,MA,ACTIVE
+EASTMOUNTAINTX.GOV,City,Non-Federal Agency,East Mountain,TX,ACTIVE
+EASTON-PA.GOV,City,Non-Federal Agency,Easton,PA,ACTIVE
+EASTONCT.GOV,City,Non-Federal Agency,Easton,CT,ACTIVE
+EASTONMD.GOV,City,Non-Federal Agency,Easton,MD,ACTIVE
+EASTORANGE-NJ.GOV,City,Non-Federal Agency,East ORange,NJ,ACTIVE
+EASTPALESTINE-OH.GOV,City,Non-Federal Agency,East Palestine,OH,ACTIVE
+EASTPORT-ME.GOV,City,Non-Federal Agency,Eastport,ME,ACTIVE
+EASTRIDGETN.GOV,City,Non-Federal Agency,East Ridge,TN,ACTIVE
+EASTTROYWI.GOV,City,Non-Federal Agency,East Troy,WI,ACTIVE
+EASTVALECA.GOV,City,Non-Federal Agency,Eastvale,CA,ACTIVE
+EASTWINDSOR-CT.GOV,City,Non-Federal Agency,Broad Brook,CT,ACTIVE
+EATONVILLE-WA.GOV,City,Non-Federal Agency,Eatonville,WA,ACTIVE
+EAUCLAIREVILLAGE-MI.GOV,City,Non-Federal Agency,Eau Claire,MI,ACTIVE
+EAUCLAIREWI.GOV,City,Non-Federal Agency,Eau Claire,WI,ACTIVE
+ECORSEMI.GOV,City,Non-Federal Agency,ECORSE,MI,ACTIVE
+EDDINGTONMAINE.GOV,City,Non-Federal Agency,Eddington,ME,ACTIVE
+EDENNY.GOV,City,Non-Federal Agency,Eden,NY,ACTIVE
+EDGEWATERFL.GOV,City,Non-Federal Agency,Edgewater,FL,ACTIVE
+EDGEWOOD-FL.GOV,City,Non-Federal Agency,Edgewood,FL,ACTIVE
+EDGEWOOD-NM.GOV,City,Non-Federal Agency,Edgewood,NM,ACTIVE
+EDINAMN.GOV,City,Non-Federal Agency,Edina,MN,ACTIVE
+EDMONDS-WA.GOV,City,Non-Federal Agency,Edmonds,WA,ACTIVE
+EDMONDSWA.GOV,City,Non-Federal Agency,Edmonds,WA,ACTIVE
+EDMONSTONMD.GOV,City,Non-Federal Agency,Edmonston,MD,ACTIVE
+EHALERTCT.GOV,City,Non-Federal Agency,East Hartford,CT,ACTIVE
+EHAMPTONNY.GOV,City,Non-Federal Agency,East Hampton,NY,ACTIVE
+ELKHARTLAKEWI.GOV,City,Non-Federal Agency,Elkhart Lake,WI,ACTIVE
+ELKOCITYNV.GOV,City,Non-Federal Agency,Elko,NV,ACTIVE
+ELKRIVERMN.GOV,City,Non-Federal Agency,Elk River,MN,ACTIVE
+ELKTONVA.GOV,City,Non-Federal Agency,Elkton,VA,ACTIVE
+ELKTOWNSHIPNJ.GOV,City,Non-Federal Agency,Monroeville,NJ,ACTIVE
+ELLAGO-TX.GOV,City,Non-Federal Agency,El Lago,TX,ACTIVE
+ELLIJAY-GA.GOV,City,Non-Federal Agency,Ellijay,GA,ACTIVE
+ELLINGTON-CT.GOV,City,Non-Federal Agency,Ellington,CT,ACTIVE
+ELLSWORTHMAINE.GOV,City,Non-Federal Agency,Ellsworth,ME,ACTIVE
+ELMIRAGE-AZ.GOV,City,Non-Federal Agency,El Mirage,AZ,ACTIVE
+ELMONTECA.GOV,City,Non-Federal Agency,El Monte,CA,ACTIVE
+ELOYAZ.GOV,City,Non-Federal Agency,Eloy,AZ,ACTIVE
+ELPASOTEXAS.GOV,City,Non-Federal Agency,El Paso,TX,ACTIVE
+EMERALDBAY-TX.GOV,City,Non-Federal Agency,Bullard,TX,ACTIVE
+EMMITSBURGMD.GOV,City,Non-Federal Agency,Emmitsburg,MD,ACTIVE
+EMPORIA-KANSAS.GOV,City,Non-Federal Agency,Emporia,KS,ACTIVE
+ENCINITASCA.GOV,City,Non-Federal Agency,Encinitas,CA,ACTIVE
+ENCINITASCALIFORNIA.GOV,City,Non-Federal Agency,Encinitas,CA,ACTIVE
+ENFIELD-CT.GOV,City,Non-Federal Agency,Enfield,CT,ACTIVE
+ENNISTX.GOV,City,Non-Federal Agency,Ennis,TX,ACTIVE
+ENON-OH.GOV,City,Non-Federal Agency,Enon,OH,ACTIVE
+ENTERPRISEAL.GOV,City,Non-Federal Agency,Enterprise,AL,ACTIVE
+ERIECO.GOV,City,Non-Federal Agency,Erie,CO,ACTIVE
+ESPANOLANM.GOV,City,Non-Federal Agency,Espanola,NM,ACTIVE
+ESSEXCT.GOV,City,Non-Federal Agency,Essex,CT,ACTIVE
+ESTERO-FL.GOV,City,Non-Federal Agency,Estero,FL,ACTIVE
+ETON-GA.GOV,City,Non-Federal Agency,Eton,GA,ACTIVE
+EUGENE-OR.GOV,City,Non-Federal Agency,Eugene,OR,ACTIVE
+EULESSTX.GOV,City,Non-Federal Agency,Euless,TX,ACTIVE
+EUREKA-MT.GOV,City,Non-Federal Agency,Eureka,MT,ACTIVE
+EUREKASPRINGSAR.GOV,City,Non-Federal Agency,Eureka Springs,AR,ACTIVE
+EVANSCOLORADO.GOV,City,Non-Federal Agency,Evans,CO,ACTIVE
+EVERETTWA.GOV,City,Non-Federal Agency,Everett,WA,ACTIVE
+EVESHAM-NJ.GOV,City,Non-Federal Agency,Marlton,NJ,ACTIVE
+EXETERNH.GOV,City,Non-Federal Agency,Exeter,NH,ACTIVE
+FABIUS-NY.GOV,City,Non-Federal Agency,Fabius,NY,ACTIVE
+FAIRFAX-VT.GOV,City,Non-Federal Agency,Fairfax,VT,ACTIVE
+FAIRFAXVA.GOV,City,Non-Federal Agency,Fairfax,VA,ACTIVE
+FAIRFIELDOH.GOV,City,Non-Federal Agency,Fairfield,OH,ACTIVE
+FAIRHOPE-AL.GOV,City,Non-Federal Agency,Fairhope,AL,ACTIVE
+FAIRMONTWV.GOV,City,Non-Federal Agency,Fairmont,WV,ACTIVE
+FAIRMOUNTHEIGHTSMD.GOV,City,Non-Federal Agency,Fairmount Heights,MD,ACTIVE
+FAIRVIEWNC.GOV,City,Non-Federal Agency,Monroe,NC,ACTIVE
+FAIRVIEWOREGON.GOV,City,Non-Federal Agency,Fairview,OR,ACTIVE
+FALLCREEKWI.GOV,City,Non-Federal Agency,Fall Creek,WI,ACTIVE
+FALLONNEVADA.GOV,City,Non-Federal Agency,Fallon,NV,ACTIVE
+FALLSCHURCHCITYVA.GOV,City,Non-Federal Agency,Falls Church,VA,ACTIVE
+FALLSCHURCHVA.GOV,City,Non-Federal Agency,Falls Church,VA,ACTIVE
+FALLSCITYOREGON.GOV,City,Non-Federal Agency,Falls City,OR,ACTIVE
+FARGO-ND.GOV,City,Non-Federal Agency,Fargo,ND,ACTIVE
+FARGOND.GOV,City,Non-Federal Agency,Fargo,ND,ACTIVE
+FARMERSBRANCHTX.GOV,City,Non-Federal Agency,Farmers Branch,TX,ACTIVE
+FARMINGTON-MO.GOV,City,Non-Federal Agency,Farmington,MO,ACTIVE
+FARMVILLENC.GOV,City,Non-Federal Agency,Farmville,NC,ACTIVE
+FARRAGUT-TN.GOV,City,Non-Federal Agency,Farragut,TN,ACTIVE
+FAYETTEVILLE-AR.GOV,City,Non-Federal Agency,Fayetteville,AR,ACTIVE
+FAYETTEVILLEFIRST-AR.GOV,City,Non-Federal Agency,Fayetteville,AR,ACTIVE
+FAYETTEVILLENC.GOV,City,Non-Federal Agency,Fayetteville,NC,ACTIVE
+FAYETTEVILLENY.GOV,City,Non-Federal Agency,Fayetteville,NY,ACTIVE
+FEDERALWAYWA.GOV,City,Non-Federal Agency,Federal Way ,WA,ACTIVE
+FERNDALEMI.GOV,City,Non-Federal Agency,Ferndale,MI,ACTIVE
+FERRISTEXAS.GOV,City,Non-Federal Agency,Ferris,TX,ACTIVE
+FIRESTONECO.GOV,City,Non-Federal Agency,Firestone,CO,ACTIVE
+FISHKILL-NY.GOV,City,Non-Federal Agency,Fishkill,NY,ACTIVE
+FITCHBURGMA.GOV,City,Non-Federal Agency,Fitchburg,MA,ACTIVE
+FITCHBURGWI.GOV,City,Non-Federal Agency,Fitchburg,WI,ACTIVE
+FITZWILLIAM-NH.GOV,City,Non-Federal Agency,Fitzwilliam,NH,ACTIVE
+FLAGSTAFFAZ.GOV,City,Non-Federal Agency,Flagstaff,AZ,ACTIVE
+FLATONIATX.GOV,City,Non-Federal Agency,Flatonia,TX,ACTIVE
+FLORENCE-KY.GOV,City,Non-Federal Agency,Florence,KY,ACTIVE
+FLORENCE-NJ.GOV,City,Non-Federal Agency,Florence,NJ,ACTIVE
+FLORENCEAZ.GOV,City,Non-Federal Agency,Florence,AZ,ACTIVE
+FLORESVILLETX.GOV,City,Non-Federal Agency,Floresville,TX,ACTIVE
+FLORIDACITYFL.GOV,City,Non-Federal Agency,Florida City,FL,ACTIVE
+FORESTGROVE-OR.GOV,City,Non-Federal Agency,FOREST GROVE,OR,ACTIVE
+FORESTHEIGHTSMD.GOV,City,Non-Federal Agency,Forest Heights,MD,ACTIVE
+FORESTPARKOK.GOV,City,Non-Federal Agency,Forest Park,OK,ACTIVE
+FORSYTH-IL.GOV,City,Non-Federal Agency,Forsyth,IL,ACTIVE
+FORTCOLLINS-CO.GOV,City,Non-Federal Agency,Fort Collins,CO,ACTIVE
+FORTLUPTON-CO.GOV,City,Non-Federal Agency,Fort Lupton,CO,ACTIVE
+FORTLUPTONCO.GOV,City,Non-Federal Agency,Fort Lupton,CO,ACTIVE
+FORTMADISON-IA.GOV,City,Non-Federal Agency,Fort Madison,IA,ACTIVE
+FORTMILLSC.GOV,City,Non-Federal Agency,Fort Mill,SC,ACTIVE
+FORTMYERSBEACHFL.GOV,City,Non-Federal Agency,Fort Myers Beach,FL,ACTIVE
+FORTSMITHAR.GOV,City,Non-Federal Agency,Fort Smith,AR,ACTIVE
+FORTWORTH-TEXAS.GOV,City,Non-Federal Agency,Fort Worth,TX,ACTIVE
+FORTWORTH-TX.GOV,City,Non-Federal Agency,Fort Worth,TX,ACTIVE
+FORTWORTHTEXAS.GOV,City,Non-Federal Agency,Fort Worth,TX,ACTIVE
+FOSTORIAOHIO.GOV,City,Non-Federal Agency,Fostoria,OH,ACTIVE
+FOXBOROUGHMA.GOV,City,Non-Federal Agency,Foxborough,MA,ACTIVE
+FRAMINGHAMMA.GOV,City,Non-Federal Agency,Framingham,MA,ACTIVE
+FRANCESTOWN-NH.GOV,City,Non-Federal Agency,Francestown,NH,ACTIVE
+FRANKFORT-IN.GOV,City,Non-Federal Agency,Frankfort,IN,ACTIVE
+FRANKFORT-KY.GOV,City,Non-Federal Agency,Frankfort,KY,ACTIVE
+FRANKLIN-IN.GOV,City,Non-Federal Agency,FRANKLIN,IN,ACTIVE
+FRANKLIN-NJ.GOV,City,Non-Federal Agency,Someret,NJ,ACTIVE
+FRANKLIN-TN.GOV,City,Non-Federal Agency,Franklin,TN,ACTIVE
+FRANKLINNJ.GOV,City,Non-Federal Agency,Somerset,NJ,ACTIVE
+FRANKLINPA.GOV,City,Non-Federal Agency,Franklin,PA,ACTIVE
+FRANKLINTN.GOV,City,Non-Federal Agency,Franklin,TN,ACTIVE
+FRANKLINWI.GOV,City,Non-Federal Agency,Franklin,WI,ACTIVE
+FREDENBERGTWP-MN.GOV,City,Non-Federal Agency,Duluth,MN,ACTIVE
+FREDERICKCO.GOV,City,Non-Federal Agency,Frederick,CO,ACTIVE
+FREDERICKOK.GOV,City,Non-Federal Agency,Frederick,OK,ACTIVE
+FREDERICKSBURGVA.GOV,City,Non-Federal Agency,Fredericksburg,VA,ACTIVE
+FREEHOLDBOROUGHNJ.GOV,City,Non-Federal Agency,Freehold,NJ,ACTIVE
+FREEPORTNY.GOV,City,Non-Federal Agency,Freeport,NY,ACTIVE
+FREETOWNMA.GOV,City,Non-Federal Agency,Assonet,MA,ACTIVE
+FREMONT.GOV,City,Non-Federal Agency,Fremont,CA,ACTIVE
+FREMONTNC.GOV,City,Non-Federal Agency,Fremont,NC,ACTIVE
+FREMONTNE.GOV,City,Non-Federal Agency,Fremont,NE,ACTIVE
+FRENCHSETTLEMENT-LA.GOV,City,Non-Federal Agency,French Settlement,LA,ACTIVE
+FRESNO.GOV,City,Non-Federal Agency,Fresno,CA,ACTIVE
+FRIDLEYMN.GOV,City,Non-Federal Agency,Fridley,MN,ACTIVE
+FRIENDSHIPHEIGHTSMD.GOV,City,Non-Federal Agency,Chevy Chase,MD,ACTIVE
+FRISCOTEXAS.GOV,City,Non-Federal Agency,Frisco,TX,ACTIVE
+FRISCOTX.GOV,City,Non-Federal Agency,Frisco,TX,ACTIVE
+FROMBERG-MT.GOV,City,Non-Federal Agency,Fromberg,MT,ACTIVE
+FRONTROYAL-VA.GOV,City,Non-Federal Agency,Front Royal,VA,ACTIVE
+FRONTROYALVA.GOV,City,Non-Federal Agency,Front Royal,VA,ACTIVE
+FRUITPORTTOWNSHIP-MI.GOV,City,Non-Federal Agency,Fruitport,MI,ACTIVE
+FULSHEARTEXAS.GOV,City,Non-Federal Agency,Fulshear,TX,ACTIVE
+GAHANNA.GOV,City,Non-Federal Agency,Gahanna,OH,ACTIVE
+GALENAKS.GOV,City,Non-Federal Agency,GALENA,KS,ACTIVE
+GALENAOHIO.GOV,City,Non-Federal Agency,Galena,OH,ACTIVE
+GALESBURG-IL.GOV,City,Non-Federal Agency,Galesburg,IL,ACTIVE
+GALLATIN-TN.GOV,City,Non-Federal Agency,Gallatin,TN,ACTIVE
+GALLAWAYTN.GOV,City,Non-Federal Agency,Gallaway,TN,ACTIVE
+GALLOWAYTWP-NJ.GOV,City,Non-Federal Agency,Galloway,NJ,ACTIVE
+GALLUPNM.GOV,City,Non-Federal Agency,GALLUP,NM,ACTIVE
+GALVAIL.GOV,City,Non-Federal Agency,Galva,IL,ACTIVE
+GALVESTONTX.GOV,City,Non-Federal Agency,Galveston,TX,ACTIVE
+GARDENCITY-GA.GOV,City,Non-Federal Agency,Garden City,GA,ACTIVE
+GARDNERKANSAS.GOV,City,Non-Federal Agency,Gardner,KS,ACTIVE
+GARDNERVILLE-NV.GOV,City,Non-Federal Agency,Gardnerville,NV,ACTIVE
+GARLANDTX.GOV,City,Non-Federal Agency,Garland,TX,ACTIVE
+GARNERNC.GOV,City,Non-Federal Agency,Garner,NC,ACTIVE
+GARRETTPARK-MD.GOV,City,Non-Federal Agency,Garrett Park,MD,ACTIVE
+GARRETTPARKMD.GOV,City,Non-Federal Agency,Garrett Park,MD,ACTIVE
+GATLINBURGTN.GOV,City,Non-Federal Agency,Gatlinburg,TN,ACTIVE
+GAUTIER-MS.GOV,City,Non-Federal Agency,Gautier,MS,ACTIVE
+GENEVAOHIO.GOV,City,Non-Federal Agency,Geneva,OH,ACTIVE
+GEORGETOWN-MI.GOV,City,Non-Federal Agency,Jenison,MI,ACTIVE
+GEORGETOWNKY.GOV,City,Non-Federal Agency,Georgetown,KY,ACTIVE
+GEORGETOWNTX.GOV,City,Non-Federal Agency,Georgetown,TX,ACTIVE
+GERMANTOWN-TN.GOV,City,Non-Federal Agency,Germantown,TN,ACTIVE
+GETTYSBURG-PA.GOV,City,Non-Federal Agency,Gettysburg,PA,ACTIVE
+GILBERTAZ.GOV,City,Non-Federal Agency,Gilbert,AZ,ACTIVE
+GILLETTEWY.GOV,City,Non-Federal Agency,Gillette,WY,ACTIVE
+GIRARDKANSAS.GOV,City,Non-Federal Agency,Girard,KS,ACTIVE
+GLASTONBURY-CT.GOV,City,Non-Federal Agency,Glastonbury,CT,ACTIVE
+GLENDALE-WI.GOV,City,Non-Federal Agency,Glendale,WI,ACTIVE
+GLENDALEAZ.GOV,City,Non-Federal Agency,Glendale,AZ,ACTIVE
+GLENDALECA.GOV,City,Non-Federal Agency,Glendale,CA,ACTIVE
+GLENNHEIGHTSTX.GOV,City,Non-Federal Agency,Glenn Heights,TX,ACTIVE
+GLENVIEWKY.GOV,City,Non-Federal Agency,Glenview,KY,ACTIVE
+GLENWILLOW-OH.GOV,City,Non-Federal Agency,Glenwillow,OH,ACTIVE
+GLENWOODSPRINGSCO.GOV,City,Non-Federal Agency,Glenwood Springs,CO,ACTIVE
+GLOBEAZ.GOV,City,Non-Federal Agency,GLOBE,AZ,ACTIVE
+GLOUCESTER-MA.GOV,City,Non-Federal Agency,Gloucester,MA,ACTIVE
+GODDARDKS.GOV,City,Non-Federal Agency,Goddard,KS,ACTIVE
+GODLEYTX.GOV,City,Non-Federal Agency,Godley,TX,ACTIVE
+GOFFSTOWNNH.GOV,City,Non-Federal Agency,Goffstown,NH,ACTIVE
+GOLDBEACHOREGON.GOV,City,Non-Federal Agency,GoldBeach,OR,ACTIVE
+GOLDENVALLEYMN.GOV,City,Non-Federal Agency,Golden Valley,MN,ACTIVE
+GOLDSBORONC.GOV,City,Non-Federal Agency,Goldsboro,NC,ACTIVE
+GOODHOPEAL.GOV,City,Non-Federal Agency,Cullman,AL,ACTIVE
+GOODLETTSVILLE-TN.GOV,City,Non-Federal Agency,Goodlettsville,TN,ACTIVE
+GOODYEARAZ.GOV,City,Non-Federal Agency,Goodyear,AZ,ACTIVE
+GOSHEN-OH.GOV,City,Non-Federal Agency,Goshen,OH,ACTIVE
+GOSHEN-OHIO.GOV,City,Non-Federal Agency,Goshen,OH,ACTIVE
+GOSHENCT.GOV,City,Non-Federal Agency,Goshen,CT,ACTIVE
+GPSHORESMI.GOV,City,Non-Federal Agency,Grosse Pointe Shores,MI,ACTIVE
+GRAFTON-MA.GOV,City,Non-Federal Agency,Grafton,MA,ACTIVE
+GRANBY-CT.GOV,City,Non-Federal Agency,Granby,CT,ACTIVE
+GRANBY-MA.GOV,City,Non-Federal Agency,Granby,MA,ACTIVE
+GRANDTERRACE-CA.GOV,City,Non-Federal Agency,Grand Terrace,CA,ACTIVE
+GRANDVIEW-IN.GOV,City,Non-Federal Agency,Grandview,IN,ACTIVE
+GRANGERIOWA.GOV,City,Non-Federal Agency,Granger,IA,ACTIVE
+GRANITEFALLSWA.GOV,City,Non-Federal Agency,Granite Falls,WA,ACTIVE
+GRANITEQUARRYNC.GOV,City,Non-Federal Agency,Granite Quarry ,NC,ACTIVE
+GRANTFORKIL.GOV,City,Non-Federal Agency,Highland,IL,ACTIVE
+GRANTSPASSOREGON.GOV,City,Non-Federal Agency,Grants Pass,OR,ACTIVE
+GRANTSVILLEUT.GOV,City,Non-Federal Agency,Grantsville,UT,ACTIVE
+GRAPEVINETEXAS.GOV,City,Non-Federal Agency,Grapevine,TX,ACTIVE
+GRAPEVINETX.GOV,City,Non-Federal Agency,Grapevine,TX,ACTIVE
+GREECENY.GOV,City,Non-Federal Agency,Rochester,NY,ACTIVE
+GREENBAYWI.GOV,City,Non-Federal Agency,Green Bay,WI,ACTIVE
+GREENBELTMD.GOV,City,Non-Federal Agency,Greenbelt,MD,ACTIVE
+GREENCASTLEPA.GOV,City,Non-Federal Agency,Greencastle,PA,ACTIVE
+GREENEVILLETN.GOV,City,Non-Federal Agency,Greeneville,TN,ACTIVE
+GREENFIELD-MA.GOV,City,Non-Federal Agency,Greenfield,MA,ACTIVE
+GREENFIELD-NH.GOV,City,Non-Federal Agency,Greenfield,NH,ACTIVE
+GREENHOUSTONTX.GOV,City,Non-Federal Agency,Houston,TX,ACTIVE
+GREENISLANDNY.GOV,City,Non-Federal Agency,Green Island,NY,ACTIVE
+GREENMOUNTAINFALLSCO.GOV,City,Non-Federal Agency,Green Mountain Falls,CO,ACTIVE
+GREENSBORO-GA.GOV,City,Non-Federal Agency,Greensboro,GA,ACTIVE
+GREENSBORO-NC.GOV,City,Non-Federal Agency,Greensboro,NC,ACTIVE
+GREENSBOROGA.GOV,City,Non-Federal Agency,Greensboro,GA,ACTIVE
+GREENVILLENC.GOV,City,Non-Federal Agency,Greenville,NC,ACTIVE
+GREENVILLESC.GOV,City,Non-Federal Agency,Greenville,SC,ACTIVE
+GRESHAMOREGON.GOV,City,Non-Federal Agency,Gresham,OR,ACTIVE
+GREYFOREST-TX.GOV,City,Non-Federal Agency,Grey Forest,TX,ACTIVE
+GRIMESIOWA.GOV,City,Non-Federal Agency,Grimes,IA,ACTIVE
+GROTON-CT.GOV,City,Non-Federal Agency,Groton,CT,ACTIVE
+GROTONMA.GOV,City,Non-Federal Agency,Groton,MA,ACTIVE
+GROTONSD.GOV,City,Non-Federal Agency,Groton,SD,ACTIVE
+GROVECITYOHIO.GOV,City,Non-Federal Agency,Grove City,OH,ACTIVE
+GROVELAND-FL.GOV,City,Non-Federal Agency,Groveland,FL,ACTIVE
+GULFBREEZEFL.GOV,City,Non-Federal Agency,Gulf Breeze,FL,ACTIVE
+GULFPORT-MS.GOV,City,Non-Federal Agency,Gulfport,MS,ACTIVE
+GULFSHORESAL.GOV,City,Non-Federal Agency,Gulf Shores,AL,ACTIVE
+GUNNISONCO.GOV,City,Non-Federal Agency,Gunnison,CO,ACTIVE
+GUNTERSVILLEAL.GOV,City,Non-Federal Agency,Guntersville,AL,ACTIVE
+GUNTERTX.GOV,City,Non-Federal Agency,Gunter,TX,ACTIVE
+GUSTAVUS-AK.GOV,City,Non-Federal Agency,Gustavus,AK,ACTIVE
+GWSCO.GOV,City,Non-Federal Agency,Glenwood Springs,CO,ACTIVE
+HADDONFIELD-NJ.GOV,City,Non-Federal Agency,Haddonfield,NJ,ACTIVE
+HADLEYMA.GOV,City,Non-Federal Agency,Hadley,MA,ACTIVE
+HAHIRAGA.GOV,City,Non-Federal Agency,Hahira,GA,ACTIVE
+HALLANDALEBEACHFL.GOV,City,Non-Federal Agency,hallandale beach,FL,ACTIVE
+HAMILTON-NY.GOV,City,Non-Federal Agency,HAMILTON,NY,ACTIVE
+HAMILTON-OH.GOV,City,Non-Federal Agency,Hamilton,OH,ACTIVE
+HAMPDENMAINE.GOV,City,Non-Federal Agency,Hampden,ME,ACTIVE
+HAMPSTEADMD.GOV,City,Non-Federal Agency,Hampstead,MD,ACTIVE
+HAMPTON.GOV,City,Non-Federal Agency,Hampton,VA,ACTIVE
+HAMPTONGA.GOV,City,Non-Federal Agency,Hampton,GA,ACTIVE
+HAMPTONNH.GOV,City,Non-Federal Agency,Hampton,NH,ACTIVE
+HAMPTONSC.GOV,City,Non-Federal Agency,Hampton,SC,ACTIVE
+HAMPTONVA.GOV,City,Non-Federal Agency,Hampton,VA,ACTIVE
+HANKSVILLEUTAH.GOV,City,Non-Federal Agency,Hanksville,UT,ACTIVE
+HANNIBAL-MO.GOV,City,Non-Federal Agency,Hannibal,MO,ACTIVE
+HANOVER-MA.GOV,City,Non-Federal Agency,Hanover,MA,ACTIVE
+HANOVERVA.GOV,City,Non-Federal Agency,Hanover,VA,ACTIVE
+HANSON-MA.GOV,City,Non-Federal Agency,Hanson,MA,ACTIVE
+HAPPYVALLEYOR.GOV,City,Non-Federal Agency,Happy Valley,OR,ACTIVE
+HARMARTOWNSHIP-PA.GOV,City,Non-Federal Agency,Freeport,PA,ACTIVE
+HARMONYTWP-NJ.GOV,City,Non-Federal Agency,Phillipsburg,NJ,ACTIVE
+HARPERCOUNTYKS.GOV,City,Non-Federal Agency,Anthony,KS,ACTIVE
+HARRAH-OK.GOV,City,Non-Federal Agency,Harrah,OK,ACTIVE
+HARRINGTONPARKNJ.GOV,City,Non-Federal Agency,HARRINGTON PARK,NJ,ACTIVE
+HARRISBURGPA.GOV,City,Non-Federal Agency,Harrisburg,PA,ACTIVE
+HARRISBURGSD.GOV,City,Non-Federal Agency,Harrisburg,SD,ACTIVE
+HARRISON-NY.GOV,City,Non-Federal Agency,Harrison,NY,ACTIVE
+HARRISONBURGVA.GOV,City,Non-Federal Agency,Harrisonburg,VA,ACTIVE
+HARRISONOH.GOV,City,Non-Federal Agency,Harrison,OH,ACTIVE
+HARRISONOHIO.GOV,City,Non-Federal Agency,Harrison,OH,ACTIVE
+HARRISONTWP-PA.GOV,City,Non-Federal Agency,Natrona Heights,PA,ACTIVE
+HARTFORD.GOV,City,Non-Federal Agency,Hartford,CT,ACTIVE
+HARTSVILLESC.GOV,City,Non-Federal Agency,Hartsville,SC,ACTIVE
+HARWICH-MA.GOV,City,Non-Federal Agency,Harwich,MA,ACTIVE
+HASTINGSMN.GOV,City,Non-Federal Agency,Hastings,MN,ACTIVE
+HAVERHILLMA.GOV,City,Non-Federal Agency,Haverhill,MA,ACTIVE
+HAVREDEGRACEMD.GOV,City,Non-Federal Agency,Havre de Grace,MD,ACTIVE
+HAWTHORNECA.GOV,City,Non-Federal Agency,Hawthorne,CA,ACTIVE
+HAYDEN-CO.GOV,City,Non-Federal Agency,Hayden,CO,ACTIVE
+HAYESTOWNSHIPMI.GOV,City,Non-Federal Agency,Charlevoix,MI,ACTIVE
+HAYSIVIRGINIA.GOV,City,Non-Federal Agency,Haysi,VA,ACTIVE
+HAYWARD-CA.GOV,City,Non-Federal Agency,Hayward,CA,ACTIVE
+HAZARDKY.GOV,City,Non-Federal Agency,Hazard,KY,ACTIVE
+HAZLEHURSTGA.GOV,City,Non-Federal Agency,Hazlehurst,GA,ACTIVE
+HEADOFTHEHARBORNY.GOV,City,Non-Federal Agency,Saint James,NY,ACTIVE
+HEATHOHIO.GOV,City,Non-Federal Agency,Heath,OH,ACTIVE
+HEDWIGTX.GOV,City,Non-Federal Agency,Houston,TX,ACTIVE
+HELENAMT.GOV,City,Non-Federal Agency,Helena,MT,ACTIVE
+HELOTES-TX.GOV,City,Non-Federal Agency,Helotes,TX,ACTIVE
+HENDERSONNEVADA.GOV,City,Non-Federal Agency,Henderson,NV,ACTIVE
+HENDERSONNV.GOV,City,Non-Federal Agency,Henderson,NV,ACTIVE
+HENDERSONTN.GOV,City,Non-Federal Agency,Henderson,TN,ACTIVE
+HENDERSONVILLENC.GOV,City,Non-Federal Agency,Hendersonville,NC,ACTIVE
+HEREFORD-TX.GOV,City,Non-Federal Agency,Hereford,TX,ACTIVE
+HERNDON-VA.GOV,City,Non-Federal Agency,Herndon,VA,ACTIVE
+HEYWORTH-IL.GOV,City,Non-Federal Agency,Heyworth,IL,ACTIVE
+HIALEAHFL.GOV,City,Non-Federal Agency,Hialeah,FL,ACTIVE
+HIAWASSEEGA.GOV,City,Non-Federal Agency,Hiawassee,GA,ACTIVE
+HICKORYCREEK-TX.GOV,City,Non-Federal Agency,Hickory Creek,TX,ACTIVE
+HICKORYNC.GOV,City,Non-Federal Agency,Hickory,NC,ACTIVE
+HIDEOUTUTAH.GOV,City,Non-Federal Agency,Hideout,UT,ACTIVE
+HIGHLANDHEIGHTS-KY.GOV,City,Non-Federal Agency,Highland Heights,KY,ACTIVE
+HIGHLANDIL.GOV,City,Non-Federal Agency,Highland,IL,ACTIVE
+HIGHLANDS-NY.GOV,City,Non-Federal Agency,Highland Falls,NY,ACTIVE
+HIGHPOINT-NC.GOV,City,Non-Federal Agency,High Point,NC,ACTIVE
+HIGHPOINTNC.GOV,City,Non-Federal Agency,High Point,NC,ACTIVE
+HILLIARDOHIO.GOV,City,Non-Federal Agency,Hilliard,OH,ACTIVE
+HILLSBORO-OREGON.GOV,City,Non-Federal Agency,HILLSBORO,OR,ACTIVE
+HILLSBOROUGHNC.GOV,City,Non-Federal Agency,Hillsborough,NC,ACTIVE
+HILTONHEADISLANDSC.GOV,City,Non-Federal Agency,Hilton Head Island,SC,ACTIVE
+HINGHAM-MA.GOV,City,Non-Federal Agency,Hingham,MA,ACTIVE
+HIRAM-GA.GOV,City,Non-Federal Agency,Hiram,GA,ACTIVE
+HOBOKENNJ.GOV,City,Non-Federal Agency,Hoboken,NJ,ACTIVE
+HOLBROOKMA.GOV,City,Non-Federal Agency,Holbrook,MA,ACTIVE
+HOLDEN-MA.GOV,City,Non-Federal Agency,Holden,MA,ACTIVE
+HOLDENMA.GOV,City,Non-Federal Agency,HOLDEN,MA,ACTIVE
+HOLDERNESS-NH.GOV,City,Non-Federal Agency,Holderness,NH,ACTIVE
+HOLLANDTOWNSHIPNJ.GOV,City,Non-Federal Agency,Milford,NJ,ACTIVE
+HOLLYWOODPARK-TX.GOV,City,Non-Federal Agency,Hollywood Park,TX,ACTIVE
+HOMERGLENIL.GOV,City,Non-Federal Agency,Homer Glen,IL,ACTIVE
+HOMEWOODIL.GOV,City,Non-Federal Agency,Homewood,IL,ACTIVE
+HONDO-TX.GOV,City,Non-Federal Agency,Hondo,TX,ACTIVE
+HOOPESTON-IL.GOV,City,Non-Federal Agency,Hoopeston,IL,ACTIVE
+HOOVERAL.GOV,City,Non-Federal Agency,Hoover,AL,ACTIVE
+HOOVERALABAMA.GOV,City,Non-Federal Agency,Hoover,AL,ACTIVE
+HOPEDALE-MA.GOV,City,Non-Federal Agency,Hopedale,MA,ACTIVE
+HOPEWELLVA.GOV,City,Non-Federal Agency,HOPEWELL,VA,ACTIVE
+HOPKINSPARK-IL.GOV,City,Non-Federal Agency,Hopkins Park,IL,ACTIVE
+HOPKINSVILLE-KY.GOV,City,Non-Federal Agency,Hopkinsville,KY,ACTIVE
+HOPKINTON-NH.GOV,City,Non-Federal Agency,Hopkinton,NH,ACTIVE
+HOPKINTONMA.GOV,City,Non-Federal Agency,Hopkinton,MA,ACTIVE
+HORICONNY.GOV,City,Non-Federal Agency,Brant Lake,NY,ACTIVE
+HORIZONCITY-TX.GOV,City,Non-Federal Agency,Horizon City,TX,ACTIVE
+HORSESHOE-BAY-TX.GOV,City,Non-Federal Agency,Horseshoe Bay,TX,ACTIVE
+HOUSTON-AK.GOV,City,Non-Federal Agency,Houston,AK,ACTIVE
+HOUSTONTX.GOV,City,Non-Federal Agency,Houston,TX,ACTIVE
+HPCA.GOV,City,Non-Federal Agency,Huntington Park,CA,ACTIVE
+HRPDCVA.GOV,City,Non-Federal Agency,Chesapeake,VA,ACTIVE
+HUACHUCACITYAZ.GOV,City,Non-Federal Agency,Huachuca City,AZ,ACTIVE
+HUDSONNH.GOV,City,Non-Federal Agency,Hudson,NH,ACTIVE
+HUETTER-ID.GOV,City,Non-Federal Agency,POST FALLS,ID,ACTIVE
+HULMEVILLE-PA.GOV,City,Non-Federal Agency,Hulmeville,PA,ACTIVE
+HUMBLETX.GOV,City,Non-Federal Agency,Humble,TX,ACTIVE
+HUNTINGBURG-IN.GOV,City,Non-Federal Agency,Huntingburg,IN,ACTIVE
+HUNTINGTONBEACHCA.GOV,City,Non-Federal Agency,Huntington Beach,CA,ACTIVE
+HUNTINGTONNY.GOV,City,Non-Federal Agency,Huntington,NY,ACTIVE
+HUNTSPOINT-WA.GOV,City,Non-Federal Agency,Hunts Point,WA,ACTIVE
+HUNTSVILLEAL.GOV,City,Non-Federal Agency,Huntsville,AL,ACTIVE
+HUNTSVILLETX.GOV,City,Non-Federal Agency,Huntsville,TX,ACTIVE
+HURLOCK-MD.GOV,City,Non-Federal Agency,Hurlock,MD,ACTIVE
+HURONTOWNSHIP-MI.GOV,City,Non-Federal Agency,New Boston,MI,ACTIVE
+HURST-TEXAS.GOV,City,Non-Federal Agency,Hurst,TX,ACTIVE
+HURSTTX.GOV,City,Non-Federal Agency,Hurst,TX,ACTIVE
+HUTTOTX.GOV,City,Non-Federal Agency,Hutto,TX,ACTIVE
+HVLNC.GOV,City,Non-Federal Agency,Hendersonville,NC,ACTIVE
+IDABEL-OK.GOV,City,Non-Federal Agency,Idabel,OK,ACTIVE
+IDAHOFALLSIDAHO.GOV,City,Non-Federal Agency,Idaho Falls,ID,ACTIVE
+ILWACO-WA.GOV,City,Non-Federal Agency,Ilwaco,WA,ACTIVE
+IMPERIALBEACHCA.GOV,City,Non-Federal Agency,Imperial Beach,CA,ACTIVE
+INCLINEVILLAGE-NV.GOV,City,Non-Federal Agency,INCLINE VILLAGE,NV,ACTIVE
+INDEPENDENCEKS.GOV,City,Non-Federal Agency,INDEPENDENCE,KS,ACTIVE
+INDEPENDENCEMO.GOV,City,Non-Federal Agency,Independence,MO,ACTIVE
+INDEPENDENCEOHIO.GOV,City,Non-Federal Agency,Independence,OH,ACTIVE
+INDIANAPOLIS-IN.GOV,City,Non-Federal Agency,Indianapolis,IN,ACTIVE
+INDIANHEADPARK-IL.GOV,City,Non-Federal Agency,Indian Head Park,IL,ACTIVE
+INDIANOLAIOWA.GOV,City,Non-Federal Agency,Indianola,IA,ACTIVE
+INDIANOLAMS.GOV,City,Non-Federal Agency,Indianola,MS,ACTIVE
+INDIANPOINT-MO.GOV,City,Non-Federal Agency,Branson,MO,ACTIVE
+INDY.GOV,City,Non-Federal Agency,Indianapolis,IN,ACTIVE
+INGLESIDETX.GOV,City,Non-Federal Agency,Ingleside,TX,ACTIVE
+INTERLACHEN-FL.GOV,City,Non-Federal Agency,Interlachen,FL,ACTIVE
+INVERNESS-FL.GOV,City,Non-Federal Agency,Inverness,FL,ACTIVE
+INVERNESS-IL.GOV,City,Non-Federal Agency,Inverness,IL,ACTIVE
+IPSWICH-MA.GOV,City,Non-Federal Agency,Ipswich,MA,ACTIVE
+IPSWICHMA.GOV,City,Non-Federal Agency,Ipswich,MA,ACTIVE
+IRONTONMO.GOV,City,Non-Federal Agency,Ironton,MO,ACTIVE
+IRVINGTONNY.GOV,City,Non-Federal Agency,Irvington,NY,ACTIVE
+IRWINDALECA.GOV,City,Non-Federal Agency,Irwindale,CA,ACTIVE
+ISLIP-NY.GOV,City,Non-Federal Agency,Islip,NY,ACTIVE
+ISLIPNY.GOV,City,Non-Federal Agency,Islip,NY,ACTIVE
+ISLIPTOWN-NY.GOV,City,Non-Federal Agency,Islip,NY,ACTIVE
+ISSAQUAHWA.GOV,City,Non-Federal Agency,Issaquah,WA,ACTIVE
+JACINTOCITY-TX.GOV,City,Non-Federal Agency,Jacinto City,TX,ACTIVE
+JACKSON-SC.GOV,City,Non-Federal Agency,Jackson,SC,ACTIVE
+JACKSONMS.GOV,City,Non-Federal Agency,Jackson,MS,ACTIVE
+JACKSONTOWNSHIP-PA.GOV,City,Non-Federal Agency,Myerstown,PA,ACTIVE
+JACKSONTOWNSHIPPA.GOV,City,Non-Federal Agency,Jackson Township,PA,ACTIVE
+JACKSONTWP-PA.GOV,City,Non-Federal Agency,Reeders,PA,ACTIVE
+JACKSONVILLENC.GOV,City,Non-Federal Agency,Jacksonville,NC,ACTIVE
+JAMESTOWN-NC.GOV,City,Non-Federal Agency,Jamestown,NC,ACTIVE
+JAMESTOWNRI.GOV,City,Non-Federal Agency,Jamestown,RI,ACTIVE
+JAMESTOWNTN.GOV,City,Non-Federal Agency,Jamestown,TN,ACTIVE
+JANESVILLEMN.GOV,City,Non-Federal Agency,Janesville,MN,ACTIVE
+JEFFERSONCITYMO.GOV,City,Non-Federal Agency,Jefferson City,MO,ACTIVE
+JEFFERSONTOWNKY.GOV,City,Non-Federal Agency,Jeffersontown,KY,ACTIVE
+JEMEZSPRINGS-NM.GOV,City,Non-Federal Agency,Jemez Springs,NM,ACTIVE
+JERICHOVT.GOV,City,Non-Federal Agency,Jericho,VT,ACTIVE
+JEROME-OH.GOV,City,Non-Federal Agency,Plain City,OH,ACTIVE
+JERSEYCITYNJ.GOV,City,Non-Federal Agency,Jersey City,NJ,ACTIVE
+JESUPGA.GOV,City,Non-Federal Agency,Jesup,GA,ACTIVE
+JOHNSCREEKGA.GOV,City,Non-Federal Agency,Johns Creek,GA,ACTIVE
+JOHNSONCITYTN.GOV,City,Non-Federal Agency,Johnson City,TN,ACTIVE
+JONESVILLENC.GOV,City,Non-Federal Agency,Jonesville,NC,ACTIVE
+JORDANMN.GOV,City,Non-Federal Agency,Jordan,MN,ACTIVE
+JUNCTIONCITY-KS.GOV,City,Non-Federal Agency,Junction City,KS,ACTIVE
+JUNCTIONCITYOREGON.GOV,City,Non-Federal Agency,Junction City,OR,ACTIVE
+JUPITERFL.GOV,City,Non-Federal Agency,Jupiter,FL,ACTIVE
+KANNAPOLISNC.GOV,City,Non-Federal Agency,Concord,NC,ACTIVE
+KANSASCITYMO.GOV,City,Non-Federal Agency,Kansas City,MO,ACTIVE
+KCMO.GOV,City,Non-Federal Agency,Kansas City,MO,ACTIVE
+KEANSBURGNJ.GOV,City,Non-Federal Agency,Keansburg,NJ,ACTIVE
+KELSO.GOV,City,Non-Federal Agency,Kelso,WA,ACTIVE
+KEMAH-TX.GOV,City,Non-Federal Agency,Kemah,TX,ACTIVE
+KENMOREWA.GOV,City,Non-Federal Agency,Kenmore,WA,ACTIVE
+KENNEBUNKPORTME.GOV,City,Non-Federal Agency,Kennebunkport,ME,ACTIVE
+KENNESAW-GA.GOV,City,Non-Federal Agency,Kennesaw,GA,ACTIVE
+KENTWA.GOV,City,Non-Federal Agency,Kent,WA,ACTIVE
+KERRVILLETX.GOV,City,Non-Federal Agency,Kerrville,TX,ACTIVE
+KILLEENTEXAS.GOV,City,Non-Federal Agency,Killeen,TX,ACTIVE
+KILLINGLYCT.GOV,City,Non-Federal Agency,Danielson,CT,ACTIVE
+KINDERHOOK-NY.GOV,City,Non-Federal Agency,Niverville,NY,ACTIVE
+KINGSLANDGA.GOV,City,Non-Federal Agency,Kingsland,GA,ACTIVE
+KINGSPORTTN.GOV,City,Non-Federal Agency,Kingsport,TN,ACTIVE
+KINGSTON-NY.GOV,City,Non-Federal Agency,Kingston,NY,ACTIVE
+KINGSTONSPRINGS-TN.GOV,City,Non-Federal Agency,Kingston Springs,TN,ACTIVE
+KINROSSTOWNSHIP-MI.GOV,City,Non-Federal Agency,Kincheloe,MI,ACTIVE
+KINSTONNC.GOV,City,Non-Federal Agency,Kinston,NC,ACTIVE
+KIRKLANDWA.GOV,City,Non-Federal Agency,Kirkland,WA,ACTIVE
+KISSIMMEE-FL.GOV,City,Non-Federal Agency,Kissimmee,FL,ACTIVE
+KISSIMMEEFL.GOV,City,Non-Federal Agency,Kissimmee,FL,ACTIVE
+KITTERYME.GOV,City,Non-Federal Agency,Kittery,ME,ACTIVE
+KITTYHAWKNC.GOV,City,Non-Federal Agency,Kitty Hawk,NC,ACTIVE
+KNIGHTDALENC.GOV,City,Non-Federal Agency,Knightdale,NC,ACTIVE
+KNOXVILLEIA.GOV,City,Non-Federal Agency,Knoxville,IA,ACTIVE
+KNOXVILLEIOWA.GOV,City,Non-Federal Agency,Knoxville,IA,ACTIVE
+KNOXVILLETN.GOV,City,Non-Federal Agency,Knoxville,TN,ACTIVE
+KUNAID.GOV,City,Non-Federal Agency,Kuna,ID,ACTIVE
+LACKAWANNANY.GOV,City,Non-Federal Agency,Lackawanna,NY,ACTIVE
+LACKAWAXENTOWNSHIPPA.GOV,City,Non-Federal Agency,Hawley,PA,ACTIVE
+LAFOLLETTETN.GOV,City,Non-Federal Agency,LaFollette,TN,ACTIVE
+LAGRANGEGA.GOV,City,Non-Federal Agency,LaGrange,GA,ACTIVE
+LAGRANGENY.GOV,City,Non-Federal Agency,Lagrangeville,NY,ACTIVE
+LAGUNAHILLSCA.GOV,City,Non-Federal Agency,Laguna Hills,CA,ACTIVE
+LAHABRACA.GOV,City,Non-Federal Agency,LA HABRA,CA,ACTIVE
+LAKEFORESTCA.GOV,City,Non-Federal Agency,Lake Forest,CA,ACTIVE
+LAKEGROVENY.GOV,City,Non-Federal Agency,Lake Grove,NY,ACTIVE
+LAKEJACKSON-TX.GOV,City,Non-Federal Agency,Lake Jackson,TX,ACTIVE
+LAKEJACKSONTX.GOV,City,Non-Federal Agency,Lake Jackson,TX,ACTIVE
+LAKELANDGA.GOV,City,Non-Federal Agency,Lakeland,GA,ACTIVE
+LAKELANDTN.GOV,City,Non-Federal Agency,Lakeland,TN,ACTIVE
+LAKEPARKNC.GOV,City,Non-Federal Agency,Indian Trail,NC,ACTIVE
+LAKEPROVIDENCELA.GOV,City,Non-Federal Agency,Lake Providence,LA,ACTIVE
+LAKESITETN.GOV,City,Non-Federal Agency,Lakesite,TN,ACTIVE
+LAKESTATION-IN.GOV,City,Non-Federal Agency,Lake Station,IN,ACTIVE
+LAKESTEVENSWA.GOV,City,Non-Federal Agency,Lake Stevens,WA,ACTIVE
+LAKEVILLE-MN.GOV,City,Non-Federal Agency,Lakeville,MN,ACTIVE
+LAKEVILLEMN.GOV,City,Non-Federal Agency,Lakeville,MN,ACTIVE
+LAKEVILLEMNFIRE.GOV,City,Non-Federal Agency,Lakeville,MN,ACTIVE
+LAKEWAY-TX.GOV,City,Non-Federal Agency,Lakeway,TX,ACTIVE
+LAKEWOODNJ.GOV,City,Non-Federal Agency,Lakewood,NJ,ACTIVE
+LANCASTERCITYSC.GOV,City,Non-Federal Agency,Lancaster,SC,ACTIVE
+LANCASTERNY.GOV,City,Non-Federal Agency,Lancaster,NY,ACTIVE
+LANESBORO-MN.GOV,City,Non-Federal Agency,Lanesboro,MN,ACTIVE
+LANESBOROUGH-MA.GOV,City,Non-Federal Agency,LANESBOROUGH,MA,ACTIVE
+LANSINGMI.GOV,City,Non-Federal Agency,Lansing,MI,ACTIVE
+LANTABUS-PA.GOV,City,Non-Federal Agency,Allentown,PA,ACTIVE
+LAPORTETX.GOV,City,Non-Federal Agency,La Porte,TX,ACTIVE
+LAREDOTEXAS.GOV,City,Non-Federal Agency,Laredo,TX,ACTIVE
+LASALLE-IL.GOV,City,Non-Federal Agency,LaSalle,IL,ACTIVE
+LASVEGASNEVADA.GOV,City,Non-Federal Agency,Las Vegas,NV,ACTIVE
+LASVEGASNM.GOV,City,Non-Federal Agency,Las Vegas,NM,ACTIVE
+LAUDERDALEBYTHESEA-FL.GOV,City,Non-Federal Agency,Lauderdale By The Sea,FL,ACTIVE
+LAUDERHILL-FL.GOV,City,Non-Federal Agency,Lauderhill,FL,ACTIVE
+LAUDERHILLFL.GOV,City,Non-Federal Agency,Lauderhill,FL,ACTIVE
+LAVERGNETN.GOV,City,Non-Federal Agency,La Vergne,TN,ACTIVE
+LAVERNIA-TX.GOV,City,Non-Federal Agency,La Vernia,TX,ACTIVE
+LAWRENCEBURGTN.GOV,City,Non-Federal Agency,Lawrenceburg,TN,ACTIVE
+LAWTONMI.GOV,City,Non-Federal Agency,Lawton,MI,ACTIVE
+LAWTONOK.GOV,City,Non-Federal Agency,Lawton,OK,ACTIVE
+LBTS-FL.GOV,City,Non-Federal Agency,Lauderdale-By-The-Sea,FL,ACTIVE
+LEADVILLE-CO.GOV,City,Non-Federal Agency,Leadville,CO,ACTIVE
+LEAGUECITY-TX.GOV,City,Non-Federal Agency,League City,TX,ACTIVE
+LEAGUECITYTX.GOV,City,Non-Federal Agency,League City,TX,ACTIVE
+LEANDERTX.GOV,City,Non-Federal Agency,Leander,TX,ACTIVE
+LEBANONCT.GOV,City,Non-Federal Agency,Lebanon,CT,ACTIVE
+LEBANONNH.GOV,City,Non-Federal Agency,Lebanon,NH,ACTIVE
+LEBANONOHIO.GOV,City,Non-Federal Agency,Lebanon,OH,ACTIVE
+LECLAIREIOWA.GOV,City,Non-Federal Agency,LECLAIRE,IA,ACTIVE
+LEEDSALABAMA.GOV,City,Non-Federal Agency,Leeds,AL,ACTIVE
+LEESBURGFLORIDA.GOV,City,Non-Federal Agency,Leesburg,FL,ACTIVE
+LEESBURGVA.GOV,City,Non-Federal Agency,Leesburg,VA,ACTIVE
+LEESVILLELA.GOV,City,Non-Federal Agency,LEESVILLE,LA,ACTIVE
+LEHI-UT.GOV,City,Non-Federal Agency,Lehi,UT,ACTIVE
+LENEXA-KS.GOV,City,Non-Federal Agency,Lenexa,KS,ACTIVE
+LENOIR-NC.GOV,City,Non-Federal Agency,Lenoir,NC,ACTIVE
+LENOIRCITYTN.GOV,City,Non-Federal Agency,Lenoir City,TN,ACTIVE
+LEOMINSTER-MA.GOV,City,Non-Federal Agency,Leominster,MA,ACTIVE
+LEONIANJ.GOV,City,Non-Federal Agency,Leonia,NJ,ACTIVE
+LEONVALLEYTEXAS.GOV,City,Non-Federal Agency,Leon Valley,TX,ACTIVE
+LEROYTOWNSHIP-MI.GOV,City,Non-Federal Agency,Webberville,MI,ACTIVE
+LETSMOVEBRIDGEPORTCT.GOV,City,Non-Federal Agency,Bridgeport,CT,ACTIVE
+LEWISBURGTN.GOV,City,Non-Federal Agency,Lewisburg,TN,ACTIVE
+LEWISTONMAINE.GOV,City,Non-Federal Agency,Lewiston,ME,ACTIVE
+LEXINGTONKY.GOV,City,Non-Federal Agency,lexington,KY,ACTIVE
+LEXINGTONNC.GOV,City,Non-Federal Agency,Lexington,NC,ACTIVE
+LEXINGTONTN.GOV,City,Non-Federal Agency,Lexington,TN,ACTIVE
+LEXINGTONVA.GOV,City,Non-Federal Agency,Lexington,VA,ACTIVE
+LHCAZ.GOV,City,Non-Federal Agency,Lake Havasu City,AZ,ACTIVE
+LIBERTYHILLTX.GOV,City,Non-Federal Agency,Liberty Hill,TX,ACTIVE
+LIBERTYIN.GOV,City,Non-Federal Agency,Liberty,IN,ACTIVE
+LIBERTYLAKEWA.GOV,City,Non-Federal Agency,Liberty Lake,WA,ACTIVE
+LIBERTYMISSOURI.GOV,City,Non-Federal Agency,Liberty,MO,ACTIVE
+LIBERTYMO.GOV,City,Non-Federal Agency,Liberty,MO,ACTIVE
+LIMERICK-ME.GOV,City,Non-Federal Agency,Limerick,ME,ACTIVE
+LINCOLNCA.GOV,City,Non-Federal Agency,Lincoln,CA,ACTIVE
+LINCOLNIL.GOV,City,Non-Federal Agency,Lincoln,IL,ACTIVE
+LINCOLNSHIREIL.GOV,City,Non-Federal Agency,Lincolnshire,IL,ACTIVE
+LINDALE-TX.GOV,City,Non-Federal Agency,Lindale,TX,ACTIVE
+LINDALETX.GOV,City,Non-Federal Agency,Lindale,TX,ACTIVE
+LINDENWOLDNJ.GOV,City,Non-Federal Agency,Lindenwold,NJ,ACTIVE
+LINNDALEVILLAGE-OH.GOV,City,Non-Federal Agency,Linndale,OH,ACTIVE
+LINTON-IN.GOV,City,Non-Federal Agency,Linton,IN,ACTIVE
+LITCHFIELD-NH.GOV,City,Non-Federal Agency,Litchfield,NH,ACTIVE
+LITCHFIELDNH.GOV,City,Non-Federal Agency,Litchfield,NH,ACTIVE
+LITTLEROCKAR.GOV,City,Non-Federal Agency,Little Rock,AR,ACTIVE
+LOCKHAVENPA.GOV,City,Non-Federal Agency,Lock Haven,PA,ACTIVE
+LOCKPORTNY.GOV,City,Non-Federal Agency,Lockport,NY,ACTIVE
+LOCUSTGROVE-GA.GOV,City,Non-Federal Agency,Locust Grove,GA,ACTIVE
+LODI.GOV,City,Non-Federal Agency,Lodi,CA,ACTIVE
+LODICA.GOV,City,Non-Federal Agency,Lodi,CA,ACTIVE
+LOGANCO.GOV,City,Non-Federal Agency,Sterling,CO,ACTIVE
+LOGANTOWNSHIP-PA.GOV,City,Non-Federal Agency,Altoona,PA,ACTIVE
+LOGANVILLE-GA.GOV,City,Non-Federal Agency,Loganville,GA,ACTIVE
+LOMALINDA-CA.GOV,City,Non-Federal Agency,Loma Linda,CA,ACTIVE
+LONDONBRITAINTOWNSHIP-PA.GOV,City,Non-Federal Agency,Landenberg,PA,ACTIVE
+LONDONKY.GOV,City,Non-Federal Agency,London,KY,ACTIVE
+LONEOAKTX.GOV,City,Non-Federal Agency,LONE OAK,TX,ACTIVE
+LONGBEACH.GOV,City,Non-Federal Agency,Long Beach,CA,ACTIVE
+LONGBEACHNY.GOV,City,Non-Federal Agency,Long Beach,NY,ACTIVE
+LONGBEACHWA.GOV,City,Non-Federal Agency,Long Beach,WA,ACTIVE
+LONGHILLNJ.GOV,City,Non-Federal Agency,Long Hill,NJ,ACTIVE
+LONGLAKEMN.GOV,City,Non-Federal Agency,Long Lake,MN,ACTIVE
+LONGMONTCOLORADO.GOV,City,Non-Federal Agency,Longmont,CO,ACTIVE
+LONGPORTNJ.GOV,City,Non-Federal Agency,Longport,NJ,ACTIVE
+LONGVIEW-WA.GOV,City,Non-Federal Agency,Longview,WA,ACTIVE
+LONGVIEWTEXAS.GOV,City,Non-Federal Agency,Longview,TX,ACTIVE
+LONGVIEWTX.GOV,City,Non-Federal Agency,Longview,TX,ACTIVE
+LONGVIEWWA.GOV,City,Non-Federal Agency,Longview,WA,ACTIVE
+LORENATX.GOV,City,Non-Federal Agency,Lorena,TX,ACTIVE
+LOSALTOSCA.GOV,City,Non-Federal Agency,Los Altos,CA,ACTIVE
+LOSANGELES-CA.GOV,City,Non-Federal Agency,Los Angeles,CA,ACTIVE
+LOSGATOSCA.GOV,City,Non-Federal Agency,Los Gatos,CA,ACTIVE
+LOSLUNASNM.GOV,City,Non-Federal Agency,Los Lunas,NM,ACTIVE
+LOSRANCHOSNM.GOV,City,Non-Federal Agency,Los Ranchos de Albuquerque,NM,ACTIVE
+LOTT-TX.GOV,City,Non-Federal Agency,Lott,TX,ACTIVE
+LOUISBURGKANSAS.GOV,City,Non-Federal Agency,Louisburg,KS,ACTIVE
+LOUISVILLECO.GOV,City,Non-Federal Agency,Louisville,CO,ACTIVE
+LOUISVILLEKY.GOV,City,Non-Federal Agency,Louisville,KY,ACTIVE
+LOUISVILLETN.GOV,City,Non-Federal Agency,Louisville,TN,ACTIVE
+LOVEJOY-GA.GOV,City,Non-Federal Agency,Lovejoy,GA,ACTIVE
+LOVETTSVILLEVA.GOV,City,Non-Federal Agency,Lovettsville,VA,ACTIVE
+LOVINGTON-IL.GOV,City,Non-Federal Agency,Lovington,IL,ACTIVE
+LOWELL-OR.GOV,City,Non-Federal Agency,Lowell,OR,ACTIVE
+LOWELLARKANSAS.GOV,City,Non-Federal Agency,Lowell,AR,ACTIVE
+LOWERALLOWAYSCREEK-NJ.GOV,City,Non-Federal Agency,Hancocks Bridge,NJ,ACTIVE
+LOWERPAXTON-PA.GOV,City,Non-Federal Agency,Harrisburg,PA,ACTIVE
+LUBBOCKTX.GOV,City,Non-Federal Agency,Lubbock,TX,ACTIVE
+LUDINGTON-MI.GOV,City,Non-Federal Agency,Ludington,MI,ACTIVE
+LUNENBURGMA.GOV,City,Non-Federal Agency,Lunenburg,MA,ACTIVE
+LYMAN-ME.GOV,City,Non-Federal Agency,Lyman,ME,ACTIVE
+LYMANSC.GOV,City,Non-Federal Agency,Lyman,SC,ACTIVE
+LYMECT.GOV,City,Non-Federal Agency,Lyme,CT,ACTIVE
+LYMENH.GOV,City,Non-Federal Agency,Lyme,NH,ACTIVE
+LYNCHBURGVA.GOV,City,Non-Federal Agency,Lynchburg,VA,ACTIVE
+LYNDEBOROUGHNH.GOV,City,Non-Federal Agency,Lyndeborough,NH,ACTIVE
+LYNDONKS.GOV,City,Non-Federal Agency,Lyndon,KS,ACTIVE
+LYNNMA.GOV,City,Non-Federal Agency,Lynn,MA,ACTIVE
+LYNNWOODWA.GOV,City,Non-Federal Agency,Lynnwood,WA,ACTIVE
+LYONSTOWNSHIPIL.GOV,City,Non-Federal Agency,Countryside,IL,ACTIVE
+MACOMB-MI.GOV,City,Non-Federal Agency,Macomb,MI,ACTIVE
+MACONGA.GOV,City,Non-Federal Agency,Macon,GA,ACTIVE
+MADEIRABEACHFL.GOV,City,Non-Federal Agency,Madeira Beach,FL,ACTIVE
+MADERA-CA.GOV,City,Non-Federal Agency,Madera,CA,ACTIVE
+MADISON-AL.GOV,City,Non-Federal Agency,Madison,AL,ACTIVE
+MADISON-IN.GOV,City,Non-Federal Agency,Madison,IN,ACTIVE
+MADISONAL.GOV,City,Non-Federal Agency,Madison,AL,ACTIVE
+MADISONLAKEMN.GOV,City,Non-Federal Agency,Madison LAke,MN,ACTIVE
+MAHARISHIVEDICCITY-IOWA.GOV,City,Non-Federal Agency,Maharishi Vedic City,IA,ACTIVE
+MAHOMET-IL.GOV,City,Non-Federal Agency,Mahomet,IL,ACTIVE
+MAHWAH-NJ.GOV,City,Non-Federal Agency,Mahwah,NJ,ACTIVE
+MAIDENNC.GOV,City,Non-Federal Agency,Maiden,NC,ACTIVE
+MALIBU-CA.GOV,City,Non-Federal Agency,Malibu,CA,ACTIVE
+MALVERNAR.GOV,City,Non-Federal Agency,Malvern,AR,ACTIVE
+MAMARONECK-NY.GOV,City,Non-Federal Agency,Mamaroneck,NY,ACTIVE
+MAMARONECKVILLAGENY.GOV,City,Non-Federal Agency,Mamaroneck,NY,ACTIVE
+MANASQUAN-NJ.GOV,City,Non-Federal Agency,MANASQUAN,NJ,ACTIVE
+MANASSASPARKVA.GOV,City,Non-Federal Agency,Manassas Park,VA,ACTIVE
+MANASSASVA.GOV,City,Non-Federal Agency,Manassas,VA,ACTIVE
+MANCHESTER-GA.GOV,City,Non-Federal Agency,Manchester,GA,ACTIVE
+MANCHESTER-VT.GOV,City,Non-Federal Agency,Manchester Center,VT,ACTIVE
+MANCHESTERCT.GOV,City,Non-Federal Agency,Manchester,CT,ACTIVE
+MANCHESTERMD.GOV,City,Non-Federal Agency,MANCHESTER,MD,ACTIVE
+MANCHESTERMO.GOV,City,Non-Federal Agency,Manchester,MO,ACTIVE
+MANCHESTERNH.GOV,City,Non-Federal Agency,Manchester,NH,ACTIVE
+MANISTEEMI.GOV,City,Non-Federal Agency,Traverse City,MI,ACTIVE
+MANITOUSPRINGS-CO.GOV,City,Non-Federal Agency,Colorado Springs,CO,ACTIVE
+MANKATO-MN.GOV,City,Non-Federal Agency,Mankato,MN,ACTIVE
+MANKATOMN.GOV,City,Non-Federal Agency,Mankato,MN,ACTIVE
+MANSFIELD-TX.GOV,City,Non-Federal Agency,Mansfield,TX,ACTIVE
+MANSFIELDCT.GOV,City,Non-Federal Agency,Mansfield,CT,ACTIVE
+MANSFIELDGA.GOV,City,Non-Federal Agency,Mans,GA,ACTIVE
+MANSFIELDTEXAS.GOV,City,Non-Federal Agency,Mansfield,TX,ACTIVE
+MANSFIELDTOWNSHIP-NJ.GOV,City,Non-Federal Agency,Port Murray,NJ,ACTIVE
+MANTUATOWNSHIPOHIO.GOV,City,Non-Federal Agency,Mantua,OH,ACTIVE
+MAPLEGROVEMN.GOV,City,Non-Federal Agency,Maple Grove,MN,ACTIVE
+MAPLEVALLEYWA.GOV,City,Non-Federal Agency,Maple Valley,WA,ACTIVE
+MAPLEWOODMN.GOV,City,Non-Federal Agency,Maplewood,MN,ACTIVE
+MARANAAZ.GOV,City,Non-Federal Agency,Marana,AZ,ACTIVE
+MARBLEFALLSTX.GOV,City,Non-Federal Agency,Marble Falls,TX,ACTIVE
+MARICOPA-AZ.GOV,City,Non-Federal Agency,Maricopa,AZ,ACTIVE
+MARIONKY.GOV,City,Non-Federal Agency,Marion,KY,ACTIVE
+MARIONMA.GOV,City,Non-Federal Agency,Marion,MA,ACTIVE
+MARIONSC.GOV,City,Non-Federal Agency,Marion,SC,ACTIVE
+MARKESANWI.GOV,City,Non-Federal Agency,Markesan,WI,ACTIVE
+MARLBORO-NJ.GOV,City,Non-Federal Agency,Marlboro,NJ,ACTIVE
+MARLBOROUGH-MA.GOV,City,Non-Federal Agency,Marlborough,MA,ACTIVE
+MARLOWNH.GOV,City,Non-Federal Agency,Marlow,NH,ACTIVE
+MAROAILLINOIS.GOV,City,Non-Federal Agency,Maroa,IL,ACTIVE
+MARSHALL-IL.GOV,City,Non-Federal Agency,Marshall,IL,ACTIVE
+MARSHFIELDMO.GOV,City,Non-Federal Agency,Marshfield,MO,ACTIVE
+MARTINSVILLE-VA.GOV,City,Non-Federal Agency,Martinsville,VA,ACTIVE
+MARYSVILLEWA.GOV,City,Non-Federal Agency,Marysville,WA,ACTIVE
+MARYVILLE-TN.GOV,City,Non-Federal Agency,maryville,TN,ACTIVE
+MASHPEEMA.GOV,City,Non-Federal Agency,Mashpee,MA,ACTIVE
+MASTICBEACHVILLAGENY.GOV,City,Non-Federal Agency,Mastic Beach,NY,ACTIVE
+MATTHEWSNC.GOV,City,Non-Federal Agency,Matthews,NC,ACTIVE
+MAYAGUEZPR.GOV,City,Non-Federal Agency,Mayaguez,PR,ACTIVE
+MAYFIELDKY.GOV,City,Non-Federal Agency,Mayfield,KY,ACTIVE
+MCCOMB-MS.GOV,City,Non-Federal Agency,McComb,MS,ACTIVE
+MCDONOUGH-GA.GOV,City,Non-Federal Agency,McDonough,GA,ACTIVE
+MCKEESPORT-PA.GOV,City,Non-Federal Agency,McKeesport,PA,ACTIVE
+MCKENZIETN.GOV,City,Non-Federal Agency,McKenzie,TN,ACTIVE
+MCMINNVILLEOREGON.GOV,City,Non-Federal Agency,McMinnville,OR,ACTIVE
+MCTX.GOV,City,Non-Federal Agency,Missouri City,TX,ACTIVE
+MEADOWSPLACETX.GOV,City,Non-Federal Agency,Meadows Place,TX,ACTIVE
+MECHANICVILLENY.GOV,City,Non-Federal Agency,Mechanicville,NY,ACTIVE
+MEDFORD-MA.GOV,City,Non-Federal Agency,Medford,MA,ACTIVE
+MEDINA-WA.GOV,City,Non-Federal Agency,Medina,WA,ACTIVE
+MEDINAMN.GOV,City,Non-Federal Agency,Medina,MN,ACTIVE
+MELVILLELA.GOV,City,Non-Federal Agency,Melville,LA,ACTIVE
+MEMPHISTN.GOV,City,Non-Federal Agency,Memphis,TN,ACTIVE
+MENDONMA.GOV,City,Non-Federal Agency,Mendon,MA,ACTIVE
+MENOMONIE-WI.GOV,City,Non-Federal Agency,Menomonie,WI,ACTIVE
+MENTONEALABAMA.GOV,City,Non-Federal Agency,Mentone,AL,ACTIVE
+MERCERISLANDWA.GOV,City,Non-Federal Agency,Mercer Island,WA,ACTIVE
+MERCHANTVILLENJ.GOV,City,Non-Federal Agency,Merchantville,NJ,ACTIVE
+MERIDENCT.GOV,City,Non-Federal Agency,Meriden,CT,ACTIVE
+MERRIMACKNH.GOV,City,Non-Federal Agency,Merrimack,NH,ACTIVE
+MESAAZ.GOV,City,Non-Federal Agency,Mesa,AZ,ACTIVE
+MESILLANM.GOV,City,Non-Federal Agency,Mesilla,NM,ACTIVE
+MESQUITENV.GOV,City,Non-Federal Agency,Mesquite,NV,ACTIVE
+MESQUITETX.GOV,City,Non-Federal Agency,Mesquite,TX,ACTIVE
+MIAMIAZ.GOV,City,Non-Federal Agency,Miami,AZ,ACTIVE
+MIAMIBEACHFL.GOV,City,Non-Federal Agency,Miami Beach,FL,ACTIVE
+MIAMIGARDENS-FL.GOV,City,Non-Federal Agency,Miami Gardens,FL,ACTIVE
+MIAMILAKES-FL.GOV,City,Non-Federal Agency,Miami Lakes,FL,ACTIVE
+MIAMISPRINGS-FL.GOV,City,Non-Federal Agency,Miami Springs,FL,ACTIVE
+MIAMITOWNSHIPOH.GOV,City,Non-Federal Agency,Milford,OH,ACTIVE
+MIAMITWPOH.GOV,City,Non-Federal Agency,Milford,OH,ACTIVE
+MIDDLEBURGVA.GOV,City,Non-Federal Agency,Middleburg,VA,ACTIVE
+MIDDLESEXBORO-NJ.GOV,City,Non-Federal Agency,Middlesex,NJ,ACTIVE
+MIDDLETONMA.GOV,City,Non-Federal Agency,Middleton,MA,ACTIVE
+MIDDLETONNH.GOV,City,Non-Federal Agency,Middleton,NH,ACTIVE
+MIDDLETOWN-CT.GOV,City,Non-Federal Agency,Middletown,CT,ACTIVE
+MIDDLETOWNCT.GOV,City,Non-Federal Agency,Middletown,CT,ACTIVE
+MIDDLETOWNVA.GOV,City,Non-Federal Agency,Middletown,VA,ACTIVE
+MIDLANDTEXAS.GOV,City,Non-Federal Agency,Midland,TX,ACTIVE
+MIDLOTHIANTX.GOV,City,Non-Federal Agency,Midlothian,TX,ACTIVE
+MIDWAY-NC.GOV,City,Non-Federal Agency,Winston-Salem,NC,ACTIVE
+MIFFLIN-OH.GOV,City,Non-Federal Agency,Gahanna,OH,ACTIVE
+MILAN-NY.GOV,City,Non-Federal Agency,Milan,NY,ACTIVE
+MILANMO.GOV,City,Non-Federal Agency,Milan,MO,ACTIVE
+MILANOHIO.GOV,City,Non-Federal Agency,Milan,OH,ACTIVE
+MILFORD-CT.GOV,City,Non-Federal Agency,Milford,CT,ACTIVE
+MILFORD-DE.GOV,City,Non-Federal Agency,Milford,DE,ACTIVE
+MILFORDNE.GOV,City,Non-Federal Agency,Milford,NE,ACTIVE
+MILLIKENCO.GOV,City,Non-Federal Agency,Milliken,CO,ACTIVE
+MILLIKENCOLORADO.GOV,City,Non-Federal Agency,Milliken,CO,ACTIVE
+MILLINGTONTN.GOV,City,Non-Federal Agency,Millington,TN,ACTIVE
+MILLSTONENJ.GOV,City,Non-Federal Agency,Millstone,NJ,ACTIVE
+MILLSWY.GOV,City,Non-Federal Agency,Mills,WY,ACTIVE
+MILLVILLENJ.GOV,City,Non-Federal Agency,Millville,NJ,ACTIVE
+MILTON-WI.GOV,City,Non-Federal Agency,Milton,WI,ACTIVE
+MILWAUKEE.GOV,City,Non-Federal Agency,Milwaukee,WI,ACTIVE
+MILWAUKIEOREGON.GOV,City,Non-Federal Agency,Milwaukie,OR,ACTIVE
+MINEOLA-NY.GOV,City,Non-Federal Agency,Mineola,NY,ACTIVE
+MINERALWELLSTX.GOV,City,Non-Federal Agency,Mineral Wells,TX,ACTIVE
+MINNEAPOLIS-MN.GOV,City,Non-Federal Agency,Minneapolis,MN,ACTIVE
+MINNEAPOLISMN.GOV,City,Non-Federal Agency,Minneapolis,MN,ACTIVE
+MINNETONKA-MN.GOV,City,Non-Federal Agency,Minnetonka,MN,ACTIVE
+MIRAMARFL.GOV,City,Non-Federal Agency,Miramar,FL,ACTIVE
+MISSIONHILLSKS.GOV,City,Non-Federal Agency,Mission Hills,KS,ACTIVE
+MISSOULA-MT.GOV,City,Non-Federal Agency,Missoula,MT,ACTIVE
+MISSOURICITYTEXAS.GOV,City,Non-Federal Agency,Missouri City,TX,ACTIVE
+MISSOURICITYTX.GOV,City,Non-Federal Agency,Missouri City,TX,ACTIVE
+MITCHELL-IN.GOV,City,Non-Federal Agency,Mitchell,IN,ACTIVE
+MOBILE-AL.GOV,City,Non-Federal Agency,Mobile,AL,ACTIVE
+MOCKSVILLENC.GOV,City,Non-Federal Agency,Mocksville,NC,ACTIVE
+MONROEGA.GOV,City,Non-Federal Agency,Monroe,GA,ACTIVE
+MONROEMI.GOV,City,Non-Federal Agency,Monroe,MI,ACTIVE
+MONROETWP-OH.GOV,City,Non-Federal Agency,Bethel,OH,ACTIVE
+MONROEWA.GOV,City,Non-Federal Agency,Monroe,WA,ACTIVE
+MONTAGUE-MA.GOV,City,Non-Federal Agency,Turners Falls,MA,ACTIVE
+MONTCLAIRCA.GOV,City,Non-Federal Agency,Montclair,CA,ACTIVE
+MONTEREYMA.GOV,City,Non-Federal Agency,Monterey,MA,ACTIVE
+MONTGOMERYAL.GOV,City,Non-Federal Agency,Montgomery,AL,ACTIVE
+MONTGOMERYMA.GOV,City,Non-Federal Agency,Montgomery,MA,ACTIVE
+MONTGOMERYOHIO.GOV,City,Non-Federal Agency,Montgomery,OH,ACTIVE
+MONTGOMERYTEXAS.GOV,City,Non-Federal Agency,Montgomery,TX,ACTIVE
+MONTICELLOIN.GOV,City,Non-Federal Agency,Monticello,IN,ACTIVE
+MOODYALABAMA.GOV,City,Non-Federal Agency,Moody,AL,ACTIVE
+MOORESVILLE-NC.GOV,City,Non-Federal Agency,Mooresville,NC,ACTIVE
+MOORPARKCA.GOV,City,Non-Federal Agency,Moorpark,CA,ACTIVE
+MOREHEAD-KY.GOV,City,Non-Federal Agency,Morehead,KY,ACTIVE
+MORGANTONNC.GOV,City,Non-Federal Agency,Morganton,NC,ACTIVE
+MORGANTOWNWV.GOV,City,Non-Federal Agency,Morgantown,WV,ACTIVE
+MORIARTYNM.GOV,City,Non-Federal Agency,Moriarty,NM,ACTIVE
+MORROBAYCA.GOV,City,Non-Federal Agency,Morro Bay,CA,ACTIVE
+MORTON-IL.GOV,City,Non-Federal Agency,Morton,IL,ACTIVE
+MOULTONBOROUGHNH.GOV,City,Non-Federal Agency,Moultonborough,NH,ACTIVE
+MOUNTAINAIRNM.GOV,City,Non-Federal Agency,Mountainair,NM,ACTIVE
+MOUNTAINHOUSECA.GOV,City,Non-Federal Agency,Mountain House,CA,ACTIVE
+MOUNTAINPARK-GA.GOV,City,Non-Federal Agency,Mountain Park,GA,ACTIVE
+MOUNTAINVIEW.GOV,City,Non-Federal Agency,Mountain View,CA,ACTIVE
+MOUNTCARMELTN.GOV,City,Non-Federal Agency,Mount Carmel,TN,ACTIVE
+MOUNTKISCONY.GOV,City,Non-Federal Agency,Mount Kisco,NY,ACTIVE
+MOUNTPLEASANTTN.GOV,City,Non-Federal Agency,Mount Pleasant,TN,ACTIVE
+MOUNTPOCONO-PA.GOV,City,Non-Federal Agency,Mount Pocono,PA,ACTIVE
+MOUNTPROSPECT-IL.GOV,City,Non-Federal Agency,Mount Prospect,IL,ACTIVE
+MOUNTPROSPECTIL.GOV,City,Non-Federal Agency,Mount Prospect,IL,ACTIVE
+MOUNTVERNONWA.GOV,City,Non-Federal Agency,Mount Vernon,WA,ACTIVE
+MQUEBRADILLASPR.GOV,City,Non-Federal Agency,Quebradillas,PR,ACTIVE
+MSVFL.GOV,City,Non-Federal Agency,Miami Shores,FL,ACTIVE
+MTCRESTEDBUTTE-CO.GOV,City,Non-Federal Agency,Mt. Crested Butte,CO,ACTIVE
+MTJULIET-TN.GOV,City,Non-Federal Agency,Mt Juliet,TN,ACTIVE
+MTPLEASANTWI.GOV,City,Non-Federal Agency,Mount Pleasant,WI,ACTIVE
+MTSHASTACA.GOV,City,Non-Federal Agency,Mt. Shasta,CA,ACTIVE
+MUKILTEOWA.GOV,City,Non-Federal Agency,Mukilteo,WA,ACTIVE
+MUNDELEIN-IL.GOV,City,Non-Federal Agency,Mundelein,IL,ACTIVE
+MUNDYTWP-MI.GOV,City,Non-Federal Agency,Swartz Creek,MI,ACTIVE
+MURFREESBOROTN.GOV,City,Non-Federal Agency,Murfreesboro,TN,ACTIVE
+MURPHYSBORO-IL.GOV,City,Non-Federal Agency,Murphysboro,IL,ACTIVE
+MURPHYTX.GOV,City,Non-Federal Agency,Murphy,TX,ACTIVE
+MURRAYKY.GOV,City,Non-Federal Agency,Murray,KY,ACTIVE
+MURRIETACA.GOV,City,Non-Federal Agency,Murrieta,CA,ACTIVE
+MUSCATINEIOWA.GOV,City,Non-Federal Agency,Muscatine,IA,ACTIVE
+MUSKEGON-MI.GOV,City,Non-Federal Agency,Muskegon,MI,ACTIVE
+MVPD.GOV,City,Non-Federal Agency,Mountain View,CA,ACTIVE
+MYARLINGTONTX.GOV,City,Non-Federal Agency,Arlington,TX,ACTIVE
+MYCOLUMBUS.GOV,City,Non-Federal Agency,Columbus,OH,ACTIVE
+MYDELRAYBEACHFL.GOV,City,Non-Federal Agency,Delray Beach,FL,ACTIVE
+NAGSHEADNC.GOV,City,Non-Federal Agency,Nags Head,NC,ACTIVE
+NANTICOKECITY-PA.GOV,City,Non-Federal Agency,NANTICOKE,PA,ACTIVE
+NANTUCKET-MA.GOV,City,Non-Federal Agency,Nantucket,MA,ACTIVE
+NAPA-CA.GOV,City,Non-Federal Agency,Napa,CA,ACTIVE
+NAPLESCITYUT.GOV,City,Non-Federal Agency,Naples,UT,ACTIVE
+NARBERTHPA.GOV,City,Non-Federal Agency,Narberth,PA,ACTIVE
+NARRAGANSETTRI.GOV,City,Non-Federal Agency,Narragansett,RI,ACTIVE
+NASHOTAH-WI.GOV,City,Non-Federal Agency,Nashotah,WI,ACTIVE
+NASHUANH.GOV,City,Non-Federal Agency,Nashua,NH,ACTIVE
+NASHVILLE.GOV,City,Non-Federal Agency,Nashville,TN,ACTIVE
+NATCHITOCHESLA.GOV,City,Non-Federal Agency,Natchitoches,LA,ACTIVE
+NATIONALCITYCA.GOV,City,Non-Federal Agency,National City,CA,ACTIVE
+NAUGATUCK-CT.GOV,City,Non-Federal Agency,Naugatuck,CT,ACTIVE
+NAVASOTATX.GOV,City,Non-Federal Agency,Navasota,TX,ACTIVE
+NAZARETHBOROUGHPA.GOV,City,Non-Federal Agency,Nazareth,PA,ACTIVE
+NBCA.GOV,City,Non-Federal Agency,Newport Beach,CA,ACTIVE
+NEBRASKACITYNE.GOV,City,Non-Federal Agency,Nebraska City,NE,ACTIVE
+NEEDHAMMA.GOV,City,Non-Federal Agency,NEEDHAM,MA,ACTIVE
+NEVADACITYCA.GOV,City,Non-Federal Agency,Nevada City,CA,ACTIVE
+NEVADAMO.GOV,City,Non-Federal Agency,Nevada,MO,ACTIVE
+NEVILLEISLAND-PA.GOV,City,Non-Federal Agency,Pittsburgh,PA,ACTIVE
+NEWARKDE.GOV,City,Non-Federal Agency,Newark,DE,ACTIVE
+NEWAUBURNMN.GOV,City,Non-Federal Agency,New Auburn,MN,ACTIVE
+NEWBEDFORD-MA.GOV,City,Non-Federal Agency,New Bedford,MA,ACTIVE
+NEWBERGOREGON.GOV,City,Non-Federal Agency,Newberg,OR,ACTIVE
+NEWBOSTONNH.GOV,City,Non-Federal Agency,New Boston,NH,ACTIVE
+NEWBRIGHTONMN.GOV,City,Non-Federal Agency,New Brighton,MN,ACTIVE
+NEWBRITAINCT.GOV,City,Non-Federal Agency,New Britain,CT,ACTIVE
+NEWBURGH-IN.GOV,City,Non-Federal Agency,Newburgh,IN,ACTIVE
+NEWBURGHHTSOH.GOV,City,Non-Federal Agency,Newburgh Heights,OH,ACTIVE
+NEWCANAANCT.GOV,City,Non-Federal Agency,New Canaan,CT,ACTIVE
+NEWCARROLLTONMD.GOV,City,Non-Federal Agency,New Carrollton,MD,ACTIVE
+NEWCASTLEPA.GOV,City,Non-Federal Agency,New Castle,PA,ACTIVE
+NEWCONCORD-OH.GOV,City,Non-Federal Agency,New Concord,OH,ACTIVE
+NEWFIELDSNH.GOV,City,Non-Federal Agency,Newfields,NH,ACTIVE
+NEWHARMONY-IN.GOV,City,Non-Federal Agency,New Harmony,IN,ACTIVE
+NEWHAVENCT.GOV,City,Non-Federal Agency,New Haven,CT,ACTIVE
+NEWHOPEMN.GOV,City,Non-Federal Agency,New Hope,MN,ACTIVE
+NEWINGTONCT.GOV,City,Non-Federal Agency,Newington,CT,ACTIVE
+NEWMARKETNH.GOV,City,Non-Federal Agency,Newmarket,NH,ACTIVE
+NEWMARLBOROUGHMA.GOV,City,Non-Federal Agency,Mill River,MA,ACTIVE
+NEWNANGA.GOV,City,Non-Federal Agency,Newnan,GA,ACTIVE
+NEWORLEANS-LA.GOV,City,Non-Federal Agency,New Orleans,LA,ACTIVE
+NEWORLEANSLA.GOV,City,Non-Federal Agency,New Orleans,LA,ACTIVE
+NEWPORT-RI.GOV,City,Non-Federal Agency,Newport,RI,ACTIVE
+NEWPORTBEACH-CA.GOV,City,Non-Federal Agency,Newport Beach,CA,ACTIVE
+NEWPORTBEACHCA.GOV,City,Non-Federal Agency,Newport Beach,CA,ACTIVE
+NEWPORTKY.GOV,City,Non-Federal Agency,Newport,KY,ACTIVE
+NEWPORTNEWSVA.GOV,City,Non-Federal Agency,Newport News,VA,ACTIVE
+NEWPORTOREGON.GOV,City,Non-Federal Agency,Newport,OR,ACTIVE
+NEWRICHMONDWI.GOV,City,Non-Federal Agency,New Richmond ,WI,ACTIVE
+NEWRUSSIATOWNSHIP-OH.GOV,City,Non-Federal Agency,Oberlin,OH,ACTIVE
+NEWTON-NH.GOV,City,Non-Federal Agency,Newton,NH,ACTIVE
+NEWTONNC.GOV,City,Non-Federal Agency,Newton,NC,ACTIVE
+NEWTOWN-CT.GOV,City,Non-Federal Agency,Newtown,CT,ACTIVE
+NEWTOWNOHIO.GOV,City,Non-Federal Agency,Newtown,OH,ACTIVE
+NEWTOWNPA.GOV,City,Non-Federal Agency,Newtown,PA,ACTIVE
+NEWWINDSOR-NY.GOV,City,Non-Federal Agency,New Windsor,NY,ACTIVE
+NEWWINDSORMD.GOV,City,Non-Federal Agency,New Windsor,MD,ACTIVE
+NIAGARAFALLSNY.GOV,City,Non-Federal Agency,Niagara Falls,NY,ACTIVE
+NIAGARAFALLSNYCARTS.GOV,City,Non-Federal Agency,Niagara Falls,NY,ACTIVE
+NICHOLSHILLS-OK.GOV,City,Non-Federal Agency,Nichols Hills,OK,ACTIVE
+NILES-IL.GOV,City,Non-Federal Agency,Niles,IL,ACTIVE
+NILESTWPMI.GOV,City,Non-Federal Agency,Niles,MI,ACTIVE
+NINNEKAHOK.GOV,City,Non-Federal Agency,NINNEKAH,OK,ACTIVE
+NISSEQUOGUENY.GOV,City,Non-Federal Agency,St. James,NY,ACTIVE
+NIXAMO.GOV,City,Non-Federal Agency,Nixa,MO,ACTIVE
+NNVA.GOV,City,Non-Federal Agency,Newport News,VA,ACTIVE
+NOGALESAZ.GOV,City,Non-Federal Agency,Nogales,AZ,ACTIVE
+NOLA.GOV,City,Non-Federal Agency,New Orleans,LA,ACTIVE
+NOLAERB.GOV,City,Non-Federal Agency,New Orleans,LA,ACTIVE
+NOLAIPM.GOV,City,Non-Federal Agency,New Orleans,LA,ACTIVE
+NOLAOIG.GOV,City,Non-Federal Agency,New Orleans,LA,ACTIVE
+NOLENSVILLETN.GOV,City,Non-Federal Agency,Nolensville,TN,ACTIVE
+NORFOLK.GOV,City,Non-Federal Agency,Norfolk,VA,ACTIVE
+NORFOLKNE.GOV,City,Non-Federal Agency,Norfolk,NE,ACTIVE
+NORFOLKVA.GOV,City,Non-Federal Agency,Norfolk,VA,ACTIVE
+NORMANDYPARKWA.GOV,City,Non-Federal Agency,Normandy Park,WA,ACTIVE
+NORMANOK.GOV,City,Non-Federal Agency,Norman,OK,ACTIVE
+NORMANPARKGA.GOV,City,Non-Federal Agency,Norman Park,GA,ACTIVE
+NORRIDGE-IL.GOV,City,Non-Federal Agency,Norridge,IL,ACTIVE
+NORTHADAMS-MA.GOV,City,Non-Federal Agency,North Adams,MA,ACTIVE
+NORTHAMPTONMA.GOV,City,Non-Federal Agency,Northampton,MA,ACTIVE
+NORTHANDOVERMA.GOV,City,Non-Federal Agency,North Andover,MA,ACTIVE
+NORTHBENDWA.GOV,City,Non-Federal Agency,North Bend,WA,ACTIVE
+NORTHBOROUGH-MA.GOV,City,Non-Federal Agency,Northborough,MA,ACTIVE
+NORTHBROOKIL.GOV,City,Non-Federal Agency,Northbrook,IL,ACTIVE
+NORTHBRUNSWICKNJ.GOV,City,Non-Federal Agency,North Brunswick,NJ,ACTIVE
+NORTHCANTONOHIO.GOV,City,Non-Federal Agency,North Canton,OH,ACTIVE
+NORTHFIELD-VT.GOV,City,Non-Federal Agency,Northfield,VT,ACTIVE
+NORTHFIELDMA.GOV,City,Non-Federal Agency,Northfield,MA,ACTIVE
+NORTHFIELDMI.GOV,City,Non-Federal Agency,Whitmore Lake,MI,ACTIVE
+NORTHFIELDVILLAGE-OH.GOV,City,Non-Federal Agency,NORTHFIELD,OH,ACTIVE
+NORTHHAMPTON-NH.GOV,City,Non-Federal Agency,North Hampton,NH,ACTIVE
+NORTHHAVEN-CT.GOV,City,Non-Federal Agency,North Haven,CT,ACTIVE
+NORTHHEMPSTEADNY.GOV,City,Non-Federal Agency,MANHASSET,NY,ACTIVE
+NORTHLEBANONTWPPA.GOV,City,Non-Federal Agency,Lebanon,PA,ACTIVE
+NORTHPORTNY.GOV,City,Non-Federal Agency,Northport,NY,ACTIVE
+NORTHPROVIDENCERI.GOV,City,Non-Federal Agency,North Providence,RI,ACTIVE
+NORTHREADINGMA.GOV,City,Non-Federal Agency,North Reading,MA,ACTIVE
+NORTHSIOUXCITY-SD.GOV,City,Non-Federal Agency,N. Sioux City,SD,ACTIVE
+NORTHSTONINGTONCT.GOV,City,Non-Federal Agency,North Stonington,CT,ACTIVE
+NORTHUNIONTOWNSHIP-PA.GOV,City,Non-Federal Agency,Lemont Furnace,PA,ACTIVE
+NORTHVERNON-IN.GOV,City,Non-Federal Agency,North Vernon,IN,ACTIVE
+NORTONVA.GOV,City,Non-Federal Agency,Norton,VA,ACTIVE
+NORWALKCA.GOV,City,Non-Federal Agency,Norwalk,CA,ACTIVE
+NORWAYMI.GOV,City,Non-Federal Agency,Norway,MI,ACTIVE
+NORWOOD-MA.GOV,City,Non-Federal Agency,Norwood,MA,ACTIVE
+NORWOODMA.GOV,City,Non-Federal Agency,Norwood,MA,ACTIVE
+NOTTINGHAM-NH.GOV,City,Non-Federal Agency,Nottingham,NH,ACTIVE
+NOWATAOK.GOV,City,Non-Federal Agency,Nowata,OK,ACTIVE
+NSIDFL.GOV,City,Non-Federal Agency,Coral Springs,FL,ACTIVE
+NYACK-NY.GOV,City,Non-Federal Agency,Nyack,NY,ACTIVE
+NYC-NY.GOV,City,Non-Federal Agency,Brooklyn,NY,ACTIVE
+NYC.GOV,City,Non-Federal Agency,Brooklyn,NY,ACTIVE
+OAK-BROOK-IL.GOV,City,Non-Federal Agency,OAK BROOK,IL,ACTIVE
+OAKBLUFFSMA.GOV,City,Non-Federal Agency,Oak Bluffs,MA,ACTIVE
+OAKHAM-MA.GOV,City,Non-Federal Agency,Oakham,MA,ACTIVE
+OAKLAND-ME.GOV,City,Non-Federal Agency,Oakland,ME,ACTIVE
+OAKLANDCA.GOV,City,Non-Federal Agency,Oakland,CA,ACTIVE
+OAKLANDPARKFL.GOV,City,Non-Federal Agency,Oakland Park,FL,ACTIVE
+OAKLAWN-IL.GOV,City,Non-Federal Agency,OAK LAWN,IL,ACTIVE
+OAKPARKMI.GOV,City,Non-Federal Agency,Oak Park,MI,ACTIVE
+OAKRIDGETN.GOV,City,Non-Federal Agency,"Oak Ridge, TN 37830 United States",TN,ACTIVE
+OAKWOODOHIO.GOV,City,Non-Federal Agency,Oakwood,OH,ACTIVE
+OBERLINKANSAS.GOV,City,Non-Federal Agency,Oberlin,KS,ACTIVE
+OCCOQUANVA.GOV,City,Non-Federal Agency,Occoquan,VA,ACTIVE
+OCEANAWV.GOV,City,Non-Federal Agency,Oceana,WV,ACTIVE
+OCEANCITYMD.GOV,City,Non-Federal Agency,Ocean City ,MD,ACTIVE
+OCEANGATE-NJ.GOV,City,Non-Federal Agency,Ocean Gate,NJ,ACTIVE
+OCEANSPRINGS-MS.GOV,City,Non-Federal Agency,Ocean Springs,MS,ACTIVE
+OCONOMOWOC-WI.GOV,City,Non-Federal Agency,Oconomowoc,WI,ACTIVE
+ODESSA-TX.GOV,City,Non-Federal Agency,Odessa,TX,ACTIVE
+OGALLALA-NE.GOV,City,Non-Federal Agency,Ogallala,NE,ACTIVE
+OGDEN-KS.GOV,City,Non-Federal Agency,Ogden ,KS,ACTIVE
+OLDLYME-CT.GOV,City,Non-Federal Agency,Old Lyme,CT,ACTIVE
+OLDSAYBROOKCT.GOV,City,Non-Federal Agency,Old Saybrook,CT,ACTIVE
+OLIVERSPRINGS-TN.GOV,City,Non-Federal Agency,Oliver Springs,TN,ACTIVE
+OLYMPIA-WA.GOV,City,Non-Federal Agency,Olympia,WA,ACTIVE
+OLYMPIAWA.GOV,City,Non-Federal Agency,Olympia,WA,ACTIVE
+OMAHA-NE.GOV,City,Non-Federal Agency,Omaha,NE,ACTIVE
+ONTARIOCA.GOV,City,Non-Federal Agency,Ontario,CA,ACTIVE
+OPALOCKAFL.GOV,City,Non-Federal Agency,OPALOCKA,FL,ACTIVE
+OPELIKA-AL.GOV,City,Non-Federal Agency,Opelika,AL,ACTIVE
+ORANGE-CT.GOV,City,Non-Federal Agency,Orange,CT,ACTIVE
+ORLANDOFL.GOV,City,Non-Federal Agency,Orlando,FL,ACTIVE
+ORMONDBEACH-FL.GOV,City,Non-Federal Agency,Ormond Beach,FL,ACTIVE
+ORONOCOTOWNSHIP-MN.GOV,City,Non-Federal Agency,Oronoco,MN,ACTIVE
+OROVALLEYAZ.GOV,City,Non-Federal Agency,Oro Valley,AZ,ACTIVE
+OSAGEBEACH-MO.GOV,City,Non-Federal Agency,OSAGE BEACH,MO,ACTIVE
+OSCODATOWNSHIPMI.GOV,City,Non-Federal Agency,Oscoda,MI,ACTIVE
+OTAYWATER.GOV,City,Non-Federal Agency,Spring Valley,CA,ACTIVE
+OTHELLOWA.GOV,City,Non-Federal Agency,Othello,WA,ACTIVE
+OTISFIELDME.GOV,City,Non-Federal Agency,OTISFIELD,ME,ACTIVE
+OTTAWAKS.GOV,City,Non-Federal Agency,Ottawa,KS,ACTIVE
+OXFORD-CT.GOV,City,Non-Federal Agency,Oxford,CT,ACTIVE
+OYSTERBAY-NY.GOV,City,Non-Federal Agency,Oyster Bay,NY,ACTIVE
+PACIFICWA.GOV,City,Non-Federal Agency,Pacific,WA,ACTIVE
+PADUCAHKY.GOV,City,Non-Federal Agency,Paducah,KY,ACTIVE
+PAGEAZ.GOV,City,Non-Federal Agency,Page,AZ,ACTIVE
+PALATKA-FL.GOV,City,Non-Federal Agency,Palatka,FL,ACTIVE
+PALMETTOBAY-FL.GOV,City,Non-Federal Agency,Palmetto Bay,FL,ACTIVE
+PALMSPRINGS-CA.GOV,City,Non-Federal Agency,Palm Springs,CA,ACTIVE
+PALMSPRINGSCA.GOV,City,Non-Federal Agency,Palm Springs,CA,ACTIVE
+PALOALTO-CA.GOV,City,Non-Federal Agency,Palo Alto,CA,ACTIVE
+PALOSHILLS-IL.GOV,City,Non-Federal Agency,Palos Hills,IL,ACTIVE
+PANORAMAVILLAGETX.GOV,City,Non-Federal Agency,Panorama Village,TX,ACTIVE
+PARADISEVALLEYAZ.GOV,City,Non-Federal Agency,Paradise Valley,AZ,ACTIVE
+PARISTEXAS.GOV,City,Non-Federal Agency,Paris,TX,ACTIVE
+PARISTN.GOV,City,Non-Federal Agency,Paris,TN,ACTIVE
+PARKERSBURGWV.GOV,City,Non-Federal Agency,Parkersburg,WV,ACTIVE
+PARKVILLEMO.GOV,City,Non-Federal Agency,Parkville,MO,ACTIVE
+PARMAHEIGHTSOH.GOV,City,Non-Federal Agency,Parma Heights,OH,ACTIVE
+PASADENACA.GOV,City,Non-Federal Agency,Pasadena,CA,ACTIVE
+PASADENATX.GOV,City,Non-Federal Agency,Pasadena,TX,ACTIVE
+PASCO-WA.GOV,City,Non-Federal Agency,Pasco,WA,ACTIVE
+PATAGONIA-AZ.GOV,City,Non-Federal Agency,Patagonia,AZ,ACTIVE
+PATERSONNJ.GOV,City,Non-Federal Agency,Paterson,NJ,ACTIVE
+PAWLING-NY.GOV,City,Non-Federal Agency,Pawling,NY,ACTIVE
+PAWNEEROCK-KS.GOV,City,Non-Federal Agency,Pawnee Rock,KS,ACTIVE
+PAXTONFL.GOV,City,Non-Federal Agency,Laurel Hill,FL,ACTIVE
+PAYSONAZ.GOV,City,Non-Federal Agency,Payson,AZ,ACTIVE
+PEABODY-MA.GOV,City,Non-Federal Agency,Peabody,MA,ACTIVE
+PEABODYMA.GOV,City,Non-Federal Agency,PEABODY,MA,ACTIVE
+PEARLANDTX.GOV,City,Non-Federal Agency,Pearland,TX,ACTIVE
+PECOSTX.GOV,City,Non-Federal Agency,Pecos,TX,ACTIVE
+PEMBROKE-MA.GOV,City,Non-Federal Agency,Pembroke,MA,ACTIVE
+PEORIAAZ.GOV,City,Non-Federal Agency,Peoria,AZ,ACTIVE
+PEORIAHEIGHTS-IL.GOV,City,Non-Federal Agency,Peoria Heights,IL,ACTIVE
+PEQUOTLAKES-MN.GOV,City,Non-Federal Agency,Pequot Lakes,MN,ACTIVE
+PERMITTINGROGERSAR.GOV,City,Non-Federal Agency,Rogers,AR,ACTIVE
+PERRY-WI.GOV,City,Non-Federal Agency,Mount Horeb,WI,ACTIVE
+PERRYTOWNSHIP-IN.GOV,City,Non-Federal Agency,Indianapolis,IN,ACTIVE
+PETERBOROUGHNH.GOV,City,Non-Federal Agency,Peterborough,NH,ACTIVE
+PETERSBURGAK.GOV,City,Non-Federal Agency,Petersburg,AK,ACTIVE
+PETERSBURGVA.GOV,City,Non-Federal Agency,Petersburg,VA,ACTIVE
+PFLUGERVILLETX.GOV,City,Non-Federal Agency,Pflugerville,TX,ACTIVE
+PHARR-TX.GOV,City,Non-Federal Agency,Pharr,TX,ACTIVE
+PHILA.GOV,City,Non-Federal Agency,Philadelphia,PA,ACTIVE
+PHILIPSBURGMT.GOV,City,Non-Federal Agency,Philipsburg,MT,ACTIVE
+PHILLIPSTON-MA.GOV,City,Non-Federal Agency,Phillipston,MA,ACTIVE
+PHOENIX.GOV,City,Non-Federal Agency,Phoenix,AZ,ACTIVE
+PHOENIXOREGON.GOV,City,Non-Federal Agency,Phoenix,OR,ACTIVE
+PIEDMONT-OK.GOV,City,Non-Federal Agency,PIEDMONT,OK,ACTIVE
+PIERMONT-NY.GOV,City,Non-Federal Agency,Piermont,NY,ACTIVE
+PIKEVILLEKY.GOV,City,Non-Federal Agency,Pikeville,KY,ACTIVE
+PILOTPOINTAK.GOV,City,Non-Federal Agency,Pilot Point,AK,ACTIVE
+PINEBLUFFSWY.GOV,City,Non-Federal Agency,Pine Bluffs,WY,ACTIVE
+PINEHURSTNC.GOV,City,Non-Federal Agency,Pinehurst,NC,ACTIVE
+PINEPLAINS-NY.GOV,City,Non-Federal Agency,Pine Plains,NY,ACTIVE
+PINETOPLAKESIDEAZ.GOV,City,Non-Federal Agency,LAKESIDE,AZ,ACTIVE
+PINEVILLENC.GOV,City,Non-Federal Agency,Pineville,NC,ACTIVE
+PITTSBORONC.GOV,City,Non-Federal Agency,Pittsboro,NC,ACTIVE
+PITTSBURGCA.GOV,City,Non-Federal Agency,PITTSBURG,CA,ACTIVE
+PITTSBURGHPA.GOV,City,Non-Federal Agency,Pittsburgh,PA,ACTIVE
+PITTSFIELD-MI.GOV,City,Non-Federal Agency,Ann Arbor,MI,ACTIVE
+PITTSFIELDNH.GOV,City,Non-Federal Agency,Pittsfield,NH,ACTIVE
+PLAINFIELDNJ.GOV,City,Non-Federal Agency,Plainfield,NJ,ACTIVE
+PLANDOMEHEIGHTS-NY.GOV,City,Non-Federal Agency,Manhasset,NY,ACTIVE
+PLANO.GOV,City,Non-Federal Agency,Plano,TX,ACTIVE
+PLATTSBURG-MO.GOV,City,Non-Federal Agency,Plattsburg,MO,ACTIVE
+PLEASANTONCA.GOV,City,Non-Federal Agency,Pleasanton,CA,ACTIVE
+PLEASANTONTX.GOV,City,Non-Federal Agency,Pleasanton,TX,ACTIVE
+PLEASANTPRAIRIE-WI.GOV,City,Non-Federal Agency,Pleasant Prairie,WI,ACTIVE
+PLEASANTPRAIRIEWI.GOV,City,Non-Federal Agency,Pleasant Prairie,WI,ACTIVE
+PLEASANTVALLEY-NY.GOV,City,Non-Federal Agency,Pleasant Valley,NY,ACTIVE
+PLEASANTVILLE-NY.GOV,City,Non-Federal Agency,Pleasantville,NY,ACTIVE
+PLOVERWI.GOV,City,Non-Federal Agency,Plover,WI,ACTIVE
+PLUMSTEAD.GOV,City,Non-Federal Agency,Plumsteadville,PA,ACTIVE
+PLYMOUTH-MA.GOV,City,Non-Federal Agency,Plymouth,MA,ACTIVE
+PLYMOUTHMN.GOV,City,Non-Federal Agency,Plymouth,MN,ACTIVE
+POCOMOKEMD.GOV,City,Non-Federal Agency,Pocomoke City,MD,ACTIVE
+POCONOPA.GOV,City,Non-Federal Agency,Tannersville,PA,ACTIVE
+POLKCITYIA.GOV,City,Non-Federal Agency,Polk City,IA,ACTIVE
+POMFRETCT.GOV,City,Non-Federal Agency,Pomfret Center,CT,ACTIVE
+POMPANOBEACHFL.GOV,City,Non-Federal Agency,Pompano Beach,FL,ACTIVE
+POMPEY-NY.GOV,City,Non-Federal Agency,MANLIUS,NY,ACTIVE
+PONCACITYOK.GOV,City,Non-Federal Agency,Ponca City,OK,ACTIVE
+POOLER-GA.GOV,City,Non-Federal Agency,Pooler,GA,ACTIVE
+POOLESVILLEMD.GOV,City,Non-Federal Agency,Poolesville,MD,ACTIVE
+POPLARBLUFF-MO.GOV,City,Non-Federal Agency,Poplar Bluff,MO,ACTIVE
+POPLARVILLEMS.GOV,City,Non-Federal Agency,Poplarvile,MS,ACTIVE
+POQUOSON-VA.GOV,City,Non-Federal Agency,Poquioson,VA,ACTIVE
+PORTAGE-MI.GOV,City,Non-Federal Agency,Portage,MI,ACTIVE
+PORTAGEMI.GOV,City,Non-Federal Agency,Portage,MI,ACTIVE
+PORTAGEWI.GOV,City,Non-Federal Agency,Portage,WI,ACTIVE
+PORTALESNM.GOV,City,Non-Federal Agency,Portales,NM,ACTIVE
+PORTARTHURTX.GOV,City,Non-Federal Agency,Port Arthur,TX,ACTIVE
+PORTCLINTON-OH.GOV,City,Non-Federal Agency,Port Clinton,OH,ACTIVE
+PORTERVILLE-CA.GOV,City,Non-Federal Agency,Porterville,CA,ACTIVE
+PORTERVILLECA.GOV,City,Non-Federal Agency,Porterville,CA,ACTIVE
+PORTLANDMAINE.GOV,City,Non-Federal Agency,Portland,ME,ACTIVE
+PORTLANDOREGON.GOV,City,Non-Federal Agency,Portland,OR,ACTIVE
+PORTLANDTX.GOV,City,Non-Federal Agency,Portland,TX,ACTIVE
+PORTSMOUTHVA.GOV,City,Non-Federal Agency,Portsmouth,VA,ACTIVE
+PORTSMOUTHVIRGINIA.GOV,City,Non-Federal Agency,Portsmouth,VA,ACTIVE
+POTTERTWP-PA.GOV,City,Non-Federal Agency,Monaca,PA,ACTIVE
+POWHATANVA.GOV,City,Non-Federal Agency,Powhatan,VA,ACTIVE
+POYNETTE-WI.GOV,City,Non-Federal Agency,Poynette,WI,ACTIVE
+PRAIRIEDUCHIEN-WI.GOV,City,Non-Federal Agency,Prairie du Chien,WI,ACTIVE
+PRAIRIEVIEWTEXAS.GOV,City,Non-Federal Agency,Prairie View,TX,ACTIVE
+PRATTVILLE-AL.GOV,City,Non-Federal Agency,Prattville,AL,ACTIVE
+PRATTVILLEAL.GOV,City,Non-Federal Agency,Prattville,AL,ACTIVE
+PRESCOTT-AZ.GOV,City,Non-Federal Agency,Prescott,AZ,ACTIVE
+PRESCOTTVALLEY-AZ.GOV,City,Non-Federal Agency,Prescott Valley,AZ,ACTIVE
+PRESQUEISLEMAINE.GOV,City,Non-Federal Agency,Presque Isle,ME,ACTIVE
+PRIESTRIVER-ID.GOV,City,Non-Federal Agency,Priest River,ID,ACTIVE
+PRINCETONNJ.GOV,City,Non-Federal Agency,Princeton,NJ,ACTIVE
+PRINCETONTX.GOV,City,Non-Federal Agency,Princeton,TX,ACTIVE
+PRINCETONWV.GOV,City,Non-Federal Agency,Princeton,WV,ACTIVE
+PROCTORMN.GOV,City,Non-Federal Agency,Proctor,MN,ACTIVE
+PROSPERTX.GOV,City,Non-Federal Agency,Prosper,TX,ACTIVE
+PROVIDENCERI.GOV,City,Non-Federal Agency,Providence,RI,ACTIVE
+PULLMAN-WA.GOV,City,Non-Federal Agency,Pullman,WA,ACTIVE
+PURCELLVILLEVA.GOV,City,Non-Federal Agency,Purcellville,VA,ACTIVE
+QUAKERTOWN-PA.GOV,City,Non-Federal Agency,Quakertown,PA,ACTIVE
+QUINCYIL.GOV,City,Non-Federal Agency,Quincy,IL,ACTIVE
+QUINCYMA.GOV,City,Non-Federal Agency,Quincy,MA,ACTIVE
+RADFORDVA.GOV,City,Non-Federal Agency,Radford,VA,ACTIVE
+RALEIGHNC.GOV,City,Non-Federal Agency,Raleigh,NC,ACTIVE
+RAMAPO-NY.GOV,City,Non-Federal Agency,Suffern,NY,ACTIVE
+RANCHOMIRAGECA.GOV,City,Non-Federal Agency,Rancho Mirage,CA,ACTIVE
+RANDOLPH-MA.GOV,City,Non-Federal Agency,Randolph,MA,ACTIVE
+RANDOLPHTOWNSHIPOHIO.GOV,City,Non-Federal Agency,Randolph,OH,ACTIVE
+RANGELY-CO.GOV,City,Non-Federal Agency,Rangely,CO,ACTIVE
+RANGELYCO.GOV,City,Non-Federal Agency,Rangely,CO,ACTIVE
+RATONNM.GOV,City,Non-Federal Agency,Raton,NM,ACTIVE
+RAYCITYGA.GOV,City,Non-Federal Agency,Ray City,GA,ACTIVE
+RAYMONDNH.GOV,City,Non-Federal Agency,Raymond,NH,ACTIVE
+READINGMA.GOV,City,Non-Federal Agency,READING,MA,ACTIVE
+READINGPA.GOV,City,Non-Federal Agency,Reading,PA,ACTIVE
+READYHOUSTONTX.GOV,City,Non-Federal Agency,Houston,TX,ACTIVE
+READYSOUTHTEXAS.GOV,City,Non-Federal Agency,San Antonio,TX,ACTIVE
+READYWESTLINNOR.GOV,City,Non-Federal Agency,West Linn,OR,ACTIVE
+REDBANKTN.GOV,City,Non-Federal Agency,Red Bank,TN,ACTIVE
+REDBAY-AL.GOV,City,Non-Federal Agency,Red Bay,AL,ACTIVE
+REDDING-CA.GOV,City,Non-Federal Agency,Redding,CA,ACTIVE
+REDMOND.GOV,City,Non-Federal Agency,Redmond,WA,ACTIVE
+REEDSBURGWI.GOV,City,Non-Federal Agency,Reedsburg,WI,ACTIVE
+REIDSVILLENC.GOV,City,Non-Federal Agency,Reidsville,NC,ACTIVE
+REMINGTON-VA.GOV,City,Non-Federal Agency,Remington,VA,ACTIVE
+RENO.GOV,City,Non-Federal Agency,Reno,NV,ACTIVE
+RENONV.GOV,City,Non-Federal Agency,Reno,NV,ACTIVE
+RENSSELAERNY.GOV,City,Non-Federal Agency,Rensselaer,NY,ACTIVE
+RENTONWA.GOV,City,Non-Federal Agency,Renton,WA,ACTIVE
+RHEACOUNTYTN.GOV,City,Non-Federal Agency,Dayton,TN,ACTIVE
+RHINEBECK-NY.GOV,City,Non-Federal Agency,Rhinebeck,NY,ACTIVE
+RHINEBECKNY.GOV,City,Non-Federal Agency,Rhinebeck,NY,ACTIVE
+RIALTOCA.GOV,City,Non-Federal Agency,Rialto,CA,ACTIVE
+RICETX.GOV,City,Non-Federal Agency,Rice,TX,ACTIVE
+RICHFIELDWI.GOV,City,Non-Federal Agency,Hubertus,WI,ACTIVE
+RICHLANDMS.GOV,City,Non-Federal Agency,Richland,MS,ACTIVE
+RICHLANDS-VA.GOV,City,Non-Federal Agency,Richlands,VA,ACTIVE
+RICHLANDSNC.GOV,City,Non-Federal Agency,Richlands,NC,ACTIVE
+RICHMOND-VA.GOV,City,Non-Federal Agency,Richmond,VA,ACTIVE
+RICHMONDHILL-GA.GOV,City,Non-Federal Agency,Richmond Hill ,GA,ACTIVE
+RICHMONDINDIANA.GOV,City,Non-Federal Agency,Richmond,IN,ACTIVE
+RICHMONDTX.GOV,City,Non-Federal Agency,RICHMOND,TX,ACTIVE
+RICHMONDVA.GOV,City,Non-Federal Agency,Richmond,VA,ACTIVE
+RICHMONDVT.GOV,City,Non-Federal Agency,Richmond,VT,ACTIVE
+RICHWOODTX.GOV,City,Non-Federal Agency,Richwood,TX,ACTIVE
+RICHWOODWV.GOV,City,Non-Federal Agency,Richwood,WV,ACTIVE
+RIDGECREST-CA.GOV,City,Non-Federal Agency,Ridgecrest,CA,ACTIVE
+RIDGEFIELDNJ.GOV,City,Non-Federal Agency,Ridgefield,NJ,ACTIVE
+RIDGELANDSC.GOV,City,Non-Federal Agency,Ridgeland,SC,ACTIVE
+RIORANCHONM.GOV,City,Non-Federal Agency,Rio Rancho,NM,ACTIVE
+RITZVILLE-WA.GOV,City,Non-Federal Agency,Ritzville,WA,ACTIVE
+RIVERDALEGA.GOV,City,Non-Federal Agency,Riverdale,GA,ACTIVE
+RIVERDALENJ.GOV,City,Non-Federal Agency,Riverdale,NJ,ACTIVE
+RIVERDALEPARKMD.GOV,City,Non-Federal Agency,Riverdale,MD,ACTIVE
+RIVERSIDECA.GOV,City,Non-Federal Agency,Riverside,CA,ACTIVE
+RIVERTONWY.GOV,City,Non-Federal Agency,Riverton,WY,ACTIVE
+ROAMINGSHORESOH.GOV,City,Non-Federal Agency,Roaming Shores,OH,ACTIVE
+ROANOKEVA.GOV,City,Non-Federal Agency,Roanoke,VA,ACTIVE
+ROBINSONPA.GOV,City,Non-Federal Agency,McDonald,PA,ACTIVE
+ROCHELLEPARKNJ.GOV,City,Non-Federal Agency,Rochelle Park,NJ,ACTIVE
+ROCHESTERMN.GOV,City,Non-Federal Agency,Rochester,MN,ACTIVE
+ROCKFORD-IL.GOV,City,Non-Federal Agency,Rockford,IL,ACTIVE
+ROCKFORDIL.GOV,City,Non-Federal Agency,Rockford,IL,ACTIVE
+ROCKHALLMD.GOV,City,Non-Federal Agency,Rock Hall,MD,ACTIVE
+ROCKLAND-MA.GOV,City,Non-Federal Agency,Rockland,MA,ACTIVE
+ROCKLANDMAINE.GOV,City,Non-Federal Agency,Rockland,ME,ACTIVE
+ROCKMART-GA.GOV,City,Non-Federal Agency,Rockmart,GA,ACTIVE
+ROCKPORTMA.GOV,City,Non-Federal Agency,Rockport,MA,ACTIVE
+ROCKPORTMAINE.GOV,City,Non-Federal Agency,Rockport,ME,ACTIVE
+ROCKVILLE-IN.GOV,City,Non-Federal Agency,Rockville,IN,ACTIVE
+ROCKVILLEMD.GOV,City,Non-Federal Agency,Rockville,MD,ACTIVE
+ROCKWELLNC.GOV,City,Non-Federal Agency,Rockwell,NC,ACTIVE
+ROCKYHILL-NJ.GOV,City,Non-Federal Agency,Rocky Hill,NJ,ACTIVE
+ROCKYHILLCT.GOV,City,Non-Federal Agency,Rocky Hill,CT,ACTIVE
+ROCKYMOUNTNC.GOV,City,Non-Federal Agency,Rocky Mount,NC,ACTIVE
+ROGERSAR.GOV,City,Non-Federal Agency,Rogers,AR,ACTIVE
+ROGERSMN.GOV,City,Non-Federal Agency,Rogers,MN,ACTIVE
+ROLESVILLENC.GOV,City,Non-Federal Agency,Rolesville,NC,ACTIVE
+ROLLINGHILLSESTATES-CA.GOV,City,Non-Federal Agency,Rolling Hills Estates,CA,ACTIVE
+ROLLINGHILLSESTATESCA.GOV,City,Non-Federal Agency,Rolling Hills Estates,CA,ACTIVE
+ROME-NY.GOV,City,Non-Federal Agency,Rome,NY,ACTIVE
+ROMI.GOV,City,Non-Federal Agency,Royal Oak,MI,ACTIVE
+ROMULUS-MI.GOV,City,Non-Federal Agency,Romulus,MI,ACTIVE
+ROSENBERGTX.GOV,City,Non-Federal Agency,Rosenberg,TX,ACTIVE
+ROSEVILLE-MI.GOV,City,Non-Federal Agency,Roseville,MI,ACTIVE
+ROSLYNNY.GOV,City,Non-Federal Agency,Roslyn,NY,ACTIVE
+ROSWELL-NM.GOV,City,Non-Federal Agency,Roswell,NM,ACTIVE
+ROUNDROCKTEXAS.GOV,City,Non-Federal Agency,Round Rock,TX,ACTIVE
+ROWE-MA.GOV,City,Non-Federal Agency,Rowe,MA,ACTIVE
+ROWLETTTX.GOV,City,Non-Federal Agency,Rowlett,TX,ACTIVE
+ROXBURY-CT.GOV,City,Non-Federal Agency,Roxbury,CT,ACTIVE
+ROYALOAKMI.GOV,City,Non-Federal Agency,Royal Oak,MI,ACTIVE
+ROYALSTON-MA.GOV,City,Non-Federal Agency,Royalston,MA,ACTIVE
+RPVCA.GOV,City,Non-Federal Agency,Rancho Palos Verdes,CA,ACTIVE
+RRNM.GOV,City,Non-Federal Agency,Rio Rancho,NM,ACTIVE
+RUIDOSO-NM.GOV,City,Non-Federal Agency,Ruidoso,NM,ACTIVE
+RUMSONNJ.GOV,City,Non-Federal Agency,Rumson,NJ,ACTIVE
+RUSSELLSPOINT-OH.GOV,City,Non-Federal Agency,Russells Point,OH,ACTIVE
+RYENY.GOV,City,Non-Federal Agency,Rye,NY,ACTIVE
+SACKETSHARBOR-NY.GOV,City,Non-Federal Agency,Sackets Harbor,NY,ACTIVE
+SADDLEBROOKNJ.GOV,City,Non-Federal Agency,Saddlebrook,NJ,ACTIVE
+SADDLEROCKNY.GOV,City,Non-Federal Agency,SADDLE ROCK,NY,ACTIVE
+SAFFORD-AZ.GOV,City,Non-Federal Agency,Safford,AZ,ACTIVE
+SAFFORDAZ.GOV,City,Non-Federal Agency,Safford,AZ,ACTIVE
+SAGHARBORNY.GOV,City,Non-Federal Agency,Sag Harbor,NY,ACTIVE
+SAHUARITAAZ.GOV,City,Non-Federal Agency,Sahuarita,AZ,ACTIVE
+SAINTPETERMN.GOV,City,Non-Federal Agency,Saint Peter,MN,ACTIVE
+SALADOTX.GOV,City,Non-Federal Agency,Salado,TX,ACTIVE
+SALEMCT.GOV,City,Non-Federal Agency,Salem,CT,ACTIVE
+SALEMVA.GOV,City,Non-Federal Agency,Salem,VA,ACTIVE
+SALISBURYMA.GOV,City,Non-Federal Agency,Salisbury,MA,ACTIVE
+SALISBURYNC.GOV,City,Non-Federal Agency,Salisbury,NC,ACTIVE
+SALTLAKECITY-UT.GOV,City,Non-Federal Agency,Salt Lake City,UT,ACTIVE
+SAMMAMISHWA.GOV,City,Non-Federal Agency,Sammamish,WA,ACTIVE
+SANANTONIO.GOV,City,Non-Federal Agency,San Antonio,TX,ACTIVE
+SANDIEGO.GOV,City,Non-Federal Agency,San Diego,CA,ACTIVE
+SANDYSPRINGSGA.GOV,City,Non-Federal Agency,Sandy Springs,GA,ACTIVE
+SANFORDFL.GOV,City,Non-Federal Agency,Sanford,FL,ACTIVE
+SANFRANCISCO-CA.GOV,City,Non-Federal Agency,San Francisco,CA,ACTIVE
+SANJOSECA.GOV,City,Non-Federal Agency,San Jose,CA,ACTIVE
+SANMARCOSTEXAS.GOV,City,Non-Federal Agency,San Marcos,TX,ACTIVE
+SANMARCOSTX.GOV,City,Non-Federal Agency,San Marcos,TX,ACTIVE
+SANMARINOCA.GOV,City,Non-Federal Agency,San Marino,CA,ACTIVE
+SANNET.GOV,City,Non-Federal Agency,San Diego,CA,ACTIVE
+SANPABLOCA.GOV,City,Non-Federal Agency,San Pablo,CA,ACTIVE
+SANTAANA-CA.GOV,City,Non-Federal Agency,Santa Ana,CA,ACTIVE
+SANTABARBARACA.GOV,City,Non-Federal Agency,Santa Barbara,CA,ACTIVE
+SANTACLARACA.GOV,City,Non-Federal Agency,Santa Clara,CA,ACTIVE
+SANTACLARITACA.GOV,City,Non-Federal Agency,Santa Clarita,CA,ACTIVE
+SANTAFENM.GOV,City,Non-Federal Agency,Santa Fe,NM,ACTIVE
+SANTAMONICACA.GOV,City,Non-Federal Agency,Santa Monica,CA,ACTIVE
+SARANACLAKENY.GOV,City,Non-Federal Agency,Saranac Lake,NY,ACTIVE
+SARDISCITYAL.GOV,City,Non-Federal Agency,SARDIS CITY,AL,ACTIVE
+SAUGUS-MA.GOV,City,Non-Federal Agency,Saugus,MA,ACTIVE
+SAULTSTEMARIE-MI.GOV,City,Non-Federal Agency,Sault Ste Marie,MI,ACTIVE
+SAVANNA-IL.GOV,City,Non-Federal Agency,Savanna,IL,ACTIVE
+SAVANNAHGA.GOV,City,Non-Federal Agency,Savannah,GA,ACTIVE
+SBMTD.GOV,City,Non-Federal Agency,Santa Barbara,CA,ACTIVE
+SCHENECTADYNY.GOV,City,Non-Federal Agency,Schenectady,NY,ACTIVE
+SCHERTZ-TX.GOV,City,Non-Federal Agency,Schertz,TX,ACTIVE
+SCIENCEHILL-KY.GOV,City,Non-Federal Agency,Science Hill,KY,ACTIVE
+SCITUATEMA.GOV,City,Non-Federal Agency,Scituate,MA,ACTIVE
+SCOTCHPLAINSNJ.GOV,City,Non-Federal Agency,SCOTCH PLAINS,NJ,ACTIVE
+SCOTTSDALEAZ.GOV,City,Non-Federal Agency,Scottsdale,AZ,ACTIVE
+SCRANTONPA.GOV,City,Non-Federal Agency,Scranton,PA,ACTIVE
+SEABROOKTX.GOV,City,Non-Federal Agency,Seabrook,TX,ACTIVE
+SEACLIFF-NY.GOV,City,Non-Federal Agency,Sea Cliff,NY,ACTIVE
+SEALBEACHCA.GOV,City,Non-Federal Agency,Seal Beach,CA,ACTIVE
+SEARANCHLAKESFLORIDA.GOV,City,Non-Federal Agency,Sea Ranch Lakes,FL,ACTIVE
+SEATPLEASANTMD.GOV,City,Non-Federal Agency,Seat Pleasant,MD,ACTIVE
+SEATTLE.GOV,City,Non-Federal Agency,Seattle,WA,ACTIVE
+SEBEWAINGMI.GOV,City,Non-Federal Agency,Sebewaing,MI,ACTIVE
+SECAUCUSNJ.GOV,City,Non-Federal Agency,Secaucus,NJ,ACTIVE
+SEDONAAZ.GOV,City,Non-Federal Agency,Sedona,AZ,ACTIVE
+SEEKONK-MA.GOV,City,Non-Federal Agency,Seekonk,MA,ACTIVE
+SEGUINTEXAS.GOV,City,Non-Federal Agency,Seguin,TX,ACTIVE
+SELAHWA.GOV,City,Non-Federal Agency,Selah,WA,ACTIVE
+SELLERSBURG-IN.GOV,City,Non-Federal Agency,Sellersburg,IN,ACTIVE
+SELMA-AL.GOV,City,Non-Federal Agency,Selma,AL,ACTIVE
+SENECASC.GOV,City,Non-Federal Agency,Seneca,SC,ACTIVE
+SEQUIMWA.GOV,City,Non-Federal Agency,SEQUIM,WA,ACTIVE
+SHAFTSBURYVT.GOV,City,Non-Federal Agency,Shaftsbury,VT,ACTIVE
+SHAKOPEEMN.GOV,City,Non-Federal Agency,Shakopee,MN,ACTIVE
+SHEBOYGANFALLS-WI.GOV,City,Non-Federal Agency,Sheboygan Falls,WI,ACTIVE
+SHEBOYGANWI.GOV,City,Non-Federal Agency,Sheboygan,WI,ACTIVE
+SHEFFIELDMA.GOV,City,Non-Federal Agency,Sheffield,MA,ACTIVE
+SHELTERCOVE-CA.GOV,City,Non-Federal Agency,Whitethorn,CA,ACTIVE
+SHERWOODOREGON.GOV,City,Non-Federal Agency,Sherwood,OR,ACTIVE
+SHIRLEY-MA.GOV,City,Non-Federal Agency,Shirley,MA,ACTIVE
+SHIVELYKY.GOV,City,Non-Federal Agency,Shively,KY,ACTIVE
+SHORELINE-WA.GOV,City,Non-Federal Agency,Shoreline,WA,ACTIVE
+SHORELINEWA.GOV,City,Non-Federal Agency,Shoreline,WA,ACTIVE
+SHOREVIEWMN.GOV,City,Non-Federal Agency,Shoreview,MN,ACTIVE
+SHOWLOWAZ.GOV,City,Non-Federal Agency,Show Low,AZ,ACTIVE
+SHREVEPORTLA.GOV,City,Non-Federal Agency,Shreveport,LA,ACTIVE
+SHREWSBURYMA.GOV,City,Non-Federal Agency,Shrewsbury,MA,ACTIVE
+SIERRAVISTAAZ.GOV,City,Non-Federal Agency,Sierra Vista,AZ,ACTIVE
+SIGNALMOUNTAINTN.GOV,City,Non-Federal Agency,Signal Mountain,TN,ACTIVE
+SILVERCITYNM.GOV,City,Non-Federal Agency,Silver City,NM,ACTIVE
+SILVERSPRINGTWP-PA.GOV,City,Non-Federal Agency,Mechanicsburg,PA,ACTIVE
+SIMONTONTEXAS.GOV,City,Non-Federal Agency,simonton,TX,ACTIVE
+SIMSBURY-CT.GOV,City,Non-Federal Agency,Simsbury,CT,ACTIVE
+SIOUXFALLSSD.GOV,City,Non-Federal Agency,Sioux Falls,SD,ACTIVE
+SISTERBAYWI.GOV,City,Non-Federal Agency,Sister Bay,WI,ACTIVE
+SLEEPYHOLLOWNY.GOV,City,Non-Federal Agency,Sleepy Hollow,NY,ACTIVE
+SLIPPERYROCKBOROUGHPA.GOV,City,Non-Federal Agency,Slippery Rock,PA,ACTIVE
+SMITHFIELDRI.GOV,City,Non-Federal Agency,Smithfield,RI,ACTIVE
+SMITHFIELDVA.GOV,City,Non-Federal Agency,Smithfield,VA,ACTIVE
+SMITHTOWNNY.GOV,City,Non-Federal Agency,Smithtown,NY,ACTIVE
+SMYRNAGA.GOV,City,Non-Federal Agency,Smyrna,GA,ACTIVE
+SNOHOMISHWA.GOV,City,Non-Federal Agency,Snohomish,WA,ACTIVE
+SNOWFLAKE-AZ.GOV,City,Non-Federal Agency,Snowflake,AZ,ACTIVE
+SOCORRONM.GOV,City,Non-Federal Agency,Socorro,NM,ACTIVE
+SODDY-DAISY-TN.GOV,City,Non-Federal Agency,Soddy-Daisy,TN,ACTIVE
+SODDY-DAISYTN.GOV,City,Non-Federal Agency,Soddy-Daisy,TN,ACTIVE
+SODDYDAISY-TN.GOV,City,Non-Federal Agency,Soddy-Daisy,TN,ACTIVE
+SODDYDAISYTN.GOV,City,Non-Federal Agency,Soddy-daisy,TN,ACTIVE
+SOLWAYTOWNSHIP-MN.GOV,City,Non-Federal Agency,Cloquet,MN,ACTIVE
+SOMERSCT.GOV,City,Non-Federal Agency,Somers,CT,ACTIVE
+SOMERSETTX.GOV,City,Non-Federal Agency,Somerset,TX,ACTIVE
+SOMERTONAZ.GOV,City,Non-Federal Agency,Somerton,AZ,ACTIVE
+SOMERVILLEMA.GOV,City,Non-Federal Agency,Somerville,MA,ACTIVE
+SOMERVILLETN.GOV,City,Non-Federal Agency,Town of Somerville,TN,ACTIVE
+SORRENTOLA.GOV,City,Non-Federal Agency,Sorrento,LA,ACTIVE
+SOUTHABINGTONPA.GOV,City,Non-Federal Agency,Chinchilla,PA,ACTIVE
+SOUTHAMBOYNJ.GOV,City,Non-Federal Agency,South Amboy,NJ,ACTIVE
+SOUTHAMPTONTOWNNY.GOV,City,Non-Federal Agency,Southampton,NY,ACTIVE
+SOUTHBEND-WA.GOV,City,Non-Federal Agency,South Bend,WA,ACTIVE
+SOUTHBENDIN.GOV,City,Non-Federal Agency,South Bend,IN,ACTIVE
+SOUTHBRUNSWICKNJ.GOV,City,Non-Federal Agency,South Brunswick,NJ,ACTIVE
+SOUTHBURLINGTONVT.GOV,City,Non-Federal Agency,South Burlington,VT,ACTIVE
+SOUTHBURY-CT.GOV,City,Non-Federal Agency,Southbury,CT,ACTIVE
+SOUTHEAST-NY.GOV,City,Non-Federal Agency,BREWSTER,NY,ACTIVE
+SOUTHHADLEYMA.GOV,City,Non-Federal Agency,South Hadley,MA,ACTIVE
+SOUTHJORDANUTAH.GOV,City,Non-Federal Agency,South Jordan,UT,ACTIVE
+SOUTHMIAMIFL.GOV,City,Non-Federal Agency,South Miami,FL,ACTIVE
+SOUTHOLDTOWNNY.GOV,City,Non-Federal Agency,Southold,NY,ACTIVE
+SOUTHPADRETEXAS.GOV,City,Non-Federal Agency,South Padre Island,TX,ACTIVE
+SOUTHPASADENACA.GOV,City,Non-Federal Agency,South Pasadena,CA,ACTIVE
+SOUTHPITTSBURG-TN.GOV,City,Non-Federal Agency,South Pittsburg,TN,ACTIVE
+SOUTHWILLIAMSPORT-PA.GOV,City,Non-Federal Agency,South Williamsport,PA,ACTIVE
+SPEEDWAYIN.GOV,City,Non-Federal Agency,Speedway,IN,ACTIVE
+SPENCERMA.GOV,City,Non-Federal Agency,Spencer,MA,ACTIVE
+SPERRYOK.GOV,City,Non-Federal Agency,Sperry,OK,ACTIVE
+SPIRITLAKEID.GOV,City,Non-Federal Agency,Spirit Lake,ID,ACTIVE
+SPRINGCITYPA.GOV,City,Non-Federal Agency,Spring City,PA,ACTIVE
+SPRINGDALEAR.GOV,City,Non-Federal Agency,Springdale,AR,ACTIVE
+SPRINGERVILLEAZ.GOV,City,Non-Federal Agency,Springerville,AZ,ACTIVE
+SPRINGFIELD-MA.GOV,City,Non-Federal Agency,Springfield,MA,ACTIVE
+SPRINGFIELD-OR.GOV,City,Non-Federal Agency,Springfield,OR,ACTIVE
+SPRINGFIELDMA.GOV,City,Non-Federal Agency,Springfield,MA,ACTIVE
+SPRINGFIELDMO.GOV,City,Non-Federal Agency,Springfield,MO,ACTIVE
+SPRINGFIELDOHIO.GOV,City,Non-Federal Agency,Springfield,OH,ACTIVE
+SPRINGHILLKS.GOV,City,Non-Federal Agency,Spring Hill,KS,ACTIVE
+SPRINGHILLLOUISIANA.GOV,City,Non-Federal Agency,Springhill,LA,ACTIVE
+SPRUCEPINE-NC.GOV,City,Non-Federal Agency,Spruce Pine,NC,ACTIVE
+STAFFORDNJ.GOV,City,Non-Federal Agency,Manawhakin,NJ,ACTIVE
+STAFFORDTX.GOV,City,Non-Federal Agency,stafford,TX,ACTIVE
+STAMFORDCT.GOV,City,Non-Federal Agency,Stamford,CT,ACTIVE
+STANHOPENJ.GOV,City,Non-Federal Agency,Stanhope,NJ,ACTIVE
+STARNC.GOV,City,Non-Federal Agency,Star,NC,ACTIVE
+STATECOLLEGEPA.GOV,City,Non-Federal Agency,State College,PA,ACTIVE
+STATESBOROGA.GOV,City,Non-Federal Agency,Statesboro,GA,ACTIVE
+STAYTONOREGON.GOV,City,Non-Federal Agency,Stayton,OR,ACTIVE
+STCHARLESCITYMO.GOV,City,Non-Federal Agency,Saint Charles,MO,ACTIVE
+STCHARLESIL.GOV,City,Non-Federal Agency,St. Charles,IL,ACTIVE
+STCROIXFALLSWI.GOV,City,Non-Federal Agency,City of St. Croix Falls,WI,ACTIVE
+STEPHENVILLETX.GOV,City,Non-Federal Agency,Stephenville,TX,ACTIVE
+STERLING-IL.GOV,City,Non-Federal Agency,Sterling,IL,ACTIVE
+STERLING-MA.GOV,City,Non-Federal Agency,Sterling,MA,ACTIVE
+STERLINGHEIGHTSMI.GOV,City,Non-Federal Agency,Sterling Heights,MI,ACTIVE
+STJOHNSAZ.GOV,City,Non-Federal Agency,St. Johns,AZ,ACTIVE
+STLOUIS-MO.GOV,City,Non-Federal Agency,St. Louis,MO,ACTIVE
+STLUCIECO.GOV,City,Non-Federal Agency,Ft. Pierce,FL,ACTIVE
+STMARYSGA.GOV,City,Non-Federal Agency,ST. MARYS,GA,ACTIVE
+STMARYSPA.GOV,City,Non-Federal Agency,St. Marys,PA,ACTIVE
+STMATTHEWSKY.GOV,City,Non-Federal Agency,Louisville,KY,ACTIVE
+STOCKTONCA.GOV,City,Non-Federal Agency,Stockton,CA,ACTIVE
+STONEHAM-MA.GOV,City,Non-Federal Agency,Stoneham,MA,ACTIVE
+STONINGTON-CT.GOV,City,Non-Federal Agency,Stonington,CT,ACTIVE
+STPAUL.GOV,City,Non-Federal Agency,Saint Paul,MN,ACTIVE
+STPETE-FL.GOV,City,Non-Federal Agency,St. Petersburg,FL,ACTIVE
+STRATHAMNH.GOV,City,Non-Federal Agency,Stratham,NH,ACTIVE
+STURGIS-SD.GOV,City,Non-Federal Agency,Sturgis,SD,ACTIVE
+STURGISMI.GOV,City,Non-Federal Agency,Sturgis,MI,ACTIVE
+STURTEVANT-WI.GOV,City,Non-Federal Agency,Sturtevant,WI,ACTIVE
+SUDBURY-MA.GOV,City,Non-Federal Agency,Sudbury,MA,ACTIVE
+SUFFOLK-VA.GOV,City,Non-Federal Agency,Suffolk,VA,ACTIVE
+SUGAR-LANDCITYTX.GOV,City,Non-Federal Agency,Sugar Land,TX,ACTIVE
+SUGAR-LANDTX.GOV,City,Non-Federal Agency,Sugar Land,TX,ACTIVE
+SUGARCITYIDAHO.GOV,City,Non-Federal Agency,Sugar City,ID,ACTIVE
+SUGARGROVEIL.GOV,City,Non-Federal Agency,Sugar Grove,IL,ACTIVE
+SUGARLAND-CITYTX.GOV,City,Non-Federal Agency,Sugar Land,TX,ACTIVE
+SUGARLAND-TX.GOV,City,Non-Federal Agency,Sugar Land,TX,ACTIVE
+SUGARLANDCITY-TX.GOV,City,Non-Federal Agency,Sugar Land,TX,ACTIVE
+SUGARLANDCITYTX.GOV,City,Non-Federal Agency,Sugar Land,TX,ACTIVE
+SUGARLANDTX.GOV,City,Non-Federal Agency,Sugar Land,TX,ACTIVE
+SULLIVANOHIO.GOV,City,Non-Federal Agency,Sullivan,OH,ACTIVE
+SUMMERVILLESC.GOV,City,Non-Federal Agency,Summerville,SC,ACTIVE
+SUMNERWA.GOV,City,Non-Federal Agency,Sumner,WA,ACTIVE
+SUMTERSC.GOV,City,Non-Federal Agency,Sumter,SC,ACTIVE
+SUNLANDPARK-NM.GOV,City,Non-Federal Agency,Sunland Park,NM,ACTIVE
+SUNNYSIDE-WA.GOV,City,Non-Federal Agency,Sunnyside,WA,ACTIVE
+SUNRISEBEACH-MO.GOV,City,Non-Federal Agency,Sunrise Beach,MO,ACTIVE
+SUNSETBEACHNC.GOV,City,Non-Federal Agency,Sunset Beach,NC,ACTIVE
+SUPERIORAZ.GOV,City,Non-Federal Agency,Superior,AZ,ACTIVE
+SUPERIORCOLORADO.GOV,City,Non-Federal Agency,Superior,CO,ACTIVE
+SURGOINSVILLETN.GOV,City,Non-Federal Agency,Surgoinsville,TN,ACTIVE
+SURPRISEAZ.GOV,City,Non-Federal Agency,Surprise,AZ,ACTIVE
+SUTTON-NH.GOV,City,Non-Federal Agency,Sutton,NH,ACTIVE
+SYLACAUGAAL.GOV,City,Non-Federal Agency,Sylacauga,AL,ACTIVE
+SYRACUSEKS.GOV,City,Non-Federal Agency,Syracuse,KS,ACTIVE
+TABERNACLENJ.GOV,City,Non-Federal Agency,Tabernacle,NJ,ACTIVE
+TACOMAWA.GOV,City,Non-Federal Agency,Tacoma,WA,ACTIVE
+TAFTTX.GOV,City,Non-Federal Agency,TAFT,TX,ACTIVE
+TALLAPOOSAGA.GOV,City,Non-Federal Agency,Tallapoosa,GA,ACTIVE
+TALLASSEE-AL.GOV,City,Non-Federal Agency,Millbrook,AL,ACTIVE
+TALLULAH-LA.GOV,City,Non-Federal Agency,Tallulah,LA,ACTIVE
+TALLULAHFALLSGA.GOV,City,Non-Federal Agency,Tallulah Falls,GA,ACTIVE
+TAMPAFL.GOV,City,Non-Federal Agency,Tampa,FL,ACTIVE
+TAPPAHANNOCK-VA.GOV,City,Non-Federal Agency,Tappahannock,VA,ACTIVE
+TAUNTON-MA.GOV,City,Non-Federal Agency,Taunton,MA,ACTIVE
+TAYLORMILLKY.GOV,City,Non-Federal Agency,Taylor Mill,KY,ACTIVE
+TAYLORSVILLEUT.GOV,City,Non-Federal Agency,Taylorsville ,UT,ACTIVE
+TAYLORTX.GOV,City,Non-Federal Agency,Taylor,TX,ACTIVE
+TEANECKNJ.GOV,City,Non-Federal Agency,Teaneck,NJ,ACTIVE
+TEGACAYSC.GOV,City,Non-Federal Agency,Tega Cay,SC,ACTIVE
+TELLURIDE-CO.GOV,City,Non-Federal Agency,Telluride,CO,ACTIVE
+TEMECULACA.GOV,City,Non-Federal Agency,Temecula,CA,ACTIVE
+TEMPE.GOV,City,Non-Federal Agency,Tempe,AZ,ACTIVE
+TEMPLETX.GOV,City,Non-Federal Agency,Temple,TX,ACTIVE
+TENNILLE-GA.GOV,City,Non-Federal Agency,Tennille,GA,ACTIVE
+THECOLONYTX.GOV,City,Non-Federal Agency,The Colony,TX,ACTIVE
+THEWOODLANDS-TX.GOV,City,Non-Federal Agency,The Woodlands,TX,ACTIVE
+THEWOODLANDSTOWNSHIP-TX.GOV,City,Non-Federal Agency,The Woodlands,TX,ACTIVE
+THOMASVILLE-NC.GOV,City,Non-Federal Agency,Thomasville,NC,ACTIVE
+THORNEBAY-AK.GOV,City,Non-Federal Agency,Thorne Bay,AK,ACTIVE
+TIFFINOHIO.GOV,City,Non-Federal Agency,Tiffin,OH,ACTIVE
+TIGARD-OR.GOV,City,Non-Federal Agency,Tigard,OR,ACTIVE
+TILLAMOOKOR.GOV,City,Non-Federal Agency,Tillamook,OR,ACTIVE
+TIMNATH-CO.GOV,City,Non-Federal Agency,Timnath,CO,ACTIVE
+TINLEYPARK-IL.GOV,City,Non-Federal Agency,Tinley Park,IL,ACTIVE
+TINLEYPARKIL.GOV,City,Non-Federal Agency,Tinley Park,IL,ACTIVE
+TIOGATX.GOV,City,Non-Federal Agency,Tioga,TX,ACTIVE
+TIPPCITYOHIO.GOV,City,Non-Federal Agency,Tipp City,OH,ACTIVE
+TISBURYMA.GOV,City,Non-Federal Agency,Tisbury,MA,ACTIVE
+TOBYHANNATWPPA.GOV,City,Non-Federal Agency,Pocono Pines,PA,ACTIVE
+TOLLAND-MA.GOV,City,Non-Federal Agency,Tolland,MA,ACTIVE
+TOMBALLTX.GOV,City,Non-Federal Agency,Tomball,TX,ACTIVE
+TOMPKINSVILLEKY.GOV,City,Non-Federal Agency,Tompkinsville,KY,ACTIVE
+TONTITOWNAR.GOV,City,Non-Federal Agency,Tontitown,AR,ACTIVE
+TOPSFIELD-MA.GOV,City,Non-Federal Agency,Topsfield,MA,ACTIVE
+TORRANCECA.GOV,City,Non-Federal Agency,Torrance,CA,ACTIVE
+TORREYUTAH.GOV,City,Non-Federal Agency,Torrey,UT,ACTIVE
+TORRINGTON-CT.GOV,City,Non-Federal Agency,Torrington,CT,ACTIVE
+TORRINGTONWY.GOV,City,Non-Federal Agency,Torrington,WY,ACTIVE
+TOWERLAKES-IL.GOV,City,Non-Federal Agency,Tower Lakes,IL,ACTIVE
+TOWNOFBETHLEHEM-NY.GOV,City,Non-Federal Agency,Delmar,NY,ACTIVE
+TOWNOFBLOWINGROCKNC.GOV,City,Non-Federal Agency,Blowing Rock,NC,ACTIVE
+TOWNOFBLYTHEWOODSC.GOV,City,Non-Federal Agency,Blythewood,SC,ACTIVE
+TOWNOFCALLAHAN-FL.GOV,City,Non-Federal Agency,Callahan,FL,ACTIVE
+TOWNOFCARRBORONC.GOV,City,Non-Federal Agency,Carrboro,NC,ACTIVE
+TOWNOFCARYNC.GOV,City,Non-Federal Agency,Cary,NC,ACTIVE
+TOWNOFCATSKILLNY.GOV,City,Non-Federal Agency,Catskill,NY,ACTIVE
+TOWNOFCHADBOURNNC.GOV,City,Non-Federal Agency,Chadbourn,NC,ACTIVE
+TOWNOFCLAYTONNC.GOV,City,Non-Federal Agency,Clayton,NC,ACTIVE
+TOWNOFDUNNWI.GOV,City,Non-Federal Agency,McFarland,WI,ACTIVE
+TOWNOFEASTHAVEN-CT.GOV,City,Non-Federal Agency,East Haven,CT,ACTIVE
+TOWNOFHALFMOON-NY.GOV,City,Non-Federal Agency,Halfmoon,NY,ACTIVE
+TOWNOFHAVERHILL-FL.GOV,City,Non-Federal Agency,Haverhill,FL,ACTIVE
+TOWNOFHAYDENAZ.GOV,City,Non-Federal Agency,Hayden,AZ,ACTIVE
+TOWNOFHOMECROFTIN.GOV,City,Non-Federal Agency,Indianapolis,IN,ACTIVE
+TOWNOFHOUNSFIELD-NY.GOV,City,Non-Federal Agency,Watertown,NY,ACTIVE
+TOWNOFISLIP-NY.GOV,City,Non-Federal Agency,Islip,NY,ACTIVE
+TOWNOFKEENENY.GOV,City,Non-Federal Agency,Keene,NY,ACTIVE
+TOWNOFKENTNY.GOV,City,Non-Federal Agency,Kent Lakes,NY,ACTIVE
+TOWNOFLAPOINTEWI.GOV,City,Non-Federal Agency,La Pointe,WI,ACTIVE
+TOWNOFLAVETA-CO.GOV,City,Non-Federal Agency,La Veta,CO,ACTIVE
+TOWNOFMAYNARD-MA.GOV,City,Non-Federal Agency,Maynard,MA,ACTIVE
+TOWNOFMONTEAGLE-TN.GOV,City,Non-Federal Agency,Monteagle,TN,ACTIVE
+TOWNOFNASHVILLENC.GOV,City,Non-Federal Agency,Nashville,NC,ACTIVE
+TOWNOFNORTH-SC.GOV,City,Non-Federal Agency,North,SC,ACTIVE
+TOWNOFNORTHEASTNY.GOV,City,Non-Federal Agency,Millerton,NY,ACTIVE
+TOWNOFORANGEVA.GOV,City,Non-Federal Agency,Orange,VA,ACTIVE
+TOWNOFOYSTERBAY-NY.GOV,City,Non-Federal Agency,Oyster Bay,NY,ACTIVE
+TOWNOFPALERMONY.GOV,City,Non-Federal Agency,FULTON,NY,ACTIVE
+TOWNOFPENNINGTONVA.GOV,City,Non-Federal Agency,Pennington Gap,VA,ACTIVE
+TOWNOFPOUGHKEEPSIE-NY.GOV,City,Non-Federal Agency,POUGHKEEPSIE,NY,ACTIVE
+TOWNOFRAMAPO-NY.GOV,City,Non-Federal Agency,Suffern,NY,ACTIVE
+TOWNOFRIVERHEADNY.GOV,City,Non-Federal Agency,Riverhead,NY,ACTIVE
+TOWNOFROBERSONVILLE-NC.GOV,City,Non-Federal Agency,Robersonville,NC,ACTIVE
+TOWNOFSHIELDS-WI.GOV,City,Non-Federal Agency,Montello,WI,ACTIVE
+TOWNOFSHIRLEY-MA.GOV,City,Non-Federal Agency,Shirley,MA,ACTIVE
+TOWNOFSMYRNA-TN.GOV,City,Non-Federal Agency,Smyrna,TN,ACTIVE
+TOWNOFSTLEO-FL.GOV,City,Non-Federal Agency,Saint Leo,FL,ACTIVE
+TOWNOFSURFSIDEFL.GOV,City,Non-Federal Agency,Surfside,FL,ACTIVE
+TOWNOFTROPICUT.GOV,City,Non-Federal Agency,Tropic,UT,ACTIVE
+TOWNOFTROUTVILLE-VA.GOV,City,Non-Federal Agency,Troutville,VA,ACTIVE
+TOWNOFVASSNC.GOV,City,Non-Federal Agency,Vass,NC,ACTIVE
+TOWNOFWALLINGFORD-CT.GOV,City,Non-Federal Agency,Wallingford,CT,ACTIVE
+TOWNOFWALWORTHNY.GOV,City,Non-Federal Agency,Walworth,NY,ACTIVE
+TOWNOFWARREN-RI.GOV,City,Non-Federal Agency,Warren,RI,ACTIVE
+TOWNOFWASHINGTONVA.GOV,City,Non-Federal Agency,Washington,VA,ACTIVE
+TOWNOFWILLSBORONY.GOV,City,Non-Federal Agency,Willsboro,NY,ACTIVE
+TOWNOFWOODSTOCKVA.GOV,City,Non-Federal Agency,Woodstock,VA,ACTIVE
+TOWNSHIPOFTABERNACLE-NJ.GOV,City,Non-Federal Agency,Tabernacle,NJ,ACTIVE
+TRAVERSECITYMI.GOV,City,Non-Federal Agency,Traverse City,MI,ACTIVE
+TRENTONGA.GOV,City,Non-Federal Agency,trenton,GA,ACTIVE
+TRICOUNTYCONSERVANCY-IN.GOV,City,Non-Federal Agency,Plainfield,IN,ACTIVE
+TRINITY-NC.GOV,City,Non-Federal Agency,Trinity,NC,ACTIVE
+TRINITYAL.GOV,City,Non-Federal Agency,Trinity,AL,ACTIVE
+TROPHYCLUBTX.GOV,City,Non-Federal Agency,Trophy Club,TX,ACTIVE
+TROUTDALEOREGON.GOV,City,Non-Federal Agency,Troutdale,OR,ACTIVE
+TROUTMANNC.GOV,City,Non-Federal Agency,Troutman,NC,ACTIVE
+TROYAL.GOV,City,Non-Federal Agency,Troy,AL,ACTIVE
+TROYMI.GOV,City,Non-Federal Agency,Troy,MI,ACTIVE
+TROYNY.GOV,City,Non-Federal Agency,Troy,NY,ACTIVE
+TROYOHIO.GOV,City,Non-Federal Agency,Troy,OH,ACTIVE
+TRUMANSBURG-NY.GOV,City,Non-Federal Agency,Trumansburg,NY,ACTIVE
+TRUMBULL-CT.GOV,City,Non-Federal Agency,Trumbull,CT,ACTIVE
+TRURO-MA.GOV,City,Non-Federal Agency,Truro,MA,ACTIVE
+TUALATINOREGON.GOV,City,Non-Federal Agency,TUALATIN,OR,ACTIVE
+TUCKERGA.GOV,City,Non-Federal Agency,Tucker,GA,ACTIVE
+TUCSONAZ.GOV,City,Non-Federal Agency,Tucson,AZ,ACTIVE
+TUKWILA-WA.GOV,City,Non-Federal Agency,Tukwila,WA,ACTIVE
+TUKWILAWA.GOV,City,Non-Federal Agency,Tukwila,WA,ACTIVE
+TULIA-TX.GOV,City,Non-Federal Agency,Tulia,TX,ACTIVE
+TULLAHOMATN.GOV,City,Non-Federal Agency,Tullahoma,TN,ACTIVE
+TUMWATERWA.GOV,City,Non-Federal Agency,Tumwater,WA,ACTIVE
+TUPELOMS.GOV,City,Non-Federal Agency,Tupelo,MS,ACTIVE
+TUPPERLAKENY.GOV,City,Non-Federal Agency,Tupper Lake,NY,ACTIVE
+TUSAYAN-AZ.GOV,City,Non-Federal Agency,Tusayan,AZ,ACTIVE
+TUSAYANAZ.GOV,City,Non-Federal Agency,Grand Canyon,AZ,ACTIVE
+TUSCALOOSA-AL.GOV,City,Non-Federal Agency,Tuscaloosa,AL,ACTIVE
+TUSKEGEEALABAMA.GOV,City,Non-Federal Agency,Tuskegee,AL,ACTIVE
+TUXEDOPARK-NY.GOV,City,Non-Federal Agency,Sloatsburg,NY,ACTIVE
+TWPOCEANNJ.GOV,City,Non-Federal Agency,Waretown,NJ,ACTIVE
+TYNGSBOROUGHMA.GOV,City,Non-Federal Agency,Tyngsborough,MA,ACTIVE
+TYRINGHAM-MA.GOV,City,Non-Federal Agency,Tyringham,MA,ACTIVE
+UCTX.GOV,City,Non-Federal Agency,Universal City,TX,ACTIVE
+UNDERHILLVT.GOV,City,Non-Federal Agency,"Underhill, Ctr",VT,ACTIVE
+UNIONBEACHNJ.GOV,City,Non-Federal Agency,Union Beach,NJ,ACTIVE
+UNIONCITY-IN.GOV,City,Non-Federal Agency,Union City,IN,ACTIVE
+UNIONCITYNJ.GOV,City,Non-Federal Agency,Union City,NJ,ACTIVE
+UNIONCITYTN.GOV,City,Non-Federal Agency,UNION CITY,TN,ACTIVE
+UNIONGAPWA.GOV,City,Non-Federal Agency,Union Gap,WA,ACTIVE
+UNIONSPRINGSAL.GOV,City,Non-Federal Agency,Union Springs,AL,ACTIVE
+UNIONTWP-HCNJ.GOV,City,Non-Federal Agency,HAMPTON,NJ,ACTIVE
+UNITYNH.GOV,City,Non-Federal Agency,Charlestown,NH,ACTIVE
+UNIVERSALCITYTEXAS.GOV,City,Non-Federal Agency,Universal City,TX,ACTIVE
+UPLANDCA.GOV,City,Non-Federal Agency,UPLAND,CA,ACTIVE
+UPPERMARLBOROMD.GOV,City,Non-Federal Agency,Upper Marlboro,MD,ACTIVE
+UPPERUWCHLAN-PA.GOV,City,Non-Federal Agency,Chester Springs,PA,ACTIVE
+UPTONMA.GOV,City,Non-Federal Agency,Upton,MA,ACTIVE
+URBANNAVA.GOV,City,Non-Federal Agency,Urbanna,VA,ACTIVE
+UTICA-IL.GOV,City,Non-Federal Agency,Utica,IL,ACTIVE
+UVALDETX.GOV,City,Non-Federal Agency,Uvalde,TX,ACTIVE
+UXBRIDGE-MA.GOV,City,Non-Federal Agency,Uxbridge,MA,ACTIVE
+VANMETERIA.GOV,City,Non-Federal Agency,Van Meter,IA,ACTIVE
+VBHIL.GOV,City,Non-Federal Agency,Barrington Hills,IL,ACTIVE
+VENETAOREGON.GOV,City,Non-Federal Agency,Veneta,OR,ACTIVE
+VERMONTVILLE-MI.GOV,City,Non-Federal Agency,Vermontville,MI,ACTIVE
+VERNON-CT.GOV,City,Non-Federal Agency,Vernon,CT,ACTIVE
+VERNONIA-OR.GOV,City,Non-Federal Agency,Vernonia,OR,ACTIVE
+VERNONTWP-PA.GOV,City,Non-Federal Agency,Meadville,PA,ACTIVE
+VERNONTX.GOV,City,Non-Federal Agency,Vernon,TX,ACTIVE
+VERONAWI.GOV,City,Non-Federal Agency,Verona,WI,ACTIVE
+VICKSBURGMS.GOV,City,Non-Federal Agency,Vicksburg,MS,ACTIVE
+VICTORVILLECA.GOV,City,Non-Federal Agency,Victorville,CA,ACTIVE
+VICTORYGARDENSNJ.GOV,City,Non-Federal Agency,Victory Gardens,NJ,ACTIVE
+VIDALIAGA.GOV,City,Non-Federal Agency,VIDALIA,GA,ACTIVE
+VIENNAVA.GOV,City,Non-Federal Agency,VIENNA,VA,ACTIVE
+VILLAGEOFBABYLONNY.GOV,City,Non-Federal Agency,Babylon,NY,ACTIVE
+VILLAGEOFCAMILLUS-NY.GOV,City,Non-Federal Agency,CAMILLUS,NY,ACTIVE
+VILLAGEOFCRESTWOODIL.GOV,City,Non-Federal Agency,Crestwood,IL,ACTIVE
+VILLAGEOFDUNLAP-IL.GOV,City,Non-Federal Agency,Dunlap,IL,ACTIVE
+VILLAGEOFGOSHEN-NY.GOV,City,Non-Federal Agency,Goshen,NY,ACTIVE
+VILLAGEOFGOUVERNEURNY.GOV,City,Non-Federal Agency,Gouverneur,NY,ACTIVE
+VILLAGEOFHEMPSTEADNY.GOV,City,Non-Federal Agency,Hemsptead,NY,ACTIVE
+VILLAGEOFKENSINGTONNY.GOV,City,Non-Federal Agency,Great Neck,NY,ACTIVE
+VILLAGEOFLINDENHURSTNY.GOV,City,Non-Federal Agency,Lindenhurst,NY,ACTIVE
+VILLAGEOFMAMARONECKNY.GOV,City,Non-Federal Agency,Mamaroneck,NY,ACTIVE
+VILLAGEOFMAZOMANIEWI.GOV,City,Non-Federal Agency,Mazomanie,WI,ACTIVE
+VILLAGEOFMCCOMBOH.GOV,City,Non-Federal Agency,McComb,OH,ACTIVE
+VILLAGEOFMISENHEIMERNC.GOV,City,Non-Federal Agency,Misenheimer,NC,ACTIVE
+VILLAGEOFNEWHAVEN-MI.GOV,City,Non-Federal Agency,New Haven,MI,ACTIVE
+VILLAGEOFNEWHOLLAND-OH.GOV,City,Non-Federal Agency,New Holland,OH,ACTIVE
+VILLAGEOFNEWTOWNOHIO.GOV,City,Non-Federal Agency,Newtown,OH,ACTIVE
+VILLAGEOFPHOENIX-NY.GOV,City,Non-Federal Agency,Phoenix,NY,ACTIVE
+VILLAGEOFPINEHURSTNC.GOV,City,Non-Federal Agency,Pinehurst,NC,ACTIVE
+VILLAGEOFQUOGUENY.GOV,City,Non-Federal Agency,Quogue,NY,ACTIVE
+VILLAGEOFRHINEBECKNY.GOV,City,Non-Federal Agency,Rhinebeck,NY,ACTIVE
+VILLAGEOFSCOTIANY.GOV,City,Non-Federal Agency,Scotia,NY,ACTIVE
+VILLAGEOFVOLENTE-TX.GOV,City,Non-Federal Agency,Volente,TX,ACTIVE
+VILLAGEOFWAUCONDA-IL.GOV,City,Non-Federal Agency,Wauconda,IL,ACTIVE
+VINTONVA.GOV,City,Non-Federal Agency,Vinton,VA,ACTIVE
+VIRGINIAGARDENS-FL.GOV,City,Non-Federal Agency,Virginia Gardens,FL,ACTIVE
+VOLENTETEXAS.GOV,City,Non-Federal Agency,Volente,TX,ACTIVE
+VOLUNTOWN.GOV,City,Non-Federal Agency,Voluntown,CT,ACTIVE
+VONORMYTX.GOV,City,Non-Federal Agency,Von Ormy,TX,ACTIVE
+WACOTX.GOV,City,Non-Federal Agency,Waco,TX,ACTIVE
+WAITEHILLOH.GOV,City,Non-Federal Agency,Waite Hill,OH,ACTIVE
+WAKEFORESTNC.GOV,City,Non-Federal Agency,WAKE FOREST,NC,ACTIVE
+WALDENTN.GOV,City,Non-Federal Agency,Signal Mountain,TN,ACTIVE
+WALKER-LA.GOV,City,Non-Federal Agency,Walker,LA,ACTIVE
+WALKERSVILLEMD.GOV,City,Non-Federal Agency,Walkersville,MD,ACTIVE
+WALLAWALLAWA.GOV,City,Non-Federal Agency,Walla Walla,WA,ACTIVE
+WALLINGFORDCT.GOV,City,Non-Federal Agency,Wallingford,CT,ACTIVE
+WALNUTGROVEMS.GOV,City,Non-Federal Agency,Walnut Grove,MS,ACTIVE
+WALTONHILLSOHIO.GOV,City,Non-Federal Agency,Walton Hills,OH,ACTIVE
+WANATAH-IN.GOV,City,Non-Federal Agency,Wanatah,IN,ACTIVE
+WAPPINGERSFALLSNY.GOV,City,Non-Federal Agency,Wappingers Falls,NY,ACTIVE
+WARNERROBINSGA.GOV,City,Non-Federal Agency,Warner Robins,GA,ACTIVE
+WARRACRES-OK.GOV,City,Non-Federal Agency,Warr Acres,OK,ACTIVE
+WARREN-MA.GOV,City,Non-Federal Agency,Warren,MA,ACTIVE
+WARRENPA.GOV,City,Non-Federal Agency,Warren,PA,ACTIVE
+WARRENTONVA.GOV,City,Non-Federal Agency,Warrenton,VA,ACTIVE
+WARWICKRI.GOV,City,Non-Federal Agency,Warwick,RI,ACTIVE
+WASHINGTON-WARRENAIRPORT-NC.GOV,City,Non-Federal Agency,WASHINGTON,NC,ACTIVE
+WASHINGTONBORO-NJ.GOV,City,Non-Federal Agency,Washington,NJ,ACTIVE
+WASHINGTONISLAND-WI.GOV,City,Non-Federal Agency,Washington Island,WI,ACTIVE
+WASHINGTONPA.GOV,City,Non-Federal Agency,Washington,PA,ACTIVE
+WASHINGTONVA.GOV,City,Non-Federal Agency,Washington,VA,ACTIVE
+WASHINGTONVILLE-NY.GOV,City,Non-Federal Agency,Washingtonville,NY,ACTIVE
+WASHINGTONVIRGINIA.GOV,City,Non-Federal Agency,Washington,VA,ACTIVE
+WATCHUNGNJ.GOV,City,Non-Federal Agency,Watchung,NJ,ACTIVE
+WATERBORO-ME.GOV,City,Non-Federal Agency,East Waterboro,ME,ACTIVE
+WATERFORDMI.GOV,City,Non-Federal Agency,Waterford,MI,ACTIVE
+WATERTOWN-MA.GOV,City,Non-Federal Agency,Watertown,MA,ACTIVE
+WATERTOWN-NY.GOV,City,Non-Federal Agency,Watertown,NY,ACTIVE
+WATERVILLE-ME.GOV,City,Non-Federal Agency,Waterville,ME,ACTIVE
+WAUCONDA-IL.GOV,City,Non-Federal Agency,Wauconda,IL,ACTIVE
+WAUKEGANIL.GOV,City,Non-Federal Agency,Waukegan,IL,ACTIVE
+WAUKESHA-WI.GOV,City,Non-Federal Agency,Waukesha,WI,ACTIVE
+WAVELAND-MS.GOV,City,Non-Federal Agency,Waveland,MS,ACTIVE
+WAYNESBURGPA.GOV,City,Non-Federal Agency,Waynesburg,PA,ACTIVE
+WAYNESVILLENC.GOV,City,Non-Federal Agency,Waynesville,NC,ACTIVE
+WEATHERFORDTX.GOV,City,Non-Federal Agency,Weatherford,TX,ACTIVE
+WEATHERLYPA.GOV,City,Non-Federal Agency,Weatherly,PA,ACTIVE
+WEBSTER-MA.GOV,City,Non-Federal Agency,Webster,MA,ACTIVE
+WEBSTER-NH.GOV,City,Non-Federal Agency,Webster,NH,ACTIVE
+WEBSTERFL.GOV,City,Non-Federal Agency,Webster,FL,ACTIVE
+WEEHAWKENNJ.GOV,City,Non-Federal Agency,Weehawken,NJ,ACTIVE
+WELAKA-FL.GOV,City,Non-Federal Agency,Welaka,FL,ACTIVE
+WELLESLEYMA.GOV,City,Non-Federal Agency,Wellesley,MA,ACTIVE
+WELLFLEET-MA.GOV,City,Non-Federal Agency,Wellfleet,MA,ACTIVE
+WELLINGTONCOLORADO.GOV,City,Non-Federal Agency,Wellington,CO,ACTIVE
+WELLINGTONFL.GOV,City,Non-Federal Agency,Wellington,FL,ACTIVE
+WELLSBURGWV.GOV,City,Non-Federal Agency,WELLSBURG,WV,ACTIVE
+WENATCHEEWA.GOV,City,Non-Federal Agency,Wenatchee,WA,ACTIVE
+WESLACOTX.GOV,City,Non-Federal Agency,Weslaco,TX,ACTIVE
+WESSONMS.GOV,City,Non-Federal Agency,Wesson,MS,ACTIVE
+WESTALLISWI.GOV,City,Non-Federal Agency,West Allis,WI,ACTIVE
+WESTAMPTONNJ.GOV,City,Non-Federal Agency,Westampton,NJ,ACTIVE
+WESTBENDWI.GOV,City,Non-Federal Agency,West Bend,WI,ACTIVE
+WESTBOYLSTON-MA.GOV,City,Non-Federal Agency,West Boylston,MA,ACTIVE
+WESTBUECHELKY.GOV,City,Non-Federal Agency,WEST BUECHEL,KY,ACTIVE
+WESTCOLUMBIASC.GOV,City,Non-Federal Agency,West Columbia,SC,ACTIVE
+WESTFARGOND.GOV,City,Non-Federal Agency,Bismarck,ND,ACTIVE
+WESTFIELDNJ.GOV,City,Non-Federal Agency,Westfield,NJ,ACTIVE
+WESTFORD-MA.GOV,City,Non-Federal Agency,Westford,MA,ACTIVE
+WESTFORDMA.GOV,City,Non-Federal Agency,Westford,MA,ACTIVE
+WESTFORKAR.GOV,City,Non-Federal Agency,West Fork,AR,ACTIVE
+WESTFRANKFORT-IL.GOV,City,Non-Federal Agency,West Frankfort,IL,ACTIVE
+WESTHARTFORDCT.GOV,City,Non-Federal Agency,West Hartford,CT,ACTIVE
+WESTHAVEN-CT.GOV,City,Non-Federal Agency,West Haven,CT,ACTIVE
+WESTJEFFERSONOHIO.GOV,City,Non-Federal Agency,West Jefferson,OH,ACTIVE
+WESTLINNOREGON.GOV,City,Non-Federal Agency,West Linn,OR,ACTIVE
+WESTMILTONOHIO.GOV,City,Non-Federal Agency,West Milton,OH,ACTIVE
+WESTMINSTER-CA.GOV,City,Non-Federal Agency,Westminster,CA,ACTIVE
+WESTMINSTER-MA.GOV,City,Non-Federal Agency,Westminster,MA,ACTIVE
+WESTMINSTERMD.GOV,City,Non-Federal Agency,Westminster,MD,ACTIVE
+WESTMORELANDTN.GOV,City,Non-Federal Agency,Westmoreland,TN,ACTIVE
+WESTONCT.GOV,City,Non-Federal Agency,Weston,CT,ACTIVE
+WESTONFL.GOV,City,Non-Federal Agency,Weston,FL,ACTIVE
+WESTONWI.GOV,City,Non-Federal Agency,Weston,WI,ACTIVE
+WESTPALMBEACH-FL.GOV,City,Non-Federal Agency,West Palm Beach,FL,ACTIVE
+WESTPORT-MA.GOV,City,Non-Federal Agency,Westport,MA,ACTIVE
+WESTPORTCT.GOV,City,Non-Federal Agency,Westport,CT,ACTIVE
+WESTSTOCKBRIDGE-MA.GOV,City,Non-Federal Agency,West Stockbridge,MA,ACTIVE
+WESTTISBURY-MA.GOV,City,Non-Federal Agency,West Tisbury,MA,ACTIVE
+WESTUTX.GOV,City,Non-Federal Agency,West University Place ,TX,ACTIVE
+WESTVALLEYCITY-UT.GOV,City,Non-Federal Agency,West Valley City,UT,ACTIVE
+WESTWOOD-MA.GOV,City,Non-Federal Agency,Westwood,MA,ACTIVE
+WESTWOODMA.GOV,City,Non-Federal Agency,Westwood,MA,ACTIVE
+WESTWOODNJ.GOV,City,Non-Federal Agency,Westwood,NJ,ACTIVE
+WETHERSFIELDCT.GOV,City,Non-Federal Agency,Wethersfield,CT,ACTIVE
+WHEELINGIL.GOV,City,Non-Federal Agency,Wheeling,IL,ACTIVE
+WHEELINGWV.GOV,City,Non-Federal Agency,Wheeling,WV,ACTIVE
+WHITECOUNTY-IL.GOV,City,Non-Federal Agency,Carmi,IL,ACTIVE
+WHITEHOUSEOH.GOV,City,Non-Federal Agency,Whitehouse,OH,ACTIVE
+WHITEPLAINSNY.GOV,City,Non-Federal Agency,White Plains,NY,ACTIVE
+WHITEWATER-WI.GOV,City,Non-Federal Agency,Whitewater,WI,ACTIVE
+WHITINGWI.GOV,City,Non-Federal Agency,Stevens Point,WI,ACTIVE
+WHITTIERALASKA.GOV,City,Non-Federal Agency,Whittier,AK,ACTIVE
+WICHITA.GOV,City,Non-Federal Agency,Wichita,KS,ACTIVE
+WICHITAFALLSTX.GOV,City,Non-Federal Agency,Wichita Falls,TX,ACTIVE
+WILBRAHAM-MA.GOV,City,Non-Federal Agency,Wilbraham,MA,ACTIVE
+WILDWOOD-FL.GOV,City,Non-Federal Agency,Wildwood,FL,ACTIVE
+WILKINSBURGPA.GOV,City,Non-Federal Agency,Wilkinsburg,PA,ACTIVE
+WILLAMINAOREGON.GOV,City,Non-Federal Agency,Willamina,OR,ACTIVE
+WILLARDNM.GOV,City,Non-Federal Agency,Willard,NM,ACTIVE
+WILLIAMSAZ.GOV,City,Non-Federal Agency,Williams,AZ,ACTIVE
+WILLIAMSBURGVA.GOV,City,Non-Federal Agency,Williamsburg,VA,ACTIVE
+WILLIAMSPORTMD.GOV,City,Non-Federal Agency,WILLIAMSPORT,MD,ACTIVE
+WILLIAMSTOWNMA.GOV,City,Non-Federal Agency,Williamstown,MA,ACTIVE
+WILLINGBORONJ.GOV,City,Non-Federal Agency,Willingboro,NJ,ACTIVE
+WILLINGTONCT.GOV,City,Non-Federal Agency,Willington,CT,ACTIVE
+WILLISTONFL.GOV,City,Non-Federal Agency,Williston,FL,ACTIVE
+WILLMARMN.GOV,City,Non-Federal Agency,Willmar,MN,ACTIVE
+WILLOUGHBYHILLS-OH.GOV,City,Non-Federal Agency,Willoughby Hills,OH,ACTIVE
+WILLOWSPRINGS-IL.GOV,City,Non-Federal Agency,Willow Springs,IL,ACTIVE
+WILMINGTONDE.GOV,City,Non-Federal Agency,Wilmington,DE,ACTIVE
+WILMINGTONMA.GOV,City,Non-Federal Agency,wilmington,MA,ACTIVE
+WILTONNH.GOV,City,Non-Federal Agency,Wilton,NH,ACTIVE
+WINCHESTER-IN.GOV,City,Non-Federal Agency,Winchester,IN,ACTIVE
+WINCHESTER-NH.GOV,City,Non-Federal Agency,Winchester,NH,ACTIVE
+WINCHESTERVA.GOV,City,Non-Federal Agency,Winchester,VA,ACTIVE
+WINDCREST-TX.GOV,City,Non-Federal Agency,Windcrest,TX,ACTIVE
+WINDGAP-PA.GOV,City,Non-Federal Agency,Wind Gap,PA,ACTIVE
+WINDHAMNH.GOV,City,Non-Federal Agency,Windham,NH,ACTIVE
+WINDSOR-VA.GOV,City,Non-Federal Agency,Windsor,VA,ACTIVE
+WINDSORWI.GOV,City,Non-Federal Agency,DeForest,WI,ACTIVE
+WINNECONNEWI.GOV,City,Non-Federal Agency,Winneconne,WI,ACTIVE
+WINSLOW-ME.GOV,City,Non-Federal Agency,Winslow,ME,ACTIVE
+WINSLOWAZ.GOV,City,Non-Federal Agency,Winslow,AZ,ACTIVE
+WOBURNMA.GOV,City,Non-Federal Agency,Woburn,MA,ACTIVE
+WOODBURN-OR.GOV,City,Non-Federal Agency,Woodburn,OR,ACTIVE
+WOODBURYMN.GOV,City,Non-Federal Agency,Woodbury,MN,ACTIVE
+WOODFIN-NC.GOV,City,Non-Federal Agency,Woodfin,NC,ACTIVE
+WOODHEIGHTS-MO.GOV,City,Non-Federal Agency,Wood Heights,MO,ACTIVE
+WOODSTOCKCT.GOV,City,Non-Federal Agency,Woodstock,CT,ACTIVE
+WOODSTOCKGA.GOV,City,Non-Federal Agency,Woodstock,GA,ACTIVE
+WOODSTOCKIL.GOV,City,Non-Federal Agency,Woodstock,IL,ACTIVE
+WOODVILLE-TX.GOV,City,Non-Federal Agency,Woodville,TX,ACTIVE
+WORCESTERMA.GOV,City,Non-Federal Agency,Worcester,MA,ACTIVE
+WRGA.GOV,City,Non-Federal Agency,Warner Robins,GA,ACTIVE
+WSPMN.GOV,City,Non-Federal Agency,West Saint Paul,MN,ACTIVE
+WVC-UT.GOV,City,Non-Federal Agency,West Valley,UT,ACTIVE
+WYLIETEXAS.GOV,City,Non-Federal Agency,Wylie,TX,ACTIVE
+WYOMINGMI.GOV,City,Non-Federal Agency,Wyoming,MI,ACTIVE
+WYOMINGOHIO.GOV,City,Non-Federal Agency,Wyoming,OH,ACTIVE
+XENIA-OH.GOV,City,Non-Federal Agency,Xenia,OH,ACTIVE
+YAKIMAWA.GOV,City,Non-Federal Agency,Yakima,WA,ACTIVE
+YAMHILLCOUNTY-OR.GOV,City,Non-Federal Agency,McMinnville,OR,ACTIVE
+YONKERSNY.GOV,City,Non-Federal Agency,Yonkers,NY,ACTIVE
+YORKTOWNTX.GOV,City,Non-Federal Agency,Yorktown,TX,ACTIVE
+YOUNGSTOWNOHIO.GOV,City,Non-Federal Agency,Youngstown,OH,ACTIVE
+YOUNGSVILLELA.GOV,City,Non-Federal Agency,Youngsville,LA,ACTIVE
+YUCAIPA-CA.GOV,City,Non-Federal Agency,Yucaipa,CA,ACTIVE
+YUMAAZ.GOV,City,Non-Federal Agency,Yuma,AZ,ACTIVE
+ZILWAUKEEMICHIGAN.GOV,City,Non-Federal Agency,Zilwaukee,MI,ACTIVE
+ADAMSCOUNTYMS.GOV,County,Non-Federal Agency,Natchez,MS,ACTIVE
+ADAMSCOUNTYOH.GOV,County,Non-Federal Agency,West Union,OH,ACTIVE
+AIKENCOUNTYSC.GOV,County,Non-Federal Agency,Aiken,SC,ACTIVE
+ALBANYCOUNTYNY.GOV,County,Non-Federal Agency,Albany,NY,ACTIVE
+ALEXANDERCOUNTY-NC.GOV,County,Non-Federal Agency,Taylorsville,NC,ACTIVE
+ALEXANDERCOUNTYNC.GOV,County,Non-Federal Agency,Taylorsville,NC,ACTIVE
+ALLEGHANYCOUNTY-NC.GOV,County,Non-Federal Agency,Sparta,NC,ACTIVE
+ALLEGHENYCOUNTYPA.GOV,County,Non-Federal Agency,Pittsburgh,PA,ACTIVE
+ALPINECOUNTYCA.GOV,County,Non-Federal Agency,Markleeville,CA,ACTIVE
+AMITECOUNTYMS.GOV,County,Non-Federal Agency,Liberty,MS,ACTIVE
+ANDROSCOGGINCOUNTYMAINE.GOV,County,Non-Federal Agency,Auburn,ME,ACTIVE
+ANOKACOUNTYMN.GOV,County,Non-Federal Agency,Anoka,MN,ACTIVE
+APPOMATTOXCOUNTYVA.GOV,County,Non-Federal Agency,Appomattox,VA,ACTIVE
+ARANSASCOUNTYTX.GOV,County,Non-Federal Agency,Rockport,TX,ACTIVE
+AUGUSTACOUNTY-VA.GOV,County,Non-Federal Agency,Verona,VA,ACTIVE
+AUGUSTACOUNTYVA.GOV,County,Non-Federal Agency,Verona,VA,ACTIVE
+AVERYCOUNTYNC.GOV,County,Non-Federal Agency,Newland,NC,ACTIVE
+BACACOUNTYCO.GOV,County,Non-Federal Agency,Springfield,CO,ACTIVE
+BALDWINCOUNTYAL.GOV,County,Non-Federal Agency,Bay Minette,AL,ACTIVE
+BALTIMORECOUNTYMD.GOV,County,Non-Federal Agency,Towson,MD,ACTIVE
+BAMBERGCOUNTYSC.GOV,County,Non-Federal Agency,Bamberg,SC,ACTIVE
+BARNSTABLECOUNTY-MA.GOV,County,Non-Federal Agency,Barnstable,MA,ACTIVE
+BARRONCOUNTYWI.GOV,County,Non-Federal Agency,Barron,WI,ACTIVE
+BASTROPCOUNTYTEXAS.GOV,County,Non-Federal Agency,Bastrop,TX,ACTIVE
+BAYCOUNTY911-MI.GOV,County,Non-Federal Agency,Bay City,MI,ACTIVE
+BAYCOUNTYFL.GOV,County,Non-Federal Agency,Panama City,FL,ACTIVE
+BCCIRCLK.GOV,County,Non-Federal Agency,Princeton,IL,ACTIVE
+BEAVERCOUNTYPA.GOV,County,Non-Federal Agency,Beaver,PA,ACTIVE
+BEDFORDCOUNTYVA.GOV,County,Non-Federal Agency,Bedford,VA,ACTIVE
+BENTONCOUNTYAR.GOV,County,Non-Federal Agency,Bentonville,AR,ACTIVE
+BENTONCOUNTYMS.GOV,County,Non-Federal Agency,Ashland,MS,ACTIVE
+BENTONCOUNTYTN.GOV,County,Non-Federal Agency,Camden,TN,ACTIVE
+BERKELEYCOUNTYSC.GOV,County,Non-Federal Agency,Moncks Corner,SC,ACTIVE
+BERRIENCOUNTY-MI.GOV,County,Non-Federal Agency,St. Joseph,MI,ACTIVE
+BIGHORNCOUNTYMT.GOV,County,Non-Federal Agency,Hardin,MT,ACTIVE
+BIGHORNCOUNTYWY.GOV,County,Non-Federal Agency,Basin,WY,ACTIVE
+BILLINGSCOUNTYND.GOV,County,Non-Federal Agency,Medora,ND,ACTIVE
+BLAINECOUNTY-MT.GOV,County,Non-Federal Agency,CHINOOK,MT,ACTIVE
+BLANDCOUNTYVA.GOV,County,Non-Federal Agency,Bland,VA,ACTIVE
+BLUEEARTHCOUNTYMN.GOV,County,Non-Federal Agency,Mankato,MN,ACTIVE
+BONNERCOUNTYID.GOV,County,Non-Federal Agency,Sandpoint,ID,ACTIVE
+BOONECOUNTY-AR.GOV,County,Non-Federal Agency,Harrison,AR,ACTIVE
+BOSSIERPARISHLA.GOV,County,Non-Federal Agency,Benton ,LA,ACTIVE
+BOTETOURTVA.GOV,County,Non-Federal Agency,Fincastle,VA,ACTIVE
+BOULDERCOUNTYCOLORADO.GOV,County,Non-Federal Agency,Boulder,CO,ACTIVE
+BOWMANCOUNTYND.GOV,County,Non-Federal Agency,Bismarck,ND,ACTIVE
+BOYDCOUNTYKY.GOV,County,Non-Federal Agency,Catlettsburg,KY,ACTIVE
+BRADFORDCOUNTYFL.GOV,County,Non-Federal Agency,Starke,FL,ACTIVE
+BRADLEYCOUNTYTN.GOV,County,Non-Federal Agency,Cleveland,TN,ACTIVE
+BRANCHCOUNTYMI.GOV,County,Non-Federal Agency,Coldwater,MI,ACTIVE
+BRAZORIACOUNTY-TX.GOV,County,Non-Federal Agency,Angleton,TX,ACTIVE
+BRAZORIACOUNTY.GOV,County,Non-Federal Agency,Angleton,TX,ACTIVE
+BRAZORIACOUNTYTX.GOV,County,Non-Federal Agency,Angleton,TX,ACTIVE
+BRAZOSCOUNTYTX.GOV,County,Non-Federal Agency,Bryan,TX,ACTIVE
+BRECKINRIDGECOUNTYKY.GOV,County,Non-Federal Agency,Hardinsburg,KY,ACTIVE
+BREVARDFL.GOV,County,Non-Federal Agency,Viera,FL,ACTIVE
+BROOKINGSCOUNTYSD.GOV,County,Non-Federal Agency,Brookings,SD,ACTIVE
+BROOMECOUNTYNY.GOV,County,Non-Federal Agency,Binghamton,NY,ACTIVE
+BROWNCOUNTY-IN.GOV,County,Non-Federal Agency,Nashville,IN,ACTIVE
+BROWNCOUNTYOHIO.GOV,County,Non-Federal Agency,Georgetown,OH,ACTIVE
+BROWNCOUNTYWI.GOV,County,Non-Federal Agency,Green Bay,WI,ACTIVE
+BRUNSWICKCOUNTYNC.GOV,County,Non-Federal Agency,Bolivia,NC,ACTIVE
+BUCHANANCOUNTY-VA.GOV,County,Non-Federal Agency,Grundy,VA,ACTIVE
+BUNCOMBECOUNTYNC.GOV,County,Non-Federal Agency,Asheville,NC,ACTIVE
+BUREAUCOUNTY-IL.GOV,County,Non-Federal Agency,Princeton,IL,ACTIVE
+CABARRUSCOUNTYNC.GOV,County,Non-Federal Agency,Concord,NC,ACTIVE
+CALHOUNCOUNTYAL.GOV,County,Non-Federal Agency,Anniston,AL,ACTIVE
+CALHOUNCOUNTYMI.GOV,County,Non-Federal Agency,Marshall,MI,ACTIVE
+CALLOWAYCOUNTY-KY.GOV,County,Non-Federal Agency,Murray,KY,ACTIVE
+CAMBRIACOUNTYPA.GOV,County,Non-Federal Agency,Ebensburg,PA,ACTIVE
+CAMDENCOUNTYNC.GOV,County,Non-Federal Agency,Camden,NC,ACTIVE
+CAMPBELLCOUNTYKY.GOV,County,Non-Federal Agency,Newport,KY,ACTIVE
+CAMPBELLCOUNTYTN.GOV,County,Non-Federal Agency,Jacksboro,TN,ACTIVE
+CAMPBELLCOUNTYVA.GOV,County,Non-Federal Agency,Rustburg,VA,ACTIVE
+CANDLERCO-GA.GOV,County,Non-Federal Agency,Metter,GA,ACTIVE
+CAPECOD-MA.GOV,County,Non-Federal Agency,Barnstable,MA,ACTIVE
+CAPEMAYCOUNTYNJ.GOV,County,Non-Federal Agency,Cape May Court House,NJ,ACTIVE
+CAPITALALERT.GOV,County,Non-Federal Agency,Fairfax,VA,ACTIVE
+CAPITALERT.GOV,County,Non-Federal Agency,Fairfax,VA,ACTIVE
+CAPITALREGION.GOV,County,Non-Federal Agency,Fairfax,VA,ACTIVE
+CAROLINECOUNTYVA.GOV,County,Non-Federal Agency,Bowling Green,VA,ACTIVE
+CARROLLCOUNTYIN.GOV,County,Non-Federal Agency,Delphi,IN,ACTIVE
+CARTERCOUNTYTN.GOV,County,Non-Federal Agency,Elizabethton,TN,ACTIVE
+CARTERETCOUNTYNC.GOV,County,Non-Federal Agency,Beaufort,NC,ACTIVE
+CASCADECOUNTYMT.GOV,County,Non-Federal Agency,Great Falls,MT,ACTIVE
+CASSCOUNTYND.GOV,County,Non-Federal Agency,Bismarck,ND,ACTIVE
+CASWELLCOUNTYNC.GOV,County,Non-Federal Agency,Yanceyville,NC,ACTIVE
+CATAWBACOUNTYNC.GOV,County,Non-Federal Agency,Newton,NC,ACTIVE
+CATRONCOUNTYNM.GOV,County,Non-Federal Agency,Reserve,NM,ACTIVE
+CECILCOUNTYMD.GOV,County,Non-Federal Agency,Elkton,MD,ACTIVE
+CEDARCOUNTYMO.GOV,County,Non-Federal Agency,Stockton,MO,ACTIVE
+CENTRECOUNTYPA.GOV,County,Non-Federal Agency,Bellefonte,PA,ACTIVE
+CHAMBERSCOUNTYAL.GOV,County,Non-Federal Agency,Lafayette,AL,ACTIVE
+CHAMBERSTX.GOV,County,Non-Federal Agency,Anahuac,TX,ACTIVE
+CHARLESCOUNTYMD.GOV,County,Non-Federal Agency,La Plata,MD,ACTIVE
+CHARLOTTECOUNTYFL.GOV,County,Non-Federal Agency,Port Charlotte,FL,ACTIVE
+CHARLTONCOUNTYGA.GOV,County,Non-Federal Agency,Folkston,GA,ACTIVE
+CHATHAMCOUNTYGA.GOV,County,Non-Federal Agency,Savannah,GA,ACTIVE
+CHEATHAMCOUNTYTN.GOV,County,Non-Federal Agency,Ashland City,TN,ACTIVE
+CHELANCOUNTYWA.GOV,County,Non-Federal Agency,Wenatchee,WA,ACTIVE
+CHEROKEECOUNTY-AL.GOV,County,Non-Federal Agency,Centre,AL,ACTIVE
+CHEROKEECOUNTY-KS.GOV,County,Non-Federal Agency,Columbus,KS,ACTIVE
+CHEROKEECOUNTY-NC.GOV,County,Non-Federal Agency,Murphy,NC,ACTIVE
+CHEROKEECOUNTYKS.GOV,County,Non-Federal Agency,Columbus,KS,ACTIVE
+CHEROKEECOUNTYSC.GOV,County,Non-Federal Agency,Gaffney,SC,ACTIVE
+CHESTERFIELDCOUNTY.GOV,County,Non-Federal Agency,Chesterfield,VA,ACTIVE
+CHEYENNECOUNTY-CO.GOV,County,Non-Federal Agency,CHEYENNE WELLS,CO,ACTIVE
+CHIPPEWACOUNTYMI.GOV,County,Non-Federal Agency,Sault Ste Marie,MI,ACTIVE
+CHRISTIANCOUNTYKY.GOV,County,Non-Federal Agency,Hopkinsville,KY,ACTIVE
+CHRISTIANCOUNTYMO.GOV,County,Non-Federal Agency,Ozark,MO,ACTIVE
+CLARKCOUNTYNV.GOV,County,Non-Federal Agency,Las Vegas,NV,ACTIVE
+CLARKCOUNTYOHIO.GOV,County,Non-Federal Agency,Springfield,OH,ACTIVE
+CLARKECOUNTY.GOV,County,Non-Federal Agency,Berryville,VA,ACTIVE
+CLARKECOUNTYMS.GOV,County,Non-Federal Agency,Quitman,MS,ACTIVE
+CLATSOPCOUNTYOR.GOV,County,Non-Federal Agency,Astoria,OR,ACTIVE
+CLAYCOUNTYMN.GOV,County,Non-Federal Agency,Moorhead,MN,ACTIVE
+CLAYCOUNTYMO.GOV,County,Non-Federal Agency,Liberty,MO,ACTIVE
+CLAYTONCOUNTYGA.GOV,County,Non-Federal Agency,Jonesboro,GA,ACTIVE
+CLAYTONCOUNTYIA.GOV,County,Non-Federal Agency,Elkader,IA,ACTIVE
+CLERMONTCOUNTYOHIO.GOV,County,Non-Federal Agency,Batavia,OH,ACTIVE
+CLINTONCOUNTY-IA.GOV,County,Non-Federal Agency,Clinton,IA,ACTIVE
+COLUMBIACOUNTYGA.GOV,County,Non-Federal Agency,Evans,GA,ACTIVE
+COLUMBIACOUNTYNY.GOV,County,Non-Federal Agency,Hudson,NY,ACTIVE
+CONVERSECOUNTYWY.GOV,County,Non-Federal Agency,Douglas,WY,ACTIVE
+COOKCOUNTYIL.GOV,County,Non-Federal Agency,Chicago,IL,ACTIVE
+COOPERCOUNTYMO.GOV,County,Non-Federal Agency,Boonville,MO,ACTIVE
+COPIAHCOUNTYMS.GOV,County,Non-Federal Agency,Hazlehurst,MS,ACTIVE
+CORONADOCA.GOV,County,Non-Federal Agency,Coronado,CA,ACTIVE
+COSCPINALCOUNTYAZ.GOV,County,Non-Federal Agency,Florence,AZ,ACTIVE
+COSTILLACOUNTY-CO.GOV,County,Non-Federal Agency,San Luis,CO,ACTIVE
+COUNTYOFVENTURACA.GOV,County,Non-Federal Agency,VENTURA,CA,ACTIVE
+COVINGTONCOUNTYMS.GOV,County,Non-Federal Agency,Collins,MS,ACTIVE
+CRAIGCOUNTYVA.GOV,County,Non-Federal Agency,New Castle,VA,ACTIVE
+CRAVENCOUNTYNC.GOV,County,Non-Federal Agency,New Bern,NC,ACTIVE
+CRAWFORDCOUNTYKANSAS.GOV,County,Non-Federal Agency,Girard,KS,ACTIVE
+CRAWFORDCOUNTYMO.GOV,County,Non-Federal Agency,Steelville,MO,ACTIVE
+CULPEPERCOUNTY.GOV,County,Non-Federal Agency,Culpeper,VA,ACTIVE
+CUMBERLANDCOUNTYTN.GOV,County,Non-Federal Agency,Crossville,TN,ACTIVE
+CURRITUCKCOUNTYNC.GOV,County,Non-Federal Agency,Currituck,NC,ACTIVE
+DADECOUNTY-GA.GOV,County,Non-Federal Agency,Trenton,GA,ACTIVE
+DAKOTACOUNTYMN.GOV,County,Non-Federal Agency,Hastings,MN,ACTIVE
+DALLASCOUNTY-TX.GOV,County,Non-Federal Agency,Dallas,TX,ACTIVE
+DALLASCOUNTYIOWA.GOV,County,Non-Federal Agency,Adel,IA,ACTIVE
+DARECOUNTYNC.GOV,County,Non-Federal Agency,Manteo,NC,ACTIVE
+DAVIDSONCOUNTYNC.GOV,County,Non-Federal Agency,Lexington,NC,ACTIVE
+DAVIECOUNTYNC.GOV,County,Non-Federal Agency,Mocksville,NC,ACTIVE
+DAVISCOUNTYUT4HEALTH.GOV,County,Non-Federal Agency,Farmington,UT,ACTIVE
+DAVISCOUNTYUTAH.GOV,County,Non-Federal Agency,Farmington,UT,ACTIVE
+DAVISUT4HEALTH.GOV,County,Non-Federal Agency,Farmington,UT,ACTIVE
+DAWSONCOUNTYNE.GOV,County,Non-Federal Agency,Lexington,NE,ACTIVE
+DCONC.GOV,County,Non-Federal Agency,Durham,NC,ACTIVE
+DECATURCOUNTYGA.GOV,County,Non-Federal Agency,Bainbridge,GA,ACTIVE
+DEKALBCOUNTYGA.GOV,County,Non-Federal Agency,Decatur,GA,ACTIVE
+DEKALBCOUNTYIL.GOV,County,Non-Federal Agency,Sycamore,IL,ACTIVE
+DESOTOCOUNTYMS.GOV,County,Non-Federal Agency,HERNANDO,MS,ACTIVE
+DICKINSONCOUNTYMI.GOV,County,Non-Federal Agency,Iron Mountain,MI,ACTIVE
+DICKSONCOUNTYTN.GOV,County,Non-Federal Agency,Charlotte,TN,ACTIVE
+DOUGLASCOUNTY-NE.GOV,County,Non-Federal Agency,Omaha,NE,ACTIVE
+DOUGLASCOUNTYNV.GOV,County,Non-Federal Agency,Minden,NV,ACTIVE
+DUNNCOUNTYWI.GOV,County,Non-Federal Agency,Menomonie,WI,ACTIVE
+DURHAMCOUNTYNC.GOV,County,Non-Federal Agency,Durham,NC,ACTIVE
+ECTORCOUNTYTX.GOV,County,Non-Federal Agency,Odessa,TX,ACTIVE
+EDGECOMBECOUNTYNC.GOV,County,Non-Federal Agency,Tarboro,NC,ACTIVE
+ELBERTCOUNTY-CO.GOV,County,Non-Federal Agency,Kiowa,CO,ACTIVE
+EMANUELCO-GA.GOV,County,Non-Federal Agency,Swainsboro,GA,ACTIVE
+ERIE.GOV,County,Non-Federal Agency,Buffalo,NY,ACTIVE
+ERIECOUNTYPA.GOV,County,Non-Federal Agency,Erie,PA,ACTIVE
+EUREKACOUNTYNV.GOV,County,Non-Federal Agency,Eureka,NV,ACTIVE
+FAIRFAXCOUNTY.GOV,County,Non-Federal Agency,Fairfax,VA,ACTIVE
+FAIRFAXCOUNTYVA.GOV,County,Non-Federal Agency,Fairfax,VA,ACTIVE
+FAIRFAXCOUNTYVIRGINIA.GOV,County,Non-Federal Agency,Fairfax,VA,ACTIVE
+FAIRFIELDCOUNTYOHIO.GOV,County,Non-Federal Agency,Lancaster,OH,ACTIVE
+FAUQUIERCOUNTY.GOV,County,Non-Federal Agency,Warrenton,VA,ACTIVE
+FENTRESSCOUNTYTN.GOV,County,Non-Federal Agency,Jamestown,TN,ACTIVE
+FORTBENDCOUNTYTX.GOV,County,Non-Federal Agency,Richmond,TX,ACTIVE
+FRANKLINCOUNTYGA.GOV,County,Non-Federal Agency,Carnesville,GA,ACTIVE
+FRANKLINCOUNTYIL.GOV,County,Non-Federal Agency,Benton,IL,ACTIVE
+FRANKLINCOUNTYMAINE.GOV,County,Non-Federal Agency,Farmington,ME,ACTIVE
+FRANKLINCOUNTYOHIO.GOV,County,Non-Federal Agency,Columbus,OH,ACTIVE
+FRANKLINCOUNTYPA.GOV,County,Non-Federal Agency,Chambersburg,PA,ACTIVE
+FRANKLINCOUNTYVA.GOV,County,Non-Federal Agency,Rocky Mount,VA,ACTIVE
+FREDERICKCOUNTYMD.GOV,County,Non-Federal Agency,Frederick,MD,ACTIVE
+FREDERICKCOUNTYVA.GOV,County,Non-Federal Agency,Winchester,VA,ACTIVE
+FREMONTCOUNTYWY.GOV,County,Non-Federal Agency,Lander,WY,ACTIVE
+FRIOCOUNTY-TX.GOV,County,Non-Federal Agency,Pearsall,TX,ACTIVE
+FULTONCOUNTYGA.GOV,County,Non-Federal Agency,Atlanta,GA,ACTIVE
+FULTONCOUNTYNY.GOV,County,Non-Federal Agency,Johnstown,NY,ACTIVE
+GADSDENCOUNTYFL.GOV,County,Non-Federal Agency,Quincy,FL,ACTIVE
+GALVESTONCOUNTYTX.GOV,County,Non-Federal Agency,Galveston,TX,ACTIVE
+GARFIELDCOUNTY-CO.GOV,County,Non-Federal Agency,Glenwood Springs,CO,ACTIVE
+GATESCOUNTYNC.GOV,County,Non-Federal Agency,Gatesville,NC,ACTIVE
+GEORGECOUNTYMS.GOV,County,Non-Federal Agency,Lucedale,MS,ACTIVE
+GGSC.GOV,County,Non-Federal Agency,Greenville,SC,ACTIVE
+GIBSONCOUNTY-IN.GOV,County,Non-Federal Agency,Princeton,IN,ACTIVE
+GILACOUNTYAZ.GOV,County,Non-Federal Agency,Globe,AZ,ACTIVE
+GILMERCOUNTY-GA.GOV,County,Non-Federal Agency,Ellijay,GA,ACTIVE
+GILMERCOUNTYWV.GOV,County,Non-Federal Agency,GLENVILLE,WV,ACTIVE
+GLOUCESTERCOUNTYNJ.GOV,County,Non-Federal Agency,Woodbury,NJ,ACTIVE
+GOGEBICCOUNTYMI.GOV,County,Non-Federal Agency,Bessemer,MI,ACTIVE
+GOLIADCOUNTYTX.GOV,County,Non-Federal Agency,Goliad,TX,ACTIVE
+GRADYCOUNTYGA.GOV,County,Non-Federal Agency,Cairo,GA,ACTIVE
+GRAINGERCOUNTYTN.GOV,County,Non-Federal Agency,Rutledge,TN,ACTIVE
+GRANTCOUNTY-OR.GOV,County,Non-Federal Agency,Canyon City,OR,ACTIVE
+GRANTCOUNTYWA.GOV,County,Non-Federal Agency,Ephrata,WA,ACTIVE
+GRAYSONCOUNTYVA.GOV,County,Non-Federal Agency,Independence,VA,ACTIVE
+GREENECOUNTYGA.GOV,County,Non-Federal Agency,Greensboro,GA,ACTIVE
+GREENECOUNTYMO.GOV,County,Non-Federal Agency,Springfield,MO,ACTIVE
+GREENECOUNTYMS.GOV,County,Non-Federal Agency,Leaksville,MS,ACTIVE
+GREENECOUNTYNC.GOV,County,Non-Federal Agency,Snow Hill,NC,ACTIVE
+GREENECOUNTYVA.GOV,County,Non-Federal Agency,Stanardsville,VA,ACTIVE
+GREENHARRISCOUNTYTX.GOV,County,Non-Federal Agency,Houston,TX,ACTIVE
+GREENMCHENRYCOUNTYIL.GOV,County,Non-Federal Agency,Woodstock,IL,ACTIVE
+GREENMCHENRYCOUNTYILLINOIS.GOV,County,Non-Federal Agency,Woodstock,IL,ACTIVE
+GREENSVILLECOUNTYVA.GOV,County,Non-Federal Agency,Emporia,VA,ACTIVE
+GREENVILLECOUNTYSC.GOV,County,Non-Federal Agency,Greenville,SC,ACTIVE
+GREENWOODSC.GOV,County,Non-Federal Agency,Greenwood,SC,ACTIVE
+GRIGGSCOUNTYND.GOV,County,Non-Federal Agency,Bismarck,ND,ACTIVE
+GULFCOUNTY-FL.GOV,County,Non-Federal Agency,Port St. Joe,FL,ACTIVE
+GWINNETTCOUNTYGA.GOV,County,Non-Federal Agency,Lawrenceville,GA,ACTIVE
+HABERSHAMCOUNTY-GA.GOV,County,Non-Federal Agency,Clarkesville,GA,ACTIVE
+HAINESALASKA.GOV,County,Non-Federal Agency,Haines,AK,ACTIVE
+HALIFAXCOUNTYVA.GOV,County,Non-Federal Agency,Halifax,VA,ACTIVE
+HALLCOUNTYGA.GOV,County,Non-Federal Agency,Gainesville,GA,ACTIVE
+HALLCOUNTYNE.GOV,County,Non-Federal Agency,Grand Island,NE,ACTIVE
+HAMBLENCOUNTYTN.GOV,County,Non-Federal Agency,Morristown,TN,ACTIVE
+HAMILTONCOUNTYFLORIDA.GOV,County,Non-Federal Agency,Jasper,FL,ACTIVE
+HAMILTONCOUNTYNY.GOV,County,Non-Federal Agency,Lake Pleasent,NY,ACTIVE
+HAMILTONCOUNTYOHIO.GOV,County,Non-Federal Agency,Cincinnati,OH,ACTIVE
+HAMILTONTN.GOV,County,Non-Federal Agency,Chattanooga,TN,ACTIVE
+HANCOCKCOUNTY-IL.GOV,County,Non-Federal Agency,Carthage,IL,ACTIVE
+HANCOCKCOUNTYGA.GOV,County,Non-Federal Agency,Sparta,GA,ACTIVE
+HANCOCKCOUNTYMS.GOV,County,Non-Federal Agency,Bay St. Louis,MS,ACTIVE
+HANOVER.GOV,County,Non-Federal Agency,Hanover,VA,ACTIVE
+HANOVERCOUNTY.GOV,County,Non-Federal Agency,Hanover,VA,ACTIVE
+HANOVERCOUNTYVA.GOV,County,Non-Federal Agency,Hanover,VA,ACTIVE
+HARALSONCOUNTYGA.GOV,County,Non-Federal Agency,Buchanan,GA,ACTIVE
+HARDINCOUNTYIA.GOV,County,Non-Federal Agency,Eldora,IA,ACTIVE
+HARRISCOUNTYGA.GOV,County,Non-Federal Agency,Hamilton,GA,ACTIVE
+HARRISCOUNTYTX.GOV,County,Non-Federal Agency,Houston,TX,ACTIVE
+HARRISONCOUNTY-MS.GOV,County,Non-Federal Agency,Gulfport,MS,ACTIVE
+HARRISONCOUNTYWV.GOV,County,Non-Federal Agency,Clarksburg,WV,ACTIVE
+HARTCOUNTYGA.GOV,County,Non-Federal Agency,Hartwell,GA,ACTIVE
+HAWAIICOUNTY.GOV,County,Non-Federal Agency,Hilo,HI,ACTIVE
+HAWKINSCOUNTYTN.GOV,County,Non-Federal Agency,Rogersville,TN,ACTIVE
+HAYWOODCOUNTYNC.GOV,County,Non-Federal Agency,Waynesville,NC,ACTIVE
+HCSHERIFF.GOV,County,Non-Federal Agency,Chattanooga,TN,ACTIVE
+HENDERSONCOUNTYTN.GOV,County,Non-Federal Agency,Lexington,TN,ACTIVE
+HENRYCOUNTYVA.GOV,County,Non-Federal Agency,Martinsville,VA,ACTIVE
+HERTFORDCOUNTYNC.GOV,County,Non-Federal Agency,Winton,NC,ACTIVE
+HINSDALECOUNTY-CO.GOV,County,Non-Federal Agency,Lake City,CO,ACTIVE
+HOWARDCOUNTYIN.GOV,County,Non-Federal Agency,Kokomo,IN,ACTIVE
+HOWARDCOUNTYMARYLAND.GOV,County,Non-Federal Agency,Ellicott City,MD,ACTIVE
+HOWARDCOUNTYMD.GOV,County,Non-Federal Agency,Ellicott City,MD,ACTIVE
+HURONCOUNTY-OH.GOV,County,Non-Federal Agency,Norwalk,OH,ACTIVE
+HYDECOUNTYNC.GOV,County,Non-Federal Agency,Swanquarter,NC,ACTIVE
+ICATCO.GOV,County,Non-Federal Agency,Newton,NC,ACTIVE
+ISLANDCOUNTYWA.GOV,County,Non-Federal Agency,Coupeville,WA,ACTIVE
+ISSAQUENACOUNTYMS.GOV,County,Non-Federal Agency,Mayersville,MS,ACTIVE
+JACKSONCOGA.GOV,County,Non-Federal Agency,Jefferson,GA,ACTIVE
+JACKSONCOUNTY-IL.GOV,County,Non-Federal Agency,Murphysboro,IL,ACTIVE
+JAMESCITYCOUNTYVA.GOV,County,Non-Federal Agency,Williamsburg,VA,ACTIVE
+JASPERCOUNTYIN.GOV,County,Non-Federal Agency,Rensselaer,IN,ACTIVE
+JASPERCOUNTYSC.GOV,County,Non-Federal Agency,Ridgeland,SC,ACTIVE
+JEFFERSONCOUNTY-MT.GOV,County,Non-Federal Agency,Boulder,MT,ACTIVE
+JEFFERSONCOUNTYFL.GOV,County,Non-Federal Agency,Monticello,FL,ACTIVE
+JEFFERSONCOUNTYGA.GOV,County,Non-Federal Agency,LOUISVILLE,GA,ACTIVE
+JEFFERSONCOUNTYMS.GOV,County,Non-Federal Agency,Fayette,MS,ACTIVE
+JEFFERSONCOUNTYTN.GOV,County,Non-Federal Agency,Dandridge,TN,ACTIVE
+JEFFERSONCOUNTYWI.GOV,County,Non-Federal Agency,Jefferson,WI,ACTIVE
+JENNINGSCOUNTY-IN.GOV,County,Non-Federal Agency,Vernon,IN,ACTIVE
+JIMWELLSCOUNTY-TX.GOV,County,Non-Federal Agency,Alice,TX,ACTIVE
+JONESCOUNTYNC.GOV,County,Non-Federal Agency,Trenton,NC,ACTIVE
+KANAWHACOUNTYWV.GOV,County,Non-Federal Agency,Charleston,WV,ACTIVE
+KAUAI.GOV,County,Non-Federal Agency,Lihue,HI,ACTIVE
+KEITHCOUNTYNE.GOV,County,Non-Federal Agency,Ogallala,NE,ACTIVE
+KENNEBECCOUNTY-ME.GOV,County,Non-Federal Agency,Augusta,ME,ACTIVE
+KENTCOUNTYMI.GOV,County,Non-Federal Agency,Grand Rapids,MI,ACTIVE
+KERNCOG-CA.GOV,County,Non-Federal Agency,Bakersfield,CA,ACTIVE
+KINGCOUNTY.GOV,County,Non-Federal Agency,Seattle,WA,ACTIVE
+KINGGEORGECOUNTYVA.GOV,County,Non-Federal Agency,King George,VA,ACTIVE
+KINGSBURYNY.GOV,County,Non-Federal Agency,Hudson Falls,NY,ACTIVE
+KNOXCOUNTYMAINE.GOV,County,Non-Federal Agency,Rockland,ME,ACTIVE
+KNOXCOUNTYTEXAS.GOV,County,Non-Federal Agency,Benjamin,TX,ACTIVE
+LACOUNTY.GOV,County,Non-Federal Agency,Downey,CA,ACTIVE
+LAKECOUNTYCA.GOV,County,Non-Federal Agency,Lakeport,CA,ACTIVE
+LAKECOUNTYIL.GOV,County,Non-Federal Agency,Waukegan,IL,ACTIVE
+LAKECOUNTYOHIO.GOV,County,Non-Federal Agency,Painesville,OH,ACTIVE
+LAKEMT.GOV,County,Non-Federal Agency,Polson,MT,ACTIVE
+LAMARCOUNTYMS.GOV,County,Non-Federal Agency,Purvis,MS,ACTIVE
+LANCASTERCOUNTYPA.GOV,County,Non-Federal Agency,Lancaster,PA,ACTIVE
+LAPAZCOUNTYAZ.GOV,County,Non-Federal Agency,Parker,AZ,ACTIVE
+LAUDERDALECOUNTYAL.GOV,County,Non-Federal Agency,Florence,AL,ACTIVE
+LAWRENCECOUNTYTN.GOV,County,Non-Federal Agency,Lawrenceburg,TN,ACTIVE
+LCCOUNTYMT.GOV,County,Non-Federal Agency,Helena,MT,ACTIVE
+LEE-COUNTY-FL.GOV,County,Non-Federal Agency,Fort Myers,FL,ACTIVE
+LEECOUNTYNC.GOV,County,Non-Federal Agency,Sanford,NC,ACTIVE
+LEONCOUNTYFL.GOV,County,Non-Federal Agency,Tallahassee,FL,ACTIVE
+LEWISCOUNTYWA.GOV,County,Non-Federal Agency,Chehalis,WA,ACTIVE
+LIBERTYCOUNTY-GA.GOV,County,Non-Federal Agency,Hinesville,GA,ACTIVE
+LIMESTONECOUNTY-AL.GOV,County,Non-Federal Agency,Athens,AL,ACTIVE
+LIMESTONECOUNTYEMA-AL.GOV,County,Non-Federal Agency,Athens,AL,ACTIVE
+LINCOLNCOUNTYNM.GOV,County,Non-Federal Agency,Carrizozo,NM,ACTIVE
+LIVINGSTONCOUNTYIL.GOV,County,Non-Federal Agency,Pontiac,IL,ACTIVE
+LIVINGSTONPARISHLA.GOV,County,Non-Federal Agency,Livingston,LA,ACTIVE
+LOGANCOUNTYCO.GOV,County,Non-Federal Agency,Sterling,CO,ACTIVE
+LOGANCOUNTYIL.GOV,County,Non-Federal Agency,Lincoln,IL,ACTIVE
+LOUDONCOUNTY-TN.GOV,County,Non-Federal Agency,Loudon,TN,ACTIVE
+LOUDOUN.GOV,County,Non-Federal Agency,Leesburg,VA,ACTIVE
+LOUDOUNCOUNTYVA.GOV,County,Non-Federal Agency,Leesburg,VA,ACTIVE
+LOWNDESCOUNTYGA.GOV,County,Non-Federal Agency,Valdosta,GA,ACTIVE
+LUCASCOUNTYOH.GOV,County,Non-Federal Agency,Toledo,OH,ACTIVE
+LUMPKINCOUNTY.GOV,County,Non-Federal Agency,Dahlonega,GA,ACTIVE
+MACOMBCOUNTYMI.GOV,County,Non-Federal Agency,Mount Clemens,MI,ACTIVE
+MACONBIBBCOUNTYGA.GOV,County,Non-Federal Agency,Macon,GA,ACTIVE
+MACONCOUNTYGA.GOV,County,Non-Federal Agency,Oglethorpe,GA,ACTIVE
+MACONCOUNTYTN.GOV,County,Non-Federal Agency,Lafayette,TN,ACTIVE
+MACOUPINCOUNTYIL.GOV,County,Non-Federal Agency,Carlinville,IL,ACTIVE
+MADISONCOUNTYAL.GOV,County,Non-Federal Agency,Huntsville,AL,ACTIVE
+MADISONCOUNTYMT.GOV,County,Non-Federal Agency,Virginia City,MT,ACTIVE
+MADISONCOUNTYNC.GOV,County,Non-Federal Agency,Marshall,NC,ACTIVE
+MADISONCOUNTYTN.GOV,County,Non-Federal Agency,Jackson,TN,ACTIVE
+MAHONINGCOUNTYOH.GOV,County,Non-Federal Agency,Youngstown,OH,ACTIVE
+MANISTEECOUNTYMI.GOV,County,Non-Federal Agency,Manistee,MI,ACTIVE
+MARICOPA.GOV,County,Non-Federal Agency,Phoenix,AZ,ACTIVE
+MARIONCOUNTY-MO.GOV,County,Non-Federal Agency,Hannibal,MO,ACTIVE
+MARSHALLCOUNTYIA.GOV,County,Non-Federal Agency,Marshalltown,IA,ACTIVE
+MARSHALLCOUNTYKY.GOV,County,Non-Federal Agency,Benton,KY,ACTIVE
+MATHEWSCOUNTYVA.GOV,County,Non-Federal Agency,Mathews,VA,ACTIVE
+MAUICOUNTY-HI.GOV,County,Non-Federal Agency,Wailuku,HI,ACTIVE
+MAUICOUNTY.GOV,County,Non-Federal Agency,Wailuku,HI,ACTIVE
+MAURYCOUNTY-TN.GOV,County,Non-Federal Agency,Columbia,TN,ACTIVE
+MCCRACKENCOUNTYKY.GOV,County,Non-Federal Agency,Paducah,KY,ACTIVE
+MCDONALDCOUNTYMO.GOV,County,Non-Federal Agency,Pineville,MO,ACTIVE
+MCHENRYCOUNTYIL.GOV,County,Non-Federal Agency,Woodstock,IL,ACTIVE
+MCHENRYCOUNTYILLINOIS.GOV,County,Non-Federal Agency,Woodstock,IL,ACTIVE
+MCINTOSHCOUNTY-GA.GOV,County,Non-Federal Agency,Darien,GA,ACTIVE
+MCLEANCOUNTYIL.GOV,County,Non-Federal Agency,Bloomington,IL,ACTIVE
+MCLEANCOUNTYND.GOV,County,Non-Federal Agency,Washburn,ND,ACTIVE
+MCMINNCOUNTYTN.GOV,County,Non-Federal Agency,Athens,TN,ACTIVE
+MEADEKY.GOV,County,Non-Federal Agency,Brandenburg,KY,ACTIVE
+MECKLENBURGCOUNTYNC.GOV,County,Non-Federal Agency,Charlotte,NC,ACTIVE
+MEETEETSECD-WY.GOV,County,Non-Federal Agency,Meeteetse,WY,ACTIVE
+MERCEDCOUNTYCA.GOV,County,Non-Federal Agency,Merced,CA,ACTIVE
+MERIWETHERCOUNTYGA.GOV,County,Non-Federal Agency,Greenville,GA,ACTIVE
+MIAMI-DADE.GOV,County,Non-Federal Agency,Miami,FL,ACTIVE
+MIAMICOUNTYIN.GOV,County,Non-Federal Agency,Peru,IN,ACTIVE
+MIAMICOUNTYOHIO.GOV,County,Non-Federal Agency,Troy,OH,ACTIVE
+MIAMIDADE.GOV,County,Non-Federal Agency,Miami,FL,ACTIVE
+MIAMIDADECOUNTY-FL.GOV,County,Non-Federal Agency,Miami,FL,ACTIVE
+MIAMIDADECOUNTYFL.GOV,County,Non-Federal Agency,Miami,FL,ACTIVE
+MIDDLESEXCOUNTYNJ.GOV,County,Non-Federal Agency,New Brunswick,NJ,ACTIVE
+MILWAUKEECOUNTYWI.GOV,County,Non-Federal Agency,Milwaukee,WI,ACTIVE
+MOBILECOUNTYAL.GOV,County,Non-Federal Agency,Mobile,AL,ACTIVE
+MONROECOUNTY-FL.GOV,County,Non-Federal Agency,Key West,FL,ACTIVE
+MONROECOUNTY.GOV,County,Non-Federal Agency,Rochester,NY,ACTIVE
+MONROECOUNTYAL.GOV,County,Non-Federal Agency,Monroeville,AL,ACTIVE
+MONROECOUNTYPA.GOV,County,Non-Federal Agency,Stroudsburg,PA,ACTIVE
+MONTGOMERYCOUNTYGA.GOV,County,Non-Federal Agency,mt. vernon,GA,ACTIVE
+MONTGOMERYCOUNTYMD.GOV,County,Non-Federal Agency,Rockville,MD,ACTIVE
+MONTGOMERYCOUNTYVA.GOV,County,Non-Federal Agency,Christiansburg,VA,ACTIVE
+MOORECOUNTYNC.GOV,County,Non-Federal Agency,Carthage,NC,ACTIVE
+MORGANCOUNTY-OH.GOV,County,Non-Federal Agency,McConnelsville,OH,ACTIVE
+MORGANCOUNTYTN.GOV,County,Non-Federal Agency,wartburg,TN,ACTIVE
+MORGANCOUNTYWV.GOV,County,Non-Federal Agency,Berkeley Springs,WV,ACTIVE
+MORRILLCOUNTYNE.GOV,County,Non-Federal Agency,Bridgeport,NE,ACTIVE
+MORRISCOUNTYNJ.GOV,County,Non-Federal Agency,Morristown,NJ,ACTIVE
+MORROWCOUNTYOHIO.GOV,County,Non-Federal Agency,Mount Gilead,OH,ACTIVE
+NASHCOUNTYNC.GOV,County,Non-Federal Agency,Nashville,NC,ACTIVE
+NASSAUCOUNTYNY.GOV,County,Non-Federal Agency,Mineola,NY,ACTIVE
+NATRONACOUNTY-WY.GOV,County,Non-Federal Agency,Casper,WY,ACTIVE
+NAVAJOCOUNTYAZ.GOV,County,Non-Federal Agency,Holbrook,AZ,ACTIVE
+NELSONCOUNTY-VA.GOV,County,Non-Federal Agency,Lovingston,VA,ACTIVE
+NIAGARACOUNTY-NY.GOV,County,Non-Federal Agency,LOCKPORT,NY,ACTIVE
+NOBLECOUNTYOHIO.GOV,County,Non-Federal Agency,Caldwell,OH,ACTIVE
+NORTONCOUNTYKS.GOV,County,Non-Federal Agency,Norton,KS,ACTIVE
+NWCLEANAIRWA.GOV,County,Non-Federal Agency,Mount Vernon,WA,ACTIVE
+OAKLANDCOUNTYMI.GOV,County,Non-Federal Agency,Pontiac,MI,ACTIVE
+OGEMAWCOUNTYMI.GOV,County,Non-Federal Agency,West Branch,MI,ACTIVE
+OGLETHORPECOUNTYGA.GOV,County,Non-Federal Agency,Lexington,GA,ACTIVE
+OHIOCOUNTYKY.GOV,County,Non-Federal Agency,Hartford,KY,ACTIVE
+OHIOCOUNTYWV.GOV,County,Non-Federal Agency,Wheeling,WV,ACTIVE
+OLDHAMCOUNTYKY.GOV,County,Non-Federal Agency,La Grange,KY,ACTIVE
+ORANGECOUNTY-VA.GOV,County,Non-Federal Agency,ORANGE,VA,ACTIVE
+ORANGECOUNTYNC.GOV,County,Non-Federal Agency,Hillsborough,NC,ACTIVE
+ORANGECOUNTYVA.GOV,County,Non-Federal Agency,Orange,VA,ACTIVE
+ORANGECOUNTYVT.GOV,County,Non-Federal Agency,Chelsea,VT,ACTIVE
+ORLEANSCOUNTYNY.GOV,County,Non-Federal Agency,Albion,NY,ACTIVE
+OSWEGOCOUNTYNY.GOV,County,Non-Federal Agency,Oswego,NY,ACTIVE
+OTSEGOCOUNTYMI.GOV,County,Non-Federal Agency,Gaylord,MI,ACTIVE
+OURAYCOUNTYCO.GOV,County,Non-Federal Agency,Ouray,CO,ACTIVE
+PARKECOUNTY-IN.GOV,County,Non-Federal Agency,Rockville,IN,ACTIVE
+PAYNECOUNTYOK.GOV,County,Non-Federal Agency,Stillwater,OK,ACTIVE
+PEMBINACOUNTYND.GOV,County,Non-Federal Agency,Cavalier,ND,ACTIVE
+PENDERCOUNTYNC.GOV,County,Non-Federal Agency,Burgaw,NC,ACTIVE
+PERQUIMANSCOUNTYNC.GOV,County,Non-Federal Agency,Hertford,NC,ACTIVE
+PICKENSCOUNTYGA.GOV,County,Non-Federal Agency,Jasper,GA,ACTIVE
+PIERCECOUNTYGA.GOV,County,Non-Federal Agency,Blackshear,GA,ACTIVE
+PIERCECOUNTYND.GOV,County,Non-Federal Agency,Rugby,ND,ACTIVE
+PIERCECOUNTYWA.GOV,County,Non-Federal Agency,Tacoma,WA,ACTIVE
+PIKECOUNTY-MO.GOV,County,Non-Federal Agency,Bowling Green,MO,ACTIVE
+PIKECOUNTYKY.GOV,County,Non-Federal Agency,Pikeville,KY,ACTIVE
+PIMA.GOV,County,Non-Federal Agency,Tucson,AZ,ACTIVE
+PINALCOUNTYAZ.GOV,County,Non-Federal Agency,Florence,AZ,ACTIVE
+PINELLAS.GOV,County,Non-Federal Agency,Clearwater,FL,ACTIVE
+PITTCOUNTYNC.GOV,County,Non-Federal Agency,Greenville,NC,ACTIVE
+PITTSYLVANIACOUNTYVA.GOV,County,Non-Federal Agency,Chatham,VA,ACTIVE
+PLYMOUTHCOUNTY-MA.GOV,County,Non-Federal Agency,Plymouth,MA,ACTIVE
+POLKCOUNTYGA.GOV,County,Non-Federal Agency,Cedartown,GA,ACTIVE
+POLKCOUNTYIOWA.GOV,County,Non-Federal Agency,Des Moines,IA,ACTIVE
+PORTAGECOUNTYWI.GOV,County,Non-Federal Agency,Stevens Point,WI,ACTIVE
+POSEYCOUNTYIN.GOV,County,Non-Federal Agency,Mount Vernon,IN,ACTIVE
+POTTAWATTAMIECOUNTY-IA.GOV,County,Non-Federal Agency,COUNCIL BLUFFS,IA,ACTIVE
+POTTCOUNTY-IA.GOV,County,Non-Federal Agency,COUNCIL BLUFFS,IA,ACTIVE
+POWELLCOUNTYMT.GOV,County,Non-Federal Agency,Deer Lodge,MT,ACTIVE
+PRESTONCOUNTYWV.GOV,County,Non-Federal Agency,Kingwood,WV,ACTIVE
+PRINCEGEORGECOUNTYVA.GOV,County,Non-Federal Agency,Prince George,VA,ACTIVE
+PRINCEGEORGESCOUNTYMD.GOV,County,Non-Federal Agency,Largo,MD,ACTIVE
+PUEBLOCOUNTYCO.GOV,County,Non-Federal Agency,Pueblo,CO,ACTIVE
+PULASKICOUNTYIL.GOV,County,Non-Federal Agency,Ullin,IL,ACTIVE
+PULASKICOUNTYVA.GOV,County,Non-Federal Agency,Pulaski,VA,ACTIVE
+PUTNAMCOUNTYNY.GOV,County,Non-Federal Agency,Carmel,NY,ACTIVE
+PUTNAMCOUNTYOHIO.GOV,County,Non-Federal Agency,Ottawa,OH,ACTIVE
+PUTNAMCOUNTYTN.GOV,County,Non-Federal Agency,Cookeville,TN,ACTIVE
+QUAYCOUNTY-NM.GOV,County,Non-Federal Agency,Tucumcari,NM,ACTIVE
+RANDOLPHCOUNTY-MO.GOV,County,Non-Federal Agency,Huntsville,MO,ACTIVE
+RANDOLPHCOUNTYALABAMA.GOV,County,Non-Federal Agency,Wedowee,AL,ACTIVE
+RANDOLPHCOUNTYNC.GOV,County,Non-Federal Agency,Asheboro,NC,ACTIVE
+RAPPAHANNOCKCOUNTYVA.GOV,County,Non-Federal Agency,Washington,VA,ACTIVE
+READYALBANYCOUNTY-NY.GOV,County,Non-Federal Agency,Albany,NY,ACTIVE
+READYHARRISCOUNTYTX.GOV,County,Non-Federal Agency,Houston,TX,ACTIVE
+READYMCHENRYCOUNTYIL.GOV,County,Non-Federal Agency,Woodstock,IL,ACTIVE
+READYMCHENRYCOUNTYILLINOIS.GOV,County,Non-Federal Agency,Woodstock,IL,ACTIVE
+REYNOLDSCOUNTY-MO.GOV,County,Non-Federal Agency,Centerville,MO,ACTIVE
+RILEYCOUNTYKS.GOV,County,Non-Federal Agency,Manhattan,KS,ACTIVE
+ROANECOUNTYTN.GOV,County,Non-Federal Agency,Kingston,TN,ACTIVE
+ROANOKECOUNTY-VA.GOV,County,Non-Federal Agency,Roanoke,VA,ACTIVE
+ROANOKECOUNTYVA.GOV,County,Non-Federal Agency,Roanoke,VA,ACTIVE
+ROANOKECOUNTYVIRGINIA.GOV,County,Non-Federal Agency,Roanoke,VA,ACTIVE
+ROCKBRIDGECOUNTYVA.GOV,County,Non-Federal Agency,Lexington,VA,ACTIVE
+ROCKCOUNTY-WI.GOV,County,Non-Federal Agency,Janesville,WI,ACTIVE
+ROCKDALECOUNTYGA.GOV,County,Non-Federal Agency,Conyers,GA,ACTIVE
+ROCKINGHAMCOUNTYVA.GOV,County,Non-Federal Agency,Harrisonburg,VA,ACTIVE
+ROSEBUDCOUNTYMT.GOV,County,Non-Federal Agency,Forsyth,MT,ACTIVE
+ROSSCOUNTYOHIO.GOV,County,Non-Federal Agency,Chillicothe,OH,ACTIVE
+RUTHERFORDCOUNTYNC.GOV,County,Non-Federal Agency,Rutherfordton,NC,ACTIVE
+RUTHERFORDCOUNTYTN.GOV,County,Non-Federal Agency,Murfreesboro,TN,ACTIVE
+SAGUACHECOUNTY-CO.GOV,County,Non-Federal Agency,Saguache,CO,ACTIVE
+SALEMCOUNTYNJ.GOV,County,Non-Federal Agency,Salem,NJ,ACTIVE
+SANDIEGOCOUNTY.GOV,County,Non-Federal Agency,San Diego,CA,ACTIVE
+SANDOVALCOUNTYNM.GOV,County,Non-Federal Agency,Bernalillo,NM,ACTIVE
+SANMIGUELCOUNTYCO.GOV,County,Non-Federal Agency,TELLURIDE,CO,ACTIVE
+SANPETECOUNTY-UT.GOV,County,Non-Federal Agency,Manti,UT,ACTIVE
+SANTACLARACOUNTYCA.GOV,County,Non-Federal Agency,San Jose,CA,ACTIVE
+SANTACRUZCOUNTYAZ.GOV,County,Non-Federal Agency,Nogales,AZ,ACTIVE
+SANTAFECOUNTYNM.GOV,County,Non-Federal Agency,Santa Fe,NM,ACTIVE
+SARATOGACOUNTYNY.GOV,County,Non-Federal Agency,Ballston Spa,NY,ACTIVE
+SAUKCOUNTYWI.GOV,County,Non-Federal Agency,Baraboo,WI,ACTIVE
+SBCOUNTY.GOV,County,Non-Federal Agency,San Bernardino,CA,ACTIVE
+SCHOHARIECOUNTY-NY.GOV,County,Non-Federal Agency,Schoharie,NY,ACTIVE
+SCOTTCOUNTY-TN.GOV,County,Non-Federal Agency,Huntsville,TN,ACTIVE
+SCOTTCOUNTYMN.GOV,County,Non-Federal Agency,Shakopee,MN,ACTIVE
+SCOTTCOUNTYMS.GOV,County,Non-Federal Agency,Forest,MS,ACTIVE
+SEBASTIANCOUNTYAR.GOV,County,Non-Federal Agency,Fort Smith,AR,ACTIVE
+SENECACOUNTYOHIO.GOV,County,Non-Federal Agency,Tiffin,OH,ACTIVE
+SEQUATCHIECOUNTY-TN.GOV,County,Non-Federal Agency,Dunlap,TN,ACTIVE
+SEVIERCOUNTYTN.GOV,County,Non-Federal Agency,Sevierville,TN,ACTIVE
+SHARKEYCOUNTYMS.GOV,County,Non-Federal Agency,Rolling Fork,MS,ACTIVE
+SHELBYCOUNTYTN.GOV,County,Non-Federal Agency,Memphis,TN,ACTIVE
+SIERRACOUNTYNM.GOV,County,Non-Federal Agency,Truth or Consequences,NM,ACTIVE
+SNOHOMISHCOUNTYWA.GOV,County,Non-Federal Agency,Everett,WA,ACTIVE
+SONOMACOUNTYCA.GOV,County,Non-Federal Agency,Santa Rosa,CA,ACTIVE
+SPENCERCOUNTYKY.GOV,County,Non-Federal Agency,Taylorsville,KY,ACTIVE
+SPOTSYLVANIACOUNTY-VA.GOV,County,Non-Federal Agency,Spotsylvania,VA,ACTIVE
+SPOTSYLVANIACOUNTYVA.GOV,County,Non-Federal Agency,Spotsylvania,VA,ACTIVE
+STAFFORDCOUNTYVA.GOV,County,Non-Federal Agency,Stafford,VA,ACTIVE
+STANLYCOUNTYNC.GOV,County,Non-Federal Agency,Albemarle,NC,ACTIVE
+STARKCOUNTYND.GOV,County,Non-Federal Agency,Bismarck,ND,ACTIVE
+STARKCOUNTYOHIO.GOV,County,Non-Federal Agency,Canton,OH,ACTIVE
+STCHARLESPARISH-LA.GOV,County,Non-Federal Agency,Hahnville,LA,ACTIVE
+STCLAIRCOUNTYIL.GOV,County,Non-Federal Agency,Belleville,IL,ACTIVE
+STEARNSCOUNTYMN.GOV,County,Non-Federal Agency,Saint Cloud,MN,ACTIVE
+STEPHENSCOUNTYTX.GOV,County,Non-Federal Agency,Breckenridge,TX,ACTIVE
+STEWARTCOUNTYGA.GOV,County,Non-Federal Agency,Lumpkin,GA,ACTIVE
+STJOHN-LA.GOV,County,Non-Federal Agency,LaPlace,LA,ACTIVE
+STJOHNBAPTISTPARISHLA.GOV,County,Non-Federal Agency,LaPlace,LA,ACTIVE
+STLOUISCOUNTYMN.GOV,County,Non-Federal Agency,Duluth,MN,ACTIVE
+STMARYPARISHLA.GOV,County,Non-Federal Agency,FRANKLIN,LA,ACTIVE
+STOKESCOUNTYNC.GOV,County,Non-Federal Agency,Danbury,NC,ACTIVE
+STONECOUNTYMS.GOV,County,Non-Federal Agency,Wiggins,MS,ACTIVE
+STORYCOUNTYIOWA.GOV,County,Non-Federal Agency,Nevada,IA,ACTIVE
+SUFFOLKCOUNTYNY.GOV,County,Non-Federal Agency,Hauppauge,NY,ACTIVE
+SULLIVANCOUNTYNH.GOV,County,Non-Federal Agency,Newport,NH,ACTIVE
+SULLIVANCOUNTYTN.GOV,County,Non-Federal Agency,Blountville,TN,ACTIVE
+SUMMERSCOUNTYWV.GOV,County,Non-Federal Agency,Hinton,WV,ACTIVE
+SUMMITCOUNTYCO.GOV,County,Non-Federal Agency,Breckenridge,CO,ACTIVE
+SUMTERCOUNTYFL.GOV,County,Non-Federal Agency,Bushnell,FL,ACTIVE
+SURRYCOUNTYVA.GOV,County,Non-Federal Agency,Surry,VA,ACTIVE
+SUSSEXCOUNTYDE.GOV,County,Non-Federal Agency,Georgetown,DE,ACTIVE
+SUSSEXCOUNTYVA.GOV,County,Non-Federal Agency,Sussex,VA,ACTIVE
+SWAINCOUNTYNC.GOV,County,Non-Federal Agency,Bryson City,NC,ACTIVE
+TALBOTCOUNTYMD.GOV,County,Non-Federal Agency,Easton,MD,ACTIVE
+TAMACOUNTYIOWA.GOV,County,Non-Federal Agency,Toledo,IA,ACTIVE
+TARRANTCOUNTYTX.GOV,County,Non-Federal Agency,Fort Worth,TX,ACTIVE
+TETONCOUNTYIDAHO.GOV,County,Non-Federal Agency,Driggs,ID,ACTIVE
+TEXASCOUNTYMISSOURI.GOV,County,Non-Federal Agency,Houston,MO,ACTIVE
+THAYERCOUNTYNE.GOV,County,Non-Federal Agency,Hebron,NE,ACTIVE
+THOMASCOUNTYGA.GOV,County,Non-Federal Agency,Thomasville,GA,ACTIVE
+THOMASCOUNTYKS.GOV,County,Non-Federal Agency,Colby,KS,ACTIVE
+THURSTONCOUNTYWA.GOV,County,Non-Federal Agency,Olympia,WA,ACTIVE
+TOMGREENCOUNTYTX.GOV,County,Non-Federal Agency,San Angelo,TX,ACTIVE
+TOMPKINSCOUNTYNY.GOV,County,Non-Federal Agency,Ithaca,NY,ACTIVE
+TOOELECOUNTYUT.GOV,County,Non-Federal Agency,Tooele,UT,ACTIVE
+TOOLECOUNTYMT.GOV,County,Non-Federal Agency,Shelby,MT,ACTIVE
+TOOMBSCOUNTYGA.GOV,County,Non-Federal Agency,Lyons,GA,ACTIVE
+TRAVISCOUNTYTX.GOV,County,Non-Federal Agency,Austin,TX,ACTIVE
+TROUSDALECOUNTYTN.GOV,County,Non-Federal Agency,Hartsville,TN,ACTIVE
+ULSTERCOUNTYNY.GOV,County,Non-Federal Agency,Kingston,NY,ACTIVE
+UNICOICOUNTYTN.GOV,County,Non-Federal Agency,Erwin,TN,ACTIVE
+UNIONCOUNTY-FL.GOV,County,Non-Federal Agency,Lake Butler,FL,ACTIVE
+UNIONCOUNTYGA.GOV,County,Non-Federal Agency,Blairsveille,GA,ACTIVE
+UNIONCOUNTYIL.GOV,County,Non-Federal Agency,Jonesboro,IL,ACTIVE
+UNIONCOUNTYIN.GOV,County,Non-Federal Agency,Liberty,IN,ACTIVE
+UNIONCOUNTYNC.GOV,County,Non-Federal Agency,Monroe,NC,ACTIVE
+UTAHCOUNTY.GOV,County,Non-Federal Agency,Provo,UT,ACTIVE
+VALLEYCOUNTYMT.GOV,County,Non-Federal Agency,Glasgow,MT,ACTIVE
+VANBURENCOUNTYIA.GOV,County,Non-Federal Agency,Keosauqua,IA,ACTIVE
+VILASCOUNTYWI.GOV,County,Non-Federal Agency,Eagle River,WI,ACTIVE
+VINTONCOUNTYOHIO.GOV,County,Non-Federal Agency,McArthur,OH,ACTIVE
+WARRENCOUNTYKY.GOV,County,Non-Federal Agency,Bowling Green,KY,ACTIVE
+WARRENCOUNTYNC.GOV,County,Non-Federal Agency,Warrenton,NC,ACTIVE
+WARRENCOUNTYNY.GOV,County,Non-Federal Agency,Lake George,NY,ACTIVE
+WARRENCOUNTYTN.GOV,County,Non-Federal Agency,McMinnville,TN,ACTIVE
+WARRICKCOUNTY.GOV,County,Non-Federal Agency,Boonville,IN,ACTIVE
+WASHAKIECOUNTYWY.GOV,County,Non-Federal Agency,Worland,WY,ACTIVE
+WASHINGTONCOUNTYGA.GOV,County,Non-Federal Agency,Sandersville,GA,ACTIVE
+WASHINGTONCOUNTYKS.GOV,County,Non-Federal Agency,Washington,KS,ACTIVE
+WASHINGTONCOUNTYNY.GOV,County,Non-Federal Agency,Fort Edward,NY,ACTIVE
+WASHTENAWCOUNTY-MI.GOV,County,Non-Federal Agency,Ann Arbor,MI,ACTIVE
+WAUKESHACOUNTY-WI.GOV,County,Non-Federal Agency,Waukesha,WI,ACTIVE
+WAUKESHACOUNTY.GOV,County,Non-Federal Agency,Waukesha,WI,ACTIVE
+WAYNECOUNTY-GA.GOV,County,Non-Federal Agency,JESUP,GA,ACTIVE
+WAYNECOUNTYMS.GOV,County,Non-Federal Agency,Waynesboro,MS,ACTIVE
+WAYNECOUNTYPA.GOV,County,Non-Federal Agency,Honesdale,PA,ACTIVE
+WEAKLEYCOUNTYTN.GOV,County,Non-Federal Agency,Dresden,TN,ACTIVE
+WEBBCOUNTYTX.GOV,County,Non-Federal Agency,Laredo,TX,ACTIVE
+WEBERCOUNTYUTAH.GOV,County,Non-Federal Agency,Ogden,UT,ACTIVE
+WEBSTERCOUNTYMO.GOV,County,Non-Federal Agency,Marshfield,MO,ACTIVE
+WESTCHESTERCOUNTYNY.GOV,County,Non-Federal Agency,White Plains,NY,ACTIVE
+WESTFELICIANAPARISH-LA.GOV,County,Non-Federal Agency,St. Francisville,LA,ACTIVE
+WHITECOUNTYGA.GOV,County,Non-Federal Agency,Cleveland,GA,ACTIVE
+WHITECOUNTYTN.GOV,County,Non-Federal Agency,Sparta,TN,ACTIVE
+WHITEPINECOUNTYNV.GOV,County,Non-Federal Agency,Ely,NV,ACTIVE
+WILLCOUNTY-IL.GOV,County,Non-Federal Agency,Joliet,IL,ACTIVE
+WILLIAMSONCOUNTY-TN.GOV,County,Non-Federal Agency,Franklin,TN,ACTIVE
+WILLIAMSONCOUNTYIL.GOV,County,Non-Federal Agency,Marion,IL,ACTIVE
+WILSONCOUNTYTN.GOV,County,Non-Federal Agency,Lebanon,TN,ACTIVE
+WILSONCOUNTYTX.GOV,County,Non-Federal Agency,Floresville,TX,ACTIVE
+WINDHAMCOUNTYVT.GOV,County,Non-Federal Agency,Newfane,VT,ACTIVE
+WINNEBAGOCOUNTYIOWA.GOV,County,Non-Federal Agency,Forest City,IA,ACTIVE
+WOODBURYCOUNTYIOWA.GOV,County,Non-Federal Agency,Sioux City,IA,ACTIVE
+WORCESTERCOUNTYMD.GOV,County,Non-Federal Agency,Snow Hill,MD,ACTIVE
+YANCEYCOUNTYNC.GOV,County,Non-Federal Agency,Burnsville,NC,ACTIVE
+YAZOOCOUNTYMS.GOV,County,Non-Federal Agency,Yazoo City,MS,ACTIVE
+YCSOAZ.GOV,County,Non-Federal Agency,Prescott,AZ,ACTIVE
+YORKCOUNTY.GOV,County,Non-Federal Agency,Yorktown,VA,ACTIVE
+YORKCOUNTYMAINE.GOV,County,Non-Federal Agency,Alfred,ME,ACTIVE
+YORKCOUNTYME.GOV,County,Non-Federal Agency,Alfred,ME,ACTIVE
+YORKCOUNTYPA.GOV,County,Non-Federal Agency,York,PA,ACTIVE
+YUMACOUNTYARIZONA.GOV,County,Non-Federal Agency,Yuma,AZ,ACTIVE
+YUMACOUNTYAZ.GOV,County,Non-Federal Agency,Yuma,AZ,ACTIVE
+ZAPATACOUNTYTX.GOV,County,Non-Federal Agency,Zapata,TX,ACTIVE
+ACUS.GOV,Federal Agency,Administrative Conference of the United States,WASHINGTON,DC,ACTIVE
+ACHP.GOV,Federal Agency,Advisory Council on Historic Preservation,Washington,DC,ACTIVE
+PRESERVEAMERICA.GOV,Federal Agency,Advisory Council on Historic Preservation,Washington,DC,ACTIVE
+ADF.GOV,Federal Agency,African Development Foundation,Washington,DC,ACTIVE
+USADF.GOV,Federal Agency,African Development Foundation,Washington,DC,ACTIVE
+ABMC.GOV,Federal Agency,American Battle Monuments Commission,Arlington,VA,ACTIVE
+AMTRAKOIG.GOV,Federal Agency,AMTRAK,Washington,DC,ACTIVE
+ARC.GOV,Federal Agency,Appalachian Regional Commission,Washington,DC,ACTIVE
+ASC.GOV,Federal Agency,Appraisal Subcommittee,Washington,DC,ACTIVE
+AFRH.GOV,Federal Agency,Armed Forces Retirement Home,Washington,DC,ACTIVE
+CIA.GOV,Federal Agency,Central Intelligence Agency,Washington,DC,ACTIVE
+IC.GOV,Federal Agency,Central Intelligence Agency,Washington,DC,ACTIVE
+ISTAC.GOV,Federal Agency,Central Intelligence Agency,Washington,DC,ACTIVE
+NCTC.GOV,Federal Agency,Central Intelligence Agency,Washington,DC,ACTIVE
+ODCI.GOV,Federal Agency,Central Intelligence Agency,Washington,DC,ACTIVE
+OPENSOURCE.GOV,Federal Agency,Central Intelligence Agency,Washington,DC,ACTIVE
+OSDE.GOV,Federal Agency,Central Intelligence Agency,Reston,VA,ACTIVE
+TTIC.GOV,Federal Agency,Central Intelligence Agency,Washington,DC,ACTIVE
+UCIA.GOV,Federal Agency,Central Intelligence Agency,Washington,DC,ACTIVE
+CHRISTOPHERCOLUMBUSFOUNDATION.GOV,Federal Agency,Christopher Columbus Fellowship Foundation,Washington,DC,ACTIVE
+CAP.GOV,Federal Agency,Civil Air Patrol,BIRMINGHAM,MI,ACTIVE
+CAPNHQ.GOV,Federal Agency,Civil Air Patrol,MAXWELL AFB,AL,ACTIVE
+ABILITYONE.FED.US,Federal Agency,Comm for People Who Are Blind/Severly Disabled,Arlington,VA,ACTIVE
+ABILITYONE.GOV,Federal Agency,Comm for People Who Are Blind/Severly Disabled,Arlington,VA,ACTIVE
+JWOD.GOV,Federal Agency,Comm for People Who Are Blind/Severly Disabled,Arlington,VA,ACTIVE
+GOODLETTSVILLE.GOV,Federal Agency,Commission on Civil Rights,Goodlettsville,TN,ACTIVE
+CFTC.GOV,Federal Agency,Commodity Futures Trading Commission,Washington,DC,ACTIVE
+SMARTCHECK.GOV,Federal Agency,Commodity Futures Trading Commission,Washington,DC,ACTIVE
+WHISTLEBLOWER.GOV,Federal Agency,Commodity Futures Trading Commission,Washington,DC,ACTIVE
+COMPLIANCE.GOV,Federal Agency,Congressional Office of Compliance,Washington,DC,ACTIVE
+BCFP.GOV,Federal Agency,Consumer Financial Protection Bureau,Washington,DC,ACTIVE
+CFPA.GOV,Federal Agency,Consumer Financial Protection Bureau,Washington,DC,ACTIVE
+CFPB.GOV,Federal Agency,Consumer Financial Protection Bureau,Washington,DC,ACTIVE
+CONSUMERBUREAU.GOV,Federal Agency,Consumer Financial Protection Bureau,Washington,DC,ACTIVE
+CONSUMERFINANCE.GOV,Federal Agency,Consumer Financial Protection Bureau,Washington,DC,ACTIVE
+CONSUMERFINANCIAL.GOV,Federal Agency,Consumer Financial Protection Bureau,Washington,DC,ACTIVE
+CONSUMERFINANCIALBUREAU.GOV,Federal Agency,Consumer Financial Protection Bureau,Washington,DC,ACTIVE
+CONSUMERFINANCIALPROTECTIONBUREAU.GOV,Federal Agency,Consumer Financial Protection Bureau,Washington,DC,ACTIVE
+CONSUMERPROTECTION.GOV,Federal Agency,Consumer Financial Protection Bureau,Washington,DC,ACTIVE
+CONSUMERPROTECTIONBUREAU.GOV,Federal Agency,Consumer Financial Protection Bureau,Washington,DC,ACTIVE
+ANCHORIT.GOV,Federal Agency,Consumer Product Safety Commission,Bethesda,MD,ACTIVE
+ATVSAFETY.GOV,Federal Agency,Consumer Product Safety Commission,Bethesda,MD,ACTIVE
+CPSC.GOV,Federal Agency,Consumer Product Safety Commission,Bethesda,MD,ACTIVE
+DRYWALLRESPONSE.GOV,Federal Agency,Consumer Product Safety Commission,Bethesda,MD,ACTIVE
+POOLSAFELY.GOV,Federal Agency,Consumer Product Safety Commission,Bethesda,MD,ACTIVE
+POOLSAFETY.GOV,Federal Agency,Consumer Product Safety Commission,Bethesda,MD,ACTIVE
+RECALLS.GOV,Federal Agency,Consumer Product Safety Commission,Bethesda,MD,ACTIVE
+SAFERPRODUCT.GOV,Federal Agency,Consumer Product Safety Commission,Bethesda,MD,ACTIVE
+SAFERPRODUCTS.GOV,Federal Agency,Consumer Product Safety Commission,Bethesda,MD,ACTIVE
+SEGURIDADCONSUMIDOR.GOV,Federal Agency,Consumer Product Safety Commission,Bethesda,MD,ACTIVE
+AMERICORE.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC,ACTIVE
+AMERICORP.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC,ACTIVE
+AMERICORPS.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC,ACTIVE
+AMERICORPSCONNECT.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC,ACTIVE
+AMERICORPSWEEK.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC,ACTIVE
+CNCS.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC,ACTIVE
+CNCSOIG.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC,ACTIVE
+CNS.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC,ACTIVE
+FEDERALMENTORINGCOUNCIL.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC,ACTIVE
+GETINVOLVED.GOV,Federal Agency,Corporation for National & Community Service,Washington ,DC,ACTIVE
+LEARNANDSERVE.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC,ACTIVE
+MENTOR.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC,ACTIVE
+MLKDAY.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC,ACTIVE
+NATIONALSERVICE.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC,ACTIVE
+NATIONALSERVICEGEAR.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC,ACTIVE
+NATIONALSERVICERESOURCES.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC,ACTIVE
+PRESIDENTIALSERVICEAWARDS.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC,ACTIVE
+SENIORCORPS.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC,ACTIVE
+SERVE.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC,ACTIVE
+SERVICE.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC,ACTIVE
+SERVICELEARNING.GOV,Federal Agency,Corporation for National & Community Service,Washington ,DC,ACTIVE
+SERVIR.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC,ACTIVE
+VISTA.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC,ACTIVE
+VISTACAMPUS.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC,ACTIVE
+VOLUNTEERINGINAMERICA.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC,ACTIVE
+CIGIE.GOV,Federal Agency,Council of Inspector General on Integrity and Efficiency,WASHINGTON,DC,ACTIVE
+IGNET.GOV,Federal Agency,Council of Inspector General on Integrity and Efficiency,Washington,DC,ACTIVE
+OVERSIGHT.GOV,Federal Agency,Council of Inspector General on Integrity and Efficiency,Washington,DC,ACTIVE
+CSOSA.FED.US,Federal Agency,Court Services and Offender Supervision,Washington,DC,ACTIVE
+CSOSA.GOV,Federal Agency,Court Services and Offender Supervision,Washington,DC,ACTIVE
+PRETRIALSERVICES.GOV,Federal Agency,Court Services and Offender Supervision,Washington,DC,ACTIVE
+PSA.GOV,Federal Agency,Court Services and Offender Supervision,Washington,DC,ACTIVE
+DNFSB.GOV,Federal Agency,Defense Nuclear Facilities Safety Board,Washington,DC,ACTIVE
+DRA.GOV,Federal Agency,Delta Regional Authority,Clarksdale,MS,ACTIVE
+DENALI.GOV,Federal Agency,Denali Commission,Anchorage,AK,ACTIVE
+FEA.GOV,Federal Agency,Denali Commission,Anchorage,AK,ACTIVE
+AFF.GOV,Federal Agency,Department of Agriculture,Boise,ID,ACTIVE
+AG.GOV,Federal Agency,Department of Agriculture,Fort Collins,CO,ACTIVE
+ARS-GRIN.GOV,Federal Agency,Department of Agriculture,Beltsville,MD,ACTIVE
+ARSUSDA.GOV,Federal Agency,Department of Agriculture,Beltsville,MD,ACTIVE
+ASKKAREN.GOV,Federal Agency,Department of Agriculture,Washington,DC,ACTIVE
+BEFOODSAFE.GOV,Federal Agency,Department of Agriculture,Washington,DC,ACTIVE
+BIOPREFERRED.GOV,Federal Agency,Department of Agriculture,Washington,DC,ACTIVE
+BOSQUE.GOV,Federal Agency,Department of Agriculture,Albuquerque,NM,ACTIVE
+CHOOSEMYPLATE.GOV,Federal Agency,Department of Agriculture,Alexandria,VA,ACTIVE
+COASTALAMERICA.GOV,Federal Agency,Department of Agriculture,Washington,DC,ACTIVE
+DIETARYGUIDELINES.GOV,Federal Agency,Department of Agriculture,Alexandria,VA,ACTIVE
+EMPOWHR.GOV,Federal Agency,Department of Agriculture,New Orleans,LA,ACTIVE
+EXECSEC.GOV,Federal Agency,Department of Agriculture,Washington,DC,ACTIVE
+FARMERCLAIMS.GOV,Federal Agency,Department of Agriculture,St. Louis,MO,ACTIVE
+FEMALEFARMERCLAIMS.GOV,Federal Agency,Department of Agriculture,St. Louis,MO,ACTIVE
+FIREINSTITUTE.GOV,Federal Agency,Department of Agriculture,Tucson,AZ,ACTIVE
+FOODSAFETYJOBS.GOV,Federal Agency,Department of Agriculture,Washington,DC,ACTIVE
+FOODSAFETYWORKINGGROUP.GOV,Federal Agency,Department of Agriculture,Washington,DC,ACTIVE
+FORESTSANDRANGELANDS.GOV,Federal Agency,Department of Agriculture,Washington,DC,ACTIVE
+FS.FED.US,Federal Agency,Department of Agriculture,Washington,DC,ACTIVE
+GREEN.GOV,Federal Agency,Department of Agriculture,Washington,DC,ACTIVE
+HISPANICFARMERCLAIMS.GOV,Federal Agency,Department of Agriculture,St. Louis,MO,ACTIVE
+ICBEMP.GOV,Federal Agency,Department of Agriculture,Portland,OR,ACTIVE
+IIOG.GOV,Federal Agency,Department of Agriculture,Meridian,ID,ACTIVE
+INVASIVESPECIESINFO.GOV,Federal Agency,Department of Agriculture,Beltsville,MD,ACTIVE
+IPM.GOV,Federal Agency,Department of Agriculture,Washington,DC,ACTIVE
+ISITDONEYET.GOV,Federal Agency,Department of Agriculture,Washington,DC,ACTIVE
+ITAP.GOV,Federal Agency,Department of Agriculture,Beltsville,MD,ACTIVE
+JUNIORFORESTRANGER.GOV,Federal Agency,Department of Agriculture,Washington,DC,ACTIVE
+LATINOFARMERCLAIMS.GOV,Federal Agency,Department of Agriculture,St. Louis,MO,ACTIVE
+LCACOMMONS.GOV,Federal Agency,Department of Agriculture,Beltsville,MD,ACTIVE
+MTBS.GOV,Federal Agency,Department of Agriculture,Salt Lake City,UT,ACTIVE
+NAFRI.GOV,Federal Agency,Department of Agriculture,Tucson,AZ,ACTIVE
+NEL.GOV,Federal Agency,Department of Agriculture,Alexandria,VA,ACTIVE
+NUTRITION.GOV,Federal Agency,Department of Agriculture,Washington,DC,ACTIVE
+NUTRITIONEVIDENCELIBRARY.GOV,Federal Agency,Department of Agriculture,Alexandria,VA,ACTIVE
+NWCG.GOV,Federal Agency,Department of Agriculture,Boise,ID,ACTIVE
+PREGUNTELEAKAREN.GOV,Federal Agency,Department of Agriculture,Washington,DC,ACTIVE
+RECREATION.GOV,Federal Agency,Department of Agriculture,Ogden,UT,ACTIVE
+REO.GOV,Federal Agency,Department of Agriculture,Portland,OR,ACTIVE
+SMOKEYBEAR.GOV,Federal Agency,Department of Agriculture,Washington,DC,ACTIVE
+START2FARM.GOV,Federal Agency,Department of Agriculture,Beltsville,MD,ACTIVE
+SYMBOLS.GOV,Federal Agency,Department of Agriculture,Washington,DC,ACTIVE
+THEPEOPLESGARDEN.GOV,Federal Agency,Department of Agriculture,Wahington,DC,ACTIVE
+USDA.GOV,Federal Agency,Department of Agriculture,Ft. Collins,CO,ACTIVE
+USDAPII.GOV,Federal Agency,Department of Agriculture,Washington,DC,ACTIVE
+WILDFIRE.GOV,Federal Agency,Department of Agriculture,Boise,ID,ACTIVE
+WOMENFARMERCLAIMS.GOV,Federal Agency,Department of Agriculture,St. Louis,MO,ACTIVE
+WOODSY.GOV,Federal Agency,Department of Agriculture,Washington,DC,ACTIVE
+WOODSYOWL.GOV,Federal Agency,Department of Agriculture,Washington,DC,ACTIVE
+AP.GOV,Federal Agency,Department of Commerce,Washington,DC,ACTIVE
+AVIATIONWEATHER.GOV,Federal Agency,Department of Commerce,Silver Spring,MD,ACTIVE
+BEA.GOV,Federal Agency,Department of Commerce,Washington,DC,ACTIVE
+BLDRDOC.GOV,Federal Agency,Department of Commerce,Boulder,CO,ACTIVE
+BUYUSA.GOV,Federal Agency,Department of Commerce,Washington,DC,ACTIVE
+CBP.GOV,Federal Agency,Department of Commerce,Alexandria,VA,ACTIVE
+CENSUS.GOV,Federal Agency,Department of Commerce,Suitland,MD,ACTIVE
+CIVILRIGHTSUSA.GOV,Federal Agency,Department of Commerce,Alexandria,VA,ACTIVE
+CLIMATE.GOV,Federal Agency,Department of Commerce,Silver Spring,MD,ACTIVE
+CLIMATECHANGE.GOV,Federal Agency,Department of Commerce,Oak Ridge,TN,ACTIVE
+COMMERCE.GOV,Federal Agency,Department of Commerce,Washington,DC,ACTIVE
+COOP-USPTO.GOV,Federal Agency,Department of Commerce,Arlington,VA,ACTIVE
+DIGITALLITERACY.GOV,Federal Agency,Department of Commerce,Washington,DC,ACTIVE
+DNSOPS.GOV,Federal Agency,Department of Commerce,Gaithersburg,MD,ACTIVE
+DOC.GOV,Federal Agency,Department of Commerce,Washington,DC,ACTIVE
+DROUGHT.GOV,Federal Agency,Department of Commerce,Asheville,NC,ACTIVE
+EDA.GOV,Federal Agency,Department of Commerce,Washington,DC,ACTIVE
+ESA.GOV,Federal Agency,Department of Commerce,Washington,DC,ACTIVE
+EXPORT.GOV,Federal Agency,Department of Commerce,Washington,DC,ACTIVE
+FCSM.GOV,Federal Agency,Department of Commerce,Suitland,MD,SERVER-HOLD
+FIRSTNET.GOV,Federal Agency,Department of Commerce,Washington,DC,ACTIVE
+FISHWATCH.GOV,Federal Agency,Department of Commerce,Silver Spring,MD,ACTIVE
+GETYOUHOME.GOV,Federal Agency,Department of Commerce,Alexandria,VA,ACTIVE
+GLOBALENTRY.GOV,Federal Agency,Department of Commerce,Alexandria,VA,ACTIVE
+GOES-R.GOV,Federal Agency,Department of Commerce,Greenbelt,MD,ACTIVE
+GPS.GOV,Federal Agency,Department of Commerce,Washington,DC,ACTIVE
+HURRICANES.GOV,Federal Agency,Department of Commerce,Miami,FL,ACTIVE
+ITDS.GOV,Federal Agency,Department of Commerce,Springfield,VA,ACTIVE
+MANUFACTURING.GOV,Federal Agency,Department of Commerce,Washington,DC,ACTIVE
+MAPSTATS.GOV,Federal Agency,Department of Commerce,Washington,DC,SERVER-HOLD
+MARINECADASTRE.GOV,Federal Agency,Department of Commerce,Charleston,SC,ACTIVE
+MBDA.GOV,Federal Agency,Department of Commerce,Washington,DC,ACTIVE
+MGI.GOV,Federal Agency,Department of Commerce,Gaithersburg,MD,ACTIVE
+NEHRP.GOV,Federal Agency,Department of Commerce,Gaithersburg,MD,ACTIVE
+NIST.GOV,Federal Agency,Department of Commerce,Gaithersburg,MD,ACTIVE
+NOAA.GOV,Federal Agency,Department of Commerce,Silver Spring,MD,ACTIVE
+NTIS.GOV,Federal Agency,Department of Commerce,Alexandria,VA,ACTIVE
+OFCM.GOV,Federal Agency,Department of Commerce,Silver Spring,MD,ACTIVE
+PAPAHANAUMOKUAKEA.GOV,Federal Agency,Department of Commerce,Silver Spring,MD,ACTIVE
+PRIVACYSHIELD.GOV,Federal Agency,Department of Commerce,Washington,DC,ACTIVE
+PSCR.GOV,Federal Agency,Department of Commerce,Boulder,CO,ACTIVE
+SDR.GOV,Federal Agency,Department of Commerce,Washington,DC,ACTIVE
+SELECTUSA.GOV,Federal Agency,Department of Commerce,Washington,DC,ACTIVE
+SPACEWEATHER.GOV,Federal Agency,Department of Commerce,Boulder,CO,ACTIVE
+SPECTRUM.GOV,Federal Agency,Department of Commerce,Washington,DC,ACTIVE
+STANDARDS.GOV,Federal Agency,Department of Commerce,Gaithersburg,MD,ACTIVE
+TIME.GOV,Federal Agency,Department of Commerce,Boulder,CO,ACTIVE
+TRADE.GOV,Federal Agency,Department of Commerce,Washington,DC,ACTIVE
+TSUNAMI.GOV,Federal Agency,Department of Commerce,Palmer,AK,ACTIVE
+USPTO.GOV,Federal Agency,Department of Commerce,Washington,DC,ACTIVE
+WDOL.GOV,Federal Agency,Department of Commerce,Alexandria,VA,ACTIVE
+WEATHER.GOV,Federal Agency,Department of Commerce,Silver Spring,MD,ACTIVE
+ADLNET.GOV,Federal Agency,Department of Defense,Washington,DC,ACTIVE
+AFTAC.GOV,Federal Agency,Department of Defense,Patrick AFB,FL,ACTIVE
+ALTUSANDC.GOV,Federal Agency,Department of Defense,"patrick, afb",FL,ACTIVE
+BRAC.GOV,Federal Agency,Department of Defense,Alexandria,VA,ACTIVE
+CMTS.GOV,Federal Agency,Department of Defense,Mobile,AL,ACTIVE
+CNSS.GOV,Federal Agency,Department of Defense,Ft George G. Meade,MD,ACTIVE
+CTOC.GOV,Federal Agency,Department of Defense,Starke,FL,ACTIVE
+CTTSO.GOV,Federal Agency,Department of Defense,Arlington,VA,ACTIVE
+DC3ON.GOV,Federal Agency,Department of Defense,Linthicum,MD,ACTIVE
+DEFENSE.GOV,Federal Agency,Department of Defense,Fort Meade,MD,ACTIVE
+DOD.GOV,Federal Agency,Department of Defense,Fort Meade,MD,ACTIVE
+EACLEARINGHOUSE.GOV,Federal Agency,Department of Defense,Arlington,VA,ACTIVE
+ERDC.GOV,Federal Agency,Department of Defense,Vicksburg,MS,ACTIVE
+FVAP.GOV,Federal Agency,Department of Defense,Alexandria,VA,ACTIVE
+IAD.GOV,Federal Agency,Department of Defense,Ft Meade,MD,ACTIVE
+IOSS.GOV,Federal Agency,Department of Defense,Greenbelt,MD,ACTIVE
+ITC.GOV,Federal Agency,Department of Defense,Ft. Washington,MD,ACTIVE
+JCCS.GOV,Federal Agency,Department of Defense,Alexandria,VA,ACTIVE
+MCRMC.GOV,Federal Agency,Department of Defense,Arlington,VA,ACTIVE
+MOJAVEDATA.GOV,Federal Agency,Department of Defense,Barstow,CA,ACTIVE
+MTMC.GOV,Federal Agency,Department of Defense,Alexandria,VA,ACTIVE
+MYPAY.GOV,Federal Agency,Department of Defense,Pensacola,FL,ACTIVE
+NCR.GOV,Federal Agency,Department of Defense,Washington,DC,ACTIVE
+NRO.GOV,Federal Agency,Department of Defense,Chantilly,VA,ACTIVE
+NROJR.GOV,Federal Agency,Department of Defense,Chantilly,VA,ACTIVE
+NSA.GOV,Federal Agency,Department of Defense,Ft. Meade,MD,ACTIVE
+NSEP.GOV,Federal Agency,Department of Defense,Arlington,VA,ACTIVE
+OEA.GOV,Federal Agency,Department of Defense,Arlington,VA,ACTIVE
+OSDBU.GOV,Federal Agency,Department of Defense,Washington,DC,ACTIVE
+PENTAGON.GOV,Federal Agency,Department of Defense,Fort Meade,MD,ACTIVE
+SITEIDIQ.GOV,Federal Agency,Department of Defense,Arlington,VA,ACTIVE
+TSWG.GOV,Federal Agency,Department of Defense,Arlington,VA,ACTIVE
+USANDC.GOV,Federal Agency,Department of Defense,Patrick AFB,FL,ACTIVE
+AAPI.GOV,Federal Agency,Department of Education,Washington,DC,ACTIVE
+BFELOB.GOV,Federal Agency,Department of Education,Washington,DC,ACTIVE
+CHILDSTATS.GOV,Federal Agency,Department of Education,Washington,DC,ACTIVE
+COLLEGENAVIGATOR.GOV,Federal Agency,Department of Education,Washington,DC,ACTIVE
+ED.GOV,Federal Agency,Department of Education,Washington,DC,ACTIVE
+EDPUBS.GOV,Federal Agency,Department of Education,Washington ,DC,ACTIVE
+EDUCATION.GOV,Federal Agency,Department of Education,Washington,DC,ACTIVE
+FAFSA.GOV,Federal Agency,Department of Education,Washington,DC,ACTIVE
+FSAPUBS.GOV,Federal Agency,Department of Education,Washington,DC,ACTIVE
+G5.GOV,Federal Agency,Department of Education,Washington,DC,ACTIVE
+NAGB.GOV,Federal Agency,Department of Education,Washington,DC,ACTIVE
+NATIONSREPORTCARD.GOV,Federal Agency,Department of Education,Washington,DC,ACTIVE
+STUDENTAID.GOV,Federal Agency,Department of Education,Washington,DC,ACTIVE
+STUDENTLOANS.GOV,Federal Agency,Department of Education,Washington,DC,ACTIVE
+AMESLAB.GOV,Federal Agency,Department of Energy,Ames,IA,ACTIVE
+ANL.GOV,Federal Agency,Department of Energy,Argonne,IL,ACTIVE
+ARM.GOV,Federal Agency,Department of Energy,Richland,WA,ACTIVE
+BIOMASSBOARD.GOV,Federal Agency,Department of Energy,Washington,DC,ACTIVE
+BNL.GOV,Federal Agency,Department of Energy,Upton,NY,ACTIVE
+BPA.GOV,Federal Agency,Department of Energy,Portland,OR,ACTIVE
+BRC.GOV,Federal Agency,Department of Energy,Washington,DC,ACTIVE
+BUILDINGAMERICA.GOV,Federal Agency,Department of Energy,Golden,CO,ACTIVE
+CASL.GOV,Federal Agency,Department of Energy,Oak Ridge,TN,ACTIVE
+CEBAF.GOV,Federal Agency,Department of Energy,Newport News,VA,ACTIVE
+CENDI.GOV,Federal Agency,Department of Energy,Oak Ridge,TN,ACTIVE
+CRT2014-2024REVIEW.GOV,Federal Agency,Department of Energy,Portland,OR,ACTIVE
+DOE.GOV,Federal Agency,Department of Energy,Washington,DC,ACTIVE
+DOEAL.GOV,Federal Agency,Department of Energy,Albuquerque,NM,ACTIVE
+EIA.GOV,Federal Agency,Department of Energy,Washington,DC,ACTIVE
+ENERGY.GOV,Federal Agency,Department of Energy,Washington,DC,ACTIVE
+ENERGYCODES.GOV,Federal Agency,Department of Energy,Richland,WA,ACTIVE
+ENERGYPLUS.GOV,Federal Agency,Department of Energy,Washington,DC,ACTIVE
+ENERGYSAVER.GOV,Federal Agency,Department of Energy,Washington,DC,ACTIVE
+ENERGYSAVERS.GOV,Federal Agency,Department of Energy,Washington,DC,ACTIVE
+FNAL.GOV,Federal Agency,Department of Energy,Batavia,IL,ACTIVE
+FUELECONOMY.GOV,Federal Agency,Department of Energy,Oak Ridge,TN,ACTIVE
+HANFORD.GOV,Federal Agency,Department of Energy,Richland,WA,ACTIVE
+HIGHPERFORMANCEBUILDINGS.GOV,Federal Agency,Department of Energy,Golden,CO,ACTIVE
+HOMEENERGYSCORE.GOV,Federal Agency,Department of Energy,Washington,DC,ACTIVE
+HYDROGEN.GOV,Federal Agency,Department of Energy,Washington,DC,ACTIVE
+INEL.GOV,Federal Agency,Department of Energy,Idaho Falls,ID,ACTIVE
+INL.GOV,Federal Agency,Department of Energy,Idaho Falls,ID,ACTIVE
+ISOTOPE.GOV,Federal Agency,Department of Energy,Oak Ridge,TN,ACTIVE
+ISOTOPES.GOV,Federal Agency,Department of Energy,Oak Ridge,TN,ACTIVE
+KAPL.GOV,Federal Agency,Department of Energy,Schenectady,NY,ACTIVE
+LANL.GOV,Federal Agency,Department of Energy,Los Alamos,NM,ACTIVE
+LBL.GOV,Federal Agency,Department of Energy,Berkeley,CA,ACTIVE
+LLNL.GOV,Federal Agency,Department of Energy,Livermore,CA,ACTIVE
+NCCRC.GOV,Federal Agency,Department of Energy,Oak Ridge,TN,ACTIVE
+NCCS.GOV,Federal Agency,Department of Energy,Oak Ridge,TN,ACTIVE
+NCRC.GOV,Federal Agency,Department of Energy,Oak Ridge,TN,ACTIVE
+NERSC.GOV,Federal Agency,Department of Energy,Berkeley,CA,ACTIVE
+NEUP.GOV,Federal Agency,Department of Energy,Washington,DC,ACTIVE
+NREL.GOV,Federal Agency,Department of Energy,Golden,CO,ACTIVE
+NRELHUB.GOV,Federal Agency,Department of Energy,Golden,CO,ACTIVE
+NTRC.GOV,Federal Agency,Department of Energy,Knoxville,TN,ACTIVE
+NUCLEAR.GOV,Federal Agency,Department of Energy,Washington,DC,ACTIVE
+ORAU.GOV,Federal Agency,Department of Energy,Oak Ridge,TN,ACTIVE
+ORNL.GOV,Federal Agency,Department of Energy,Oak Ridge,TN,ACTIVE
+OSTI.GOV,Federal Agency,Department of Energy,Oak Ridge,TN,ACTIVE
+PNL.GOV,Federal Agency,Department of Energy,Richland,WA,ACTIVE
+PNNL.GOV,Federal Agency,Department of Energy,Richland,WA,ACTIVE
+RL.GOV,Federal Agency,Department of Energy,Richland,WA,ACTIVE
+SALMONRECOVERY.GOV,Federal Agency,Department of Energy,Portland,OR,ACTIVE
+SANDIA.GOV,Federal Agency,Department of Energy,Albuquerque,NM,ACTIVE
+SCIDAC.GOV,Federal Agency,Department of Energy,Oak Ridge,TN,ACTIVE
+SCIENCE.GOV,Federal Agency,Department of Energy,Oak Ridge,TN,ACTIVE
+SCIENCEACCELERATOR.GOV,Federal Agency,Department of Energy,Oak Ridge,TN,ACTIVE
+SMARTGRID.GOV,Federal Agency,Department of Energy,Washington,DC,ACTIVE
+SNS.GOV,Federal Agency,Department of Energy,Oak Ridge,TN,ACTIVE
+SOLARDECATHLON.GOV,Federal Agency,Department of Energy,Golden,CO,ACTIVE
+SRS.GOV,Federal Agency,Department of Energy,Aiken,SC,ACTIVE
+SWPA.GOV,Federal Agency,Department of Energy,Tulsa,OK,ACTIVE
+UNNPP.GOV,Federal Agency,Department of Energy,West Mifflin,PA,ACTIVE
+UNRPNET.GOV,Federal Agency,Department of Energy,Washington,DC,ACTIVE
+WAPA.GOV,Federal Agency,Department of Energy,Lakewood,CO,ACTIVE
+WINDPOWERINGAMERICA.GOV,Federal Agency,Department of Energy,Golden,CO,ACTIVE
+YMP.GOV,Federal Agency,Department of Energy,Las Vegas,NV,ACTIVE
+ACF.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+ACL.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+AFTERSCHOOL.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+AGING.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+AGINGSTATS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+AHCPR.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE
+AHRQ.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE
+AIDS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+ALZHEIMERS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+AOA.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+BAM.GOV,Federal Agency,Department of Health And Human Services,Atlanta,GA,ACTIVE
+BESTBONESFOREVER.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+BETOBACCOFREE.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+BIOETHICS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+BIOSECURITYBOARD.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+BRAINHEALTH.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+CANCER.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE
+CANCERNET.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE
+CDC.GOV,Federal Agency,Department of Health And Human Services,Atlanta,GA,ACTIVE
+CHILDWELFARE.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+CLINICALTRIAL.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE
+CLINICALTRIALS.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE
+CLUBDRUGS.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE
+CMS.GOV,Federal Agency,Department of Health And Human Services,Baltimore,MD,ACTIVE
+COLLEGEDRINKINGPREVENTION.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE
+CUIDADODESALUD.GOV,Federal Agency,Department of Health And Human Services,Baltimore,MD,ACTIVE
+DHHS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+DIABETESCOMMITTEE.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+DOCLINE.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE
+DONACIONDEORGANOS.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE
+DRUGABUSE.GOV,Federal Agency,Department of Health And Human Services,Baltimore,MD,ACTIVE
+DRUGFREEWORKPLACE.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE
+EDISON.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE
+ELDERCARE.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+ENDINGTHEDOCUMENTGAME.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+ERRP.GOV,Federal Agency,Department of Health And Human Services,Baltimore,MD,ACTIVE
+FATHERHOOD.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+FDA.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE
+FINDYOUTHINFO.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE
+FITNESS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+FLU.GOV,Federal Agency,Department of Health And Human Services,Washington ,DC,ACTIVE
+FOODSAFETY.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+FRESHEMPIRE.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+FRUITSANDVEGGIESMATTER.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+GENBANK.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE
+GENOME.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE
+GIRLSHEALTH.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+GLOBALHEALTH.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE
+GRANTS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+GRANTSOLUTIONS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+GUIDELINE.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE
+GUIDELINES.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE
+HCQUALITYCOMMISSION.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE
+HEALTH.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+HEALTHCARE.GOV,Federal Agency,Department of Health And Human Services,Baltimore,MD,ACTIVE
+HEALTHDATA.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+HEALTHFINDER.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+HEALTHINDICATORS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+HEALTHIT.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+HEALTHREFORM.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+HEALTHYPEOPLE.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+HEARTTRUTH.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE
+HHS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+HHSOIG.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+HHSOPS.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE
+HIV.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+HRSA.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE
+IDEALAB.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+IEDISON.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE
+IHS.GOV,Federal Agency,Department of Health And Human Services,Albuquerque,NM,ACTIVE
+INSUREKIDSNOW.GOV,Federal Agency,Department of Health And Human Services,Baltimore,MD,ACTIVE
+KNOWTHEFACTSFIRST.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+LOCATORPLUS.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE
+LONGTERMCARE.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+MEDICAID.GOV,Federal Agency,Department of Health And Human Services,Baltimore,MD,ACTIVE
+MEDICALCOUNTERMEASURES.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+MEDICALRESERVECORPS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+MEDICARE.GOV,Federal Agency,Department of Health And Human Services,Baltimore,MD,ACTIVE
+MEDLINE.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE
+MEDLINEPLUS.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE
+MENTALHEALTH.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE
+MESH.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE
+MIMEDICARE.GOV,Federal Agency,Department of Health And Human Services,Baltimore,MD,ACTIVE
+MYMEDICARE.GOV,Federal Agency,Department of Health And Human Services,Baltimore,MD,ACTIVE
+NATIONALCHILDRENSSTUDY.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE
+NCIFCRF.GOV,Federal Agency,Department of Health And Human Services,Frederick,MD,ACTIVE
+NGC.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE
+NIH.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE
+NIHSENIORHEALTH.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE
+NIOSH.GOV,Federal Agency,Department of Health And Human Services,Atlanta,GA,ACTIVE
+NLM.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE
+NNLM.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE
+ORGANDONOR.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE
+PANDEMICFLU.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+PHE.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+PSC.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE
+PUBMED.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE
+PUBMEDCENTRAL.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE
+QUIC.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE
+QUICK.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE
+RECOVERYMONTH.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE
+SAFEYOUTH.GOV,Federal Agency,Department of Health And Human Services,Atlanta,GA,ACTIVE
+SAMHSA.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE
+SELECTAGENTS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+SMOKEFREE.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE
+STEROIDABUSE.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE
+STOPALCOHOLABUSE.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+STOPBULLYING.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+STOPMEDICAREFRAUD.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+SURGEONGENERAL.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+THECOOLSPOT.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE
+THEREALCOST.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+THISFREELIFE.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+TISSUEENGINEERING.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD,ACTIVE
+TOBACCO.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+USABILITY.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+USBM.GOV,Federal Agency,Department of Health And Human Services,Atlanta,GA,ACTIVE
+USPHS.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD,ACTIVE
+VACCINES.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+WHAGING.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+WHITEHOUSECONFERENCEONAGING.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+WOMENSHEALTH.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+YOUTH.GOV,Federal Agency,Department of Health And Human Services,Washington,DC,ACTIVE
+BIOMETRICS.GOV,Federal Agency,Department of Homeland Security,Arlington,VA,ACTIVE
+CITIZENCORPS.GOV,Federal Agency,Department of Homeland Security,Washington,DC,ACTIVE
+CPNIREPORTING.GOV,Federal Agency,Department of Homeland Security,Washington,DC,ACTIVE
+DHS.GOV,Federal Agency,Department of Homeland Security,Washington,DC,ACTIVE
+DISASTERASSISTANCE.GOV,Federal Agency,Department of Homeland Security,Bluemont,VA,ACTIVE
+FEMA.GOV,Federal Agency,Department of Homeland Security,Washington,DC,ACTIVE
+FIRSTRESPONDER.GOV,Federal Agency,Department of Homeland Security,Washington,DC,ACTIVE
+FIRSTRESPONDERTRAINING.GOV,Federal Agency,Department of Homeland Security,Washington,DC,ACTIVE
+FLETA.GOV,Federal Agency,Department of Homeland Security,Glynco,GA,ACTIVE
+FLETC.GOV,Federal Agency,Department of Homeland Security,Glynco,GA,ACTIVE
+FLIGHTSCHOOLCANDIDATES.GOV,Federal Agency,Department of Homeland Security,Rockville,MD,ACTIVE
+FLOODSMART.GOV,Federal Agency,Department of Homeland Security,Bluemont,VA,ACTIVE
+HOMELANDSECURITY.GOV,Federal Agency,Department of Homeland Security,Washington,DC,ACTIVE
+ICE.GOV,Federal Agency,Department of Homeland Security,Washington,DC,ACTIVE
+LISTO.GOV,Federal Agency,Department of Homeland Security,Washington,DC,ACTIVE
+LLIS.GOV,Federal Agency,Department of Homeland Security,Washington,DC,ACTIVE
+NMSC.GOV,Federal Agency,Department of Homeland Security,St Augustine,FL,ACTIVE
+READY.GOV,Federal Agency,Department of Homeland Security,Washington,DC,ACTIVE
+READYBUSINESS.GOV,Federal Agency,Department of Homeland Security,Washington,DC,ACTIVE
+SAFECOMPROGRAM.GOV,Federal Agency,Department of Homeland Security,Washington,DC,ACTIVE
+SAFETYACT.GOV,Federal Agency,Department of Homeland Security,Washington,DC,ACTIVE
+SECRETSERVICE.GOV,Federal Agency,Department of Homeland Security,Washington D.C.,DC,ACTIVE
+TSA.GOV,Federal Agency,Department of Homeland Security,Arlington,VA,ACTIVE
+US-CERT.GOV,Federal Agency,Department of Homeland Security,Washington,DC,ACTIVE
+USCG.GOV,Federal Agency,Department of Homeland Security,Alexandria,VA,ACTIVE
+USCIS.GOV,Federal Agency,Department of Homeland Security,Washington,DC,ACTIVE
+USSS.GOV,Federal Agency,Department of Homeland Security,Washington,DC,ACTIVE
+DISASTERHOUSING.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC,ACTIVE
+FHA.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC,ACTIVE
+GINNIEMAE.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC,ACTIVE
+HOMESALES.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC,ACTIVE
+HUD.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC,ACTIVE
+HUDOIG.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC,ACTIVE
+HUDUSER.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC,ACTIVE
+NATIONALHOUSING.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC,ACTIVE
+NATIONALHOUSINGLOCATOR.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC,ACTIVE
+NHL.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC,ACTIVE
+NLS.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC,ACTIVE
+ADA.GOV,Federal Agency,Department of Justice,Rockville,MD,ACTIVE
+ADR.GOV,Federal Agency,Department of Justice,Rockville,MD,ACTIVE
+AMBERALERT.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+ATF.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE
+ATFONLINE.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE
+BATS.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+BIOMETRICCOE.GOV,Federal Agency,Department of Justice,Clarksburg,WV,ACTIVE
+BJA.GOV,Federal Agency,Department of Justice,Washington ,DC,ACTIVE
+BJS.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE
+BOP.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE
+CJIS.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE
+CRIMESOLUTIONS.GOV,Federal Agency,Department of Justice,Washinton ,DC,ACTIVE
+CRIMEVICTIMS.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+CYBERCRIME.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE
+DEA.GOV,Federal Agency,Department of Justice,Rockville,MD,ACTIVE
+DEADIVERSION.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+DEAECOM.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+DEALS.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE
+DNA.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+DOJ.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+DSAC.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+EGUARDIAN.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE
+EPIC.GOV,Federal Agency,Department of Justice,Rockville,MD,ACTIVE
+EPIC2.GOV,Federal Agency,Department of Justice,Arlington ,VA,ACTIVE
+ESP.GOV,Federal Agency,Department of Justice,Falls Church,VA,ACTIVE
+ESPANOLFORLAWENFORCEMENT.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+FARA.GOV,Federal Agency,Department of Justice,potomac,MD,ACTIVE
+FBI.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE
+FBIJOBS.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE
+FIRSTFREEDOM.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+FOIA.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE
+FORENSICSCIENCE.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE
+FORFEITURE.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+FPI.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE
+GETSMARTABOUTDRUGS.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+HELPINGAMERICASYOUTH.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+IC3.GOV,Federal Agency,Department of Justice,Fairmont,WV,ACTIVE
+INTERPOL.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+IPRCENTER.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE
+JUSTICE.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE
+JUSTTHINKTWICE.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+JUVENILECOUNCIL.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+LEARNATF.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE
+LEARNDOJ.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE
+LEO.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+LEP.GOV,Federal Agency,Department of Justice,Rockville,MD,ACTIVE
+LOOKSTOOGOOD.GOV,Federal Agency,Department of Justice,Fairmont,WV,ACTIVE
+LOOKSTOOGOODTOBETRUE.GOV,Federal Agency,Department of Justice,Fairmont,WV,ACTIVE
+MALWAREINVESTIGATOR.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE
+MEDALOFVALOR.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+METHRESOURCES.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+NAMUS.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+NATIONALGANGCENTER.GOV,Federal Agency,Department of Justice,Tallahassee,FL,ACTIVE
+NCIRC.GOV,Federal Agency,Department of Justice,Tallahassee,FL,ACTIVE
+NCJRS.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+NIBIN.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE
+NICIC.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE
+NICSEZCHECKFBI.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE
+NIEM.GOV,Federal Agency,Department of Justice,Tallahassee,FL,ACTIVE
+NIJ.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE
+NMVTIS.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE
+NSOPR.GOV,Federal Agency,Department of Justice,Tallahassee,FL,ACTIVE
+NSOPW.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE
+NVTC.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE
+OJJDP.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+OJP.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE
+OVC.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+OVCTTAC.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+PROJECTSAFECHILDHOOD.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+PROJECTSAFENEIGHBORHOODS.GOV,Federal Agency,Department of Justice,Rockville,MD,ACTIVE
+PSN.GOV,Federal Agency,Department of Justice,Rocckville,MD,ACTIVE
+PSOB.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+RCFL.GOV,Federal Agency,Department of Justice,McLean,VA,ACTIVE
+REENTRY.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+SCRA.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+SERVICEMEMBERS.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+SMART.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE
+STOPFRAUD.GOV,Federal Agency,Department of Justice,Rockville,MD,ACTIVE
+TECHTRACK.GOV,Federal Agency,Department of Justice,Arlington,VA,ACTIVE
+TRIBALJUSTICEANDSAFETY.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+UCRDATATOOL.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE
+UNICOR.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE
+USDOJ.GOV,Federal Agency,Department of Justice,Rockville,MD,ACTIVE
+USERRA.GOV,Federal Agency,Department of Justice,Potpmac,MD,ACTIVE
+USMARSHALS.GOV,Federal Agency,Department of Justice,Rockville,MD,ACTIVE
+VCF.GOV,Federal Agency,Department of Justice,Washington,DC,ACTIVE
+VEHICLEHISTORY.GOV,Federal Agency,Department of Justice,Potomac,MD,ACTIVE
+AMERICASHEROESATWORK.GOV,Federal Agency,Department of Labor,Washington,DC,ACTIVE
+BENEFITS.GOV,Federal Agency,Department of Labor,Washington,DC,ACTIVE
+BLS.GOV,Federal Agency,Department of Labor,Washington,DC,ACTIVE
+DISABILITY.GOV,Federal Agency,Department of Labor,Washington,DC,ACTIVE
+DOL-ESA.GOV,Federal Agency,Department of Labor,Washington,DC,ACTIVE
+DOL.GOV,Federal Agency,Department of Labor,Washington,DC,ACTIVE
+DOLETA.GOV,Federal Agency,Department of Labor,Washington,DC,ACTIVE
+GOVBENEFITS.GOV,Federal Agency,Department of Labor,Washington,DC,ACTIVE
+GOVLOANS.GOV,Federal Agency,Department of Labor,Washington,DC,ACTIVE
+JOBCORPS.GOV,Federal Agency,Department of Labor,Austin,TX,ACTIVE
+LABOR.GOV,Federal Agency,Department of Labor,Washington,DC,ACTIVE
+MSHA.GOV,Federal Agency,Department of Labor,Arlington,VA,ACTIVE
+MYNEXTMOVE.GOV,Federal Agency,Department of Labor,Washington,DC,ACTIVE
+OSHA.GOV,Federal Agency,Department of Labor,Washington,DC,ACTIVE
+UNIONREPORTS.GOV,Federal Agency,Department of Labor,Washington,DC,ACTIVE
+VETERANS.GOV,Federal Agency,Department of Labor,Washington,DC,ACTIVE
+WHISTLEBLOWERS.GOV,Federal Agency,Department of Labor,Washington,DC,ACTIVE
+WRP.GOV,Federal Agency,Department of Labor,Washington,DC,ACTIVE
+YOUTHRULES.GOV,Federal Agency,Department of Labor,Washington,DC,ACTIVE
+AMERICA.GOV,Federal Agency,Department of State,Washington,DC,ACTIVE
+CONTINENTALSHELF.GOV,Federal Agency,Department of State,Washington,DC,ACTIVE
+CWC.GOV,Federal Agency,Department of State,Washington,DC,ACTIVE
+ECOPARTNERSHIPS.GOV,Federal Agency,Department of State,Washington,DC,ACTIVE
+FAN.GOV,Federal Agency,Department of State,Washington,DC,ACTIVE
+FOREIGNASSISTANCE.GOV,Federal Agency,Department of State,Washington,DC,ACTIVE
+FSGB.GOV,Federal Agency,Department of State,Washington,DC,ACTIVE
+GHI.GOV,Federal Agency,Department of State,Washington,DC,ACTIVE
+HUMANRIGHTS.GOV,Federal Agency,Department of State,Washington ,DC,ACTIVE
+IAWG.GOV,Federal Agency,Department of State,Washington,DC,ACTIVE
+IBWC.GOV,Federal Agency,Department of State,El Paso,TX,ACTIVE
+ICASS.GOV,Federal Agency,Department of State,Washington,DC,ACTIVE
+OSAC.GOV,Federal Agency,Department of State,Washington,DC,ACTIVE
+PEPFAR.GOV,Federal Agency,Department of State,Washington,DC,ACTIVE
+STATE.GOV,Federal Agency,Department of State,Washington,DC,ACTIVE
+USCONSULATE.GOV,Federal Agency,Department of State,Washington,DC,ACTIVE
+USEMBASSY-MEXICO.GOV,Federal Agency,Department of State,Mexico City,11,ACTIVE
+USEMBASSY.GOV,Federal Agency,Department of State,Washington,DC,ACTIVE
+USINT.GOV,Federal Agency,Department of State,Washington,DC,ACTIVE
+USMISSION.GOV,Federal Agency,Department of State,Washington,DC,ACTIVE
+USVPP.GOV,Federal Agency,Department of State,Washington,DC,ACTIVE
+STATEOIG.GOV,Federal Agency,Department of State OIG,Arlington,VA,ACTIVE
+ABANDONEDMINES.GOV,Federal Agency,Department of the Interior,Washington,DC,ACTIVE
+ACWI.GOV,Federal Agency,Department of the Interior,Reston,VA,ACTIVE
+ALASKACENTERS.GOV,Federal Agency,Department of the Interior,Washington,DC,ACTIVE
+AMERICANLATINOMUSEUM.GOV,Federal Agency,Department of the Interior,Washington,WV,ACTIVE
+AMERICASGREATOUTDOORS.GOV,Federal Agency,Department of the Interior,Washington,DC,ACTIVE
+ANSTASKFORCE.GOV,Federal Agency,Department of the Interior,Arlington,VA,ACTIVE
+BIA.GOV,Federal Agency,Department of the Interior,Reston,VA,ACTIVE
+BIOECO.GOV,Federal Agency,Department of the Interior,Denver,CO,ACTIVE
+BLM.GOV,Federal Agency,Department of the Interior,Denver,CO,ACTIVE
+BLMNTL.GOV,Federal Agency,Department of the Interior,Denver,CO,ACTIVE
+BOEM.GOV,Federal Agency,Department of the Interior,Herndon,VA,ACTIVE
+BOEMRE.GOV,Federal Agency,Department of the Interior,Herndon,VA,ACTIVE
+BOR.GOV,Federal Agency,Department of the Interior,Denver,CO,ACTIVE
+BSEE.GOV,Federal Agency,Department of the Interior,Herndon,VA,ACTIVE
+CORALREEF.GOV,Federal Agency,Department of the Interior,Denver,CO,ACTIVE
+CUPCAO.GOV,Federal Agency,Department of the Interior,Denver,CO,ACTIVE
+DOI.GOV,Federal Agency,Department of the Interior,Washington,DC,ACTIVE
+DOIOIG.GOV,Federal Agency,Department of the Interior,RESTON,VA,ACTIVE
+EARTHQUAKE.GOV,Federal Agency,Department of the Interior,Menlo Park,CA,ACTIVE
+EVERGLADESRESTORATION.GOV,Federal Agency,Department of the Interior,Davie,FL,ACTIVE
+FCG.GOV,Federal Agency,Department of the Interior,Denver,CO,ACTIVE
+FGDC.GOV,Federal Agency,Department of the Interior,Reston,VA,ACTIVE
+FIRECODE.GOV,Federal Agency,Department of the Interior,Boise,ID,ACTIVE
+FIRELEADERSHIP.GOV,Federal Agency,Department of the Interior,Boise,ID,ACTIVE
+FIRENET.GOV,Federal Agency,Department of the Interior,Boise,ID,ACTIVE
+FIRESCIENCE.GOV,Federal Agency,Department of the Interior,Boise,ID,ACTIVE
+FWS.GOV,Federal Agency,Department of the Interior,Lakewood,CO,ACTIVE
+GCDAMP.GOV,Federal Agency,Department of the Interior,Denver,CO,ACTIVE
+GCMRC.GOV,Federal Agency,Department of the Interior,Flagstaff,AZ,ACTIVE
+GEOCOMMUNICATOR.GOV,Federal Agency,Department of the Interior,Denver,CO,ACTIVE
+GEOMAC.GOV,Federal Agency,Department of the Interior,Denver,CO,ACTIVE
+GEOPLATFORM.GOV,Federal Agency,Department of the Interior,Washington,DC,ACTIVE
+IAT.GOV,Federal Agency,Department of the Interior,Boise,ID,ACTIVE
+INDIANAFFAIRS.GOV,Federal Agency,Department of the Interior,Reston,VA,ACTIVE
+INTERIOR.GOV,Federal Agency,Department of the Interior,Washington,DC,ACTIVE
+INVASIVESPECIES.GOV,Federal Agency,Department of the Interior,Washington,DC,ACTIVE
+JEM.GOV,Federal Agency,Department of the Interior,Lafayett,LA,ACTIVE
+KLAMATHRESTORATION.GOV,Federal Agency,Department of the Interior,Yreka,CA,ACTIVE
+LACOAST.GOV,Federal Agency,Department of the Interior,Lafayette,LA,ACTIVE
+LANDFIRE.GOV,Federal Agency,Department of the Interior,Sioux Falls,SD,ACTIVE
+LANDIMAGING.GOV,Federal Agency,Department of the Interior,Reston,VA,ACTIVE
+LCA.GOV,Federal Agency,Department of the Interior,Lafayette,LA,ACTIVE
+LCRMSCP.GOV,Federal Agency,Department of the Interior,Denver,CO,ACTIVE
+LMVSCI.GOV,Federal Agency,Department of the Interior,Lafayette,LA,ACTIVE
+LOWERMISSISSIPPIVALLEYSCIENCE.GOV,Federal Agency,Department of the Interior,Lafayette,LA,ACTIVE
+MARINE.GOV,Federal Agency,Department of the Interior,Camarillo,CA,ACTIVE
+MITIGATIONCOMMISSION.GOV,Federal Agency,Department of the Interior,Denver,CO,ACTIVE
+MMS.GOV,Federal Agency,Department of the Interior,Herndon,VA,ACTIVE
+MRLC.GOV,Federal Agency,Department of the Interior,Sioux Falls,SD,ACTIVE
+NATIONALATLAS.GOV,Federal Agency,Department of the Interior,Reston,VA,ACTIVE
+NATIONALMAP.GOV,Federal Agency,Department of the Interior,Reston,VA,ACTIVE
+NATIVEONESTOP.GOV,Federal Agency,Department of the Interior,Reston,VA,ACTIVE
+NBC.GOV,Federal Agency,Department of the Interior,Denver,CO,ACTIVE
+NDEP.GOV,Federal Agency,Department of the Interior,Reston,VA,ACTIVE
+NDOP.GOV,Federal Agency,Department of the Interior,Reston,VA,ACTIVE
+NEMI.GOV,Federal Agency,Department of the Interior,Middleton,WI,ACTIVE
+NFPORS.GOV,Federal Agency,Department of the Interior,Washington,DC,ACTIVE
+NIFC.GOV,Federal Agency,Department of the Interior,Boise,ID,ACTIVE
+NOLAENVIRONMENTAL.GOV,Federal Agency,Department of the Interior,Lafayette,LA,ACTIVE
+NPS.GOV,Federal Agency,Department of the Interior,WASHINGTON DC,DC,ACTIVE
+ONHIR.GOV,Federal Agency,Department of the Interior,Flagstaff,AZ,ACTIVE
+ONRR.GOV,Federal Agency,Department of the Interior,Herndon,VA,ACTIVE
+OSM.GOV,Federal Agency,Department of the Interior,Washington,DC,ACTIVE
+OSMRE.GOV,Federal Agency,Department of the Interior,Washington,DC,ACTIVE
+PIEDRASBLANCAS.GOV,Federal Agency,Department of the Interior,Sacramento,CA,ACTIVE
+REPORTBAND.GOV,Federal Agency,Department of the Interior,Laurel,MD,ACTIVE
+RIVERS.GOV,Federal Agency,Department of the Interior,Burbank,WA,ACTIVE
+SAFECOM.GOV,Federal Agency,Department of the Interior,Boise,ID,ACTIVE
+SCIENCEBASE.GOV,Federal Agency,Department of the Interior,Denver,CO,ACTIVE
+SIERRAWILD.GOV,Federal Agency,Department of the Interior,Yosemite,CA,ACTIVE
+SNAP.GOV,Federal Agency,Department of the Interior,Washington,DC,ACTIVE
+USBR.GOV,Federal Agency,Department of the Interior,Denver,CO,ACTIVE
+USGS.GOV,Federal Agency,Department of the Interior,Reston,VA,ACTIVE
+UTAHFIREINFO.GOV,Federal Agency,Department of the Interior,Denver,CO,ACTIVE
+VOLCANO.GOV,Federal Agency,Department of the Interior,Anchorage,AK,ACTIVE
+VOLUNTEER.GOV,Federal Agency,Department of the Interior,Reston,VA,ACTIVE
+WATERMONITOR.GOV,Federal Agency,Department of the Interior,Reston,VA,ACTIVE
+WILDLIFEADAPTATIONSTRATEGY.GOV,Federal Agency,Department of the Interior,Arlington,VA,ACTIVE
+WLCI.GOV,Federal Agency,Department of the Interior,Denver,CO,ACTIVE
+YOUTHGO.GOV,Federal Agency,Department of the Interior,Shepherdstown,WV,ACTIVE
+AMA.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+AMERICATHEBEAUTIFULQUARTERS.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+ASAP.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+AYUDACONMIBANCO.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+BANKANSWERS.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+BANKCUSTOMER.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+BANKCUSTOMERASSISTANCE.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+BANKHELP.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+BANKNET.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+BEP.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+BFEM.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+BONDPRO.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+CCAC.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+CDFIFUND.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+COMPLAINTREFERRALEXPRESS.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+COMPTROLLEROFTHECURRENCY.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+DIRECTOASUCUENTA.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+EAGLECASH.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+EFTPS.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+ETA-FIND.GOV,Federal Agency,Department of the Treasury,DALLAS,TX,ACTIVE
+ETHICSBURG.GOV,Federal Agency,Department of the Treasury,Parkersburg,WV,ACTIVE
+EYENOTE.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+FEDERALINVESTMENTS.GOV,Federal Agency,Department of the Treasury,Pakersburg,WV,ACTIVE
+FEDERALSPENDING.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+FEDINVEST.GOV,Federal Agency,Department of the Treasury,Parkersburg,WV,ACTIVE
+FEDSPENDING.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+FINANCIALRESEARCH.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+FINANCIALSTABILITY.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+FINCEN.GOV,Federal Agency,Department of the Treasury,Vienna,VA,ACTIVE
+FSOC.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+FTTESTTWAI.GOV,Federal Agency,Department of the Treasury,Hyattsville,MD,ACTIVE
+GODIRECT.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+GWA.GOV,Federal Agency,Department of the Treasury,Hyattsville,MD,ACTIVE
+HELPWITHMYBANK.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+HELPWITHMYCHECKINGACCOUNT.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+HELPWITHMYCREDITCARD.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+HELPWITHMYCREDITCARDBANK.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+HELPWITHMYMORTGAGE.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+HELPWITHMYMORTGAGEBANK.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+IPAC.GOV,Federal Agency,Department of the Treasury,Boston,MA,ACTIVE
+IPP.GOV,Federal Agency,Department of the Treasury,McLean,VA,ACTIVE
+IRS.GOV,Federal Agency,Department of the Treasury,McLean,VA,ACTIVE
+IRSAUCTIONS.GOV,Federal Agency,Department of the Treasury,McLean,VA,ACTIVE
+IRSNET.GOV,Federal Agency,Department of the Treasury,McLean,VA,ACTIVE
+IRSSALES.GOV,Federal Agency,Department of the Treasury,McLean,VA,ACTIVE
+IRSVIDEOS.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+ITS.GOV,Federal Agency,Department of the Treasury,McLean,VA,ACTIVE
+MAKINGHOMEAFFORDABLE.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+MHA.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+MONEYFACTORY.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+MONEYFACTORYSTORE.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+MSB.GOV,Federal Agency,Department of the Treasury,Vienna,VA,ACTIVE
+MYIRA.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+MYMONEY.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+MYRA.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+NATIONALBANK.GOV,Federal Agency,Department of the Treasury,McLean,VA,ACTIVE
+NATIONALBANKHELP.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+NATIONALBANKNET.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+NAVYCASH.GOV,Federal Agency,Department of the Treasury,McLean,VA,ACTIVE
+OCC.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+OCCHELPS.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+OCCNET.GOV,Federal Agency,Department of the Treasury,Landover,MD,ACTIVE
+OTS.GOV,Federal Agency,Department of the Treasury,McLean,VA,ACTIVE
+PATRIOTBONDS.GOV,Federal Agency,Department of the Treasury,Parkersburg,WV,ACTIVE
+PAY.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+PRACOMMENT.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+QATESTTWAI.GOV,Federal Agency,Department of the Treasury,Hyattsville,MD,ACTIVE
+SAVINGSBOND.GOV,Federal Agency,Department of the Treasury,Mclean,VA,ACTIVE
+SAVINGSBONDS.GOV,Federal Agency,Department of the Treasury,McLean,VA,ACTIVE
+SAVINGSBONDWIZARD.GOV,Federal Agency,Department of the Treasury,Mclean,VA,ACTIVE
+SIGTARP.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+SLGS.GOV,Federal Agency,Department of the Treasury,Mclean,VA,ACTIVE
+TAAPS.GOV,Federal Agency,Department of the Treasury,Mclean,VA,ACTIVE
+TAX.GOV,Federal Agency,Department of the Treasury,McLean,VA,ACTIVE
+TCIS.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+TIGTA.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+TIGTANET.GOV,Federal Agency,Department of the Treasury,McLean,VA,ACTIVE
+TRANSPARENCY.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+TREAS.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+TREASLOCKBOX.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+TREASURY.FED.US,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+TREASURY.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+TREASURYAUCTION.GOV,Federal Agency,Department of the Treasury,Parkersburg,WV,ACTIVE
+TREASURYAUCTIONS.GOV,Federal Agency,Department of the Treasury,Mclean,VA,ACTIVE
+TREASURYDIRECT.GOV,Federal Agency,Department of the Treasury,McLean,VA,ACTIVE
+TREASURYECM.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+TREASURYHUNT.GOV,Federal Agency,Department of the Treasury,Parkersburg,WV,ACTIVE
+TREASURYSCAMS.GOV,Federal Agency,Department of the Treasury,Mclean,VA,ACTIVE
+TRS.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+TTB.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+TTBONLINE.GOV,Federal Agency,Department of the Treasury,McLean,VA,ACTIVE
+TTLPLUS.GOV,Federal Agency,Department of the Treasury,St. Louis,MO,ACTIVE
+TWAI.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+USASPENDING.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+USDEBITCARD.GOV,Federal Agency,Department of the Treasury,Mclean,VA,ACTIVE
+USMINT.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+USTREAS.GOV,Federal Agency,Department of the Treasury,McLean,VA,ACTIVE
+VERIFYPAYMENT.GOV,Federal Agency,Department of the Treasury,Parkersburg,WV,ACTIVE
+WIZARD.GOV,Federal Agency,Department of the Treasury,Mclean,VA,ACTIVE
+WORKPLACE.GOV,Federal Agency,Department of the Treasury,Washington,DC,ACTIVE
+911.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE
+BTS.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE
+CFLHD.GOV,Federal Agency,Department of Transportation,Lakewood,CO,ACTIVE
+DISTRACTEDDRIVING.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE
+DISTRACTION.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE
+DOT.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE
+DOTIDEAHUB.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE
+DOTTRAFFICRECORDS.GOV,Federal Agency,Department of Transportation,Room 2202,DC,ACTIVE
+EMS.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE
+ESC.GOV,Federal Agency,Department of Transportation,Oklahoma City,OK,ACTIVE
+FAA.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE
+FAASAFETY.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE
+JCCBI.GOV,Federal Agency,Department of Transportation,Oklahoma City,OK,ACTIVE
+MDA.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE
+NHTSA.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE
+NTDPROGRAM.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE
+PLAINLANGUAGE.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE
+PROTECTYOURMOVE.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE
+SAFEOCS.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE
+SAFERCAR.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE
+SAFERTRUCK.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE
+SHARETHEROADSAFELY.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE
+STRONGPORTS.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE
+SUSTAINABLECOMMUNITIES.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE
+TFHRC.GOV,Federal Agency,Department of Transportation,Mclean,VA,ACTIVE
+TRAFFICSAFETYMARKETING.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE
+TRANSPORTATION.GOV,Federal Agency,Department of Transportation,Washington,DC,ACTIVE
+CDCO.GOV,Federal Agency,Department of Veterans Affairs,Austin,TX,ACTIVE
+NATIONALRESOURCEDIRECTORY.GOV,Federal Agency,Department of Veterans Affairs,Washington,DC,ACTIVE
+NRD.GOV,Federal Agency,Department of Veterans Affairs,Washington,DC,ACTIVE
+VA.GOV,Federal Agency,Department of Veterans Affairs,Washington,DC,ACTIVE
+VETBIZ.GOV,Federal Agency,Department of Veterans Affairs,Washington,DC,ACTIVE
+VETS.GOV,Federal Agency,Department of Veterans Affairs,Washington,DC,ACTIVE
+DNI.GOV,Federal Agency,Director of National Intelligence,McLean,VA,ACTIVE
+IARPA-IDEAS.GOV,Federal Agency,Director of National Intelligence,Washington,DC,ACTIVE
+IARPA.GOV,Federal Agency,Director of National Intelligence,College Park,MD,ACTIVE
+ICJOINTDUTY.GOV,Federal Agency,Director of National Intelligence,Washington,DC,ACTIVE
+INTELINK.GOV,Federal Agency,Director of National Intelligence,Ft. George G. Meade,MD,ACTIVE
+INTELLIGENCE.GOV,Federal Agency,Director of National Intelligence,Washington,DC,ACTIVE
+ISE.GOV,Federal Agency,Director of National Intelligence,Washington ,DC,ACTIVE
+NCIX.GOV,Federal Agency,Director of National Intelligence,Washington,DC,ACTIVE
+NCSC.GOV,Federal Agency,Director of National Intelligence,Bethesda,MD,ACTIVE
+NMIC.GOV,Federal Agency,Director of National Intelligence,Washington,DC,SERVER-HOLD
+ODNI.GOV,Federal Agency,Director of National Intelligence,Washington,DC,ACTIVE
+OSIS.GOV,Federal Agency,Director of National Intelligence,Fort George G. Meade,MD,ACTIVE
+PIX.GOV,Federal Agency,Director of National Intelligence,Washington,DC,ACTIVE
+QART.GOV,Federal Agency,Director of National Intelligence,Washington,DC,ACTIVE
+UGOV.GOV,Federal Agency,Director of National Intelligence,Fort George G Meade,MD,ACTIVE
+AIRNOW.GOV,Federal Agency,Environmental Protection Agency,Durham,NC,ACTIVE
+CBI-EPA.GOV,Federal Agency,Environmental Protection Agency,Durham,NC,ACTIVE
+ENERGYSTAR.GOV,Federal Agency,Environmental Protection Agency,Washington,DC,ACTIVE
+EPA.GOV,Federal Agency,Environmental Protection Agency,Research Triangle Park,NC,ACTIVE
+FDMS.GOV,Federal Agency,Environmental Protection Agency,Washington,DC,ACTIVE
+FEDCENTER.GOV,Federal Agency,Environmental Protection Agency,Champaign,IL,ACTIVE
+FRTR.GOV,Federal Agency,Environmental Protection Agency,Omaha,NE,ACTIVE
+GREENGOV.GOV,Federal Agency,Environmental Protection Agency, Washington,DC,ACTIVE
+OFEE.GOV,Federal Agency,Environmental Protection Agency,Washington,DC,ACTIVE
+REGULATIONS.GOV,Federal Agency,Environmental Protection Agency,Washington,DC,ACTIVE
+RELOCATEFEDS.GOV,Federal Agency,Environmental Protection Agency,Cincinnati,OH,ACTIVE
+SUSTAINABILITY.GOV,Federal Agency,Environmental Protection Agency,Washington,DC,ACTIVE
+URBANWATERS.GOV,Federal Agency,Environmental Protection Agency,Washington,DC,ACTIVE
+EEOC.GOV,Federal Agency,Equal Employment Opportunity Commission,Washington,DC,ACTIVE
+AIDREFUGEES.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE
+ASTRONGMIDDLECLASS.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE
+BUDGET.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE
+CHANGE.GOV,Federal Agency,Executive Office of the President,Arlington,VA,ACTIVE
+EARMARKS.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE
+EGOV.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE
+EOP.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE
+ETHICS.GOV,Federal Agency,Executive Office of the President,Washington ,DC,ACTIVE
+EXRWH.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE
+FISCALCOMMISSION.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE
+HC.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE
+ITDASHBOARD.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE
+JOININGFORCES.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE
+LETSMOVE.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE
+MAX.GOV,Federal Agency,Executive Office of the President,NW,WA,ACTIVE
+NEPA.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE
+NOTALONE.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE
+NSTIC.GOV,Federal Agency,Executive Office of the President,Gaithersburg,MD,ACTIVE
+OMB.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE
+OMBLOG.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE
+ONDCP.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE
+OSTP.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE
+PAYMENTACCURACY.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE
+PCI.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE
+PRESIDIO.GOV,Federal Agency,Executive Office of the President,San Francisco,CA,ACTIVE
+PRESIDIOTRUST.GOV,Federal Agency,Executive Office of the President,San Francisco,CA,ACTIVE
+REACHHIGHER.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE
+SAVE.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE
+SAVEAWARD.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE
+STRONGMIDDLECLASS.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE
+USDIGITALSERVICE.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE
+USDS.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE
+USTR.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE
+WH.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE
+WHITEHOUSE.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE
+WHITEHOUSEDRUGPOLICY.GOV,Federal Agency,Executive Office of the President,Washington,DC,ACTIVE
+EXIM.GOV,Federal Agency,Export/Import Bank of the U.S.,Washington,DC,ACTIVE
+EXIMCOOP.GOV,Federal Agency,Export/Import Bank of the U.S.,Washington,DC,ACTIVE
+FCA.GOV,Federal Agency,Farm Credit Administration,McLean,VA,ACTIVE
+FCSIC.GOV,Federal Agency,Farm Credit Administration,McLean,VA,ACTIVE
+BROADBAND.GOV,Federal Agency,Federal Communications Commission,Washington,DC,ACTIVE
+BROADBANDMAP.GOV,Federal Agency,Federal Communications Commission,Washington,DC,ACTIVE
+DTV.GOV,Federal Agency,Federal Communications Commission,Washington,DC,ACTIVE
+FCC.GOV,Federal Agency,Federal Communications Commission,Washington,DC,ACTIVE
+FCCUNIVERSITY.GOV,Federal Agency,Federal Communications Commission,Washington,DC,ACTIVE
+LIFELINE.GOV,Federal Agency,Federal Communications Commission,Washington,DC,ACTIVE
+NBM.GOV,Federal Agency,Federal Communications Commission,Washington,DC,ACTIVE
+OPENINTERNET.GOV,Federal Agency,Federal Communications Commission,Washington,DC,ACTIVE
+ECONOMICINCLUSION.GOV,Federal Agency,Federal Deposit Insurance Corporation,Arlington,VA,ACTIVE
+FDIC.GOV,Federal Agency,Federal Deposit Insurance Corporation,Arlington,VA,ACTIVE
+FDICCONNECT.GOV,Federal Agency,Federal Deposit Insurance Corporation,Arlington,VA,ACTIVE
+FDICIG.GOV,Federal Agency,Federal Deposit Insurance Corporation,Arlington,VA,ACTIVE
+FDICOIG.GOV,Federal Agency,Federal Deposit Insurance Corporation,Washington,DC,ACTIVE
+FDICSALES.GOV,Federal Agency,Federal Deposit Insurance Corporation,Arlington,VA,ACTIVE
+FDICSEGURO.GOV,Federal Agency,Federal Deposit Insurance Corporation,Arlington,VA,ACTIVE
+MYFDIC.GOV,Federal Agency,Federal Deposit Insurance Corporation,Arlington,VA,ACTIVE
+MYFDICINSURANCE.GOV,Federal Agency,Federal Deposit Insurance Corporation,Arlington,VA,ACTIVE
+FEC.GOV,Federal Agency,Federal Elections Commission,Washington,DC,ACTIVE
+FERC.GOV,Federal Agency,Federal Energy Regulatory Commission,Washington,DC,ACTIVE
+FERCALT.GOV,Federal Agency,Federal Energy Regulatory Commission,Washington,DC,ACTIVE
+FHFA.GOV,Federal Agency,Federal Housing Finance Agency,Washington,DC,ACTIVE
+FHFB.GOV,Federal Agency,Federal Housing Finance Agency,Washington,DC,ACTIVE
+HARP.GOV,Federal Agency,Federal Housing Finance Agency,Washington,DC,ACTIVE
+OFHEO.GOV,Federal Agency,Federal Housing Finance Agency,Washington,DC,ACTIVE
+FHFAOIG.GOV,Federal Agency,Federal Housing Finance Agency Office of Inspector General,Washington,DC,ACTIVE
+FLRA.GOV,Federal Agency,Federal Labor Relations Authority,Washington,DC,ACTIVE
+FMC.GOV,Federal Agency,Federal Maritime Commission,Washington,DC,ACTIVE
+FMCS.GOV,Federal Agency,Federal Mediation and Conciliation Service,Washington,DC,ACTIVE
+FBIIC.GOV,Federal Agency,Federal Reserve System,Washington,DC,ACTIVE
+FEDCENTENNIAL.GOV,Federal Agency,Federal Reserve System,Washington,DC,ACTIVE
+FEDERALRESERVE.GOV,Federal Agency,Federal Reserve System,Washington,DC,ACTIVE
+FEDERALRESERVE100.GOV,Federal Agency,Federal Reserve System,Washington ,DC,ACTIVE
+FEDERALRESERVE2013.GOV,Federal Agency,Federal Reserve System,Washington,DC,ACTIVE
+FEDERALRESERVECENTENNIAL.GOV,Federal Agency,Federal Reserve System,Washington ,DC,ACTIVE
+FEDERALRESERVECENTENNIALCELEBRATION.GOV,Federal Agency,Federal Reserve System,Washington,DC,ACTIVE
+FEDERALRESERVECONSUMERHELP.GOV,Federal Agency,Federal Reserve System,Washington,DC,ACTIVE
+FEDPARTNERSHIP.GOV,Federal Agency,Federal Reserve System,Washington,DC,ACTIVE
+FFIEC.GOV,Federal Agency,Federal Reserve System,Washington,DC,ACTIVE
+FRB.FED.US,Federal Agency,Federal Reserve System,Washington,DC,ACTIVE
+FRB.GOV,Federal Agency,Federal Reserve System,Washington,DC,ACTIVE
+FRS.GOV,Federal Agency,Federal Reserve System,Washington,DC,ACTIVE
+NEWMONEY.GOV,Federal Agency,Federal Reserve System,Washington,DC,ACTIVE
+USCURRENCY.GOV,Federal Agency,Federal Reserve System,Washington,DC,ACTIVE
+EXPLORETSP.GOV,Federal Agency,Federal Retirement Thrift Investment Board,Washington,DC,ACTIVE
+FRTIB.GOV,Federal Agency,Federal Retirement Thrift Investment Board,Washington,DC,ACTIVE
+FRTIBTEST.GOV,Federal Agency,Federal Retirement Thrift Investment Board,Washigton,DC,ACTIVE
+TSP.GOV,Federal Agency,Federal Retirement Thrift Investment Board,Washington,DC,ACTIVE
+TSPTEST.GOV,Federal Agency,Federal Retirement Thrift Investment Board,Washington,DC,ACTIVE
+ADMONGO.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE
+ALERTAENLINEA.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE
+ANNUALCREDITREPORT.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE
+CONSUMER.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE
+CONSUMERSENTINEL.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE
+CONSUMERSENTINELNETWORK.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE
+CONSUMIDOR.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE
+DONOTCALL.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE
+DONTSERVETEENS.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE
+ECONSUMER.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE
+FREECREDITREPORT.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE
+FTC.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE
+FTCCOMPLAINTASSISTANT.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE
+FTCEFILE.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE
+HSR.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE
+IDENTITYTHEFT.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE
+IDTHEFT.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE
+NCPW.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE
+ONGUARDONLINE.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE
+ONLINEONGUARD.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE
+PROTECCIONDELCONSUMIDOR.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE
+ROBODEIDENTIDAD.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE
+SENTINEL.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE
+UCE.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE
+USICN.GOV,Federal Agency,Federal Trade Commission,Washington,DC,ACTIVE
+18F.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+ACQUISITION.GOV,Federal Agency,General Services Administration,Arlington,VA,ACTIVE
+AFADVANTAGE.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+APP.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+APPS.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+BUSINESSUSA.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+BUYACCESSIBLE.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+CAO.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+CBCA.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+CFDA.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+CFO.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+CFOC.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+CHALLENGE.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+CHALLENGES.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+CIO.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+CITIZENSCIENCE.GOV,Federal Agency,General Services Administration,NW,DC,ACTIVE
+CLOUD.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+COMPUTERS4LEARNING.GOV,Federal Agency,General Services Administration,Arlington,VA,ACTIVE
+COMPUTERSFORLEARNING.GOV,Federal Agency,General Services Administration,Arlington,VA,ACTIVE
+CONNECT.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+CONSUMERACTION.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+CONTRACTDIRECTORY.GOV,Federal Agency,General Services Administration,Arlington,VA,ACTIVE
+CPARS.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+DATA.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+DIGITALGOV.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+DOTGOV.GOV,Federal Agency,General Services Administration,Fairfax,VA,ACTIVE
+EAC.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+ECPIC.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+EISENHOWERMEMORIAL.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+EPLS.GOV,Federal Agency,General Services Administration,Arlington,VA,ACTIVE
+ESRS.GOV,Federal Agency,General Services Administration,arlington,VA,ACTIVE
+EVERYKID.GOV,Federal Agency,General Services Administration,Washington DC,DC,ACTIVE
+EVERYKIDINAPARK.GOV,Federal Agency,General Services Administration,Washington DC,DC,ACTIVE
+FACA.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+FACADATABASE.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+FAI.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+FAPIIS.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+FAQ.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+FBO.GOV,Federal Agency,General Services Administration,Arlington,VA,ACTIVE
+FED.US,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+FEDBIZOPPS.GOV,Federal Agency,General Services Administration,Arlington,VA,ACTIVE
+FEDIDCARD.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+FEDINFO.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+FEDRAMP.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+FEDROOMS.GOV,Federal Agency,General Services Administration,Arlington,VA,ACTIVE
+FIDO.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+FIRSTGOV.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+FMI.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+FORMS.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+FPDS.GOV,Federal Agency,General Services Administration,Arlington,VA,ACTIVE
+FPKI-LAB.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+FPKI.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+FRPG.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+FRPP-PA.GOV,Federal Agency,General Services Administration,WASHINGTON,DC,ACTIVE
+FSD.GOV,Federal Agency,General Services Administration,Arlington,VA,ACTIVE
+FSRS.GOV,Federal Agency,General Services Administration,Crystal City,VA,ACTIVE
+GOBIERNO.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+GOBIERNOUSA.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+GOVSALES.GOV,Federal Agency,General Services Administration,Arlington,VA,ACTIVE
+GSA.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+GSAADVANTAGE.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+GSAAUCTIONS.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+GSAIG.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+GSAXCESS.GOV,Federal Agency,General Services Administration,Arlington,VA,ACTIVE
+HOWTO.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+IDMANAGEMENT.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+INFO.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+KIDS.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+LEARNPERFORMANCE.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+LOGIN.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+MYUSA.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+NBRC.GOV,Federal Agency,General Services Administration,Bangor,ME,ACTIVE
+NETWORX.GOV,Federal Agency,General Services Administration,Fairfax,VA,ACTIVE
+NIC.GOV,Federal Agency,General Services Administration,Fairfax,VA,ACTIVE
+PARTNER4SOLUTIONS.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+PCLOB.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+PERFORMANCE.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+PIC.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+PIF.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+PPIRS.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+PRESIDENTIALINNOVATIONFELLOWS.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+PTT.GOV,Federal Agency,General Services Administration,Washington D.C.,DC,ACTIVE
+REALESTATESALES.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+REALPROPERTYPROFILE.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+REGINFO.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+ROCIS.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+SAM.GOV,Federal Agency,General Services Administration,Arlington,VA,ACTIVE
+SANDBOX.GOV,Federal Agency,General Services Administration,Washinton,DC,ACTIVE
+SBST.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+SECTION508.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+SFTOOL.GOV,Federal Agency,General Services Administration,Chicago,IL,ACTIVE
+STRATEGICSOURCING.GOV,Federal Agency,General Services Administration,Arlington,VA,ACTIVE
+SUPPORTTHEVOTER.GOV,Federal Agency,General Services Administration,WASHINGTON,DC,ACTIVE
+UNITEDSTATES.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+US.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+USA.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+USAGOV.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+USAPERFORMANCE.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+USCIRF.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+USGOVERNMENT.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+USIP.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+USSM.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+VEF.GOV,Federal Agency,General Services Administration,Arlington,VA,ACTIVE
+VITM.GOV,Federal Agency,General Services Administration,Arlington,VA,ACTIVE
+VOTE.GOV,Federal Agency,General Services Administration,Washington,DC,ACTIVE
+VOTEBYMAIL.GOV,Federal Agency,General Services Administration,SILVER SPRING,MD,ACTIVE
+CONGRESSIONALDIRECTORY.GOV,Federal Agency,Government Printing Office,Washington,DC,ACTIVE
+CONGRESSIONALRECORD.GOV,Federal Agency,Government Printing Office,Washington,DC,ACTIVE
+ECFR.GOV,Federal Agency,Government Printing Office,Washington,DC,ACTIVE
+FDLP.GOV,Federal Agency,Government Printing Office,Washington,DC,ACTIVE
+FDSYS.GOV,Federal Agency,Government Printing Office,Washington,DC,ACTIVE
+FEDERALREGISTER.GOV,Federal Agency,Government Printing Office,Washington,DC,ACTIVE
+FEDREG.GOV,Federal Agency,Government Printing Office,Washington,DC,ACTIVE
+FMSHRC.GOV,Federal Agency,Government Printing Office,Washington,DC,ACTIVE
+GOVINFO.GOV,Federal Agency,Government Printing Office,Washington,DC,ACTIVE
+GPO.GOV,Federal Agency,Government Printing Office,Washington,DC,ACTIVE
+HOUSECALENDAR.GOV,Federal Agency,Government Printing Office,Washington,DC,ACTIVE
+OFR.GOV,Federal Agency,Government Printing Office,Washington,DC,ACTIVE
+OPENWORLD.GOV,Federal Agency,Government Printing Office,Washington,DC,ACTIVE
+PRESIDENTIALDOCUMENTS.GOV,Federal Agency,Government Printing Office,Washington,DC,ACTIVE
+SENATECALENDAR.GOV,Federal Agency,Government Printing Office,Washington,DC,ACTIVE
+STOPFAKES.GOV,Federal Agency,Government Printing Office,Washington,DC,ACTIVE
+USCAPITOLPOLICE.GOV,Federal Agency,Government Printing Office,Washington,DC,ACTIVE
+USCC.GOV,Federal Agency,Government Printing Office,Washington,DC,ACTIVE
+USCODE.GOV,Federal Agency,Government Printing Office,Washington,DC,ACTIVE
+USGOVERNMENTMANUAL.GOV,Federal Agency,Government Printing Office,College Park,MD,ACTIVE
+WELCOMETOUSA.GOV,Federal Agency,Government Printing Office,Washington,DC,ACTIVE
+RESTORETHEGULF.GOV,Federal Agency,Gulf Coast Ecosystem Restoration Council (GCERC),Silver Spring,MD,ACTIVE
+TRUMAN.GOV,Federal Agency,Harry S. Truman Scholarship Foundation,Washington,DC,ACTIVE
+IMLS.GOV,Federal Agency,Institute of Museum and Library Services,Washington,DC,ACTIVE
+IAF.GOV,Federal Agency,Inter-American Foundation,Washington,DC,ACTIVE
+BBG.GOV,Federal Agency,International Broadcasting Bureau,Washington,DC,ACTIVE
+IBB.GOV,Federal Agency,International Broadcasting Bureau,Washington,DC,ACTIVE
+VOA.GOV,Federal Agency,International Broadcasting Bureau,Washington,DC,ACTIVE
+JAMESMADISON.GOV,Federal Agency,James Madison Memorial Fellowship Foundation,Alexandria,VA,ACTIVE
+LSC.GOV,Federal Agency,Legal Services Corporation,Washington,DC,ACTIVE
+AFRICANAMERICANHISTORYMONTH.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+AMERICANMEMORY.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+AMERICASLIBRARY.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+AMERICASSTORY.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+AMERICASTORY.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+ASIANPACIFICHERITAGE.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+COMMISSION.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+CONGRESS.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+COPYRIGHT.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+CRS.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+DIGITALPRESERVATION.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+DIGITIZATIONGUIDELINES.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+HISPANICHERITAGEMONTH.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+JEWISHHERITAGE.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+JEWISHHERITAGEMONTH.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+LAW.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+LCTL.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+LIBRARYOFCONGRESS.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+LIS.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+LITERACY.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+LOC.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+LOCTPS.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+NATIVEAMERICANHERITAGEMONTH.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+PRIMARYSOURCES.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+READ.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+SECTION108.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+TEACHINGPRIMARYSOURCES.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+TEACHINGWITHPRIMARYSOURCES.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+THOMAS.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+TPS.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+UNITEDSTATESCONGRESS.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+USCONGRESS.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+WDL.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+WOMENSHISTORYMONTH.GOV,Federal Agency,Library of Congress,Washington,DC,ACTIVE
+MMC.GOV,Federal Agency,Marine Mammal Commission,Bethesda,MD,ACTIVE
+MACPAC.GOV,Federal Agency,Medicaid and CHIP Payment and Access Commission,Washington,DC,ACTIVE
+MEDPAC.GOV,Federal Agency,Medical Payment Advisory Commission,Washington,DC,ACTIVE
+MSPB.GOV,Federal Agency,Merit Systems Protection Board,Washington,DC,ACTIVE
+MCC.GOV,Federal Agency,Millennium Challenge Corporation,Washington,DC,ACTIVE
+ECR.GOV,Federal Agency,Morris K. Udall Foundation,Tucson,AZ,ACTIVE
+UDALL.GOV,Federal Agency,Morris K. Udall Foundation,Tucson,AZ,ACTIVE
+GLOBE.GOV,Federal Agency,National Aeronautics and Space Administration,Greenbelt,MD,ACTIVE
+NASA.GOV,Federal Agency,National Aeronautics and Space Administration,MSFC,AL,ACTIVE
+NSWP.GOV,Federal Agency,National Aeronautics and Space Administration,MSFC,AL,ACTIVE
+SCIJINKS.GOV,Federal Agency,National Aeronautics and Space Administration,MSFC,AL,ACTIVE
+USGEO.GOV,Federal Agency,National Aeronautics and Space Administration,MSFC,AL,ACTIVE
+9-11COMMISSION.GOV,Federal Agency,National Archives and Records Administration,College Park,MD,ACTIVE
+911COMMISSION.GOV,Federal Agency,National Archives and Records Administration,College Park,MD,ACTIVE
+ARCHIVES.GOV,Federal Agency,National Archives and Records Administration,College Park,MD,ACTIVE
+CLINTONLIBRARY.GOV,Federal Agency,National Archives and Records Administration,Little Rock,AR,ACTIVE
+EMERGENCY-FEDERAL-REGISTER.GOV,Federal Agency,National Archives and Records Administration,College Park,MD,ACTIVE
+FCIC.GOV,Federal Agency,National Archives and Records Administration,College Park,MD,ACTIVE
+FORDLIBRARYMUSEUM.GOV,Federal Agency,National Archives and Records Administration,College Park,MD,ACTIVE
+FRC.GOV,Federal Agency,National Archives and Records Administration,College Park,MD,ACTIVE
+GEORGEWBUSHLIBRARY.GOV,Federal Agency,National Archives and Records Administration,College Park,MD,ACTIVE
+HISTORY.GOV,Federal Agency,National Archives and Records Administration,College Park,MD,ACTIVE
+JIMMYCARTERLIBRARY.GOV,Federal Agency,National Archives and Records Administration,College,MD,ACTIVE
+NARA-AT-WORK.GOV,Federal Agency,National Archives and Records Administration,College Park,MD,ACTIVE
+NARA.GOV,Federal Agency,National Archives and Records Administration,College Park,MD,ACTIVE
+NIXONLIBRARY.GOV,Federal Agency,National Archives and Records Administration,College Park,MD,ACTIVE
+OGIS.GOV,Federal Agency,National Archives and Records Administration,College Park,MD,ACTIVE
+OURDOCUMENTS.GOV,Federal Agency,National Archives and Records Administration,College Park,MD,ACTIVE
+REAGANLIBRARY.GOV,Federal Agency,National Archives and Records Administration,College Park,MD,ACTIVE
+RECORDSMANAGEMENT.GOV,Federal Agency,National Archives and Records Administration,College Park,MD,ACTIVE
+WARTIMECONTRACTING.GOV,Federal Agency,National Archives and Records Administration,College Park,MD,ACTIVE
+WEBHARVEST.GOV,Federal Agency,National Archives and Records Administration,College Park,MD,ACTIVE
+NCPC.GOV,Federal Agency,National Capital Planning Commission,Washington,DC,ACTIVE
+NCD.GOV,Federal Agency,National Council on Disability,Washington,DC,ACTIVE
+MYCREDITUNION.GOV,Federal Agency,National Credit Union Administration,Alexandria,VA,ACTIVE
+NCUA.GOV,Federal Agency,National Credit Union Administration,Alexandria,VA,ACTIVE
+ARTS.GOV,Federal Agency,National Endowment for the Arts,Washington,DC,ACTIVE
+NEA.GOV,Federal Agency,National Endowment for the Arts,Washington,DC,ACTIVE
+HUMANITIES.GOV,Federal Agency,National Endowment for the Humanities,Washington,DC,ACTIVE
+NEH.GOV,Federal Agency,National Endowment for the Humanities,Washington,DC,ACTIVE
+PCAH.GOV,Federal Agency,National Endowment for the Humanities,Washington,DC,ACTIVE
+WETHEPEOPLE.GOV,Federal Agency,National Endowment for the Humanities,Washington,DC,ACTIVE
+NGA.GOV,Federal Agency,National Gallery of Art,Washington,DC,ACTIVE
+NIGC.GOV,Federal Agency,National Indian Gaming Commission,Washington,DC,ACTIVE
+NLRB.GOV,Federal Agency,National Labor Relations Board,Washington,DC,ACTIVE
+NMB.GOV,Federal Agency,National Mediation Board,Washington,DC,ACTIVE
+NANO.GOV,Federal Agency,National Nanotechnology Coordination Office,Arlington,VA,ACTIVE
+ARCTIC.GOV,Federal Agency,National Science Foundation,Arlington,VA,ACTIVE
+NSF.GOV,Federal Agency,National Science Foundation,Arlington,VA,ACTIVE
+RESEARCH.GOV,Federal Agency,National Science Foundation,Arlington,VA,ACTIVE
+SAC.GOV,Federal Agency,National Science Foundation,Arlington,VA,ACTIVE
+SCIENCE360.GOV,Federal Agency,National Science Foundation,Arlington,VA,ACTIVE
+USAP.GOV,Federal Agency,National Science Foundation,Arlington,VA,ACTIVE
+INTELLIGENCECAREERS.GOV,Federal Agency,National Security Agency,Ft. Meade,MD,ACTIVE
+LPS.GOV,Federal Agency,National Security Agency,College Park,MD,ACTIVE
+NTSB.GOV,Federal Agency,National Transportation Safety Board,Washington,DC,ACTIVE
+ITRD.GOV,Federal Agency,Networking Information Technology Research and Development (NITRD),Arlington,VA,ACTIVE
+NITRD.GOV,Federal Agency,Networking Information Technology Research and Development (NITRD),Arlington,VA,ACTIVE
+HERITAGEABROAD.GOV,Federal Agency,Non-Federal Agency,Washington,DC,ACTIVE
+IAB.GOV,Federal Agency,Non-Federal Agency,Quantico,VA,ACTIVE
+JUSFC.GOV,Federal Agency,Non-Federal Agency,Washington,DC,ACTIVE
+NWTRB.GOV,Federal Agency,Non-Federal Agency,Arlington,VA,ACTIVE
+PPPL.GOV,Federal Agency,Non-Federal Agency,Princeton,NJ,ACTIVE
+SERVEINDIANA.GOV,Federal Agency,Non-Federal Agency,Indianapolis,IN,ACTIVE
+SJI.GOV,Federal Agency,Non-Federal Agency,Reston,VA,ACTIVE
+WMATC.GOV,Federal Agency,Non-Federal Agency,Silver Spring,MD,ACTIVE
+NRC-GATEWAY.GOV,Federal Agency,Nuclear Regulatory Commission,Rockville,MD,ACTIVE
+NRC.GOV,Federal Agency,Nuclear Regulatory Commission,Rockville,MD,ACTIVE
+OSHRC.GOV,Federal Agency,Occupational Safety & Health Review Commission,Washington,DC,ACTIVE
+INTEGRITY.GOV,Federal Agency,Office of Government Ethics,Washington,DC,ACTIVE
+APPLICATIONMANAGER.GOV,Federal Agency,Office of Personnel Management,Macon,GA,ACTIVE
+CHCOC.GOV,Federal Agency,Office of Personnel Management,Washington,DC,ACTIVE
+E-QIP.GOV,Federal Agency,Office of Personnel Management,Washington,DC,ACTIVE
+EMPLOYEEEXPRESS.GOV,Federal Agency,Office of Personnel Management,Macon,GA,ACTIVE
+FEB.GOV,Federal Agency,Office of Personnel Management,Washington,DC,ACTIVE
+FEDERALJOBS.GOV,Federal Agency,Office of Personnel Management,Macon,GA,ACTIVE
+FEDJOBS.GOV,Federal Agency,Office of Personnel Management,Macon,GA,ACTIVE
+FEDSHIREVETS.GOV,Federal Agency,Office of Personnel Management,Washington,DC,ACTIVE
+FEGLI.GOV,Federal Agency,Office of Personnel Management,Washington,DC,ACTIVE
+FSAFEDS.GOV,Federal Agency,Office of Personnel Management,Washington,DC,ACTIVE
+GOLEARN.GOV,Federal Agency,Office of Personnel Management,Washington,DC,ACTIVE
+GOVERNMENTJOBS.GOV,Federal Agency,Office of Personnel Management,Macon,GA,ACTIVE
+HRU.GOV,Federal Agency,Office of Personnel Management,Washington,DC,ACTIVE
+LMRCOUNCIL.GOV,Federal Agency,Office of Personnel Management,Washington,DC,ACTIVE
+OPM.GOV,Federal Agency,Office of Personnel Management,Macon,GA,ACTIVE
+PAC.GOV,Federal Agency,Office of Personnel Management,Washington,DC,ACTIVE
+PMF.GOV,Federal Agency,Office of Personnel Management,Washington,DC,ACTIVE
+TELEWORK.GOV,Federal Agency,Office of Personnel Management,Washington,DC,ACTIVE
+UNLOCKTALENT.GOV,Federal Agency,Office of Personnel Management,Washington,DC,ACTIVE
+USAJOBS.GOV,Federal Agency,Office of Personnel Management,Washington,DC,ACTIVE
+USALEARNING.GOV,Federal Agency,Office of Personnel Management,Washington,DC,ACTIVE
+USASTAFFING.GOV,Federal Agency,Office of Personnel Management,Macon,GA,ACTIVE
+OPIC.GOV,Federal Agency,Overseas Private Investment Corporation,Washington,DC,ACTIVE
+PBGC.GOV,Federal Agency,Pension Benefit Guaranty Corporation,Washington,DC,ACTIVE
+PRC.GOV,Federal Agency,Postal Rate Commission,Washington,DC,ACTIVE
+RRB.GOV,Federal Agency,Railroad Retirement Board,Chicago,IL,ACTIVE
+INVESTOR.GOV,Federal Agency,Securities and Exchange Commission,Alexandria,VA,ACTIVE
+SEC.GOV,Federal Agency,Securities and Exchange Commission,Alexandria,VA,ACTIVE
+SSS.GOV,Federal Agency,Selective Service System,Arlington,VA,ACTIVE
+BUSINESS.GOV,Federal Agency,Small Business Administration,Washington,DC,ACTIVE
+HSA.GOV,Federal Agency,Small Business Administration,Washington,DC,ACTIVE
+NWBC.GOV,Federal Agency,Small Business Administration,Washington,DC,ACTIVE
+ONLINEWBC.GOV,Federal Agency,Small Business Administration,Washington,DC,ACTIVE
+SBA.GOV,Federal Agency,Small Business Administration,Washington,DC,ACTIVE
+SBIR.GOV,Federal Agency,Small Business Administration,Arlington,VA,ACTIVE
+WOMENBIZ.GOV,Federal Agency,Small Business Administration,Washington,DC,ACTIVE
+ITIS.GOV,Federal Agency,Smithsonian Institution,Washington,DC,ACTIVE
+SEGUROSOCIAL.GOV,Federal Agency,Social Security Administration,Baltimore,MD,ACTIVE
+SOCIALSECURITY.GOV,Federal Agency,Social Security Administration,Baltimore,MD,ACTIVE
+SSA.GOV,Federal Agency,Social Security Administration,Baltimore,MD,ACTIVE
+SSAB.GOV,Federal Agency,Social Security Advisory Board,WASHINGTON,DC,ACTIVE
+STENNIS.GOV,Federal Agency,Stennis Center for Public Service,Starkville,MS,ACTIVE
+STB.GOV,Federal Agency,Surface Transportation Board (STB),Washington,DC,ACTIVE
+TVA.GOV,Federal Agency,Tennessee Valley Authority,Knoxville,TN,ACTIVE
+TVAOIG.GOV,Federal Agency,Tennessee Valley Authority,Knoxville,TN,ACTIVE
+TSC.GOV,Federal Agency,Terrorist Screening Center,Washington,DC,ACTIVE
+PTF.GOV,Federal Agency,The Intelligence Community,Washington,DC,ACTIVE
+AOC.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+CAPITAL.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+CAPITOL.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+CAPITOLFLAGS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+CBO.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+CBONEWS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+CECC.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+CHINA-COMMISSION.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+CHINACOMMISSION.GOV,Federal Agency,The Legislative Branch (Congress),Washington,MD,ACTIVE
+CITIZENCOSPONSORS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+CITIZENS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+COSPONSOR.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+CSCE.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+DEMOCRATICLEADER.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+DEMOCRATICWHIP.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+DEMOCRATS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+DEMS.GOV,Federal Agency,The Legislative Branch (Congress),Washington DC,DC,ACTIVE
+ESECLAB.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+FASAB.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+GAO.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+GAONET.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+GOP.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+GOPCONFERENCE.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,SERVER-HOLD
+GOPLEADER.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+HOUSE.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+HOUSECOMMUNICATIONS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+HOUSEDEMOCRATS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+HOUSEDEMS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+HOUSELIVE.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+HOUSENEWSLETTERS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+JCT.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+LISTENSTOYOU.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+MAJORITYLEADER.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+MAJORITYWHIP.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+PDBCECC.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+PPDCECC.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+REPUBLICANS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+SEN.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+SENATE.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+SENATERESTAURANTS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+SPEAKER.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+TAXREFORM.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+USBG.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+USCAPITAL.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+USCAPITOL.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+USCAPITOLVISITORCENTER.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,SERVER-HOLD
+USCVC.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,SERVER-HOLD
+USHOUSE.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+USHR.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+VISITTHECAPITAL.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+VISITTHECAPITOL.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC,ACTIVE
+SC-US.GOV,Federal Agency,The Supreme Court,Washington,DC,ACTIVE
+SCINET-TEST.GOV,Federal Agency,The Supreme Court,Washington,DC,ACTIVE
+SCINET.GOV,Federal Agency,The Supreme Court,Washington,DC,ACTIVE
+SCUS.GOV,Federal Agency,The Supreme Court,WASHINGTON,DC,ACTIVE
+SUPREME-COURT.GOV,Federal Agency,The Supreme Court,Washington,DC,ACTIVE
+SUPREMECOURT.GOV,Federal Agency,The Supreme Court,Washington,DC,ACTIVE
+SUPREMECOURTUS.GOV,Federal Agency,The Supreme Court,Washington,DC,ACTIVE
+WORLDWAR1CENTENNIAL.GOV,Federal Agency,The United States World War One Centennial Commission,Washington,DC,ACTIVE
+ACCESS-BOARD.GOV,Federal Agency,U. S. Access Board,Washington,DC,ACTIVE
+USHMM.GOV,Federal Agency,U. S. Holocaust Memorial Museum,Washington,DC,ACTIVE
+USITC.GOV,Federal Agency,U. S. International Trade Commission,Washington,DC,ACTIVE
+OSC.GOV,Federal Agency,U. S. Office of Special Counsel,Washington,DC,ACTIVE
+OSCNET.GOV,Federal Agency,U. S. Office of Special Counsel,Washington,DC,ACTIVE
+PEACECORE.GOV,Federal Agency,U. S. Peace Corps,Washington,DC,ACTIVE
+PEACECORP.GOV,Federal Agency,U. S. Peace Corps,Washington,DC,ACTIVE
+PEACECORPS.GOV,Federal Agency,U. S. Peace Corps,Washington,DC,ACTIVE
+CHANGEOFADDRESS.GOV,Federal Agency,U. S. Postal Service,Washington,DC,ACTIVE
+MAIL.GOV,Federal Agency,U. S. Postal Service,Raleigh,NC,ACTIVE
+POSTOFFICE.GOV,Federal Agency,U. S. Postal Service,Raleigh,NC,ACTIVE
+PURCHASING.GOV,Federal Agency,U. S. Postal Service,Raleigh,NC,ACTIVE
+USPIS.GOV,Federal Agency,U. S. Postal Service,Arlington,VA,ACTIVE
+USPS.GOV,Federal Agency,U. S. Postal Service,Raleigh,NC,ACTIVE
+BANKRUPTCY.GOV,Federal Agency,U.S Courts,Washington,DC,ACTIVE
+CAVC.GOV,Federal Agency,U.S Courts,Washington,DC,ACTIVE
+DCSC.GOV,Federal Agency,U.S Courts,Washington,DC,ACTIVE
+FEDCIR.GOV,Federal Agency,U.S Courts,Washington,DC,SERVER-HOLD
+FEDERALCOURTS.GOV,Federal Agency,U.S Courts,Washington,DC,ACTIVE
+FEDERALPROBATION.GOV,Federal Agency,U.S Courts,Washington,DC,ACTIVE
+FEDERALRULES.GOV,Federal Agency,U.S Courts,Washington,DC,ACTIVE
+FJC.GOV,Federal Agency,U.S Courts,Washington,DC,ACTIVE
+JUDICIALCONFERENCE.GOV,Federal Agency,U.S Courts,Washington,DC,ACTIVE
+NMCOURT.FED.US,Federal Agency,U.S Courts,Albuquerque,NM,ACTIVE
+PACER.GOV,Federal Agency,U.S Courts,Washington,DC,ACTIVE
+USBANKRUPTCY.GOV,Federal Agency,U.S Courts,Washington,DC,ACTIVE
+USC.GOV,Federal Agency,U.S Courts,Washington,DC,ACTIVE
+USCAVC.GOV,Federal Agency,U.S Courts,Washington,DC,SERVER-HOLD
+USCOURTS.GOV,Federal Agency,U.S Courts,Washington,DC,ACTIVE
+USCVA.GOV,Federal Agency,U.S Courts,Washington,DC,SERVER-HOLD
+USPROBATION.GOV,Federal Agency,U.S Courts,Washington,DC,ACTIVE
+USSC.GOV,Federal Agency,U.S Courts,Washington,DC,ACTIVE
+USTAXCOURT.GOV,Federal Agency,U.S Courts,Washington,DC,ACTIVE
+VETAPP.GOV,Federal Agency,U.S Courts,Washington,DC,SERVER-HOLD
+CHILDRENINADVERSITY.GOV,Federal Agency,U.S. Agency for International Development,Washington,DC,ACTIVE
+DFAFACTS.GOV,Federal Agency,U.S. Agency for International Development,Washington,DC,ACTIVE
+FEEDTHEFUTURE.GOV,Federal Agency,U.S. Agency for International Development,Washington,DC,ACTIVE
+LETGIRLSLEARN.GOV,Federal Agency,U.S. Agency for International Development,Washington,DC,ACTIVE
+NEGLECTEDDISEASES.GOV,Federal Agency,U.S. Agency for International Development,Washington,DC,ACTIVE
+OFDA.GOV,Federal Agency,U.S. Agency for International Development,Washington,DC,ACTIVE
+PMI.GOV,Federal Agency,U.S. Agency for International Development,Washington,DC,ACTIVE
+USAID.GOV,Federal Agency,U.S. Agency for International Development,Washington,DC,ACTIVE
+USAIDALLNET.GOV,Federal Agency,U.S. Agency for International Development,Arlington,VA,ACTIVE
+USCP.GOV,Federal Agency,U.S. Capitol Police,Washington,DC,ACTIVE
+CHEMSAFETY.GOV,Federal Agency,U.S. Chemical Safety and Hazard Investigation Board,Washington,DC,ACTIVE
+CSB.GOV,Federal Agency,U.S. Chemical Safety and Hazard Investigation Board,Washington,DC,ACTIVE
+SAFETYVIDEOS.GOV,Federal Agency,U.S. Chemical Safety and Hazard Investigation Board,Washington,DC,ACTIVE
+CFA.GOV,Federal Agency,U.S. Commission of Fine Arts,Washington,DC,ACTIVE
+USCCR.GOV,Federal Agency,U.S. Commission on Civil Rights,Washington,DC,ACTIVE
+PEACECORPSOIG.GOV,Federal Agency,"U.S. Postal Service, Office of Inspector General",Washington,DC,ACTIVE
+USPSOIG.GOV,Federal Agency,"U.S. Postal Service, Office of Inspector General",Arlington,VA,ACTIVE
+USTDA.GOV,Federal Agency,U.S. Trade and Development Agency,Arlington,VA,ACTIVE
+CARBONCYCLESCIENCE.GOV,Federal Agency,United Stated Global Change Research Program,Washington,DC,SERVER-HOLD
+GLOBALCHANGE.GOV,Federal Agency,United Stated Global Change Research Program,Washington,DC,ACTIVE
+IPCC-WG2.GOV,Federal Agency,United Stated Global Change Research Program,Stanford,CA,ACTIVE
+USGCRP.GOV,Federal Agency,United Stated Global Change Research Program,Washington,DC,ACTIVE
+OGE.GOV,Federal Agency,United States Office of Government Ethics,Washington,DC,ACTIVE
+ICH.GOV,Federal Agency,US Interagency Council on Homelessness,washington,DC,ACTIVE
+USICH.GOV,Federal Agency,US Interagency Council on Homelessness,Washington,DC,ACTIVE
+29PALMSBOMI-NSN.GOV,Native Sovereign Nation,Indian Affairs,Coachella,CA,ACTIVE
+ABSENTEESHAWNEETRIBE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Shawnee,OK,ACTIVE
+AGUACALIENTE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Palm Springs,CA,ACTIVE
+AHA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Hogansburg,NY,ACTIVE
+AK-CHIN-NSN.GOV,Native Sovereign Nation,Indian Affairs,Maricopa,AZ,ACTIVE
+BADRIVER-NSN.GOV,Native Sovereign Nation,Indian Affairs,Odanah,WI,ACTIVE
+BARONA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Lakeside,CA,ACTIVE
+BEARRIVER-NSN.GOV,Native Sovereign Nation,Indian Affairs,Loleta,CA,ACTIVE
+BIHASITKA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Sitka,AK,ACTIVE
+BLUELAKERANCHERIA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Blue Lake,CA,ACTIVE
+BOISFORTE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Nett Lake,MN,ACTIVE
+BRB-NSN.GOV,Native Sovereign Nation,Indian Affairs,LOLETA,CA,ACTIVE
+BURNSPAIUTE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Burns,OR,ACTIVE
+CABAZONINDIANS-NSN.GOV,Native Sovereign Nation,Indian Affairs,Indio,CA,ACTIVE
+CADDONATION-NSN.GOV,Native Sovereign Nation,Indian Affairs,Binger,OK,ACTIVE
+CAHTOTRIBE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Laytonville,CA,ACTIVE
+CAMPO-NSN.GOV,Native Sovereign Nation,Indian Affairs,Campo,CA,ACTIVE
+CAYUGANATION-NSN.GOV,Native Sovereign Nation,Indian Affairs,Seneca Falls ,NY,ACTIVE
+CCTHITA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Juneau,AK,ACTIVE
+CDATRIBE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Plummer,ID,ACTIVE
+CHEROKEE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Tahlequah,OK,ACTIVE
+CHICKASAW-GOVERNMENT-NSN.GOV,Native Sovereign Nation,Indian Affairs,Ada,OK,ACTIVE
+CHICKASAW-NSN.GOV,Native Sovereign Nation,Indian Affairs,Ada,OK,ACTIVE
+CHICKASAWARTISANS-NSN.GOV,Native Sovereign Nation,Indian Affairs,Ada,OK,ACTIVE
+CHICKASAWGOVERNMENT-NSN.GOV,Native Sovereign Nation,Indian Affairs,Ada,OK,ACTIVE
+CHICKASAWJUDICIAL-NSN.GOV,Native Sovereign Nation,Indian Affairs,Ada,OK,ACTIVE
+CHICKASAWLEGISLATURE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Ada,OK,ACTIVE
+CHICKASAWNATION-NSN.GOV,Native Sovereign Nation,Indian Affairs,Ada,OK,ACTIVE
+CHICKASAWTRIBE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Ada,OK,ACTIVE
+CHILKOOT-NSN.GOV,Native Sovereign Nation,Indian Affairs,Haines,AK,ACTIVE
+CHITIMACHA.GOV,Native Sovereign Nation,Indian Affairs,Charenton,LA,ACTIVE
+CHUKCHANSI-NSN.GOV,Native Sovereign Nation,Indian Affairs,Fresno,CA,ACTIVE
+CIT-NSN.GOV,Native Sovereign Nation,Indian Affairs,Havasu Lake,CA,ACTIVE
+COLUSA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Colusa,CA,ACTIVE
+COYOTEVALLEY-NSN.GOV,Native Sovereign Nation,Indian Affairs,Redwood valley,CA,ACTIVE
+CRHC-NSN.GOV,Native Sovereign Nation,Indian Affairs,Chico,CA,ACTIVE
+CRIT-NSN.GOV,Native Sovereign Nation,Indian Affairs,Parker,AZ,ACTIVE
+CROW-NSN.GOV,Native Sovereign Nation,Indian Affairs,Crow Agency,MT,ACTIVE
+CRST-NSN.GOV,Native Sovereign Nation,Indian Affairs,EAGLE BUTTE,SD,ACTIVE
+EKLUTNA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Chugiak,AK,ACTIVE
+ELYSHOSHONETRIBE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Ely,NV,ACTIVE
+ESTOO-NSN.GOV,Native Sovereign Nation,Indian Affairs,Wyandotte,OK,ACTIVE
+EWIIAAPAAYP-NSN.GOV,Native Sovereign Nation,Indian Affairs,Alpine,CA,ACTIVE
+EYAK-NSN.GOV,Native Sovereign Nation,Indian Affairs,Cordova,AK,ACTIVE
+FCP-NSN.GOV,Native Sovereign Nation,Indian Affairs,Crandon,WI,ACTIVE
+FCPOTAWATOMI-NSN.GOV,Native Sovereign Nation,Indian Affairs,Crandon,WI,ACTIVE
+FORTSILLAPACHE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Apache,OK,ACTIVE
+GILARIVER-NSN.GOV,Native Sovereign Nation,Indian Affairs,Sacaton,AZ,ACTIVE
+GLT-NSN.GOV,Native Sovereign Nation,Indian Affairs,Dorr,MI,ACTIVE
+GUNLAKETRIBE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Dorr,MI,ACTIVE
+HANNAHVILLEPOTAWATOMI-NSN.GOV,Native Sovereign Nation,Indian Affairs,Wilson,MI,ACTIVE
+HAVASUPAI-NSN.GOV,Native Sovereign Nation,Indian Affairs,Supai,AZ,ACTIVE
+HOOPA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Hoopa,CA,ACTIVE
+HOPI-NSN.GOV,Native Sovereign Nation,Indian Affairs,Kykotsmovi,AZ,ACTIVE
+HPULTRIBE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Upper Lake,CA,ACTIVE
+HUALAPAI-NSN.GOV,Native Sovereign Nation,Indian Affairs,Peach Springs,AZ,ACTIVE
+IIPAYNATION-NSN.GOV,Native Sovereign Nation,Indian Affairs,santa ysabel,CA,ACTIVE
+ISLETAPUEBLO-NSN.GOV,Native Sovereign Nation,Indian Affairs,Isleta,NM,ACTIVE
+JACKSONRANCHERIA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Jackson,CA,ACTIVE
+KAIBABPAIUTE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Fredonia,AZ,ACTIVE
+KAWAIKA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Laguna,NM,ACTIVE
+KAYENTATOWNSHIP-NSN.GOV,Native Sovereign Nation,Indian Affairs,Kayenta,AZ,ACTIVE
+KBIC-NSN.GOV,Native Sovereign Nation,Indian Affairs,Baraga,MI,ACTIVE
+KENAITZE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Kenai,AK,ACTIVE
+KEWEENAWBAY-NSN.GOV,Native Sovereign Nation,Indian Affairs,Baraga,MI,ACTIVE
+KTIK-NSN.GOV,Native Sovereign Nation,Indian Affairs,Horton,KS,ACTIVE
+LAGUNA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Laguna,NM,ACTIVE
+LAGUNAPUEBLO-NSN.GOV,Native Sovereign Nation,Indian Affairs,Laguna,NM,ACTIVE
+LAJOLLA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Pauma Valley,CA,ACTIVE
+LCO-NSN.GOV,Native Sovereign Nation,Indian Affairs,Hayward,WI,ACTIVE
+LTBBODAWA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Harbor Springs,MI,ACTIVE
+LUMMI-NSN.GOV,Native Sovereign Nation,Indian Affairs,Bellingham,WA,ACTIVE
+MASHANTUCKET-NSN.GOV,Native Sovereign Nation,Indian Affairs,Mashantucket,CT,ACTIVE
+MASHANTUCKETPEQUOT-NSN.GOV,Native Sovereign Nation,Indian Affairs,Mashantucket,CT,ACTIVE
+MASHANTUCKETWESTERNPEQUOT-NSN.GOV,Native Sovereign Nation,Indian Affairs,Mashantucket,CT,ACTIVE
+MCN-NSN.GOV,Native Sovereign Nation,Indian Affairs,Okmulgee,OK,ACTIVE
+MECHOOPDA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Chico,CA,ACTIVE
+MENOMINEE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Keshena,WI,ACTIVE
+MESAGRANDEBAND-NSN.GOV,Native Sovereign Nation,Indian Affairs,SantaYsabel,CA,ACTIVE
+MESKWAKI-NSN.GOV,Native Sovereign Nation,Indian Affairs,Tama,IA,ACTIVE
+MICCOSUKEE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Miami,FL,ACTIVE
+MICMAC-NSN.GOV,Native Sovereign Nation,Indian Affairs,Presque Isle,ME,ACTIVE
+MIDDLETOWNRANCHERIA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Middletown,CA,ACTIVE
+MILLELACSBAND-NSN.GOV,Native Sovereign Nation,Indian Affairs,Onamia,MN,ACTIVE
+MOAPABANDOFPAIUTES-NSN.GOV,Native Sovereign Nation,Indian Affairs,Moapa,NV,SERVER-HOLD
+MOHICAN-NSN.GOV,Native Sovereign Nation,Indian Affairs,Bowler,WI,ACTIVE
+MORONGO-NSN.GOV,Native Sovereign Nation,Indian Affairs,Banning,CA,ACTIVE
+MPGE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Mashantucket,CT,ACTIVE
+MPTN-NSN.GOV,Native Sovereign Nation,Indian Affairs,Mashantucket,CT,ACTIVE
+MUSCOGEENATION-NSN.GOV,Native Sovereign Nation,Indian Affairs,Okmulgee,OK,ACTIVE
+NCIHA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Ukiah,CA,ACTIVE
+NFR-NSN.GOV,Native Sovereign Nation,Indian Affairs,North Fork,CA,ACTIVE
+NFRIHA-NSN.GOV,Native Sovereign Nation,Indian Affairs,North Fork,CA,ACTIVE
+NINILCHIKTRIBE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Ninilchik,AK,ACTIVE
+NISQUALLY-NSN.GOV,Native Sovereign Nation,Indian Affairs,Olympia,WA,ACTIVE
+NOOKSACK-NSN.GOV,Native Sovereign Nation,Indian Affairs,Deming,WA,ACTIVE
+NORTHFORKRANCHERIA-NSN.GOV,Native Sovereign Nation,Indian Affairs,North Fork ,CA,ACTIVE
+NVB-NSN.GOV,Native Sovereign Nation,Indian Affairs,Barrow,AK,ACTIVE
+OHKAYOWINGEH-NSN.GOV,Native Sovereign Nation,Indian Affairs,San Juan Pueblo,NM,ACTIVE
+OMAHA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Macy,NE,ACTIVE
+ONEIDA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Oneida,WI,ACTIVE
+OSAGECONGRESS-NSN.GOV,Native Sovereign Nation,Indian Affairs,Pawhuska,OK,ACTIVE
+OSAGENATION-NSN.GOV,Native Sovereign Nation,Indian Affairs,Pawhuska,OK,ACTIVE
+PASCUAYAQUI-NSN.GOV,Native Sovereign Nation,Indian Affairs,Tucson,AZ,ACTIVE
+PASKENTA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Corning,CA,ACTIVE
+PAUMA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Pauma Valley,CA,ACTIVE
+PCI-NSN.GOV,Native Sovereign Nation,Indian Affairs,Atmore,AL,ACTIVE
+PECHANGA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Temecula,CA,ACTIVE
+PEQUOT-NSN.GOV,Native Sovereign Nation,Indian Affairs,Mashantucket,CT,ACTIVE
+PHC-NSN.GOV,Native Sovereign Nation,Indian Affairs,Princeton,ME,ACTIVE
+POARCHCREEKINDIANS-NSN.GOV,Native Sovereign Nation,Indian Affairs,ATMORE,AL,ACTIVE
+POKAGONBAND-NSN.GOV,Native Sovereign Nation,Indian Affairs,DOWAGIAC,MI,ACTIVE
+POL-NSN.GOV,Native Sovereign Nation,Indian Affairs,Laguna,NM,ACTIVE
+PUYALLUPTRIBE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Tacoma,WA,ACTIVE
+QVIR-NSN.GOV,Native Sovereign Nation,Indian Affairs,Fort jones,CA,ACTIVE
+RAMONA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Anza,CA,ACTIVE
+REDCLIFF-NSN.GOV,Native Sovereign Nation,Indian Affairs,Bayfield,WI,ACTIVE
+ROSEBUDSIOUXTRIBE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Rosebud,SD,ACTIVE
+RST-NSN.GOV,Native Sovereign Nation,Indian Affairs,Rosebud,SD,ACTIVE
+RSTWATER-NSN.GOV,Native Sovereign Nation,Indian Affairs,Rosebud,SD,ACTIVE
+SACANDFOXNATION-NSN.GOV,Native Sovereign Nation,Indian Affairs,Stroud,OK,ACTIVE
+SANMANUEL-NSN.GOV,Native Sovereign Nation,Indian Affairs,Highland,CA,ACTIVE
+SANTAANA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Santa Ana,NM,ACTIVE
+SANTAROSACAHUILLA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Anza,CA,ACTIVE
+SCAT-NSN.GOV,Native Sovereign Nation,Indian Affairs,Peridot,AZ,ACTIVE
+SCC-NSN.GOV,Native Sovereign Nation,Indian Affairs,Crandon,WI,ACTIVE
+SEMINOLENATION-NSN.GOV,Native Sovereign Nation,Indian Affairs,Wewoka,OK,ACTIVE
+SHOALWATERBAY-NSN.GOV,Native Sovereign Nation,Indian Affairs,Tokeland,WA,ACTIVE
+SIR-NSN.GOV,Native Sovereign Nation,Indian Affairs,Susanville,CA,ACTIVE
+SITKATRIBE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Sitka,AK,ACTIVE
+SNO-NSN.GOV,Native Sovereign Nation,Indian Affairs,Wewoka,OK,ACTIVE
+SOBOBA-NSN.GOV,Native Sovereign Nation,Indian Affairs,San Jacinto,CA,ACTIVE
+SOUTHERNUTE-NSN.GOV,Native Sovereign Nation,Indian Affairs,IGNACIO,CO,ACTIVE
+SRMT-NSN.GOV,Native Sovereign Nation,Indian Affairs,Akwesasne,NY,ACTIVE
+SRPMIC-NSN.GOV,Native Sovereign Nation,Indian Affairs,Scottsdale,AZ,ACTIVE
+SUSANVILLEINDIANRANCHERIA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Susanville,CA,ACTIVE
+SWINOMISH-NSN.GOV,Native Sovereign Nation,Indian Affairs,La Conner,WA,ACTIVE
+SWO-NSN.GOV,Native Sovereign Nation,Indian Affairs,Agency Village,SD,ACTIVE
+SYCUAN-NSN.GOV,Native Sovereign Nation,Indian Affairs,El Cajon,CA,ACTIVE
+TACHI-YOKUT-NSN.GOV,Native Sovereign Nation,Indian Affairs,Lemoore,CA,ACTIVE
+TAMAYA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Santa Ana,NM,ACTIVE
+TEJONINDIANTRIBE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Bakersfield,CA,ACTIVE
+TMDCI-NSN.GOV,Native Sovereign Nation,Indian Affairs,Thermal,CA,ACTIVE
+TOLOWA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Smith River,CA,ACTIVE
+TONATION-NSN.GOV,Native Sovereign Nation,Indian Affairs,Sells,AZ,ACTIVE
+TORRESMARTINEZ-NSN.GOV,Native Sovereign Nation,Indian Affairs,Thermal,CA,ACTIVE
+TULALIP-NSN.GOV,Native Sovereign Nation,Indian Affairs,Tulalip,WA,ACTIVE
+TULALIPAIR-NSN.GOV,Native Sovereign Nation,Indian Affairs,Tulalip,WA,ACTIVE
+TULALIPTRIBES-NSN.GOV,Native Sovereign Nation,Indian Affairs,Tulalip,WA,ACTIVE
+TULERIVERTRIBE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Porterville,CA,ACTIVE
+TWENTYNINEPALMSBOMI-NSN.GOV,Native Sovereign Nation,Indian Affairs,Coachella,CA,ACTIVE
+UKB-NSN.GOV,Native Sovereign Nation,Indian Affairs,Tahlequah,OK,ACTIVE
+UPPERSIOUXCOMMUNITY-NSN.GOV,Native Sovereign Nation,Indian Affairs,Granite Falls,MN,ACTIVE
+VIEJAS-NSN.GOV,Native Sovereign Nation,Indian Affairs,Alpine,CA,ACTIVE
+WARMSPRINGS-NSN.GOV,Native Sovereign Nation,Indian Affairs,Warm Springs,OR,ACTIVE
+WESTERNPEQUOT-NSN.GOV,Native Sovereign Nation,Indian Affairs,Mashantucket,CT,ACTIVE
+WHITEEARTH-NSN.GOV,Native Sovereign Nation,Indian Affairs,Ogema,MN,ACTIVE
+WILTONRANCHERIA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Elk Grove,CA,ACTIVE
+WINNEMUCCAINDIANCOLONYOFNEVADA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Winnemucca,NV,ACTIVE
+WYANDOTTE-NATION-NSN.GOV,Native Sovereign Nation,Indian Affairs,Wyandotte,OK,ACTIVE
+YAKAMAFISH-NSN.GOV,Native Sovereign Nation,Indian Affairs,Toppenish,WA,ACTIVE
+YAKAMANATION-NSN.GOV,Native Sovereign Nation,Indian Affairs,Toppenish,WA,ACTIVE
+YOCHADEHE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Brooks,CA,ACTIVE
+YPT-NSN.GOV,Native Sovereign Nation,Indian Affairs,Yerington,NV,ACTIVE
+CHILKAT-NSN.GOV,Native Sovereign Nation,Non-Federal Agency,Haines,AK,ACTIVE
+DINEH-NSN.GOV,Native Sovereign Nation,Non-Federal Agency,Window Rock,AZ,ACTIVE
+LRBOI-NSN.GOV,Native Sovereign Nation,Non-Federal Agency,Manistee,MI,ACTIVE
+NAVAJO-NSN.GOV,Native Sovereign Nation,Non-Federal Agency,Window Rock,AZ,ACTIVE
+YDSP-NSN.GOV,Native Sovereign Nation,Non-Federal Agency,El Pas,TX,ACTIVE
+MTC.GOV,State/Local Govt,Multistate Tax Commission,Washington,DC,ACTIVE
+IUS.GOV,State/Local Govt,National Gallery of Art,Boise,ID,ACTIVE
+511MAINE.GOV,State/Local Govt,Non-Federal Agency,Augusta,ME,ACTIVE
+511NY.GOV,State/Local Govt,Non-Federal Agency,Albany,NY,ACTIVE
+511TX.GOV,State/Local Govt,Non-Federal Agency,Austin,TX,ACTIVE
+511WI.GOV,State/Local Govt,Non-Federal Agency,Madison,WI,ACTIVE
+ABLETN.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE
+ACCESSTN.GOV,State/Local Govt,Non-Federal Agency,NASHVILLE,TN,ACTIVE
+ADRCNJ.GOV,State/Local Govt,Non-Federal Agency,Mercerville,NJ,ACTIVE
+AGAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AGUTAH.GOV,State/Local Govt,Non-Federal Agency,Salt Lake City,UT,ACTIVE
+AK.GOV,State/Local Govt,Non-Federal Agency,Juneau,AK,ACTIVE
+AKAEROSPACE.GOV,State/Local Govt,Non-Federal Agency,Anchorage,AK,ACTIVE
+AKLEG.GOV,State/Local Govt,Non-Federal Agency,Juneau,AK,ACTIVE
+AL-LEGISLATURE.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE
+AL.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE
+ALABAMA.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE
+ALABAMAAGELINE.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE
+ALABAMACONNECT.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE
+ALABAMADA.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE
+ALABAMADEMENTIA.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE
+ALABAMAHOUSEPHOTOS.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE
+ALABAMASMP.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE
+ALABAMAVOTES.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE
+ALABPP.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE
+ALACOP.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE
+ALACOURT.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE
+ALADA.GOV,State/Local Govt,Non-Federal Agency,Mongomery,AL,ACTIVE
+ALADNA.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE
+ALAPPEALS.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE
+ALASAFE.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE
+ALASKA.GOV,State/Local Govt,Non-Federal Agency,Juneau,AK,ACTIVE
+ALASKACARE.GOV,State/Local Govt,Non-Federal Agency,Juneau,AK,ACTIVE
+ALDOI.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE
+ALEA.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE
+ALHOUSE.GOV,State/Local Govt,Non-Federal Agency,Montgomery ,AL,ACTIVE
+ALPHARETTA-GA.GOV,State/Local Govt,Non-Federal Agency,Alpharetta,GA,ACTIVE
+ALSENATE.GOV,State/Local Govt,Non-Federal Agency,Montgomery ,AL,ACTIVE
+AMERICANSAMOA.GOV,State/Local Govt,Non-Federal Agency,Pago Pago,AS,ACTIVE
+AMESBURYMA.GOV,State/Local Govt,Non-Federal Agency,Amesbury,MA,ACTIVE
+ANNAPOLIS.GOV,State/Local Govt,Non-Federal Agency,Annapolis,MD,ACTIVE
+ANNAPOLISMD.GOV,State/Local Govt,Non-Federal Agency,Annapolis,MD,ACTIVE
+AQMD.GOV,State/Local Govt,Non-Federal Agency,Diamond Bar,CA,ACTIVE
+AR.GOV,State/Local Govt,Non-Federal Agency,Little Rock,AR,ACTIVE
+ARCOURTS.GOV,State/Local Govt,Non-Federal Agency,Little Rock,AR,ACTIVE
+ARIZONA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+ARIZONAJOBCONNECTION.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+ARIZONATURBOCOURT.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+ARKANSAS.GOV,State/Local Govt,Non-Federal Agency,Little Rock,AR,ACTIVE
+ARKANSASAG.GOV,State/Local Govt,Non-Federal Agency,Little Rock,AR,ACTIVE
+ARKANSASED.GOV,State/Local Govt,Non-Federal Agency,Little Rock,AR,ACTIVE
+ARKLEGAUDIT.GOV,State/Local Govt,Non-Federal Agency,Little Rock,AR,ACTIVE
+ARTREASURY.GOV,State/Local Govt,Non-Federal Agency,Litlte Rock,AR,ACTIVE
+ARTRS.GOV,State/Local Govt,Non-Federal Agency,Little Rock,AR,ACTIVE
+AS.GOV,State/Local Govt,Non-Federal Agency,Pago Pago,AS,ACTIVE
+ASAFERFLORIDA.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+ASEPA.GOV,State/Local Govt,Non-Federal Agency,Pago Pago,AS,ACTIVE
+ATHOMEILLINOIS.GOV,State/Local Govt,Non-Federal Agency,Chicago,IL,ACTIVE
+ATLASALABAMA.GOV,State/Local Govt,Non-Federal Agency,TUSCALOOSA,AL,ACTIVE
+ATTORNEYGENERAL.GOV,State/Local Govt,Non-Federal Agency,Harrisburg,PA,ACTIVE
+AUGUSTAGA.GOV,State/Local Govt,Non-Federal Agency,Augusta,GA,ACTIVE
+AVON-MA.GOV,State/Local Govt,Non-Federal Agency,Avon,MA,ACTIVE
+AZ-ACOIHC.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZ-FHSD.GOV,State/Local Govt,Non-Federal Agency,Fountain Hills,AZ,ACTIVE
+AZ.GOV,State/Local Govt,Non-Federal Agency,Phoeniz,AZ,ACTIVE
+AZ511.GOV,State/Local Govt,Non-Federal Agency,Pheonix,AZ,ACTIVE
+AZ529.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZ911.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZABRC.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZACCOUNTANCY.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZACTIC.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZAFIS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZAG.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZAHCCCS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZARTS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZASRS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZAUDITOR.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZBN.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZBNP.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZBOA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZBOC.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZBOEC.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZBOF.GOV,State/Local Govt,Non-Federal Agency,PHOENIX,AZ,ACTIVE
+AZBORDERTRASH.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZBOTA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZBOXINGANDMMA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZBROADBAND.GOV,State/Local Govt,Non-Federal Agency,PHOENIX,AZ,ACTIVE
+AZBTR.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZCAAA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZCANCERCONTROL.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZCC.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZCIA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZCJC.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZCLEANELECTIONS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZCLIMATECHANGE.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZCOOP.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZCORPCOM.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZCORPCOMM.GOV,State/Local Govt,Non-Federal Agency,Phoenxi,AZ,ACTIVE
+AZCORRECTIONS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZCOURTDOCS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZCOURTS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZCVD.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZDA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZDAARS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZDCS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZDDPC.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZDEMA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZDEQ.GOV,State/Local Govt,Non-Federal Agency,Phx,AZ,ACTIVE
+AZDES.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZDFI.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZDHS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZDIABETES.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZDJC.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZDO.GOV,State/Local Govt,Non-Federal Agency,Scottsdale,AZ,ACTIVE
+AZDOA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZDOC.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZDOH.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZDOHS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZDOR.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZDOSH.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZDOT.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZDPS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZDVS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZECDH.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZED.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZEIN.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZENVIROKIDS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZEPIP.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZFIRSTTHINGSFIRST.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZFTF.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZGADA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZGAMING.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZGFD.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZGITA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZGOHS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZGOVERNOR.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZGRANTS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZGU.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZGUARD.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZHC.GOV,State/Local Govt,Non-Federal Agency,Pheonix,AZ,ACTIVE
+AZHEALTH.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZHIGHERED.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZHOUSE.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZHOUSING.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZHS.GOV,State/Local Govt,Non-Federal Agency,Tempe,AZ,ACTIVE
+AZICA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZINSURANCE.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZINVESTOR.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZJOBCONNECTION.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZJUVED.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZKIDSCARE.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZKIDSNEEDU.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZLAND.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZLEG.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZLGMA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZLIBRARY.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZLINKS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZLIQUOR.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZLOTTERY.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZMAG.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZMD.GOV,State/Local Govt,Non-Federal Agency,Scottsdale,AZ,ACTIVE
+AZMINORITYHEALTH.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZMORTGAGERESOURCE.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZMYFAMILYBENEFITS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZND.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZNET.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZOCA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZOSPB.GOV,State/Local Govt,Non-Federal Agency,phoenix,AZ,ACTIVE
+AZOT.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZPA.GOV,State/Local Govt,Non-Federal Agency,Scottsdale,AZ,ACTIVE
+AZPARKS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZPCRPD.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZPH.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZPHARMACY.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZPOST.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZPPSE.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZPSIC.GOV,State/Local Govt,Non-Federal Agency,PHOENIX,AZ,ACTIVE
+AZQUALITYFIRST.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZRACING.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZRE.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZRECYCLES.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZREPORTCARD.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZROC.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZRRA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZRUCO.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZSAL.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZSENATE.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZSF.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZSFB.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZSHARE.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZSOS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZSTATEJOBS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZSTATEPARKS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZSTATS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZSTEPSUP.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZSUMMERFOOD.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZSURPLUS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZTAXES.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZTRANSPORTATIONBOARD.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZTREASURER.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZTREASURY.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZTURBOCOURT.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZUI.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZUITAX.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZUNCLAIMED.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZVOICES.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZWATER.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZWATERBANK.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZWIC.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZWIFA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZWPF.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+AZYES.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+B4WV.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE
+BAAQMD.GOV,State/Local Govt,Non-Federal Agency,San Francisco,CA,ACTIVE
+BABYARIZONA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+BARHARBORMAINE.GOV,State/Local Govt,Non-Federal Agency,Bar Harbor,ME,ACTIVE
+BART.GOV,State/Local Govt,Non-Federal Agency,Oakland,CA,ACTIVE
+BATONROUGELA.GOV,State/Local Govt,Non-Federal Agency,Baton Rouge,LA,ACTIVE
+BEGA-DC.GOV,State/Local Govt,Non-Federal Agency,Washington,DC,ACTIVE
+BEREADYUTAH.GOV,State/Local Govt,Non-Federal Agency,Salt Lake City,UT,ACTIVE
+BETSYLEHMANCENTERMA.GOV,State/Local Govt,Non-Federal Agency,Boston,MA,ACTIVE
+BLNC.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+BOATIDAHO.GOV,State/Local Govt,Non-Federal Agency,Boise,ID,ACTIVE
+BOIMI.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI,ACTIVE
+BOULDERCOUNTY-CO.GOV,State/Local Govt,Non-Federal Agency,Boulder,CO,ACTIVE
+BRAINTREEMA.GOV,State/Local Govt,Non-Federal Agency,Braintree,MA,ACTIVE
+BRANDCOLORADO.GOV,State/Local Govt,Non-Federal Agency,Boulder,CO,ACTIVE
+BREWERMAINE.GOV,State/Local Govt,Non-Federal Agency,Brewer,ME,ACTIVE
+BROCKTON-MA.GOV,State/Local Govt,Non-Federal Agency,Brockton,MA,ACTIVE
+BRUNSWICKMD.GOV,State/Local Govt,Non-Federal Agency,Brunswick,MD,ACTIVE
+BURKECOUNTY-GA.GOV,State/Local Govt,Non-Federal Agency,Waynesboro,GA,ACTIVE
+BUSINESS4WV.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE
+BUYNJBONDS.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+CA.GOV,State/Local Govt,Non-Federal Agency,Rancho Cordova,CA,ACTIVE
+CAHWNET.GOV,State/Local Govt,Non-Federal Agency,Sacramento,CA,ACTIVE
+CALIFORNIA.GOV,State/Local Govt,Non-Federal Agency,Rancho Cordova,CA,ACTIVE
+CALIFORNIADESERT.GOV,State/Local Govt,Non-Federal Agency,Barstow,CA,ACTIVE
+CAMBRIDGERETIREMENTMA.GOV,State/Local Govt,Non-Federal Agency,Cambridge,MA,ACTIVE
+CAMDENCOUNTYGA.GOV,State/Local Govt,Non-Federal Agency,Woodbine,GA,ACTIVE
+CANBYOREGON.GOV,State/Local Govt,Non-Federal Agency,Canby,OR,ACTIVE
+CAPITALREGIONUPDATES.GOV,State/Local Govt,Non-Federal Agency,Fairfax,VA,ACTIVE
+CASAAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+CHIAMASS.GOV,State/Local Govt,Non-Federal Agency,Boston,MA,ACTIVE
+CHOOSEIDAHO.GOV,State/Local Govt,Non-Federal Agency,Boise,ID,ACTIVE
+CITYOFBOSTON.GOV,State/Local Govt,Non-Federal Agency,Boston,MA,ACTIVE
+CLAIMITTN.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE
+CLAYCOUNTYIN.GOV,State/Local Govt,Non-Federal Agency,Brazil,IN,ACTIVE
+CLEARSPRINGMD.GOV,State/Local Govt,Non-Federal Agency,Clear Spring,MD,ACTIVE
+CMSPLANFLORIDA.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL,ACTIVE
+CO.GOV,State/Local Govt,Non-Federal Agency,Lakewood,CO,ACTIVE
+COAG.GOV,State/Local Govt,Non-Federal Agency,Denver,CO,ACTIVE
+COBBCOUNTYGA.GOV,State/Local Govt,Non-Federal Agency,Marietta,GA,ACTIVE
+COBERTURAMEDICAILLINOIS.GOV,State/Local Govt,Non-Federal Agency,Chicago,IL,ACTIVE
+COCICJIS.GOV,State/Local Govt,Non-Federal Agency,Golden,CO,ACTIVE
+CODOT.GOV,State/Local Govt,Non-Federal Agency,Denver,CO,ACTIVE
+COLLEGEGOALARIZONA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+COLLEGEGOALOREGON.GOV,State/Local Govt,Non-Federal Agency,Eugene,OR,ACTIVE
+COLLIERCOUNTYFL.GOV,State/Local Govt,Non-Federal Agency,Naples,FL,ACTIVE
+COLORADO.GOV,State/Local Govt,Non-Federal Agency,Lakewood,CO,ACTIVE
+COLORADOATTORNEYGENERAL.GOV,State/Local Govt,Non-Federal Agency,Denver,CO,ACTIVE
+COLORADOJUDICIAL.GOV,State/Local Govt,Non-Federal Agency,Denver,CO,ACTIVE
+COLORADOJUDICIALPERFORMANCE.GOV,State/Local Govt,Non-Federal Agency,Denver,CO,ACTIVE
+COLORADOLABORLAW.GOV,State/Local Govt,Non-Federal Agency,Denver,CO,ACTIVE
+COLORADOPOST.GOV,State/Local Govt,Non-Federal Agency,Denver,CO,ACTIVE
+COLORADOPOSTGRANTS.GOV,State/Local Govt,Non-Federal Agency,Denver,CO,ACTIVE
+COLORADORCJC.GOV,State/Local Govt,Non-Federal Agency,Denver,CO,ACTIVE
+COLORADOUI.GOV,State/Local Govt,Non-Federal Agency,Denver,CO,ACTIVE
+COLORADOWORKS.GOV,State/Local Govt,Non-Federal Agency,Denver,CO,ACTIVE
+COMPARECAREWV.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE
+CONCORD-MA.GOV,State/Local Govt,Non-Federal Agency,Concord,MA,ACTIVE
+CONNECTND.GOV,State/Local Govt,Non-Federal Agency,Bisamarck,ND,ACTIVE
+CONSERVEALABAMA.GOV,State/Local Govt,Non-Federal Agency,MONTGOMERY,AL,ACTIVE
+CONSHOHOCKENPA.GOV,State/Local Govt,Non-Federal Agency,Conshohocken,PA,ACTIVE
+COSIPA.GOV,State/Local Govt,Non-Federal Agency,Denver,CO,ACTIVE
+COUNCILBLUFFS-IA.GOV,State/Local Govt,Non-Federal Agency,Council Bluffs,IA,ACTIVE
+COURTNEWSOHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+COURTSWV.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE
+COVERTENNESSEE.GOV,State/Local Govt,Non-Federal Agency,NASHVILLE,TN,ACTIVE
+COVERTN.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE
+COWORKFORCE.GOV,State/Local Govt,Non-Federal Agency,Denver,CO,ACTIVE
+CRESTEDBUTTE-CO.GOV,State/Local Govt,Non-Federal Agency,Crested Butte,CO,ACTIVE
+CSIMT.GOV,State/Local Govt,Non-Federal Agency,Helena,MT,ACTIVE
+CSTX.GOV,State/Local Govt,Non-Federal Agency,College Station,TX,ACTIVE
+CT.GOV,State/Local Govt,Non-Federal Agency,Hartford,CT,ACTIVE
+CTALERT.GOV,State/Local Govt,Non-Federal Agency,Middletown,CT,ACTIVE
+CTBROWNFIELDS.GOV,State/Local Govt,Non-Federal Agency,Hartford,CT,ACTIVE
+CTGROWN.GOV,State/Local Govt,Non-Federal Agency,Hartford,CT,ACTIVE
+CTPROBATE.GOV,State/Local Govt,Non-Federal Agency,West Hartford,CT,ACTIVE
+DA16CO.GOV,State/Local Govt,Non-Federal Agency,LA JUNTA,CO,ACTIVE
+DC.GOV,State/Local Govt,Non-Federal Agency,Washington,DC,ACTIVE
+DCAPPEALS.GOV,State/Local Govt,Non-Federal Agency,Washington,DC,ACTIVE
+DCCODE.GOV,State/Local Govt,Non-Federal Agency,Washington,DC,ACTIVE
+DCCOUNCIL.GOV,State/Local Govt,Non-Federal Agency,Washington,DC,ACTIVE
+DCCOURT.GOV,State/Local Govt,Non-Federal Agency,Washington,DC,ACTIVE
+DCCOURTS.GOV,State/Local Govt,Non-Federal Agency,Washington,DC,ACTIVE
+DCCOURTSNEWS.GOV,State/Local Govt,Non-Federal Agency,Washington,DC,ACTIVE
+DE.GOV,State/Local Govt,Non-Federal Agency,Dover,DE,ACTIVE
+DEBTREPORTINGIOWA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+DEL.GOV,State/Local Govt,Non-Federal Agency,Dover,DE,ACTIVE
+DELAWARE.GOV,State/Local Govt,Non-Federal Agency,Dover,DE,ACTIVE
+DELAWAREINSURANCE.GOV,State/Local Govt,Non-Federal Agency,Dover,DE,ACTIVE
+DELDOT.GOV,State/Local Govt,Non-Federal Agency,Dover,DE,ACTIVE
+DEVAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+DIGITALARIZONA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+DIGITALAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+DMG.GOV,State/Local Govt,Non-Federal Agency,Barstow,CA,ACTIVE
+DNSSECOHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+DNSTESTOHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+DOJMT.GOV,State/Local Govt,Non-Federal Agency,Helena,MT,ACTIVE
+DOSEOFREALITYWI.GOV,State/Local Govt,Non-Federal Agency,Madison,WI,ACTIVE
+DOUBLECHECKIOWA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+DRACUTMA.GOV,State/Local Govt,Non-Federal Agency,Dracut,MA,ACTIVE
+DRIVENC.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+DUDLEYMA.GOV,State/Local Govt,Non-Federal Agency,Dudley,MA,ACTIVE
+DWGPA.GOV,State/Local Govt,Non-Federal Agency,Delaware Water Gap,PA,ACTIVE
+EASTHAM-MA.GOV,State/Local Govt,Non-Federal Agency,Eastham,MA,ACTIVE
+EASTVALLEYFUSIONCENTERAZ.GOV,State/Local Govt,Non-Federal Agency,Mesa,AZ,ACTIVE
+EDGEWOODKY.GOV,State/Local Govt,Non-Federal Agency,Edgewood,KY,ACTIVE
+EDUCATEIOWA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+EFILETEXAS.GOV,State/Local Govt,Non-Federal Agency,Austin,TX,ACTIVE
+EGREMONT-MA.GOV,State/Local Govt,Non-Federal Agency,Egremont,MA,ACTIVE
+EHAWAII.GOV,State/Local Govt,Non-Federal Agency,Honolulu,HI,ACTIVE
+EISGATEWAYPACIFICWA.GOV,State/Local Govt,Non-Federal Agency,Lacey,WA,ACTIVE
+ELEARNINGNC.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+ELIZABETHTOWNKY.GOV,State/Local Govt,Non-Federal Agency,Elizabethtown,KY,ACTIVE
+EVFCAZ.GOV,State/Local Govt,Non-Federal Agency,Mesa,AZ,ACTIVE
+EVFUSIONCENTERAZ.GOV,State/Local Govt,Non-Federal Agency,Mesa,AZ,ACTIVE
+EWYOMING.GOV,State/Local Govt,Non-Federal Agency,Cheyenne,WY,ACTIVE
+EXPLOREMAINE.GOV,State/Local Govt,Non-Federal Agency,Augusta,ME,ACTIVE
+FAIRHAVEN-MA.GOV,State/Local Govt,Non-Federal Agency,Fairhaven,MA,ACTIVE
+FAMILYRESOURCEAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+FAYETTECOUNTYGA.GOV,State/Local Govt,Non-Federal Agency,Fayetteville,GA,ACTIVE
+FAYETTEVILLE-GA.GOV,State/Local Govt,Non-Federal Agency,Fayetteville,GA,ACTIVE
+FILELOCAL-WA.GOV,State/Local Govt,Non-Federal Agency,Seattle,WA,ACTIVE
+FIRSTNETME.GOV,State/Local Govt,Non-Federal Agency,Augusta,ME,ACTIVE
+FIRSTTHINGSFIRSTAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+FL.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+FLBOARDOFMEDICINE.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL,ACTIVE
+FLCENSUS.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+FLCOURTS1.GOV,State/Local Govt,Non-Federal Agency,Pensacola,FL,ACTIVE
+FLCRC.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+FLDOI.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+FLDOT.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+FLHEALTH.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+FLHEALTHCOMPLAINT.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+FLHEALTHSOURCE.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+FLHISTORICCAPITOL.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+FLHOUSE.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+FLHSMV.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+FLLEG.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+FLLEGISLATIVEMAILINGS.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+FLORIDA.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+FLORIDAABUSEHOTLINE.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+FLORIDAHEALTH.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+FLORIDAHEALTHFINDER.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+FLORIDALOBBYIST.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+FLORIDANET.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+FLORIDAOPC.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+FLORIDAPACE.GOV,State/Local Govt,Non-Federal Agency,Kissimmee,FL,ACTIVE
+FLORIDAREDISTRICTING.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+FLORIDASACUPUNCTURE.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL,ACTIVE
+FLORIDASATHLETICTRAINING.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL,ACTIVE
+FLORIDASCHIROPRACTICMEDICINE.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL,ACTIVE
+FLORIDASCHOOLBUSSAFETY.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+FLORIDASCLINICALLABS.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL,ACTIVE
+FLORIDASDENTISTRY.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL,ACTIVE
+FLORIDASENATE.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+FLORIDASHEALTH.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+FLORIDASHEARINGAIDSPECIALISTS.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL,ACTIVE
+FLORIDASMASSAGETHERAPY.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL,ACTIVE
+FLORIDASMENTALHEALTHPROFESSIONS.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL,ACTIVE
+FLORIDASNURSING.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL,ACTIVE
+FLORIDASNURSINGHOMEADMIN.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL,ACTIVE
+FLORIDASOCCUPATIONALTHERAPY.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL,ACTIVE
+FLORIDASOPTICIANRY.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL,ACTIVE
+FLORIDASOPTOMETRY.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL,ACTIVE
+FLORIDASORTHOTISTSPROSTHETISTS.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL,ACTIVE
+FLORIDASOSTEOPATHICMEDICINE.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL,ACTIVE
+FLORIDASPHARMACY.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL,ACTIVE
+FLORIDASPHYSICALTHERAPY.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL,ACTIVE
+FLORIDASPODIATRICMEDICINE.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL,ACTIVE
+FLORIDASPSYCHOLOGY.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL,ACTIVE
+FLORIDASRESPIRATORYCARE.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL,ACTIVE
+FLORIDASSPEECHAUDIOLOGY.GOV,State/Local Govt,Non-Federal Agency,TALLAHASSEE,FL,ACTIVE
+FLORIDASUNSETREVIEWS.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+FLORIDASUNSHINE.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+FLRCM.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+FLSENATE.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+FLSUNSHINE.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+FLWG.GOV,State/Local Govt,Non-Federal Agency,Opa Locka,FL,ACTIVE
+FOIA-DC.GOV,State/Local Govt,Non-Federal Agency,Washington,DC,ACTIVE
+FOIAXPRESS-DC.GOV,State/Local Govt,Non-Federal Agency,Washington,DC,ACTIVE
+FORTLAUDERDALE.GOV,State/Local Govt,Non-Federal Agency,Fort Lauderdale,FL,ACTIVE
+FRAMES.GOV,State/Local Govt,Non-Federal Agency,Moscow,ID,ACTIVE
+FREEPORTFLORIDA.GOV,State/Local Govt,Non-Federal Agency,Freeport,FL,ACTIVE
+FUTUREREADYIOWA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+GA.GOV,State/Local Govt,Non-Federal Agency,Atlanta,GA,ACTIVE
+GACOURTS.GOV,State/Local Govt,Non-Federal Agency,Atlanta,GA,ACTIVE
+GADOL.GOV,State/Local Govt,Non-Federal Agency,Atlanta,GA,ACTIVE
+GAITHERSBURGMD.GOV,State/Local Govt,Non-Federal Agency,Gaithersburg,MD,ACTIVE
+GAPROBATE.GOV,State/Local Govt,Non-Federal Agency,Atlanta,GA,ACTIVE
+GARDNER-MA.GOV,State/Local Govt,Non-Federal Agency,GARDNER,MA,ACTIVE
+GATREES.GOV,State/Local Govt,Non-Federal Agency,Dry Branch,GA,ACTIVE
+GEARUPIOWA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+GEARUPTN.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE
+GEORGETOWNMA.GOV,State/Local Govt,Non-Federal Agency,Georgetown,MA,ACTIVE
+GEORGIA.GOV,State/Local Govt,Non-Federal Agency,Atlanta,GA,ACTIVE
+GEORGIACOURTS.GOV,State/Local Govt,Non-Federal Agency,Atlanta,GA,ACTIVE
+GEORGIAHEALTHINFO.GOV,State/Local Govt,Non-Federal Agency,Atlanta,GA,ACTIVE
+GETCOVEREDILLINOIS.GOV,State/Local Govt,Non-Federal Agency,Chicago,IL,ACTIVE
+GETKANSASBENEFITS.GOV,State/Local Govt,Non-Federal Agency,Topeka,KS,ACTIVE
+GETREADYHAWAII.GOV,State/Local Govt,Non-Federal Agency,Honolulu,HI,ACTIVE
+GETTYSBURGPA.GOV,State/Local Govt,Non-Federal Agency,Gettysburg,PA,ACTIVE
+GIS10SERVICEMT.GOV,State/Local Govt,Non-Federal Agency,Helena,MT,ACTIVE
+GISSERVICEMT.GOV,State/Local Govt,Non-Federal Agency,Helena,MT,ACTIVE
+GISTESTSERVICEMT.GOV,State/Local Govt,Non-Federal Agency,Helena,MT,ACTIVE
+GLYNNCOUNTY-GA.GOV,State/Local Govt,Non-Federal Agency,Brunswick,GA,ACTIVE
+GOLFMANOROH.GOV,State/Local Govt,Non-Federal Agency,Golf Manor,OH,ACTIVE
+GOVOTEVERMONT.GOV,State/Local Govt,Non-Federal Agency,Montpelier,VT,ACTIVE
+GRAFTONTWP-OH.GOV,State/Local Govt,Non-Federal Agency,Grafton Township,OH,ACTIVE
+GREATIOWATREASUREHUNT.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+GRFDAZ.GOV,State/Local Govt,Non-Federal Agency,Tucson,AZ,ACTIVE
+GRINNELLIOWA.GOV,State/Local Govt,Non-Federal Agency,Grinnell,IA,ACTIVE
+GUAM.GOV,State/Local Govt,Non-Federal Agency,Agana,GU,ACTIVE
+HAMILTONMA.GOV,State/Local Govt,Non-Federal Agency,So. Hamilton,MA,ACTIVE
+HARFORDCOUNTYMD.GOV,State/Local Govt,Non-Federal Agency,Bel Air,MD,ACTIVE
+HAWAII.GOV,State/Local Govt,Non-Federal Agency,Honolulu,HI,ACTIVE
+HEALTH-E-ARIZONA-PLUS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+HEALTH-E-ARIZONAPLUS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+HEALTHCAREHELPMASS.GOV,State/Local Govt,Non-Federal Agency,Boston,MA,ACTIVE
+HEALTHEARIZONA.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+HEALTHEARIZONAPLUS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+HEALTHVERMONT.GOV,State/Local Govt,Non-Federal Agency,Burlington,VT,ACTIVE
+HEALTHYIOWA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+HEALTHYSD.GOV,State/Local Govt,Non-Federal Agency,Pierre,SD,ACTIVE
+HEALTHYTEETHAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+HI.GOV,State/Local Govt,Non-Federal Agency,Honolulu,HI,ACTIVE
+HIJOSSALUDABLESOREGON.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE
+HINSDALEMA.GOV,State/Local Govt,Non-Federal Agency,Hinsdale,MA,ACTIVE
+HIREACOLORADOVET.GOV,State/Local Govt,Non-Federal Agency,Denver,CO,ACTIVE
+HOMEAGAINNEVADA.GOV,State/Local Govt,Non-Federal Agency,Las Vegas,NV,ACTIVE
+HOMEBASEIOWA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+HOMEMEANSNEVADA.GOV,State/Local Govt,Non-Federal Agency,Las Vegas,NV,ACTIVE
+HONOLULU.GOV,State/Local Govt,Non-Federal Agency,Honolulu,HI,ACTIVE
+IA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IAABATEDOC.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IAHEALTHLINK.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IASHP.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IASIMPLEABATE.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IAVOTERS.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+ID.GOV,State/Local Govt,Non-Federal Agency,Boise,ID,ACTIVE
+IDAHO.GOV,State/Local Govt,Non-Federal Agency,Boise,ID,ACTIVE
+IDAHOBYWAYS.GOV,State/Local Govt,Non-Federal Agency,Boise,ID,ACTIVE
+IDAHOPREPARES.GOV,State/Local Govt,Non-Federal Agency,Boise,ID,ACTIVE
+IDAHOVOTES.GOV,State/Local Govt,Non-Federal Agency,Boise,ID,ACTIVE
+IDAHOWORKS.GOV,State/Local Govt,Non-Federal Agency,Boise,ID,ACTIVE
+IHAVEAPLANIOWA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IJOBSIOWA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IL.GOV,State/Local Govt,Non-Federal Agency,Springfield,IL,ACTIVE
+ILATTORNEYGENERAL.GOV,State/Local Govt,Non-Federal Agency,Chicago,IL,ACTIVE
+ILGA.GOV,State/Local Govt,Non-Federal Agency,Springfield,IL,ACTIVE
+ILLINOIS-HISTORY.GOV,State/Local Govt,Non-Federal Agency,Springfield,IL,ACTIVE
+ILLINOIS.GOV,State/Local Govt,Non-Federal Agency,Springfield,IL,ACTIVE
+ILLINOISATTORNEYGENERAL.GOV,State/Local Govt,Non-Federal Agency,Chicago,IL,ACTIVE
+ILLINOISCOMPTROLLER.GOV,State/Local Govt,Non-Federal Agency,Springfield,IL,ACTIVE
+ILLINOISCOURTS.GOV,State/Local Govt,Non-Federal Agency,Springfield,IL,ACTIVE
+ILLINOISHISTORY.GOV,State/Local Govt,Non-Federal Agency,Springfield,IL,ACTIVE
+ILLINOISRETIREMENT.GOV,State/Local Govt,Non-Federal Agency,Springfield,IL,ACTIVE
+ILLINOISTREASURER.GOV,State/Local Govt,Non-Federal Agency,Springfield,IL,ACTIVE
+ILSOS.GOV,State/Local Govt,Non-Federal Agency,Springfield,IL,ACTIVE
+IN.GOV,State/Local Govt,Non-Federal Agency,Indianapolis,IN,ACTIVE
+INCOURTS.GOV,State/Local Govt,Non-Federal Agency,Indianapolis,IN,ACTIVE
+INDIANA.GOV,State/Local Govt,Non-Federal Agency,Indianapolis,IN,ACTIVE
+INDIANAMOTORSPORTS.GOV,State/Local Govt,Non-Federal Agency,Indianapolis,IN,ACTIVE
+INDIANAUNCLAIMED.GOV,State/Local Govt,Non-Federal Agency,Indianapolis,IN,ACTIVE
+INNOCENCECOMMISSION-NC.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+INTEGRATEAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+INVESTINIOWA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWAAGING.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWAAGRICULTURE.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWAATTORNEYGENERAL.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWACHILDSUPPORT.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWACLEANAIR.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWACOLLEGEAID.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWACOLLEGEAIDDATACENTER.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWACORE.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWACOURTS.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWACULTURE.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWADIVISIONOFLABOR.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWADNR.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWADOT.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWAELECTRICAL.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWAELEVATORS.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWAFINANCEAUTHORITY.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWAFINANCIALAIDAPPLICATION.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWAFORMS.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWAFRAUDFIGHTERS.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWAGRANTS.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWAGREATPLACES.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWAJNC.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWAJQC.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWALIFT.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWALMI.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWAMORTGAGEHELP.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWANEXT.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWAOSHA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWAPIB.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWAPMA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWASMOKEFREEAIR.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWASTEM.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWATAXANDTAGS.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWATEST.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWATITLEGUARANTY.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWATREASURER.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWAWDB.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWAWORKCOMP.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWAWORKFORCE.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+IOWAWORKFORCEDEVELOPMENT.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+JASPERINDIANA.GOV,State/Local Govt,Non-Federal Agency,Jasper,IN,ACTIVE
+JOBS4TN.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE
+JOBSFORTN.GOV,State/Local Govt,Non-Federal Agency,38401,TN,ACTIVE
+JUDNJ.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+KANSAS.GOV,State/Local Govt,Non-Federal Agency,Topeka,KS,ACTIVE
+KANSASEMPLOYER.GOV,State/Local Govt,Non-Federal Agency,Topeka,KS,ACTIVE
+KANSASMONEY.GOV,State/Local Govt,Non-Federal Agency,Topeka,KS,ACTIVE
+KANSASREADY.GOV,State/Local Govt,Non-Federal Agency,Topeka,KS,ACTIVE
+KANSASTAG.GOV,State/Local Govt,Non-Federal Agency,Topeka,KS,ACTIVE
+KDHEKS.GOV,State/Local Govt,Non-Federal Agency,Topeka,KS,ACTIVE
+KENTUCKY.GOV,State/Local Govt,Non-Federal Agency,Frankfort,KY,ACTIVE
+KIDCENTRALTENNESSEE.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE
+KIDCENTRALTN.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE
+KPL.GOV,State/Local Govt,Non-Federal Agency,KALAMAZOO,MI,ACTIVE
+KS.GOV,State/Local Govt,Non-Federal Agency,Topeka,KS,ACTIVE
+KSCAREERNAV.GOV,State/Local Govt,Non-Federal Agency,Topeka,KS,ACTIVE
+KSDA.GOV,State/Local Govt,Non-Federal Agency,Topeka,KS,ACTIVE
+KSHOUSINGCORP.GOV,State/Local Govt,Non-Federal Agency,Topeka,KS,ACTIVE
+KSREADY.GOV,State/Local Govt,Non-Federal Agency,Topeka,KS,ACTIVE
+KY.GOV,State/Local Govt,Non-Federal Agency,Frankfort,KY,ACTIVE
+LA.GOV,State/Local Govt,Non-Federal Agency,Baton Rouge,LA,ACTIVE
+LAFASTSTART.GOV,State/Local Govt,Non-Federal Agency,Baton Rouge,LA,ACTIVE
+LAFAYETTELA.GOV,State/Local Govt,Non-Federal Agency,Lafayette,LA,ACTIVE
+LAJUDICIAL.GOV,State/Local Govt,Non-Federal Agency,New Orleans,LA,ACTIVE
+LAKECOUNTYFL.GOV,State/Local Govt,Non-Federal Agency,Tavares,FL,ACTIVE
+LAKEPARK-FL.GOV,State/Local Govt,Non-Federal Agency,Lake Park,FL,ACTIVE
+LAKEPARKFLORIDA.GOV,State/Local Govt,Non-Federal Agency,Lake Park,FL,ACTIVE
+LAMOINE-ME.GOV,State/Local Govt,Non-Federal Agency,Lamoine,ME,ACTIVE
+LEADERSHIPAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+LEGMT.GOV,State/Local Govt,Non-Federal Agency,Helena,MT,ACTIVE
+LEXINGTON-MA.GOV,State/Local Govt,Non-Federal Agency,Lexington,MA,ACTIVE
+LEXINGTONMA.GOV,State/Local Govt,Non-Federal Agency,Lexington,MA,ACTIVE
+LGADMI.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI,ACTIVE
+LGO-VI.GOV,State/Local Govt,Non-Federal Agency,St. Thomas,VI,ACTIVE
+LICENSEDINIOWA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+LISTOVIRGINIA.GOV,State/Local Govt,Non-Federal Agency,Richmond,VA,ACTIVE
+LIVEHEALTHYNEVADA.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV,ACTIVE
+LOUISIANA.GOV,State/Local Govt,Non-Federal Agency,Baton Rouge,LA,ACTIVE
+LOUISIANAENTERTAINMENT.GOV,State/Local Govt,Non-Federal Agency,Baton Rouge,LA,ACTIVE
+LOUISIANAFASTSTART.GOV,State/Local Govt,Non-Federal Agency,Baton Rouge,LA,ACTIVE
+LOUISIANAMAP.GOV,State/Local Govt,Non-Federal Agency,Baton Rouge,LA,ACTIVE
+LOUISIANAMUSIC.GOV,State/Local Govt,Non-Federal Agency,Baton Rouge,LA,ACTIVE
+LOWELLMA.GOV,State/Local Govt,Non-Federal Agency,Lowell,MA,ACTIVE
+LOXAHATCHEEGROVESFL.GOV,State/Local Govt,Non-Federal Agency,Loxahatchee Groves,FL,ACTIVE
+MA.GOV,State/Local Govt,Non-Federal Agency,Boston,MA,ACTIVE
+MAHOUSE.GOV,State/Local Govt,Non-Federal Agency,Boston,MA,ACTIVE
+MAINE.GOV,State/Local Govt,Non-Federal Agency,Augusta,ME,ACTIVE
+MAINEDOT.GOV,State/Local Govt,Non-Federal Agency,Augusta,ME,ACTIVE
+MAINEFLU.GOV,State/Local Govt,Non-Federal Agency,Augusta,ME,ACTIVE
+MAINEFORESTSERVICE.GOV,State/Local Govt,Non-Federal Agency,AUGUSTA,ME,ACTIVE
+MAINEPUBLICHEALTH.GOV,State/Local Govt,Non-Federal Agency,Augusta,ME,ACTIVE
+MAINEQUALITYFORUM.GOV,State/Local Govt,Non-Federal Agency,Augusta,ME,ACTIVE
+MAINESERVICECOMMISSION.GOV,State/Local Govt,Non-Federal Agency,Augusta,ME,ACTIVE
+MAJURY.GOV,State/Local Govt,Non-Federal Agency,Boston,MA,ACTIVE
+MAKINGCOLORADO.GOV,State/Local Govt,Non-Federal Agency,Boulder,CO,ACTIVE
+MALEGISLATURE.GOV,State/Local Govt,Non-Federal Agency,Boston,MA,ACTIVE
+MAPWV.GOV,State/Local Govt,Non-Federal Agency,Morgantown,WV,ACTIVE
+MARIETTAGA.GOV,State/Local Govt,Non-Federal Agency,Marietta,GA,ACTIVE
+MARIETTAGEORGIA.GOV,State/Local Govt,Non-Federal Agency,Marietta,GA,ACTIVE
+MARSHFIELD-MA.GOV,State/Local Govt,Non-Federal Agency,Marshfield,MA,ACTIVE
+MARYLAND.GOV,State/Local Govt,Non-Federal Agency,Annapolis,MD,ACTIVE
+MARYLANDCOURTS.GOV,State/Local Govt,Non-Federal Agency,Annapolis,MD,ACTIVE
+MARYLANDHEALTHCONNECTION.GOV,State/Local Govt,Non-Federal Agency,Baltimore,MD,ACTIVE
+MARYLANDSOS.GOV,State/Local Govt,Non-Federal Agency,ANNAPOLIS,MD,ACTIVE
+MASENATE.GOV,State/Local Govt,Non-Federal Agency,Boston,MA,ACTIVE
+MASS.GOV,State/Local Govt,Non-Federal Agency,Boston,MA,ACTIVE
+MASSACHUSETTS.GOV,State/Local Govt,Non-Federal Agency,Boston,MA,ACTIVE
+MCAC-MD.GOV,State/Local Govt,Non-Federal Agency,Calverton ,MD,ACTIVE
+MD.GOV,State/Local Govt,Non-Federal Agency,Annapolis,MD,ACTIVE
+MDCAC.GOV,State/Local Govt,Non-Federal Agency,Woodlawn,MD,ACTIVE
+MDCACDOM.GOV,State/Local Govt,Non-Federal Agency,Woodlawn,MD,ACTIVE
+MDCOURTS.GOV,State/Local Govt,Non-Federal Agency,Annapolis,MD,ACTIVE
+ME.GOV,State/Local Govt,Non-Federal Agency,Augusta,ME,ACTIVE
+MEASURETN.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE
+MEDCMI.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI,ACTIVE
+MENTORMICHIGAN.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI,ACTIVE
+MGCBMI.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI,ACTIVE
+MHB.GOV,State/Local Govt,Non-Federal Agency,Mobile,AL,ACTIVE
+MI.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI,ACTIVE
+MI365.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI,ACTIVE
+MIAMI-FL.GOV,State/Local Govt,Non-Federal Agency,Miami,FL,ACTIVE
+MIBUSINESS1STOP.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI,ACTIVE
+MIBUSINESSONESTOP.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI,ACTIVE
+MICH.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI,ACTIVE
+MICHIGAN.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI,ACTIVE
+MICHIGANIDC.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI,ACTIVE
+MILLENNIUMBULKEISWA.GOV,State/Local Govt,Non-Federal Agency,Lacey,WA,ACTIVE
+MILLERSBURGKY.GOV,State/Local Govt,Non-Federal Agency,Millersburg,KY,ACTIVE
+MILTON-FREEWATER-OR.GOV,State/Local Govt,Non-Federal Agency,Milton-Freewater,OR,ACTIVE
+MINNESOTA.GOV,State/Local Govt,Non-Federal Agency,St. Paul,MN,ACTIVE
+MIRAMAR-FL.GOV,State/Local Govt,Non-Federal Agency,Miramar,FL,ACTIVE
+MISSISSIPPI.GOV,State/Local Govt,Non-Federal Agency,Jackson,MS,ACTIVE
+MISSOURI.GOV,State/Local Govt,Non-Federal Agency,Jefferson City,MO,ACTIVE
+MISSOURIINVESTORPROTECTION.GOV,State/Local Govt,Non-Federal Agency,Jefferson City,MO,ACTIVE
+MN.GOV,State/Local Govt,Non-Federal Agency,St. Paul,MN,ACTIVE
+MNCOURTS.GOV,State/Local Govt,Non-Federal Agency,St. Paul,MN,ACTIVE
+MNDISABILITY.GOV,State/Local Govt,Non-Federal Agency,St. Paul,MN,ACTIVE
+MNDNR.GOV,State/Local Govt,Non-Federal Agency,St. Paul,MN,ACTIVE
+MNDOT.GOV,State/Local Govt,Non-Federal Agency,St. Paul,MN,ACTIVE
+MNHOUSING.GOV,State/Local Govt,Non-Federal Agency,St. Paul,MN,ACTIVE
+MO.GOV,State/Local Govt,Non-Federal Agency,Jefferson City,MO,ACTIVE
+MOAPPED.GOV,State/Local Govt,Non-Federal Agency,St. Louis,MO,ACTIVE
+MODOT.GOV,State/Local Govt,Non-Federal Agency,Jefferson City,MO,ACTIVE
+MONSON-MA.GOV,State/Local Govt,Non-Federal Agency,Monson,MA,ACTIVE
+MONTANA.GOV,State/Local Govt,Non-Federal Agency,Helena,MT,ACTIVE
+MOPROSECUTORS.GOV,State/Local Govt,Non-Federal Agency,Jefferson City,MO,ACTIVE
+MRCOG-NM.GOV,State/Local Govt,Non-Federal Agency,Albuquerque,NM,ACTIVE
+MS.GOV,State/Local Govt,Non-Federal Agency,Jackson,MS,ACTIVE
+MSLMI.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI,ACTIVE
+MSPADMI.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI,ACTIVE
+MT.GOV,State/Local Govt,Non-Federal Agency,Helena,MT,ACTIVE
+MTCOUNTYRESULTS.GOV,State/Local Govt,Non-Federal Agency,Helena,MT,ACTIVE
+MTELECTIONRESULTS.GOV,State/Local Govt,Non-Federal Agency,Helena,MT,ACTIVE
+MTSOSFILINGS.GOV,State/Local Govt,Non-Federal Agency,Helena,MT,ACTIVE
+MURRAYCOUNTYGA.GOV,State/Local Govt,Non-Federal Agency,Chatsworth,GA,ACTIVE
+MYALABAMA.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE
+MYALASKA.GOV,State/Local Govt,Non-Federal Agency,Juneau,AK,ACTIVE
+MYFLORIDA.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+MYFLORIDACENSUS.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+MYFLORIDAHOUSE.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+MYHAWAII.GOV,State/Local Govt,Non-Federal Agency,Honolulu,HI,ACTIVE
+MYIN.GOV,State/Local Govt,Non-Federal Agency,Indianapolis,IN,ACTIVE
+MYINDIANA.GOV,State/Local Govt,Non-Federal Agency,Indianapolis,IN,ACTIVE
+MYNCRETIREMENT.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+MYNEVADA.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV,ACTIVE
+MYOHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+MYSC.GOV,State/Local Govt,Non-Federal Agency,Cloumbia,SC,ACTIVE
+MYTENNESSEE.GOV,State/Local Govt,Non-Federal Agency,Smyrna,TN,ACTIVE
+NATICKMA.GOV,State/Local Govt,Non-Federal Agency,Natick,MA,ACTIVE
+NC.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCAGR.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCBAR.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCBROADBAND.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCCARELINK.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCCERTIFIEDPARALEGAL.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCCIVILWAR150.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCCOB.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCCOURTS.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCCPABOARD.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCCRIMELAB.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCDCI.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCDCR.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCDENR.GOV,State/Local Govt,Non-Federal Agency,RALEIGH,NC,ACTIVE
+NCDHHS.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCDOI.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCDOJ.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCDOR.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCDOT.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCDPS.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCESC.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCFAST.GOV,State/Local Govt,Non-Federal Agency,RTP,NC,ACTIVE
+NCFINDOFFENDER.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCFORECLOSUREPREVENTION.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCFORESTPRODUCTS.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCFORESTSERVICE.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCGRANTS.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCICAC.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCISAAC.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCLAMP.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCLAP.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCLAWSPECIALISTS.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCMORTGAGEHELP.GOV,State/Local Govt,Non-Federal Agency,27609,NC,ACTIVE
+NCONEMAP.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCOPENBOOK.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCPARKS.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCPUBLICSCHOOLS.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCREC.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCRETIREMENT.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCSBE.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCSBI.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCSTATE.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCSTATEBAR.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCTREASURER.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCVISION25.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NCWORKS.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+ND.GOV,State/Local Govt,Non-Federal Agency,Bismarck,ND,ACTIVE
+NDCENSUS.GOV,State/Local Govt,Non-Federal Agency,Bismarck,ND,ACTIVE
+NDCLOUD.GOV,State/Local Govt,Non-Federal Agency,Bismarck,North Dakota,ACTIVE
+NDCOURTS.GOV,State/Local Govt,Non-Federal Agency,Bismarck,ND,ACTIVE
+NDDATACENTER.GOV,State/Local Govt,Non-Federal Agency,Bismarck,ND,ACTIVE
+NDDOHPRESSROOM.GOV,State/Local Govt,Non-Federal Agency,Bismarck,ND,ACTIVE
+NDHAN.GOV,State/Local Govt,Non-Federal Agency,Bismarck,ND,ACTIVE
+NDHEALTH.GOV,State/Local Govt,Non-Federal Agency,Bismarck,ND,ACTIVE
+NDSTUDIES.GOV,State/Local Govt,Non-Federal Agency,Bismarck,ND,ACTIVE
+NE.GOV,State/Local Govt,Non-Federal Agency,Lincoln,NE,ACTIVE
+NEBRASKA.GOV,State/Local Govt,Non-Federal Agency,Lincoln,NE,ACTIVE
+NEBRASKACORN.GOV,State/Local Govt,Non-Federal Agency,Lincoln,NE,ACTIVE
+NEBRASKALEGISLATURE.GOV,State/Local Govt,Non-Federal Agency,Lincoln,NE,ACTIVE
+NEBRASKAMAP.GOV,State/Local Govt,Non-Federal Agency,Lincoln,NE,ACTIVE
+NEBRASKASPENDING.GOV,State/Local Govt,Non-Federal Agency,Lincoln,NE,ACTIVE
+NEBRASKAUNICAMERAL.GOV,State/Local Govt,Non-Federal Agency,Lincoln,NE,ACTIVE
+NEHEALTHINSURANCEINFO.GOV,State/Local Govt,Non-Federal Agency,Lincoln,NE,ACTIVE
+NETWORKMARYLAND.GOV,State/Local Govt,Non-Federal Agency,Annapolis,MD,ACTIVE
+NETWORKNEBRASKA.GOV,State/Local Govt,Non-Federal Agency,Lincoln,NE,ACTIVE
+NEVADA.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV,ACTIVE
+NEVADAGUARD.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV,ACTIVE
+NEVADAHOMEAGAIN.GOV,State/Local Govt,Non-Federal Agency,Las Vegas,NV,ACTIVE
+NEVADAREADY.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV,ACTIVE
+NEVADATREASURER.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV,ACTIVE
+NEWENGLAND511.GOV,State/Local Govt,Non-Federal Agency,Montpelier,VT,ACTIVE
+NEWHAMPSHIRE.GOV,State/Local Govt,Non-Federal Agency,Concord,NH,ACTIVE
+NEWJERSEY.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+NEWJERSEYBUSINESS.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+NEWJERSEYHOMEKEEPER.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+NEWMEXICO.GOV,State/Local Govt,Non-Federal Agency,Santa Fe,NM,ACTIVE
+NEWTONMA.GOV,State/Local Govt,Non-Federal Agency,Newton,MA,ACTIVE
+NEWYORKHEALTH.GOV,State/Local Govt,Non-Federal Agency,Albany,NY,ACTIVE
+NEXTCHAPTERTN.GOV,State/Local Govt,Non-Federal Agency,Smyrna,TN,ACTIVE
+NH.GOV,State/Local Govt,Non-Federal Agency,Concord,NH,ACTIVE
+NJ.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+NJALERT.GOV,State/Local Govt,Non-Federal Agency,Hamilton,NJ,ACTIVE
+NJCANCER.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+NJCCC.GOV,State/Local Govt,Non-Federal Agency,Atlantic City,NJ,ACTIVE
+NJCCR.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+NJCIVILRIGHTS.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+NJCONSUMERAFFAIRS.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+NJCOURTS.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+NJDOC.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+NJFLUPANDEMIC.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+NJHAS.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+NJHMFA.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+NJHOMEKEEPER.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+NJHOMELANDSECURITY.GOV,State/Local Govt,Non-Federal Agency,Hamilton,NJ,ACTIVE
+NJHOUSING.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+NJHOUSINGRESOURCECENTER.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+NJHRC.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+NJHUMANTRAFFICKING.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+NJJUD.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+NJMEADOWLANDS.GOV,State/Local Govt,Non-Federal Agency,Lyndhurst,NJ,ACTIVE
+NJMEDICALBOARD.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+NJMVC.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+NJMVCONLINE.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+NJOHSP.GOV,State/Local Govt,Non-Federal Agency,Hamilton,NJ,ACTIVE
+NJPAAD.GOV,State/Local Govt,Non-Federal Agency,Mercerville,NJ,ACTIVE
+NJSDA.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+NJSECURITIES.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+NJSENIORGOLD.GOV,State/Local Govt,Non-Federal Agency,Mercerville,NJ,ACTIVE
+NJSHC.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+NJSNAP.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+NJSPEAKUP.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+NJSRGOLD.GOV,State/Local Govt,Non-Federal Agency,Mercerville,NJ,ACTIVE
+NJSTART.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+NM.GOV,State/Local Govt,Non-Federal Agency,Santa Fe,NM,ACTIVE
+NMAG.GOV,State/Local Govt,Non-Federal Agency,Santa Fe,NM,ACTIVE
+NMCOURTS.GOV,State/Local Govt,Non-Federal Agency,Santa Fe,NM,ACTIVE
+NMLEGIS.GOV,State/Local Govt,Non-Federal Agency,Santa Fe,NM,ACTIVE
+NMSTO.GOV,State/Local Govt,Non-Federal Agency,Santa Fe,NM,ACTIVE
+NORTH-DAKOTA.GOV,State/Local Govt,Non-Federal Agency,Bismarck,ND,ACTIVE
+NORTHCAROLINA.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NORTHDAKOTA.GOV,State/Local Govt,Non-Federal Agency,Bismarck,ND,ACTIVE
+NORTHMIAMIFL.GOV,State/Local Govt,Non-Federal Agency,North Miami,FL,ACTIVE
+NOSCAMNC.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+NV.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV,ACTIVE
+NVCOURTS.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV,ACTIVE
+NVDOW.GOV,State/Local Govt,Non-Federal Agency,Reno,NV,ACTIVE
+NVDPSPUB.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV,ACTIVE
+NVEASE.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV,ACTIVE
+NVGGMS.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV,ACTIVE
+NVPREPAID.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV,ACTIVE
+NVSEXOFFENDERS.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV,ACTIVE
+NVSILVERFLUME.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV,ACTIVE
+NVSOS.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV,ACTIVE
+NY.GOV,State/Local Govt,Non-Federal Agency,Albany,NY,ACTIVE
+NYALERT.GOV,State/Local Govt,Non-Federal Agency,Albany,NY,ACTIVE
+NYASSEMBLY.GOV,State/Local Govt,Non-Federal Agency,Albany,NY,ACTIVE
+NYCOURTHELP.GOV,State/Local Govt,Non-Federal Agency,Troy,NY,ACTIVE
+NYCOURTS.GOV,State/Local Govt,Non-Federal Agency,Troy,NY,ACTIVE
+NYGOVOFFICE.GOV,State/Local Govt,Non-Federal Agency,Albany,NY,ACTIVE
+NYHALLOFGOVERNORS.GOV,State/Local Govt,Non-Federal Agency,Albany,NY,ACTIVE
+NYHEALTH.GOV,State/Local Govt,Non-Federal Agency,Albany,NY,ACTIVE
+NYHOUSINGSEARCH.GOV,State/Local Govt,Non-Federal Agency,Albany,NY,ACTIVE
+NYJUROR.GOV,State/Local Govt,Non-Federal Agency,New York,NY,ACTIVE
+NYOPENFORBUSINESS.GOV,State/Local Govt,Non-Federal Agency,Albany,NY,ACTIVE
+NYPA.GOV,State/Local Govt,Non-Federal Agency,WHITE PLAINS,NY,ACTIVE
+NYPREPARE.GOV,State/Local Govt,Non-Federal Agency,Albany,NY,ACTIVE
+NYSCANALS.GOV,State/Local Govt,Non-Federal Agency,Albany,NY,ACTIVE
+NYSDOT.GOV,State/Local Govt,Non-Federal Agency,Albany,NY,ACTIVE
+NYSED.GOV,State/Local Govt,Non-Federal Agency,Albany,NY,ACTIVE
+NYSENATE.GOV,State/Local Govt,Non-Federal Agency,Albany,NY,ACTIVE
+NYSTAX.GOV,State/Local Govt,Non-Federal Agency,Albany,NY,ACTIVE
+NYSTHRUWAY.GOV,State/Local Govt,Non-Federal Agency,Albany,NY,ACTIVE
+OCFODC.GOV,State/Local Govt,Non-Federal Agency,Washington,DC,ACTIVE
+OCPR.GOV,State/Local Govt,Non-Federal Agency,San Juan,PR,ACTIVE
+OH.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOAGRICULTURE.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOANALYTICS.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOATTORNEYGENERAL.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOAUDITOR.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOBMV.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOCENTERFORNURSING.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOCHECKBOOK.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOCOURTOFCLAIMS.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOCOURTS.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIODNR.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOHERETOHELP.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOHOUSE.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOHOUSINGLOCATOR.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOJOBS.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOJUDICIALCENTER.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOMEANSACCESSIBILITY.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOMEANSJOBS.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOMEANSTRAINING.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOMEANSVETERANSJOBS.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIONOSMOKELAW.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOPMP.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIORED.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIORESPONDS.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOSAFEID.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOSECRETARYOFSTATE.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOSENATE.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOSUPREMECOURT.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOTHIRDFRONTIER.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOTPES.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOTREASURER.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOVALUESVETERANS.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOVALUESVETS.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOVET.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOVETERANSHOME.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOVETHOF.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOVETS.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOVETSHOF.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OHIOWOMENVETS.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OK.GOV,State/Local Govt,Non-Federal Agency,Oklahoma City,OK,ACTIVE
+OKBENEFITS.GOV,State/Local Govt,Non-Federal Agency,Oklahoma City,OK,ACTIVE
+OKC.GOV,State/Local Govt,Non-Federal Agency,Oklahoma City,OK,ACTIVE
+OKCOMMERCE.GOV,State/Local Govt,Non-Federal Agency,Oklahoma city,OK,ACTIVE
+OKDHS.GOV,State/Local Govt,Non-Federal Agency,Oklahoma City,OK,ACTIVE
+OKDRS.GOV,State/Local Govt,Non-Federal Agency,Oklahoma City,OK,ACTIVE
+OKGEOSURVEY1.GOV,State/Local Govt,Non-Federal Agency,Norman,OK,ACTIVE
+OKHOUSE.GOV,State/Local Govt,Non-Federal Agency,Oklahoma City,OK,ACTIVE
+OKLAHOMA.GOV,State/Local Govt,Non-Federal Agency,Oklahoma City,OK,ACTIVE
+OKLAHOMABENEFITS.GOV,State/Local Govt,Non-Federal Agency,Oklahoma City,OK,ACTIVE
+OKLAHOMAWORKS.GOV,State/Local Govt,Non-Federal Agency,Oklahoma City,OK,ACTIVE
+OKLEGISLATURE.GOV,State/Local Govt,Non-Federal Agency,Oklahoma City,OK,ACTIVE
+OKSENATE.GOV,State/Local Govt,Non-Federal Agency,Oklahoma City,OK,ACTIVE
+OLATHEKS.GOV,State/Local Govt,Non-Federal Agency,Olathe,KS,ACTIVE
+ONESTOPFLORIDA.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,SERVER-HOLD
+ONSLOWCOUNTYNC.GOV,State/Local Govt,Non-Federal Agency,Jacksonville,NC,ACTIVE
+OPC-DC.GOV,State/Local Govt,Non-Federal Agency,Washington,DC,ACTIVE
+OPEN-DC.GOV,State/Local Govt,Non-Federal Agency,Washington,DC,ACTIVE
+OPENMYFLORIDABUSINESS.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+OPENOHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+OR-MEDICAID.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE
+OR.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE
+ORCLIMATECHANGE.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE
+OREGON.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE
+OREGONATTORNEYGENERAL.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE
+OREGONBENEFITSONLINE.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE
+OREGONBUDGET.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE
+OREGONBUYS.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE
+OREGONCHILDSUPPORT.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE
+OREGONCONSUMER.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE
+OREGONFORESTRY.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE
+OREGONHEALTHCARE.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE
+OREGONHEALTHYKIDS.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE
+OREGONHOMEOWNERSUPPORT.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE
+OREGONLEGISLATURE.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE
+OREGONMARINERESERVES.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE
+OREGONMETRO.GOV,State/Local Govt,Non-Federal Agency,Portland,OR,ACTIVE
+OREGONMOTORVOTER.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE
+OREGONRX.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE
+OREGONSTUDENTAID.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE
+OREGONUSF.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE
+OREGONVOTES.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE
+ORHEALTHCARE.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE
+OSE-CT.GOV,State/Local Govt,Non-Federal Agency,Hartford,CT,ACTIVE
+OUTDOORNEBRASKA.GOV,State/Local Govt,Non-Federal Agency,Lincoln,NE,ACTIVE
+OVERLANDPARKKS.GOV,State/Local Govt,Non-Federal Agency,Overland Park,KS,ACTIVE
+PA.GOV,State/Local Govt,Non-Federal Agency,Harrisburg,PA,ACTIVE
+PA529.GOV,State/Local Govt,Non-Federal Agency,Harrisburg,PA,ACTIVE
+PA529ABLE.GOV,State/Local Govt,Non-Federal Agency,Harrisburg,PA,ACTIVE
+PAABLE.GOV,State/Local Govt,Non-Federal Agency,Harrisburg,PA,ACTIVE
+PAACPAMMMI.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI,ACTIVE
+PAAUDITOR.GOV,State/Local Govt,Non-Federal Agency,Harrisburg,PA,ACTIVE
+PACIFICFLYWAY.GOV,State/Local Govt,Non-Federal Agency,Vancouver,WA,ACTIVE
+PADILLABAY.GOV,State/Local Govt,Non-Federal Agency,MOUNT VERNON,WA,ACTIVE
+PAHOUSE.GOV,State/Local Govt,Non-Federal Agency,Harrisburg,PA,ACTIVE
+PAINVEST.GOV,State/Local Govt,Non-Federal Agency,Harrisburg,PA,ACTIVE
+PALMBEACHCOUNTYTAXCOLLECTOR-FL.GOV,State/Local Govt,Non-Federal Agency,West Palm Beach,FL,ACTIVE
+PANYNJ.GOV,State/Local Govt,Non-Federal Agency,New York,NY,ACTIVE
+PAOPENFORBUSINESS.GOV,State/Local Govt,Non-Federal Agency,Harrisburg,PA,ACTIVE
+PARTNERSFORHEALTHTN.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE
+PASEN.GOV,State/Local Govt,Non-Federal Agency,Harrisburg,PA,ACTIVE
+PASENATE.GOV,State/Local Govt,Non-Federal Agency,Harrisburg,PA,ACTIVE
+PATREASURY.GOV,State/Local Govt,Non-Federal Agency,Harrisburg,PA,ACTIVE
+PAULDING.GOV,State/Local Govt,Non-Federal Agency,Dallas,GA,ACTIVE
+PAYIOWA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+PAYMAINE.GOV,State/Local Govt,Non-Federal Agency,Augusta,ME,ACTIVE
+PEACHTREECORNERSGA.GOV,State/Local Govt,Non-Federal Agency,PEACHTREE CORNERS,GA,ACTIVE
+PENNDOT.GOV,State/Local Govt,Non-Federal Agency,Harrisburg,PA,ACTIVE
+PENNSYLVANIA.GOV,State/Local Govt,Non-Federal Agency,Harrisburg,PA,ACTIVE
+PERRY-GA.GOV,State/Local Govt,Non-Federal Agency,Perry,GA,ACTIVE
+PINECREST-FL.GOV,State/Local Govt,Non-Federal Agency,Pinecrest,FL,ACTIVE
+PINELLASCOUNTY-FL.GOV,State/Local Govt,Non-Federal Agency,Clearwater,FL,ACTIVE
+PINELLASCOUNTYFL.GOV,State/Local Govt,Non-Federal Agency,Clearwater,FL,ACTIVE
+PLAINVILLE-CT.GOV,State/Local Govt,Non-Federal Agency,Plainville,CT,ACTIVE
+PPA-OR.GOV,State/Local Govt,Non-Federal Agency,Salem,OR,ACTIVE
+PR.GOV,State/Local Govt,Non-Federal Agency,San Juan,PR,ACTIVE
+PREVENTHAIAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+PROVINCETOWN-MA.GOV,State/Local Govt,Non-Federal Agency,Provincetown,MA,ACTIVE
+PUERTORICO.GOV,State/Local Govt,Non-Federal Agency,San Juan,PR,ACTIVE
+QAAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+QUALITYFIRSTAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+READYALABAMA.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE
+READYNH.GOV,State/Local Govt,Non-Federal Agency,Concord,NH,ACTIVE
+READYVIRGINIA.GOV,State/Local Govt,Non-Federal Agency,Richmond,VA,ACTIVE
+READYWV.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE
+RECYCLEOHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+REDISTRICTINGFLORIDA.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+REGISTERTOVOTENV.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV,ACTIVE
+RELAYUTAH.GOV,State/Local Govt,Non-Federal Agency,Salt Lake City,UT,ACTIVE
+REPORTITTN.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE
+RETIREREADYTN.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE
+RHODEISLAND.GOV,State/Local Govt,Non-Federal Agency,Providence,RI,ACTIVE
+RI.GOV,State/Local Govt,Non-Federal Agency,Providence,RI,ACTIVE
+RIDESHAREWI.GOV,State/Local Govt,Non-Federal Agency,Madison,WI,ACTIVE
+RIDESHAREWISCONSIN.GOV,State/Local Govt,Non-Federal Agency,Madison,WI,ACTIVE
+RILEGISLATURE.GOV,State/Local Govt,Non-Federal Agency,Providence,RI,ACTIVE
+RIPSGA.GOV,State/Local Govt,Non-Federal Agency,North Scituate,RI,ACTIVE
+RISP.GOV,State/Local Govt,Non-Federal Agency,North Scituate,RI,ACTIVE
+ROCKISLANDTOWNSHIPIL.GOV,State/Local Govt,Non-Federal Agency,Rock Island,IL,ACTIVE
+ROWANCOUNTYNC.GOV,State/Local Govt,Non-Federal Agency,Salisbury,NC,ACTIVE
+RSA-AL.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE
+RULEWATCHOHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+SACOMAINE.GOV,State/Local Govt,Non-Federal Agency,Saco,ME,ACTIVE
+SAFEHOMEALABAMA.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE
+SAFERFLORIDAHIGHWAYS.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+SAFERFLORIDAROADS.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+SAFESD.GOV,State/Local Govt,Non-Federal Agency,Pierre,SD,ACTIVE
+SALINA-KS.GOV,State/Local Govt,Non-Federal Agency,Salina,KS,ACTIVE
+SANDPOINTIDAHO.GOV,State/Local Govt,Non-Federal Agency,Sandpoint,ID,ACTIVE
+SAOMT.GOV,State/Local Govt,Non-Federal Agency,Helena,MT,ACTIVE
+SAVEMYHOMEAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+SAVEOURHOMEAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+SC.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC,ACTIVE
+SCAG.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC,ACTIVE
+SCCONSUMER.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC,ACTIVE
+SCDEW.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC,ACTIVE
+SCDHEC.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC,ACTIVE
+SCDHHS.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC,ACTIVE
+SCDPS.GOV,State/Local Govt,Non-Federal Agency,Blythewood,SC,ACTIVE
+SCFC.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC,ACTIVE
+SCHELP.GOV,State/Local Govt,Non-Federal Agency,Columbia`,SC,ACTIVE
+SCHOUSE.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC,ACTIVE
+SCNEWHIRE.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC,ACTIVE
+SCOH.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+SCOHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+SCOTTCOUNTYIOWA.GOV,State/Local Govt,Non-Federal Agency,Davenport,IA,ACTIVE
+SCSENATE.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC,ACTIVE
+SCSERV.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC,ACTIVE
+SCSTATEHOUSE.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC,ACTIVE
+SD.GOV,State/Local Govt,Non-Federal Agency,Pierre,SD,ACTIVE
+SDAUDITOR.GOV,State/Local Govt,Non-Federal Agency,Pierre,SD,ACTIVE
+SDBMOE.GOV,State/Local Govt,Non-Federal Agency,Pierre,SD,ACTIVE
+SDLEGISLATURE.GOV,State/Local Govt,Non-Federal Agency,pierre,SD,ACTIVE
+SDSOS.GOV,State/Local Govt,Non-Federal Agency,Pierre,SD,ACTIVE
+SDTREASURER.GOV,State/Local Govt,Non-Federal Agency,Pierre,SD,ACTIVE
+SEDGWICK.GOV,State/Local Govt,Non-Federal Agency,Wichita,KS,ACTIVE
+SEELYVILLE-IN.GOV,State/Local Govt,Non-Federal Agency,Seelyville,IN,ACTIVE
+SEMINOLECOUNTYFL.GOV,State/Local Govt,Non-Federal Agency,Sanford,FL,ACTIVE
+SERVEALABAMA.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE
+SERVEIDAHO.GOV,State/Local Govt,Non-Federal Agency,Boise,ID,ACTIVE
+SERVEOHIO.GOV,State/Local Govt,Non-Federal Agency,Columb us,OH,ACTIVE
+SERVGA.GOV,State/Local Govt,Non-Federal Agency,Atlanta,GA,ACTIVE
+SFWMD.GOV,State/Local Govt,Non-Federal Agency,West Palm Beach,FL,ACTIVE
+SHAPINGNEWJERSEY.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+SHAPINGNJ.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ,ACTIVE
+SHAREOHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+SHREWSBURY-MA.GOV,State/Local Govt,Non-Federal Agency,Shrewsbury,MA,ACTIVE
+SOSNC.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+SOUTHCAROLINA.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC,ACTIVE
+SOUTHERNSHORES-NC.GOV,State/Local Govt,Non-Federal Agency,Southern Shores,NC,ACTIVE
+SPACEFLORIDA.GOV,State/Local Govt,Non-Federal Agency,Cape Canaveral,FL,ACTIVE
+STAGINGAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+STATEOFSOUTHCAROLINA.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC,ACTIVE
+STATEOFWV.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE
+STILLWATERCOUNTYMT.GOV,State/Local Govt,Non-Federal Agency,Columbus,MT,ACTIVE
+STOPFRAUDCOLORADO.GOV,State/Local Govt,Non-Federal Agency,Denver,CO,ACTIVE
+STOUGHTON-MA.GOV,State/Local Govt,Non-Federal Agency,Stoughton,MA,ACTIVE
+STOW-MA.GOV,State/Local Govt,Non-Federal Agency,Stow,MA,ACTIVE
+STPAULSNC.GOV,State/Local Govt,Non-Federal Agency,St. Pauls,NC,ACTIVE
+SUNRISEFL.GOV,State/Local Govt,Non-Federal Agency,Sunrise,FL,ACTIVE
+SUNRISEFLORIDA.GOV,State/Local Govt,Non-Federal Agency,Sunrise,FL,ACTIVE
+SUPREMECOURTOFOHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+SURFCITYNC.GOV,State/Local Govt,Non-Federal Agency,Surf City,NC,ACTIVE
+SWEETHOMEALABAMA.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL,ACTIVE
+TAKOMAPARKMD.GOV,State/Local Govt,Non-Federal Agency,Takoma Park,MD,ACTIVE
+TEACHIOWA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+TEAMGA.GOV,State/Local Govt,Non-Federal Agency,Atlanta,GA,ACTIVE
+TEAMGEORGIA.GOV,State/Local Govt,Non-Federal Agency,Atlanta,GA,ACTIVE
+TEAMTN.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE
+TENNESSEE.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE
+TENNESSEECOLLEGEADVISER.GOV,State/Local Govt,Non-Federal Agency,Smyrna,TN,ACTIVE
+TENNESSEECOLLEGEADVISOR.GOV,State/Local Govt,Non-Federal Agency,Smyrna,TN,ACTIVE
+TENNESSEEIIS.GOV,State/Local Govt,Non-Federal Agency,Smyrna,TN,ACTIVE
+TENNESSEEPROMISE.GOV,State/Local Govt,Non-Federal Agency,Smyrna,TN,ACTIVE
+TENNESSEERECONNECT.GOV,State/Local Govt,Non-Federal Agency,Smyrna,TN,ACTIVE
+TESTOHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+TEWKSBURY-MA.GOV,State/Local Govt,Non-Federal Agency,Tewksbury,MA,ACTIVE
+TEXAS.GOV,State/Local Govt,Non-Federal Agency,Austin,TX,ACTIVE
+TEXAS511.GOV,State/Local Govt,Non-Federal Agency,Austin,TX,ACTIVE
+TEXASAGRICULTURE.GOV,State/Local Govt,Non-Federal Agency,Austin,TX,ACTIVE
+TEXASATTORNEYGENERAL.GOV,State/Local Govt,Non-Federal Agency,Austin,TX,ACTIVE
+TEXASCHILDRENSCOMMISSION.GOV,State/Local Govt,Non-Federal Agency,Austin,TX,ACTIVE
+TEXASFIGHTSIDTHEFT.GOV,State/Local Govt,Non-Federal Agency,Austin,TX,ACTIVE
+TEXASONLINE.GOV,State/Local Govt,Non-Federal Agency,Austin,TX,ACTIVE
+TEXASSTATEPARKS.GOV,State/Local Govt,Non-Federal Agency,Austin,TX,ACTIVE
+TEXASSUPREMECOURTCOMMISSION.GOV,State/Local Govt,Non-Federal Agency,Austin,TX,ACTIVE
+THA.GOV,State/Local Govt,Non-Federal Agency,Topeka,KS,ACTIVE
+THEFTAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ,ACTIVE
+THERIGHTCALLIOWA.GOV,State/Local Govt,Non-Federal Agency,Des Moines,IA,ACTIVE
+THESTATEOFSOUTHCAROLINA.GOV,State/Local Govt,Non-Federal Agency,Columbia,SC,ACTIVE
+TN.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE
+TNAG.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE
+TNCOLLATERALMANAGEMENT.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE
+TNCOLLEGEADVISER.GOV,State/Local Govt,Non-Federal Agency,Smyrna,TN,ACTIVE
+TNCOLLEGEADVISOR.GOV,State/Local Govt,Non-Federal Agency,Smyrna,TN,ACTIVE
+TNCOURTS.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE
+TNECD.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE
+TNEDU.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE
+TNFAFSAFRENZY.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE
+TNIIS.GOV,State/Local Govt,Non-Federal Agency,Smyrna,TN,ACTIVE
+TNK12.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE
+TNPROMISE.GOV,State/Local Govt,Non-Federal Agency,Smyrna,TN,ACTIVE
+TNQUITLINE.GOV,State/Local Govt,Non-Federal Agency,Smyrna,TN,ACTIVE
+TNREADY.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE
+TNRECONNECT.GOV,State/Local Govt,Non-Federal Agency,Smyrna,TN,ACTIVE
+TNTOOLKIT.GOV,State/Local Govt,Non-Federal Agency,Smyrna,TN,ACTIVE
+TNTREASURY.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE
+TNVACATION.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE
+TOURISMOHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+TOWNOFGOLDENMEADOW-LA.GOV,State/Local Govt,Non-Federal Agency,Golden Meadow,LA,ACTIVE
+TOWNOFWINGATENC.GOV,State/Local Govt,Non-Federal Agency,Wingate,NC,ACTIVE
+TRANSPARENCYFLORIDA.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL,ACTIVE
+TRANSPARENCYWV.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE
+TRAVELWYOMING.GOV,State/Local Govt,Non-Federal Agency,Cheyenne,WY,ACTIVE
+TRUSTTENNESSEE.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE
+TRUSTTN.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE
+TTD.GOV,State/Local Govt,Non-Federal Agency,East Norwalk,CT,ACTIVE
+TX.GOV,State/Local Govt,Non-Federal Agency,Austin,TX,ACTIVE
+TX511.GOV,State/Local Govt,Non-Federal Agency,Austin,TX,ACTIVE
+TXAG.GOV,State/Local Govt,Non-Federal Agency,Austin,TX,ACTIVE
+TXCOURTS.GOV,State/Local Govt,Non-Federal Agency,Austin,TX,ACTIVE
+TXDMV.GOV,State/Local Govt,Non-Federal Agency,Austin,TX,ACTIVE
+TXDOT.GOV,State/Local Govt,Non-Federal Agency,Austin,TX,ACTIVE
+TXDPS.GOV,State/Local Govt,Non-Federal Agency,Austin,TX,ACTIVE
+TXMAP.GOV,State/Local Govt,Non-Federal Agency,Austin,TX,ACTIVE
+TXOAG.GOV,State/Local Govt,Non-Federal Agency,Austin,TX,ACTIVE
+US41WISCONSIN.GOV,State/Local Govt,Non-Federal Agency,Madison,WI,ACTIVE
+UTAH.GOV,State/Local Govt,Non-Federal Agency,Salt Lake City,UT,ACTIVE
+UTAHLAKE.GOV,State/Local Govt,Non-Federal Agency,Salt Lake City,UT,ACTIVE
+UTAHTRUST.GOV,State/Local Govt,Non-Federal Agency,North Salt Lake,UT,ACTIVE
+UTCOURTS.GOV,State/Local Govt,Non-Federal Agency,Salt Lake City,UT,ACTIVE
+VACOURTS.GOV,State/Local Govt,Non-Federal Agency,Richmond,VA,ACTIVE
+VAEMERGENCY.GOV,State/Local Govt,Non-Federal Agency,Richmond,VA,ACTIVE
+VERMONT.GOV,State/Local Govt,Non-Federal Agency,Montpelier,VT,ACTIVE
+VERMONTHEALTHCONNECT.GOV,State/Local Govt,Non-Federal Agency,Montpelier,VT,ACTIVE
+VERMONTTAXAMNESTY.GOV,State/Local Govt,Non-Federal Agency,Montpelier,VT,ACTIVE
+VERMONTTREASURER.GOV,State/Local Govt,Non-Federal Agency,Montpelier,VT,ACTIVE
+VERMONTVOTESFORKIDS.GOV,State/Local Govt,Non-Federal Agency,Montpelier,VT,ACTIVE
+VI.GOV,State/Local Govt,Non-Federal Agency,St. Thomas,VI,ACTIVE
+VIALERT.GOV,State/Local Govt,Non-Federal Agency,St. Thomas,VI,ACTIVE
+VIBIR.GOV,State/Local Govt,Non-Federal Agency,St. Thomas,VI,ACTIVE
+VIDOL.GOV,State/Local Govt,Non-Federal Agency,St. Thomas,VI,ACTIVE
+VIHFA.GOV,State/Local Govt,Non-Federal Agency,St. Thomas,VI,ACTIVE
+VILLAGEOFPENINSULA-OH.GOV,State/Local Govt,Non-Federal Agency,Peninsula,OH,ACTIVE
+VIRGINIA.GOV,State/Local Govt,Non-Federal Agency,Chester,VA,ACTIVE
+VIRGINIACAPITAL.GOV,State/Local Govt,Non-Federal Agency,Richmond,VA,ACTIVE
+VIRGINIACAPITOL.GOV,State/Local Govt,Non-Federal Agency,Richmond,VA,ACTIVE
+VIRGINIAGENERALASSEMBLY.GOV,State/Local Govt,Non-Federal Agency,Richmond,VA,ACTIVE
+VIRGINIARESOURCES.GOV,State/Local Govt,Non-Federal Agency,Richmond,VA,ACTIVE
+VIRGINIASTATEPARKS.GOV,State/Local Govt,Non-Federal Agency,Richmond,VA,ACTIVE
+VISITIDAHO.GOV,State/Local Govt,Non-Federal Agency,Boise,ID,ACTIVE
+VISITNEBRASKA.GOV,State/Local Govt,Non-Federal Agency,Lincoln,NE,ACTIVE
+VISITNH.GOV,State/Local Govt,Non-Federal Agency,Concord,NH,ACTIVE
+VISITWYO.GOV,State/Local Govt,Non-Federal Agency,Cheyenne,WY,ACTIVE
+VISITWYOMING.GOV,State/Local Govt,Non-Federal Agency,Cheyenne,WY,ACTIVE
+VITEMA.GOV,State/Local Govt,Non-Federal Agency,St. Thomas,VI,ACTIVE
+VIVOTE.GOV,State/Local Govt,Non-Federal Agency,St Croix,VI,ACTIVE
+VOLUNTEERLOUISIANA.GOV,State/Local Govt,Non-Federal Agency,Baton Rouge,LA,ACTIVE
+VOTETEXAS.GOV,State/Local Govt,Non-Federal Agency,Austin,TX,ACTIVE
+VT.GOV,State/Local Govt,Non-Federal Agency,Montpelier,VT,ACTIVE
+VTALERT.GOV,State/Local Govt,Non-Federal Agency,Montpelier,VT,ACTIVE
+WA.GOV,State/Local Govt,Non-Federal Agency,Olympia,WA,ACTIVE
+WAKECOUNTYNC.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+WALDOCOUNTYME.GOV,State/Local Govt,Non-Federal Agency,Belfast,ME,ACTIVE
+WALPOLE-MA.GOV,State/Local Govt,Non-Federal Agency,Walpole,MA,ACTIVE
+WALTONCOUNTYGA.GOV,State/Local Govt,Non-Federal Agency,Monroe,GA,ACTIVE
+WASHINGTON-NC.GOV,State/Local Govt,Non-Federal Agency,Washington,NC,ACTIVE
+WASHINGTON.GOV,State/Local Govt,Non-Federal Agency,Olympia,WA,ACTIVE
+WASHINGTONDC.GOV,State/Local Govt,Non-Federal Agency,"Washington,",DC,ACTIVE
+WASHINGTONNC.GOV,State/Local Govt,Non-Federal Agency,Washington,NC,ACTIVE
+WASHINGTONSTATE.GOV,State/Local Govt,Non-Federal Agency,Olympia,WA,ACTIVE
+WATAUGACOUNTYNC.GOV,State/Local Govt,Non-Federal Agency,Boone,NC,ACTIVE
+WCNYH.GOV,State/Local Govt,Non-Federal Agency,New YOrk,NY,ACTIVE
+WENHAMMA.GOV,State/Local Govt,Non-Federal Agency,Wenham,MA,ACTIVE
+WESTVIRGINIA.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE
+WHITMAN-MA.GOV,State/Local Govt,Non-Federal Agency,Whitman,MA,ACTIVE
+WHYNEVADA.GOV,State/Local Govt,Non-Federal Agency,Carson City,NV,ACTIVE
+WI-TIME.GOV,State/Local Govt,Non-Federal Agency,Madison,WI,ACTIVE
+WI-WORCS.GOV,State/Local Govt,Non-Federal Agency,Madison,WI,ACTIVE
+WI.GOV,State/Local Govt,Non-Federal Agency,Madison,WI,ACTIVE
+WIBADGERTRACS.GOV,State/Local Govt,Non-Federal Agency,Madison,WI,ACTIVE
+WICONNECTIONS2030.GOV,State/Local Govt,Non-Federal Agency,Madison,WI,ACTIVE
+WICOURTS.GOV,State/Local Govt,Non-Federal Agency,MADISON,WI,ACTIVE
+WIDOC.GOV,State/Local Govt,Non-Federal Agency,Madison,WI,ACTIVE
+WIGRANTS.GOV,State/Local Govt,Non-Federal Agency,Madison,WI,ACTIVE
+WILAWLIBRARY.GOV,State/Local Govt,Non-Federal Agency,Madison,WI,ACTIVE
+WILDOHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH,ACTIVE
+WILMINGTON-NC.GOV,State/Local Govt,Non-Federal Agency,Wilmington,NC,ACTIVE
+WILMINGTONNC.GOV,State/Local Govt,Non-Federal Agency,Wilmington,NC,ACTIVE
+WINTERGARDEN-FL.GOV,State/Local Govt,Non-Federal Agency,Winter Garden,FL,ACTIVE
+WINTERPORTMAINE.GOV,State/Local Govt,Non-Federal Agency,Winterport,ME,ACTIVE
+WINTERSPRINGSFL.GOV,State/Local Govt,Non-Federal Agency,Winter Springs,FL,ACTIVE
+WISC.GOV,State/Local Govt,Non-Federal Agency,Madison,WI,ACTIVE
+WISCONSIN.GOV,State/Local Govt,Non-Federal Agency,Madison,WI,ACTIVE
+WISCONSINCRIMEALERT.GOV,State/Local Govt,Non-Federal Agency,Madison,WI,ACTIVE
+WISCONSINDMV.GOV,State/Local Govt,Non-Federal Agency,Madison,WI,ACTIVE
+WISCONSINDOT.GOV,State/Local Govt,Non-Federal Agency,Madison,WI,ACTIVE
+WISCONSINFREIGHTPLAN.GOV,State/Local Govt,Non-Federal Agency,Madison,WI,ACTIVE
+WISCONSINRAILPLAN.GOV,State/Local Govt,Non-Federal Agency,Madison,WI,ACTIVE
+WISCONSINROUNDABOUTS.GOV,State/Local Govt,Non-Federal Agency,Madison,WI,ACTIVE
+WMATA.GOV,State/Local Govt,Non-Federal Agency,Washington,DC,ACTIVE
+WORKFORCEONETOUCHTN.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN,ACTIVE
+WORKFORNC.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC,ACTIVE
+WSDOT.GOV,State/Local Govt,Non-Federal Agency,Olympia,WA,ACTIVE
+WV.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE
+WV457.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE
+WVAGO.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE
+WVCOMMERCE.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE
+WVCONSUMERPROTECTION.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE
+WVCSI.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE
+WVDHSEM.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE
+WVDNR.GOV,State/Local Govt,Non-Federal Agency,South Charleston,WV,ACTIVE
+WVHOUSE.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE
+WVINSURANCE.GOV,State/Local Govt,Non-Federal Agency,Charleson,WV,ACTIVE
+WVLEGISLATURE.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE
+WVOASIS.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE
+WVOT.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE
+WVOTA.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE
+WVPRESIDENT.GOV,State/Local Govt,Non-Federal Agency,Morgantown,WV,ACTIVE
+WVPURCHASING.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE
+WVREVENUE.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE
+WVSAO.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE
+WVSENATE.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE
+WVSENIORSERVICES.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE
+WVSP.GOV,State/Local Govt,Non-Federal Agency,South Charleston,WV,ACTIVE
+WVSPEAKER.GOV,State/Local Govt,Non-Federal Agency,Morgantown,WV,ACTIVE
+WVSTO.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE
+WVSURPLUS.GOV,State/Local Govt,Non-Federal Agency,Dunbar,WV,ACTIVE
+WVTAX.GOV,State/Local Govt,Non-Federal Agency,Charleston,WV,ACTIVE
+WY.GOV,State/Local Govt,Non-Federal Agency,Cheyenne,WY,ACTIVE
+WYCAMPAIGNFINANCE.GOV,State/Local Govt,Non-Federal Agency,Cheyenne,WY,ACTIVE
+WYO.GOV,State/Local Govt,Non-Federal Agency,Cheyenne,WY,ACTIVE
+WYOBOARDS.GOV,State/Local Govt,Non-Federal Agency,Cheyenne,WY,ACTIVE
+WYOLEG.GOV,State/Local Govt,Non-Federal Agency,Cheyenne,WY,ACTIVE
+WYOMING.GOV,State/Local Govt,Non-Federal Agency,Cheyenne,WY,ACTIVE
+WYOMINGAGCARE.GOV,State/Local Govt,Non-Federal Agency,Cheyenne,WY,ACTIVE
+WYOMINGLMI.GOV,State/Local Govt,Non-Federal Agency,cheyenne,WY,ACTIVE
+WYOMINGOFFICEOFTOURISM.GOV,State/Local Govt,Non-Federal Agency,Cheyenne,WY,ACTIVE
+WYOREG.GOV,State/Local Govt,Non-Federal Agency,cheyenne,WY,ACTIVE
+WYWINDFALL.GOV,State/Local Govt,Non-Federal Agency,cheyenne,WY,ACTIVE
+YADKINCOUNTY.GOV,State/Local Govt,Non-Federal Agency,Yadkinville,NC,ACTIVE
+YADKINCOUNTYNC.GOV,State/Local Govt,Non-Federal Agency,Yadkinville,NC,ACTIVE
+YANCEYVILLENC.GOV,State/Local Govt,Non-Federal Agency,Roxboro,NC,ACTIVE
+ZEROINWISCONSIN.GOV,State/Local Govt,Non-Federal Agency,Madison,WI,ACTIVE
+ZIONSVILLE-IN.GOV,State/Local Govt,Non-Federal Agency,Zionsville,IN,ACTIVE


### PR DESCRIPTION
This updates the .gov domain dataset for June 30th, 2016.

Two things worth noting here:

* I have copied `2016-06-30-full.csv` to `current-full.csv`. In future updates (for as long as this repository continues getting updates -- I'd still love for data.gov to become canonical and current), I'll keep overwriting `current-full.csv` with the latest data. This means that there's a single consistent permalink, and downstream users can code it once and forget about it.

* This dataset not only includes added and removed domains since the last update (2016-05-02), but also some additional domains that were not included in this dataset until recently. These additional domains include many of the domains seen in the response data provided by GSA via @thejefflarson's FOIA appeal, which @thejefflarson has [also posted publicly to GitHub](https://github.com/thejefflarson/government-domains).

