### PR TITLE
Remove two bad "dns name" hostnames from the Censys snapshot

### DIFF
--- a/dotgov-websites/censys-federal-snapshot.csv
+++ b/dotgov-websites/censys-federal-snapshot.csv
@@ -2939,8 +2939,6 @@ discoverreceiver.cbp.dhs.gov
 discoverreceiver.hq.dhs.gov
 discoverreceiver.ice.dhs.gov
 discoverreceiver.uscis.dhs.gov
-dns name=trainingprism-test.dhs.gov
-dns name=trainingprism.dhs.gov
 dp-int-exvip1.cbp.dhs.gov
 dp-int-exvip2.cbp.dhs.gov
 ds.cbp.dhs.gov


### PR DESCRIPTION
This removes two bad hostnames from the Censys snapshot as a quick fix:

```
dns name=trainingprism-test.dhs.gov
dns name=trainingprism.dhs.gov
```

See https://github.com/18F/domain-scan/issues/200 for the issue tracking fixing the underlying cause.

Fixes #112.