### PR TITLE
Updating .gov list from March 27 2018

### DIFF
--- a/dotgov-domains/current-federal.csv
+++ b/dotgov-domains/current-federal.csv
@@ -1,9 +1,7 @@
-﻿Domain Name,Domain Type,Agency,City,State
-ACUS.GOV,Federal Agency,Administrative Conference of the United States,WASHINGTON,DC
+Domain Name,Domain Type,Agency,City,State
+ACUS.GOV,Federal Agency,Administrative Conference of the United States,Washington,DC
 ACHP.GOV,Federal Agency,Advisory Council on Historic Preservation,Washington,DC
 PRESERVEAMERICA.GOV,Federal Agency,Advisory Council on Historic Preservation,Washington,DC
-ADF.GOV,Federal Agency,African Development Foundation,Washington,DC
-USADF.GOV,Federal Agency,African Development Foundation,Washington,DC
 ABMC.GOV,Federal Agency,American Battle Monuments Commission,Arlington,VA
 ABMCSCHOLAR.GOV,Federal Agency,American Battle Monuments Commission,Arlington,VA
 NATIONALMALL.GOV,Federal Agency,American Battle Monuments Commission,Arlington,VA
@@ -20,24 +18,24 @@ VISITTHECAPITAL.GOV,Federal Agency,Architect of the Capitol,Washington,DC
 VISITTHECAPITOL.GOV,Federal Agency,Architect of the Capitol,Washington,DC
 AFRH.GOV,Federal Agency,Armed Forces Retirement Home,Washington,DC
 GOLDWATERSCHOLARSHIP.GOV,Federal Agency,Barry Goldwater Scholarship and Excellence in Education Foundation,Springfield,VA
+BBG.GOV,Federal Agency,Broadcasting Board of Governors,Washington,DC
+IBB.GOV,Federal Agency,Broadcasting Board of Governors,Washington,DC
+VOA.GOV,Federal Agency,Broadcasting Board of Governors,Washington,DC
 CIA.GOV,Federal Agency,Central Intelligence Agency,Washington,DC
-DF.GOV,Federal Agency,Central Intelligence Agency,WASHINGTON,DC
+DF.GOV,Federal Agency,Central Intelligence Agency,Washington,DC
 IC.GOV,Federal Agency,Central Intelligence Agency,Washington,DC
 ISTAC.GOV,Federal Agency,Central Intelligence Agency,Washington,DC
 NCTC.GOV,Federal Agency,Central Intelligence Agency,Washington,DC
 ODCI.GOV,Federal Agency,Central Intelligence Agency,Washington,DC
 OPENSOURCE.GOV,Federal Agency,Central Intelligence Agency,Washington,DC
 OSDE.GOV,Federal Agency,Central Intelligence Agency,Reston,VA
-OSDLS.GOV,Federal Agency,Central Intelligence Agency,McLean,VA
 TTIC.GOV,Federal Agency,Central Intelligence Agency,Washington,DC
 UCIA.GOV,Federal Agency,Central Intelligence Agency,Washington,DC
 CHEMSAFETY.GOV,Federal Agency,Chemical Safety Board,Washington,DC
 CSB.GOV,Federal Agency,Chemical Safety Board,Washington,DC
 SAFETYVIDEOS.GOV,Federal Agency,Chemical Safety Board,Washington,DC
-CAP.GOV,Federal Agency,Civil Air Patrol,BIRMINGHAM,MI
-CAPNHQ.GOV,Federal Agency,Civil Air Patrol,MAXWELL AFB,AL
-ABILITYONE.GOV,Federal Agency,Comm for People Who Are Blind/Severly Disabled,Arlington,VA
-JWOD.GOV,Federal Agency,Comm for People Who Are Blind/Severly Disabled,Arlington,VA
+CAP.GOV,Federal Agency,Civil Air Patrol,Birmingham,MI
+CAPNHQ.GOV,Federal Agency,Civil Air Patrol,Maxwell AFB,AL
 CFTC.GOV,Federal Agency,Commodity Futures Trading Commission,Washington,DC
 SMARTCHECK.GOV,Federal Agency,Commodity Futures Trading Commission,Washington,DC
 WHISTLEBLOWER.GOV,Federal Agency,Commodity Futures Trading Commission,Washington,DC
@@ -77,9 +75,9 @@ SERVE.GOV,Federal Agency,Corporation for National & Community Service,Washington
 SERVICE.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC
 VISTACAMPUS.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC
 VOLUNTEERINGINAMERICA.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC
-CIGIE.GOV,Federal Agency,Council of Inspector General on Integrity and Efficiency,WASHINGTON,DC
-IGNET.GOV,Federal Agency,Council of Inspector General on Integrity and Efficiency,Washington,DC
-OVERSIGHT.GOV,Federal Agency,Council of Inspector General on Integrity and Efficiency,Washington,DC
+CIGIE.GOV,Federal Agency,Council of Inspectors General on Integrity and Efficiency,Washington,DC
+IGNET.GOV,Federal Agency,Council of Inspectors General on Integrity and Efficiency,Washington,DC
+OVERSIGHT.GOV,Federal Agency,Council of Inspectors General on Integrity and Efficiency,Washington,DC
 CSOSA.FED.US,Federal Agency,Court Services and Offender Supervision,Washington,DC
 CSOSA.GOV,Federal Agency,Court Services and Offender Supervision,Washington,DC
 PRETRIALSERVICES.GOV,Federal Agency,Court Services and Offender Supervision,Washington,DC
@@ -88,49 +86,6 @@ DNFSB.GOV,Federal Agency,Defense Nuclear Facilities Safety Board,Washington,DC
 DRA.GOV,Federal Agency,Delta Regional Authority,Clarksdale,MS
 DENALI.GOV,Federal Agency,Denali Commission,Anchorage,AK
 FEA.GOV,Federal Agency,Denali Commission,Anchorage,AK
-AFF.GOV,Federal Agency,Department of Agriculture,Boise,ID
-AG.GOV,Federal Agency,Department of Agriculture,Fort Collins,CO
-ARS-GRIN.GOV,Federal Agency,Department of Agriculture,Beltsville,MD
-ARSUSDA.GOV,Federal Agency,Department of Agriculture,Beltsville,MD
-ASKKAREN.GOV,Federal Agency,Department of Agriculture,Washington,DC
-BEFOODSAFE.GOV,Federal Agency,Department of Agriculture,Washington,DC
-BIOPREFERRED.GOV,Federal Agency,Department of Agriculture,Washington,DC
-BOSQUE.GOV,Federal Agency,Department of Agriculture,Albuquerque,NM
-CHOOSEMYPLATE.GOV,Federal Agency,Department of Agriculture,Alexandria,VA
-COASTALAMERICA.GOV,Federal Agency,Department of Agriculture,Washington,DC
-DIETARYGUIDELINES.GOV,Federal Agency,Department of Agriculture,Alexandria,VA
-EMPOWHR.GOV,Federal Agency,Department of Agriculture,New Orleans,LA
-EXECSEC.GOV,Federal Agency,Department of Agriculture,Washington,DC
-FARMERS.GOV,Federal Agency,Department of Agriculture,Washington,DC
-FOODSAFETYJOBS.GOV,Federal Agency,Department of Agriculture,Washington,DC
-FORESTSANDRANGELANDS.GOV,Federal Agency,Department of Agriculture,Washington,DC
-FS.FED.US,Federal Agency,Department of Agriculture,Washington,DC
-GREEN.GOV,Federal Agency,Department of Agriculture,Washington,DC
-ICBEMP.GOV,Federal Agency,Department of Agriculture,Portland,OR
-INVASIVESPECIESINFO.GOV,Federal Agency,Department of Agriculture,Beltsville,MD
-IPM.GOV,Federal Agency,Department of Agriculture,Washington,DC
-ISITDONEYET.GOV,Federal Agency,Department of Agriculture,Washington,DC
-ITAP.GOV,Federal Agency,Department of Agriculture,Beltsville,MD
-JUNIORFORESTRANGER.GOV,Federal Agency,Department of Agriculture,Washington,DC
-LCACOMMONS.GOV,Federal Agency,Department of Agriculture,Beltsville,MD
-MTBS.GOV,Federal Agency,Department of Agriculture,Salt Lake City,UT
-MYPLATE.GOV,Federal Agency,Department of Agriculture,Alexandria,VA
-NAFRI.GOV,Federal Agency,Department of Agriculture,Tucson,AZ
-NEL.GOV,Federal Agency,Department of Agriculture,Alexandria,VA
-NUTRITION.GOV,Federal Agency,Department of Agriculture,Washington,DC
-NUTRITIONEVIDENCELIBRARY.GOV,Federal Agency,Department of Agriculture,Alexandria,VA
-NWCG.GOV,Federal Agency,Department of Agriculture,Boise,ID
-PREGUNTELEAKAREN.GOV,Federal Agency,Department of Agriculture,Washington,DC
-RECREATION.GOV,Federal Agency,Department of Agriculture,Ogden,UT
-REO.GOV,Federal Agency,Department of Agriculture,Portland,OR
-SMOKEYBEAR.GOV,Federal Agency,Department of Agriculture,Washington,DC
-SYMBOLS.GOV,Federal Agency,Department of Agriculture,Washington,DC
-THEPEOPLESGARDEN.GOV,Federal Agency,Department of Agriculture,Wahington,DC
-USDA.GOV,Federal Agency,Department of Agriculture,Ft. Collins,CO
-USDAPII.GOV,Federal Agency,Department of Agriculture,Washington,DC
-WILDFIRE.GOV,Federal Agency,Department of Agriculture,Boise,ID
-WOODSY.GOV,Federal Agency,Department of Agriculture,Washington,DC
-WOODSYOWL.GOV,Federal Agency,Department of Agriculture,Washington,DC
 2020CENSUS.GOV,Federal Agency,Department of Commerce,Suitland,MD
 AP.GOV,Federal Agency,Department of Commerce,Washington,DC
 AVIATIONWEATHER.GOV,Federal Agency,Department of Commerce,Silver Spring,MD
@@ -185,11 +140,11 @@ WEATHER.GOV,Federal Agency,Department of Commerce,Silver Spring,MD
 XD.GOV,Federal Agency,Department of Commerce,Suitland,MD
 ADLNET.GOV,Federal Agency,Department of Defense,Washington,DC
 AFTAC.GOV,Federal Agency,Department of Defense,Patrick AFB,FL
-ALTUSANDC.GOV,Federal Agency,Department of Defense,"patrick, afb",FL
+ALTUSANDC.GOV,Federal Agency,Department of Defense,Patrick AFB,FL
 BRAC.GOV,Federal Agency,Department of Defense,Alexandria,VA
 BUSINESSDEFENSE.GOV,Federal Agency,Department of Defense,Washington,DC
 CMTS.GOV,Federal Agency,Department of Defense,Mobile,AL
-CNSS.GOV,Federal Agency,Department of Defense,Ft George G. Meade,MD
+CNSS.GOV,Federal Agency,Department of Defense,Fort Meade,MD
 CTOC.GOV,Federal Agency,Department of Defense,Starke,FL
 CTTSO.GOV,Federal Agency,Department of Defense,Arlington,VA
 DC3ON.GOV,Federal Agency,Department of Defense,Linthicum,MD
@@ -198,19 +153,20 @@ DOD.GOV,Federal Agency,Department of Defense,Fort Meade,MD
 EACLEARINGHOUSE.GOV,Federal Agency,Department of Defense,Arlington,VA
 ERDC.GOV,Federal Agency,Department of Defense,Vicksburg,MS
 FVAP.GOV,Federal Agency,Department of Defense,Alexandria,VA
-IAD.GOV,Federal Agency,Department of Defense,Ft Meade,MD
+IAD.GOV,Federal Agency,Department of Defense,Fort Meade,MD
 IOSS.GOV,Federal Agency,Department of Defense,Greenbelt,MD
-ITC.GOV,Federal Agency,Department of Defense,Ft. Washington,MD
+ITC.GOV,Federal Agency,Department of Defense,Fort Washington,MD
 JCCS.GOV,Federal Agency,Department of Defense,Alexandria,VA
 MOJAVEDATA.GOV,Federal Agency,Department of Defense,Barstow,CA
 MTMC.GOV,Federal Agency,Department of Defense,Alexandria,VA
 MYPAY.GOV,Federal Agency,Department of Defense,Pensacola,FL
-NATIONALRESOURCEDIRECTORY.GOV,Federal Agency,Department of Defense,ARLINGTON,VA
+NATIONALRESOURCEDIRECTORY.GOV,Federal Agency,Department of Defense,Arlington,VA
+NBIS.GOV,Federal Agency,Department of Defense,Fort Meade,MD
 NCR.GOV,Federal Agency,Department of Defense,Washington,DC
-NRD.GOV,Federal Agency,Department of Defense,ARLINGTON,VA
+NRD.GOV,Federal Agency,Department of Defense,Arlington,VA
 NRO.GOV,Federal Agency,Department of Defense,Chantilly,VA
 NROJR.GOV,Federal Agency,Department of Defense,Chantilly,VA
-NSA.GOV,Federal Agency,Department of Defense,Ft. Meade,MD
+NSA.GOV,Federal Agency,Department of Defense,Fort Meade,MD
 NSEP.GOV,Federal Agency,Department of Defense,Alexandria,VA
 OEA.GOV,Federal Agency,Department of Defense,Arlington,VA
 PENTAGON.GOV,Federal Agency,Department of Defense,Fort Meade,MD
@@ -237,7 +193,6 @@ ARM.GOV,Federal Agency,Department of Energy,Richland,WA
 BIOMASSBOARD.GOV,Federal Agency,Department of Energy,Washington,DC
 BNL.GOV,Federal Agency,Department of Energy,Upton,NY
 BPA.GOV,Federal Agency,Department of Energy,Portland,OR
-BRC.GOV,Federal Agency,Department of Energy,Washington,DC
 BUILDINGAMERICA.GOV,Federal Agency,Department of Energy,Golden,CO
 CASL.GOV,Federal Agency,Department of Energy,Oak Ridge,TN
 CEBAF.GOV,Federal Agency,Department of Energy,Newport News,VA
@@ -294,123 +249,124 @@ UNNPP.GOV,Federal Agency,Department of Energy,West Mifflin,PA
 UNRPNET.GOV,Federal Agency,Department of Energy,Washington,DC
 WAPA.GOV,Federal Agency,Department of Energy,Lakewood,CO
 YMP.GOV,Federal Agency,Department of Energy,Las Vegas,NV
-ACF.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-ACL.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-AFTERSCHOOL.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-AGING.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-AGINGSTATS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-AHCPR.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
-AHRQ.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
-AIDS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-ALZHEIMERS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-AOA.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-BAM.GOV,Federal Agency,Department of Health And Human Services,Atlanta,GA
-BETOBACCOFREE.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-BIOETHICS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-BRAINHEALTH.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-CANCER.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
-CANCERNET.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
-CDC.GOV,Federal Agency,Department of Health And Human Services,Atlanta,GA
-CDCPARTNERS.GOV,Federal Agency,Department of Health And Human Services,Atlanta,GA
-CEREBROSANO.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
-CHILDCARE.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-CHILDWELFARE.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-CLINICALTRIAL.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
-CLINICALTRIALS.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
-CMS.GOV,Federal Agency,Department of Health And Human Services,Baltimore,MD
-COLLEGEDRINKINGPREVENTION.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
-CUIDADODESALUD.GOV,Federal Agency,Department of Health And Human Services,Baltimore,MD
-DHHS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-DIABETESCOMMITTEE.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-DOCLINE.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
-DONACIONDEORGANOS.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
-DRUGABUSE.GOV,Federal Agency,Department of Health And Human Services,Baltimore,MD
-DRUGFREEWORKPLACE.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
-EDISON.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
-ELDERCARE.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-ENDINGTHEDOCUMENTGAME.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-EVERYTRYCOUNTS.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
-FATHERHOOD.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-FDA.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
-FITNESS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-FLU.GOV,Federal Agency,Department of Health And Human Services,Atlanta,GA
-FOODSAFETY.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-FRESHEMPIRE.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-FRUITSANDVEGGIESMATTER.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-GENBANK.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
-GENOME.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
-GIRLSHEALTH.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-GLOBALHEALTH.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
-GRANTS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-GRANTSOLUTIONS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-GUIDELINE.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
-GUIDELINES.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
-HC.GOV,Federal Agency,Department of Health And Human Services,Baltimore,MD
-HCQUALITYCOMMISSION.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
-HEALTH.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-HEALTHCARE.GOV,Federal Agency,Department of Health And Human Services,Baltimore,MD
-HEALTHDATA.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-HEALTHFINDER.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-HEALTHINDICATORS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-HEALTHIT.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-HEALTHYPEOPLE.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-HEARTTRUTH.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
-HHS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-HHSOIG.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-HHSOPS.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
-HIV.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-HRSA.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
-IDEALAB.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-IEDISON.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
-IHS.GOV,Federal Agency,Department of Health And Human Services,Albuquerque,NM
-INSUREKIDSNOW.GOV,Federal Agency,Department of Health And Human Services,Baltimore,MD
-LOCATORPLUS.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
-LONGTERMCARE.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-MEDICAID.GOV,Federal Agency,Department of Health And Human Services,Baltimore,MD
-MEDICALCOUNTERMEASURES.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-MEDICARE.GOV,Federal Agency,Department of Health And Human Services,Baltimore,MD
-MEDLINE.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
-MEDLINEPLUS.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
-MENTALHEALTH.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
-MESH.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
-MYMEDICARE.GOV,Federal Agency,Department of Health And Human Services,Baltimore,MD
-NATIONALCHILDRENSSTUDY.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
-NCIFCRF.GOV,Federal Agency,Department of Health And Human Services,Frederick,MD
-NGC.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
-NIH.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
-NIHSENIORHEALTH.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
-NIOSH.GOV,Federal Agency,Department of Health And Human Services,Atlanta,GA
-NLM.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
-NNLM.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
-OPIOIDS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-ORGANDONOR.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
-PANDEMICFLU.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-PHE.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-PSC.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
-PUBMED.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
-PUBMEDCENTRAL.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
-QUIC.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
-RECOVERYMONTH.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
-SAFEYOUTH.GOV,Federal Agency,Department of Health And Human Services,Atlanta,GA
-SAMHSA.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
-SELECTAGENTS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-SMOKEFREE.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
-STOPALCOHOLABUSE.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-STOPBULLYING.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-SURGEONGENERAL.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-THECOOLSPOT.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
-THEREALCOST.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-THISFREELIFE.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-TISSUEENGINEERING.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
-TOBACCO.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-USABILITY.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-USBM.GOV,Federal Agency,Department of Health And Human Services,Atlanta,GA
-USPHS.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
-VACCINES.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-WHAGING.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-WHITEHOUSECONFERENCEONAGING.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-WOMENSHEALTH.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-YOUTH.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+ACF.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+ACL.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+AFTERSCHOOL.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+AGING.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+AGINGSTATS.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+AHCPR.GOV,Federal Agency,Department of Health and Human Services,Rockville,MD
+AHRQ.GOV,Federal Agency,Department of Health and Human Services,Rockville,MD
+AIDS.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+ALZHEIMERS.GOV,Federal Agency,Department of Health and Human Services,Bethesda,MD
+AOA.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+BAM.GOV,Federal Agency,Department of Health and Human Services,Atlanta,GA
+BETOBACCOFREE.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+BIOETHICS.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+BRAINHEALTH.GOV,Federal Agency,Department of Health and Human Services,Bethesda,MD
+CANCER.GOV,Federal Agency,Department of Health and Human Services,Rockville,MD
+CANCERNET.GOV,Federal Agency,Department of Health and Human Services,Rockville,MD
+CDC.GOV,Federal Agency,Department of Health and Human Services,Atlanta,GA
+CDCPARTNERS.GOV,Federal Agency,Department of Health and Human Services,Atlanta,GA
+CEREBROSANO.GOV,Federal Agency,Department of Health and Human Services,Bethesda,MD
+CHILDCARE.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+CHILDWELFARE.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+CLINICALTRIAL.GOV,Federal Agency,Department of Health and Human Services,Bethesda,MD
+CLINICALTRIALS.GOV,Federal Agency,Department of Health and Human Services,Bethesda,MD
+CMS.GOV,Federal Agency,Department of Health and Human Services,Baltimore,MD
+COLLEGEDRINKINGPREVENTION.GOV,Federal Agency,Department of Health and Human Services,Bethesda,MD
+CUIDADODESALUD.GOV,Federal Agency,Department of Health and Human Services,Baltimore,MD
+DHHS.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+DIABETESCOMMITTEE.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+DOCLINE.GOV,Federal Agency,Department of Health and Human Services,Bethesda,MD
+DONACIONDEORGANOS.GOV,Federal Agency,Department of Health and Human Services,Rockville,MD
+DRUGABUSE.GOV,Federal Agency,Department of Health and Human Services,Baltimore,MD
+DRUGFREEWORKPLACE.GOV,Federal Agency,Department of Health and Human Services,Rockville,MD
+EDISON.GOV,Federal Agency,Department of Health and Human Services,Bethesda,MD
+ELDERCARE.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+ENDINGTHEDOCUMENTGAME.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+EVERYTRYCOUNTS.GOV,Federal Agency,Department of Health and Human Services,Bethesda,MD
+FATHERHOOD.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+FDA.GOV,Federal Agency,Department of Health and Human Services,Rockville,MD
+FITNESS.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+FLU.GOV,Federal Agency,Department of Health and Human Services,Atlanta,GA
+FOODSAFETY.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+FRESHEMPIRE.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+FRUITSANDVEGGIESMATTER.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+GENBANK.GOV,Federal Agency,Department of Health and Human Services,Bethesda,MD
+GENOME.GOV,Federal Agency,Department of Health and Human Services,Bethesda,MD
+GIRLSHEALTH.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+GLOBALHEALTH.GOV,Federal Agency,Department of Health and Human Services,Rockville,MD
+GRANTS.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+GRANTSOLUTIONS.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+GUIDELINE.GOV,Federal Agency,Department of Health and Human Services,Rockville,MD
+GUIDELINES.GOV,Federal Agency,Department of Health and Human Services,Rockville,MD
+HC.GOV,Federal Agency,Department of Health and Human Services,Baltimore,MD
+HCQUALITYCOMMISSION.GOV,Federal Agency,Department of Health and Human Services,Rockville,MD
+HEALTH.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+HEALTHCARE.GOV,Federal Agency,Department of Health and Human Services,Baltimore,MD
+HEALTHDATA.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+HEALTHFINDER.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+HEALTHINDICATORS.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+HEALTHIT.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+HEALTHYPEOPLE.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+HEARTTRUTH.GOV,Federal Agency,Department of Health and Human Services,Bethesda,MD
+HHS.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+HHSOIG.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+HHSOPS.GOV,Federal Agency,Department of Health and Human Services,Rockville,MD
+HIV.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+HRSA.GOV,Federal Agency,Department of Health and Human Services,Rockville,MD
+IDEALAB.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+IEDISON.GOV,Federal Agency,Department of Health and Human Services,Bethesda,MD
+IHS.GOV,Federal Agency,Department of Health and Human Services,Albuquerque,NM
+INSUREKIDSNOW.GOV,Federal Agency,Department of Health and Human Services,Baltimore,MD
+LOCATORPLUS.GOV,Federal Agency,Department of Health and Human Services,Bethesda,MD
+LONGTERMCARE.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+MEDICAID.GOV,Federal Agency,Department of Health and Human Services,Baltimore,MD
+MEDICALCOUNTERMEASURES.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+MEDICARE.GOV,Federal Agency,Department of Health and Human Services,Baltimore,MD
+MEDLINE.GOV,Federal Agency,Department of Health and Human Services,Bethesda,MD
+MEDLINEPLUS.GOV,Federal Agency,Department of Health and Human Services,Bethesda,MD
+MENTALHEALTH.GOV,Federal Agency,Department of Health and Human Services,Rockville,MD
+MESH.GOV,Federal Agency,Department of Health and Human Services,Bethesda,MD
+MYMEDICARE.GOV,Federal Agency,Department of Health and Human Services,Baltimore,MD
+NATIONALCHILDRENSSTUDY.GOV,Federal Agency,Department of Health and Human Services,Bethesda,MD
+NCIFCRF.GOV,Federal Agency,Department of Health and Human Services,Frederick,MD
+NGC.GOV,Federal Agency,Department of Health and Human Services,Rockville,MD
+NIH.GOV,Federal Agency,Department of Health and Human Services,Bethesda,MD
+NIHSENIORHEALTH.GOV,Federal Agency,Department of Health and Human Services,Bethesda,MD
+NIOSH.GOV,Federal Agency,Department of Health and Human Services,Atlanta,GA
+NLM.GOV,Federal Agency,Department of Health and Human Services,Bethesda,MD
+NNLM.GOV,Federal Agency,Department of Health and Human Services,Bethesda,MD
+OPIOIDS.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+ORGANDONOR.GOV,Federal Agency,Department of Health and Human Services,Rockville,MD
+PANDEMICFLU.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+PHE.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+PSC.GOV,Federal Agency,Department of Health and Human Services,Rockville,MD
+PUBMED.GOV,Federal Agency,Department of Health and Human Services,Bethesda,MD
+PUBMEDCENTRAL.GOV,Federal Agency,Department of Health and Human Services,Bethesda,MD
+QUIC.GOV,Federal Agency,Department of Health and Human Services,Rockville,MD
+RECOVERYMONTH.GOV,Federal Agency,Department of Health and Human Services,Rockville,MD
+SAFEYOUTH.GOV,Federal Agency,Department of Health and Human Services,Atlanta,GA
+SAMHSA.GOV,Federal Agency,Department of Health and Human Services,Rockville,MD
+SELECTAGENTS.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+SMOKEFREE.GOV,Federal Agency,Department of Health and Human Services,Rockville,MD
+STOPALCOHOLABUSE.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+STOPBULLYING.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+SURGEONGENERAL.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+THECOOLSPOT.GOV,Federal Agency,Department of Health and Human Services,Rockville,MD
+THEREALCOST.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+THISFREELIFE.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+TISSUEENGINEERING.GOV,Federal Agency,Department of Health and Human Services,Bethesda,MD
+TOBACCO.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+TOX21.GOV,Federal Agency,Department of Health and Human Services,Rockville,MD
+USABILITY.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+USBM.GOV,Federal Agency,Department of Health and Human Services,Atlanta,GA
+USPHS.GOV,Federal Agency,Department of Health and Human Services,Rockville,MD
+VACCINES.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+WHAGING.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+WHITEHOUSECONFERENCEONAGING.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+WOMENSHEALTH.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+YOUTH.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
 BIOMETRICS.GOV,Federal Agency,Department of Homeland Security,Arlington,VA
 CBP.GOV,Federal Agency,Department of Homeland Security,Washington,DC
 CPNIREPORTING.GOV,Federal Agency,Department of Homeland Security,Washington,DC
@@ -436,23 +392,23 @@ READY.GOV,Federal Agency,Department of Homeland Security,Washington,DC
 READYBUSINESS.GOV,Federal Agency,Department of Homeland Security,Washington,DC
 SAFECOMPROGRAM.GOV,Federal Agency,Department of Homeland Security,Washington,DC
 SAFETYACT.GOV,Federal Agency,Department of Homeland Security,Washington,DC
-SECRETSERVICE.GOV,Federal Agency,Department of Homeland Security,Washington D.C.,DC
+SECRETSERVICE.GOV,Federal Agency,Department of Homeland Security,Washington,DC
 TSA.GOV,Federal Agency,Department of Homeland Security,Arlington,VA
 US-CERT.GOV,Federal Agency,Department of Homeland Security,Washington,DC
 USCG.GOV,Federal Agency,Department of Homeland Security,Alexandria,VA
 USCIS.GOV,Federal Agency,Department of Homeland Security,Washington,DC
 USSS.GOV,Federal Agency,Department of Homeland Security,Washington,DC
-DISASTERHOUSING.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC
-FHA.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC
-GINNIEMAE.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC
-HOMESALES.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC
-HUD.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC
-HUDOIG.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC
-HUDUSER.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC
-NATIONALHOUSING.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC
-NATIONALHOUSINGLOCATOR.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC
-NHL.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC
-NLS.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC
+DISASTERHOUSING.GOV,Federal Agency,Department of Housing and Urban Development,Washington,DC
+FHA.GOV,Federal Agency,Department of Housing and Urban Development,Washington,DC
+GINNIEMAE.GOV,Federal Agency,Department of Housing and Urban Development,Washington,DC
+HOMESALES.GOV,Federal Agency,Department of Housing and Urban Development,Washington,DC
+HUD.GOV,Federal Agency,Department of Housing and Urban Development,Washington,DC
+HUDOIG.GOV,Federal Agency,Department of Housing and Urban Development,Washington,DC
+HUDUSER.GOV,Federal Agency,Department of Housing and Urban Development,Washington,DC
+NATIONALHOUSING.GOV,Federal Agency,Department of Housing and Urban Development,Washington,DC
+NATIONALHOUSINGLOCATOR.GOV,Federal Agency,Department of Housing and Urban Development,Washington,DC
+NHL.GOV,Federal Agency,Department of Housing and Urban Development,Washington,DC
+NLS.GOV,Federal Agency,Department of Housing and Urban Development,Washington,DC
 ADA.GOV,Federal Agency,Department of Justice,Rockville,MD
 ADR.GOV,Federal Agency,Department of Justice,Rockville,MD
 AMBERALERT.GOV,Federal Agency,Department of Justice,Potomac,MD
@@ -475,7 +431,7 @@ DSAC.GOV,Federal Agency,Department of Justice,Potomac,MD
 EGUARDIAN.GOV,Federal Agency,Department of Justice,Washington,DC
 ELDERJUSTICE.GOV,Federal Agency,Department of Justice,Washington,DC
 EPIC.GOV,Federal Agency,Department of Justice,Rockville,MD
-FARA.GOV,Federal Agency,Department of Justice,potomac,MD
+FARA.GOV,Federal Agency,Department of Justice,Potomac,MD
 FBI.GOV,Federal Agency,Department of Justice,Washington,DC
 FBIJOBS.GOV,Federal Agency,Department of Justice,Washington,DC
 FIRSTFREEDOM.GOV,Federal Agency,Department of Justice,Potomac,MD
@@ -535,7 +491,6 @@ DOL-ESA.GOV,Federal Agency,Department of Labor,Washington,DC
 DOL.GOV,Federal Agency,Department of Labor,Washington,DC
 DOLETA.GOV,Federal Agency,Department of Labor,Washington,DC
 EMPLOYER.GOV,Federal Agency,Department of Labor,Washington,DC
-GOVBENEFITS.GOV,Federal Agency,Department of Labor,Washington,DC
 GOVLOANS.GOV,Federal Agency,Department of Labor,Washington,DC
 HIREVETS.GOV,Federal Agency,Department of Labor,Washington,DC
 JOBCORPS.GOV,Federal Agency,Department of Labor,Austin,TX
@@ -569,7 +524,7 @@ USASEANCONNECT.GOV,Federal Agency,Department of State,Jakarta,Jakarta
 USCONSULATE.GOV,Federal Agency,Department of State,Washington,DC
 USEMBASSY.GOV,Federal Agency,Department of State,Washington,DC
 USMISSION.GOV,Federal Agency,Department of State,Washington,DC
-STATEOIG.GOV,Federal Agency,Department of State OIG,Arlington,VA
+STATEOIG.GOV,Federal Agency,"Department of State, Office of Inspector General",Arlington,VA
 ABANDONEDMINES.GOV,Federal Agency,Department of the Interior,Washington,DC
 ACWI.GOV,Federal Agency,Department of the Interior,Reston,VA
 ALASKACENTERS.GOV,Federal Agency,Department of the Interior,Washington,DC
@@ -583,7 +538,7 @@ BSEE.GOV,Federal Agency,Department of the Interior,Herndon,VA
 CORALREEF.GOV,Federal Agency,Department of the Interior,Denver,CO
 CUPCAO.GOV,Federal Agency,Department of the Interior,Denver,CO
 DOI.GOV,Federal Agency,Department of the Interior,Washington,DC
-DOIOIG.GOV,Federal Agency,Department of the Interior,RESTON,VA
+DOIOIG.GOV,Federal Agency,Department of the Interior,Reston,VA
 EARTHQUAKE.GOV,Federal Agency,Department of the Interior,Menlo Park,CA
 EVERGLADESRESTORATION.GOV,Federal Agency,Department of the Interior,Davie,FL
 FCG.GOV,Federal Agency,Department of the Interior,Denver,CO
@@ -620,7 +575,7 @@ NBC.GOV,Federal Agency,Department of the Interior,Denver,CO
 NEMI.GOV,Federal Agency,Department of the Interior,Middleton,WI
 NFPORS.GOV,Federal Agency,Department of the Interior,Washington,DC
 NIFC.GOV,Federal Agency,Department of the Interior,Boise,ID
-NPS.GOV,Federal Agency,Department of the Interior,WASHINGTON DC,DC
+NPS.GOV,Federal Agency,Department of the Interior,Washington,DC
 ONHIR.GOV,Federal Agency,Department of the Interior,Flagstaff,AZ
 ONRR.GOV,Federal Agency,Department of the Interior,Herndon,VA
 OSM.GOV,Federal Agency,Department of the Interior,Washington,DC
@@ -659,7 +614,7 @@ COMPTROLLEROFTHECURRENCY.GOV,Federal Agency,Department of the Treasury,Washingto
 DIRECTOASUCUENTA.GOV,Federal Agency,Department of the Treasury,Washington,DC
 EAGLECASH.GOV,Federal Agency,Department of the Treasury,Washington,DC
 EFTPS.GOV,Federal Agency,Department of the Treasury,Washington,DC
-ETA-FIND.GOV,Federal Agency,Department of the Treasury,DALLAS,TX
+ETA-FIND.GOV,Federal Agency,Department of the Treasury,Dallas,TX
 ETHICSBURG.GOV,Federal Agency,Department of the Treasury,Parkersburg,WV
 EYENOTE.GOV,Federal Agency,Department of the Treasury,Washington,DC
 FEDERALINVESTMENTS.GOV,Federal Agency,Department of the Treasury,Pakersburg,WV
@@ -744,7 +699,7 @@ DISTRACTEDDRIVING.GOV,Federal Agency,Department of Transportation,Washington,DC
 DISTRACTION.GOV,Federal Agency,Department of Transportation,Washington,DC
 DOT.GOV,Federal Agency,Department of Transportation,Washington,DC
 DOTIDEAHUB.GOV,Federal Agency,Department of Transportation,Washington,DC
-DOTTRAFFICRECORDS.GOV,Federal Agency,Department of Transportation,Room 2202,DC
+DOTTRAFFICRECORDS.GOV,Federal Agency,Department of Transportation,Washington,DC
 EMS.GOV,Federal Agency,Department of Transportation,Washington,DC
 ESC.GOV,Federal Agency,Department of Transportation,Oklahoma City,OK
 FAA.GOV,Federal Agency,Department of Transportation,Washington,DC
@@ -774,16 +729,16 @@ IARPA-IDEAS.GOV,Federal Agency,Director of National Intelligence,Washington,DC
 IARPA.GOV,Federal Agency,Director of National Intelligence,College Park,MD
 ICJOINTDUTY.GOV,Federal Agency,Director of National Intelligence,Washington,DC
 INTEL.GOV,Federal Agency,Director of National Intelligence,McLean,VA
-INTELINK.GOV,Federal Agency,Director of National Intelligence,Ft. George G. Meade,MD
+INTELINK.GOV,Federal Agency,Director of National Intelligence,Fort Meade,MD
 INTELLIGENCE.GOV,Federal Agency,Director of National Intelligence,Washington,DC
 ISE.GOV,Federal Agency,Director of National Intelligence,Washington ,DC
 NCIX.GOV,Federal Agency,Director of National Intelligence,Washington,DC
 NCSC.GOV,Federal Agency,Director of National Intelligence,Bethesda,MD
 ODNI.GOV,Federal Agency,Director of National Intelligence,Washington,DC
-OSIS.GOV,Federal Agency,Director of National Intelligence,Fort George G. Meade,MD
+OSIS.GOV,Federal Agency,Director of National Intelligence,Fort Meade,MD
 PIX.GOV,Federal Agency,Director of National Intelligence,Washington,DC
 QART.GOV,Federal Agency,Director of National Intelligence,Washington,DC
-UGOV.GOV,Federal Agency,Director of National Intelligence,Fort George G Meade,MD
+UGOV.GOV,Federal Agency,Director of National Intelligence,Fort Meade,MD
 AIRNOW.GOV,Federal Agency,Environmental Protection Agency,Durham,NC
 CBI-EPA.GOV,Federal Agency,Environmental Protection Agency,Durham,NC
 E-ENTERPRISE.GOV,Federal Agency,Environmental Protection Agency,Washington,DC
@@ -798,7 +753,6 @@ GREENGOV.GOV,Federal Agency,Environmental Protection Agency,Washington,DC
 REGULATIONS.GOV,Federal Agency,Environmental Protection Agency,Washington,DC
 RELOCATEFEDS.GOV,Federal Agency,Environmental Protection Agency,Cincinnati,OH
 SUSTAINABILITY.GOV,Federal Agency,Environmental Protection Agency,Washington,DC
-TOX21.GOV,Federal Agency,Environmental Protection Agency,Rockville,MD
 URBANWATERS.GOV,Federal Agency,Environmental Protection Agency,Washington,DC
 EEOC.GOV,Federal Agency,Equal Employment Opportunity Commission,Washington,DC
 BUDGET.GOV,Federal Agency,Executive Office of the President,Washington,DC
@@ -810,7 +764,7 @@ EARMARKS.GOV,Federal Agency,Executive Office of the President,Washington,DC
 EOP.GOV,Federal Agency,Executive Office of the President,Washington,DC
 GREATAGAIN.GOV,Federal Agency,Executive Office of the President,Washington,DC
 ITDASHBOARD.GOV,Federal Agency,Executive Office of the President,Washington,DC
-MAX.GOV,Federal Agency,Executive Office of the President,NW,WA
+MAX.GOV,Federal Agency,Executive Office of the President,Washington,DC
 NEPA.GOV,Federal Agency,Executive Office of the President,Washington,DC
 NOTALONE.GOV,Federal Agency,Executive Office of the President,Washington,DC
 OMB.GOV,Federal Agency,Executive Office of the President,Washington,DC
@@ -845,28 +799,28 @@ FDICIG.GOV,Federal Agency,Federal Deposit Insurance Corporation,Arlington,VA
 FDICOIG.GOV,Federal Agency,Federal Deposit Insurance Corporation,Washington,DC
 FDICSEGURO.GOV,Federal Agency,Federal Deposit Insurance Corporation,Arlington,VA
 MYFDIC.GOV,Federal Agency,Federal Deposit Insurance Corporation,Arlington,VA
-FEC.GOV,Federal Agency,Federal Elections Commission,Washington,DC
+FEC.GOV,Federal Agency,Federal Election Commission,Washington,DC
 FERC.GOV,Federal Agency,Federal Energy Regulatory Commission,Washington,DC
 FERCALT.GOV,Federal Agency,Federal Energy Regulatory Commission,Washington,DC
 FHFA.GOV,Federal Agency,Federal Housing Finance Agency,Washington,DC
 HARP.GOV,Federal Agency,Federal Housing Finance Agency,Washington,DC
-FHFAOIG.GOV,Federal Agency,Federal Housing Finance Agency Office of Inspector General,Washington,DC
+FHFAOIG.GOV,Federal Agency,"Federal Housing Finance Agency, Office of Inspector General",Washington,DC
 FLRA.GOV,Federal Agency,Federal Labor Relations Authority,Washington,DC
 FMC.GOV,Federal Agency,Federal Maritime Commission,Washington,DC
 FMCS.GOV,Federal Agency,Federal Mediation and Conciliation Service,Washington,DC
-FMSHRC.GOV,Federal Agency,Federal Mine Safety and Health Review Company,Washington,DC
-FBIIC.GOV,Federal Agency,Federal Reserve System,Washington,DC
-FEDERALRESERVE.GOV,Federal Agency,Federal Reserve System,Washington,DC
-FEDERALRESERVE100.GOV,Federal Agency,Federal Reserve System,Washington ,DC
-FEDERALRESERVE2013.GOV,Federal Agency,Federal Reserve System,Washington,DC
-FEDERALRESERVECONSUMERHELP.GOV,Federal Agency,Federal Reserve System,Washington,DC
-FEDPARTNERSHIP.GOV,Federal Agency,Federal Reserve System,Washington,DC
-FFIEC.GOV,Federal Agency,Federal Reserve System,Washington,DC
-FRB.FED.US,Federal Agency,Federal Reserve System,Washington,DC
-FRB.GOV,Federal Agency,Federal Reserve System,Washington,DC
-FRS.GOV,Federal Agency,Federal Reserve System,Washington,DC
-NEWMONEY.GOV,Federal Agency,Federal Reserve System,Washington,DC
-USCURRENCY.GOV,Federal Agency,Federal Reserve System,Washington,DC
+FMSHRC.GOV,Federal Agency,Federal Mine Safety and Health Review Commission,Washington,DC
+FBIIC.GOV,Federal Agency,Federal Reserve Board of Governors,Washington,DC
+FEDERALRESERVE.GOV,Federal Agency,Federal Reserve Board of Governors,Washington,DC
+FEDERALRESERVE100.GOV,Federal Agency,Federal Reserve Board of Governors,Washington ,DC
+FEDERALRESERVE2013.GOV,Federal Agency,Federal Reserve Board of Governors,Washington,DC
+FEDERALRESERVECONSUMERHELP.GOV,Federal Agency,Federal Reserve Board of Governors,Washington,DC
+FEDPARTNERSHIP.GOV,Federal Agency,Federal Reserve Board of Governors,Washington,DC
+FFIEC.GOV,Federal Agency,Federal Reserve Board of Governors,Washington,DC
+FRB.FED.US,Federal Agency,Federal Reserve Board of Governors,Washington,DC
+FRB.GOV,Federal Agency,Federal Reserve Board of Governors,Washington,DC
+FRS.GOV,Federal Agency,Federal Reserve Board of Governors,Washington,DC
+NEWMONEY.GOV,Federal Agency,Federal Reserve Board of Governors,Washington,DC
+USCURRENCY.GOV,Federal Agency,Federal Reserve Board of Governors,Washington,DC
 EXPLORETSP.GOV,Federal Agency,Federal Retirement Thrift Investment Board,Washington,DC
 FRTIB.GOV,Federal Agency,Federal Retirement Thrift Investment Board,Washington,DC
 FRTIBTEST.GOV,Federal Agency,Federal Retirement Thrift Investment Board,Washigton,DC
@@ -896,6 +850,7 @@ ROBODEIDENTIDAD.GOV,Federal Agency,Federal Trade Commission,Washington,DC
 SENTINEL.GOV,Federal Agency,Federal Trade Commission,Washington,DC
 UCE.GOV,Federal Agency,Federal Trade Commission,Washington,DC
 18F.GOV,Federal Agency,General Services Administration,Washington,DC
+ACCESSIBILITY.GOV,Federal Agency,General Services Administration,Washington,DC
 ACQUISITION.GOV,Federal Agency,General Services Administration,Arlington,VA
 AFADVANTAGE.GOV,Federal Agency,General Services Administration,Washington,DC
 APP.GOV,Federal Agency,General Services Administration,Washington,DC
@@ -910,7 +865,7 @@ CFOC.GOV,Federal Agency,General Services Administration,Washington,DC
 CHALLENGE.GOV,Federal Agency,General Services Administration,Washington,DC
 CHALLENGES.GOV,Federal Agency,General Services Administration,Washington,DC
 CIO.GOV,Federal Agency,General Services Administration,Washington,DC
-CITIZENSCIENCE.GOV,Federal Agency,General Services Administration,NW,DC
+CITIZENSCIENCE.GOV,Federal Agency,General Services Administration,Washington,DC
 CLOUD.GOV,Federal Agency,General Services Administration,Washington,DC
 COMPUTERSFORLEARNING.GOV,Federal Agency,General Services Administration,Arlington,VA
 CONNECT.GOV,Federal Agency,General Services Administration,Washington,DC
@@ -918,15 +873,15 @@ CONSUMERACTION.GOV,Federal Agency,General Services Administration,Washington,DC
 CONTRACTDIRECTORY.GOV,Federal Agency,General Services Administration,Arlington,VA
 CPARS.GOV,Federal Agency,General Services Administration,Washington,DC
 DATA.GOV,Federal Agency,General Services Administration,Washington,DC
-DIGITAL.GOV,Federal Agency,General Services Administration,Washington D.C.,DC
+DIGITAL.GOV,Federal Agency,General Services Administration,Washington,DC
 DIGITALDASHBOARD.GOV,Federal Agency,General Services Administration,Washington,DC
 DIGITALGOV.GOV,Federal Agency,General Services Administration,Washington,DC
 DOTGOV.GOV,Federal Agency,General Services Administration,Fairfax,VA
 EAC.GOV,Federal Agency,General Services Administration,Washington,DC
 ECPIC.GOV,Federal Agency,General Services Administration,Washington,DC
 EISENHOWERMEMORIAL.GOV,Federal Agency,General Services Administration,Washington,DC
-ESRS.GOV,Federal Agency,General Services Administration,arlington,VA
-EVERYKIDINAPARK.GOV,Federal Agency,General Services Administration,Washington DC,DC
+ESRS.GOV,Federal Agency,General Services Administration,Arlington,VA
+EVERYKIDINAPARK.GOV,Federal Agency,General Services Administration,Washington,DC
 FACA.GOV,Federal Agency,General Services Administration,Washington,DC
 FACADATABASE.GOV,Federal Agency,General Services Administration,Washington,DC
 FAI.GOV,Federal Agency,General Services Administration,Washington,DC
@@ -948,7 +903,7 @@ FPISC.GOV,Federal Agency,General Services Administration,Washington,DC
 FPKI-LAB.GOV,Federal Agency,General Services Administration,Washington,DC
 FPKI.GOV,Federal Agency,General Services Administration,Washington,DC
 FRPG.GOV,Federal Agency,General Services Administration,Washington,DC
-FRPP-PA.GOV,Federal Agency,General Services Administration,WASHINGTON,DC
+FRPP-PA.GOV,Federal Agency,General Services Administration,Washington,DC
 FSD.GOV,Federal Agency,General Services Administration,Arlington,VA
 FSRS.GOV,Federal Agency,General Services Administration,Crystal City,VA
 GOBIERNO.GOV,Federal Agency,General Services Administration,Washington,DC
@@ -969,7 +924,7 @@ HOWTO.GOV,Federal Agency,General Services Administration,Washington,DC
 IDENTITYSANDBOX.GOV,Federal Agency,General Services Administration,Washington,DC
 IDMANAGEMENT.GOV,Federal Agency,General Services Administration,Washington,DC
 INFO.GOV,Federal Agency,General Services Administration,Washington,DC
-INNOVATION.GOV,Federal Agency,General Services Administration,NW,DC
+INNOVATION.GOV,Federal Agency,General Services Administration,Washington,DC
 KIDS.GOV,Federal Agency,General Services Administration,Washington,DC
 LOGIN.GOV,Federal Agency,General Services Administration,Washington,DC
 NBRC.GOV,Federal Agency,General Services Administration,Concord,NH
@@ -982,12 +937,12 @@ PERFORMANCE.GOV,Federal Agency,General Services Administration,Washington,DC
 PIC.GOV,Federal Agency,General Services Administration,Washington,DC
 PIF.GOV,Federal Agency,General Services Administration,Washington,DC
 PKI-LAB.GOV,Federal Agency,General Services Administration,Washington,DC
-PKI.GOV,Federal Agency,General Services Administration,Wahington,DC
+PKI.GOV,Federal Agency,General Services Administration,Washington,DC
 PLAINLANGUAGE.GOV,Federal Agency,General Services Administration,Washington,DC
 PPIRS.GOV,Federal Agency,General Services Administration,Washington,DC
 PRESIDENTIALINNOVATIONFELLOWS.GOV,Federal Agency,General Services Administration,Washington,DC
-PROMESA.GOV,Federal Agency,General Services Administration,WASHINGTON,DC
-PTT.GOV,Federal Agency,General Services Administration,Washington D.C.,DC
+PROMESA.GOV,Federal Agency,General Services Administration,Washington,DC
+PTT.GOV,Federal Agency,General Services Administration,Washington,DC
 REALESTATESALES.GOV,Federal Agency,General Services Administration,Washington,DC
 REALPROPERTYPROFILE.GOV,Federal Agency,General Services Administration,Washington,DC
 REGINFO.GOV,Federal Agency,General Services Administration,Washington,DC
@@ -1007,7 +962,7 @@ USAGOV.GOV,Federal Agency,General Services Administration,Washington,DC
 USGOVERNMENT.GOV,Federal Agency,General Services Administration,Washington,DC
 USSM.GOV,Federal Agency,General Services Administration,Washington,DC
 VOTE.GOV,Federal Agency,General Services Administration,Washington,DC
-VOTEBYMAIL.GOV,Federal Agency,General Services Administration,SILVER SPRING,MD
+VOTEBYMAIL.GOV,Federal Agency,General Services Administration,Silver Spring,MD
 CONGRESSIONALDIRECTORY.GOV,Federal Agency,Government Publishing Office,Washington,DC
 CONGRESSIONALRECORD.GOV,Federal Agency,Government Publishing Office,Washington,DC
 ECFR.GOV,Federal Agency,Government Publishing Office,Washington,DC
@@ -1025,13 +980,10 @@ SENATECALENDAR.GOV,Federal Agency,Government Publishing Office,Washington,DC
 USCC.GOV,Federal Agency,Government Publishing Office,Washington,DC
 USCODE.GOV,Federal Agency,Government Publishing Office,Washington,DC
 USGOVERNMENTMANUAL.GOV,Federal Agency,Government Publishing Office,College Park,MD
-RESTORETHEGULF.GOV,Federal Agency,Gulf Coast Ecosystem Restoration Council (GCERC),Silver Spring,MD
+RESTORETHEGULF.GOV,Federal Agency,Gulf Coast Ecosystem Restoration Council,Silver Spring,MD
 TRUMAN.GOV,Federal Agency,Harry S. Truman Scholarship Foundation,Washington,DC
 IMLS.GOV,Federal Agency,Institute of Museum and Library Services,Washington,DC
 IAF.GOV,Federal Agency,Inter-American Foundation,Washington,DC
-BBG.GOV,Federal Agency,International Broadcasting Bureau,Washington,DC
-IBB.GOV,Federal Agency,International Broadcasting Bureau,Washington,DC
-VOA.GOV,Federal Agency,International Broadcasting Bureau,Washington,DC
 JAMESMADISON.GOV,Federal Agency,James Madison Memorial Fellowship Foundation,Alexandria,VA
 JUSFC.GOV,Federal Agency,Japan-US Friendship Commision,Washington,DC
 KENNEDY-CENTER.GOV,Federal Agency,John F. Kennedy Center for Performing Arts,Washington,DC
@@ -1072,12 +1024,12 @@ MEDPAC.GOV,Federal Agency,Medical Payment Advisory Commission,Washington,DC
 MSPB.GOV,Federal Agency,Merit Systems Protection Board,Washington,DC
 MCC.GOV,Federal Agency,Millennium Challenge Corporation,Washington,DC
 MCCTEST.GOV,Federal Agency,Millennium Challenge Corporation,Washington,DC
-ECR.GOV,Federal Agency,Morris K. Udall Foundation,Tucson,AZ
-UDALL.GOV,Federal Agency,Morris K. Udall Foundation,Tucson,AZ
+ECR.GOV,Federal Agency,Morris K. Udall and Stewart L. Udall Foundation,Tucson,AZ
+UDALL.GOV,Federal Agency,Morris K. Udall and Stewart L. Udall Foundation,Tucson,AZ
 GLOBE.GOV,Federal Agency,National Aeronautics and Space Administration,Greenbelt,MD
-NASA.GOV,Federal Agency,National Aeronautics and Space Administration,MSFC,AL
-SCIJINKS.GOV,Federal Agency,National Aeronautics and Space Administration,MSFC,AL
-USGEO.GOV,Federal Agency,National Aeronautics and Space Administration,MSFC,AL
+NASA.GOV,Federal Agency,National Aeronautics and Space Administration,Huntsville,AL
+SCIJINKS.GOV,Federal Agency,National Aeronautics and Space Administration,Huntsville,AL
+USGEO.GOV,Federal Agency,National Aeronautics and Space Administration,Huntsville,AL
 9-11COMMISSION.GOV,Federal Agency,National Archives and Records Administration,College Park,MD
 911COMMISSION.GOV,Federal Agency,National Archives and Records Administration,College Park,MD
 ARCHIVES.GOV,Federal Agency,National Archives and Records Administration,College Park,MD
@@ -1088,7 +1040,7 @@ FORDLIBRARYMUSEUM.GOV,Federal Agency,National Archives and Records Administratio
 FRC.GOV,Federal Agency,National Archives and Records Administration,College Park,MD
 GEORGEWBUSHLIBRARY.GOV,Federal Agency,National Archives and Records Administration,College Park,MD
 HISTORY.GOV,Federal Agency,National Archives and Records Administration,College Park,MD
-JIMMYCARTERLIBRARY.GOV,Federal Agency,National Archives and Records Administration,College,MD
+JIMMYCARTERLIBRARY.GOV,Federal Agency,National Archives and Records Administration,College Park,MD
 NARA-AT-WORK.GOV,Federal Agency,National Archives and Records Administration,College Park,MD
 NARA.GOV,Federal Agency,National Archives and Records Administration,College Park,MD
 NIXONLIBRARY.GOV,Federal Agency,National Archives and Records Administration,College Park,MD
@@ -1121,17 +1073,16 @@ RESEARCH.GOV,Federal Agency,National Science Foundation,Alexandria,VA
 SAC.GOV,Federal Agency,National Science Foundation,Alexandria,VA
 SCIENCE360.GOV,Federal Agency,National Science Foundation,Alexandria,VA
 USAP.GOV,Federal Agency,National Science Foundation,Arlington,VA
-INTELLIGENCECAREERS.GOV,Federal Agency,National Security Agency,Ft. Meade,MD
+INTELLIGENCECAREERS.GOV,Federal Agency,National Security Agency,Fort Meade,MD
 LPS.GOV,Federal Agency,National Security Agency,College Park,MD
 NTSB.GOV,Federal Agency,National Transportation Safety Board,Washington,DC
-ITRD.GOV,Federal Agency,Networking Information Technology Research and Development (NITRD),Arlington,VA
-NITRD.GOV,Federal Agency,Networking Information Technology Research and Development (NITRD),Arlington,VA
+ITRD.GOV,Federal Agency,Networking Information Technology Research and Development,Arlington,VA
+NITRD.GOV,Federal Agency,Networking Information Technology Research and Development,Arlington,VA
 NRC-GATEWAY.GOV,Federal Agency,Nuclear Regulatory Commission,Rockville,MD
 NRC.GOV,Federal Agency,Nuclear Regulatory Commission,Rockville,MD
 OSHRC.GOV,Federal Agency,Occupational Safety & Health Review Commission,Washington,DC
 INTEGRITY.GOV,Federal Agency,Office of Government Ethics,Washington,DC
 OGE.GOV,Federal Agency,Office of Government Ethics,Washington,DC
-USITCOIG.GOV,Federal Agency,Office of Inspector General for the U.S. International Trade Commission,Washington,DC
 APPLICATIONMANAGER.GOV,Federal Agency,Office of Personnel Management,Macon,GA
 CHCOC.GOV,Federal Agency,Office of Personnel Management,Washington,DC
 CYBERCAREERS.GOV,Federal Agency,Office of Personnel Management,Washington,DC
@@ -1146,7 +1097,6 @@ FSAFEDS.GOV,Federal Agency,Office of Personnel Management,Washington,DC
 GOLEARN.GOV,Federal Agency,Office of Personnel Management,Washington,DC
 GOVERNMENTJOBS.GOV,Federal Agency,Office of Personnel Management,Macon,GA
 HRU.GOV,Federal Agency,Office of Personnel Management,Washington,DC
-LMRCOUNCIL.GOV,Federal Agency,Office of Personnel Management,Washington,DC
 NBIB.GOV,Federal Agency,Office of Personnel Management,Washington,DC
 OPM.GOV,Federal Agency,Office of Personnel Management,Macon,GA
 PAC.GOV,Federal Agency,Office of Personnel Management,Washington,DC
@@ -1158,7 +1108,7 @@ USALEARNING.GOV,Federal Agency,Office of Personnel Management,Washington,DC
 USASTAFFING.GOV,Federal Agency,Office of Personnel Management,Macon,GA
 OPIC.GOV,Federal Agency,Overseas Private Investment Corporation,Washington,DC
 PBGC.GOV,Federal Agency,Pension Benefit Guaranty Corporation,Washington,DC
-PRC.GOV,Federal Agency,Postal Rate Commission,Washington,DC
+PRC.GOV,Federal Agency,Postal Regulatory Commission,Washington,DC
 RRB.GOV,Federal Agency,Railroad Retirement Board,Chicago,IL
 INVESTOR.GOV,Federal Agency,Securities and Exchange Commission,Washington,DC
 SEC.GOV,Federal Agency,Securities and Exchange Commission,Washington,DC
@@ -1171,93 +1121,62 @@ ITIS.GOV,Federal Agency,Smithsonian Institution,Washington,DC
 SEGUROSOCIAL.GOV,Federal Agency,Social Security Administration,Baltimore,MD
 SOCIALSECURITY.GOV,Federal Agency,Social Security Administration,Baltimore,MD
 SSA.GOV,Federal Agency,Social Security Administration,Baltimore,MD
-SSAB.GOV,Federal Agency,Social Security Advisory Board,WASHINGTON,DC
-SJI.GOV,Federal Agency,State Justice Institute (SJI),Reston,VA
+SSAB.GOV,Federal Agency,Social Security Advisory Board,Washington,DC
+SJI.GOV,Federal Agency,State Justice Institute,Reston,VA
 STENNIS.GOV,Federal Agency,Stennis Center for Public Service,Starkville,MS
-STB.GOV,Federal Agency,Surface Transportation Board (STB),Washington,DC
+STB.GOV,Federal Agency,Surface Transportation Board,Washington,DC
 TVA.GOV,Federal Agency,Tennessee Valley Authority,Knoxville,TN
 TVAOIG.GOV,Federal Agency,Tennessee Valley Authority,Knoxville,TN
 TSC.GOV,Federal Agency,Terrorist Screening Center,Washington,DC
 PTF.GOV,Federal Agency,The Intelligence Community,Washington,DC
-CBO.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
-CBONEWS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
-CECC.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
-CHINA-COMMISSION.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
-CHINACOMMISSION.GOV,Federal Agency,The Legislative Branch (Congress),Washington,MD
-CITIZENCOSPONSORS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
-CITIZENS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
-COSPONSOR.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
-CSCE.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
-DEMOCRATICLEADER.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
-DEMOCRATICWHIP.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
-DEMOCRATS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
-DEMS.GOV,Federal Agency,The Legislative Branch (Congress),Washington DC,DC
-ESECLAB.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
-FASAB.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
-GAO.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
-GAONET.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
-GOP.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
-GOPLEADER.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
-HOUSE.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
-HOUSECOMMUNICATIONS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
-HOUSED.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
-HOUSEDEMOCRATS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
-HOUSEDEMS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
-HOUSELIVE.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
-HOUSENEWSLETTERS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
-JCT.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
-LISTENSTOYOU.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
-MAJORITYLEADER.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
-MAJORITYWHIP.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
-PDBCECC.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
-PPDCECC.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
-REPUBLICANS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
-SEN.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
-SENATE.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
-SPEAKER.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
-TAXREFORM.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
-TMDBHOUSE.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
-USHOUSE.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
-USHR.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+CBO.GOV,Federal Agency,The Legislative Branch,Washington,DC
+CBONEWS.GOV,Federal Agency,The Legislative Branch,Washington,DC
+CECC.GOV,Federal Agency,The Legislative Branch,Washington,DC
+CHINA-COMMISSION.GOV,Federal Agency,The Legislative Branch,Washington,DC
+CHINACOMMISSION.GOV,Federal Agency,The Legislative Branch,Washington,MD
+CITIZENCOSPONSORS.GOV,Federal Agency,The Legislative Branch,Washington,DC
+CITIZENS.GOV,Federal Agency,The Legislative Branch,Washington,DC
+COSPONSOR.GOV,Federal Agency,The Legislative Branch,Washington,DC
+CSCE.GOV,Federal Agency,The Legislative Branch,Washington,DC
+DEMOCRATICLEADER.GOV,Federal Agency,The Legislative Branch,Washington,DC
+DEMOCRATICWHIP.GOV,Federal Agency,The Legislative Branch,Washington,DC
+DEMOCRATS.GOV,Federal Agency,The Legislative Branch,Washington,DC
+DEMS.GOV,Federal Agency,The Legislative Branch,Washington,DC
+ESECLAB.GOV,Federal Agency,The Legislative Branch,Washington,DC
+FASAB.GOV,Federal Agency,The Legislative Branch,Washington,DC
+GAO.GOV,Federal Agency,The Legislative Branch,Washington,DC
+GAONET.GOV,Federal Agency,The Legislative Branch,Washington,DC
+GOP.GOV,Federal Agency,The Legislative Branch,Washington,DC
+GOPLEADER.GOV,Federal Agency,The Legislative Branch,Washington,DC
+HOUSE.GOV,Federal Agency,The Legislative Branch,Washington,DC
+HOUSECOMMUNICATIONS.GOV,Federal Agency,The Legislative Branch,Washington,DC
+HOUSED.GOV,Federal Agency,The Legislative Branch,Washington,DC
+HOUSEDEMOCRATS.GOV,Federal Agency,The Legislative Branch,Washington,DC
+HOUSEDEMS.GOV,Federal Agency,The Legislative Branch,Washington,DC
+HOUSELIVE.GOV,Federal Agency,The Legislative Branch,Washington,DC
+HOUSENEWSLETTERS.GOV,Federal Agency,The Legislative Branch,Washington,DC
+JCT.GOV,Federal Agency,The Legislative Branch,Washington,DC
+LISTENSTOYOU.GOV,Federal Agency,The Legislative Branch,Washington,DC
+MAJORITYLEADER.GOV,Federal Agency,The Legislative Branch,Washington,DC
+MAJORITYWHIP.GOV,Federal Agency,The Legislative Branch,Washington,DC
+PDBCECC.GOV,Federal Agency,The Legislative Branch,Washington,DC
+PPDCECC.GOV,Federal Agency,The Legislative Branch,Washington,DC
+REPUBLICANS.GOV,Federal Agency,The Legislative Branch,Washington,DC
+SEN.GOV,Federal Agency,The Legislative Branch,Washington,DC
+SENATE.GOV,Federal Agency,The Legislative Branch,Washington,DC
+SPEAKER.GOV,Federal Agency,The Legislative Branch,Washington,DC
+TAXREFORM.GOV,Federal Agency,The Legislative Branch,Washington,DC
+TMDBHOUSE.GOV,Federal Agency,The Legislative Branch,Washington,DC
+USHOUSE.GOV,Federal Agency,The Legislative Branch,Washington,DC
+USHR.GOV,Federal Agency,The Legislative Branch,Washington,DC
 SC-US.GOV,Federal Agency,The Supreme Court,Washington,DC
 SCINET-TEST.GOV,Federal Agency,The Supreme Court,Washington,DC
 SCINET.GOV,Federal Agency,The Supreme Court,Washington,DC
-SCUS.GOV,Federal Agency,The Supreme Court,WASHINGTON,DC
+SCUS.GOV,Federal Agency,The Supreme Court,Washington,DC
 SUPREME-COURT.GOV,Federal Agency,The Supreme Court,Washington,DC
 SUPREMECOURT.GOV,Federal Agency,The Supreme Court,Washington,DC
 SUPREMECOURTUS.GOV,Federal Agency,The Supreme Court,Washington,DC
 WORLDWAR1CENTENNIAL.GOV,Federal Agency,The United States World War One Centennial Commission,Washington,DC
-ACCESS-BOARD.GOV,Federal Agency,U. S. Access Board,Washington,DC
-USHMM.GOV,Federal Agency,U. S. Holocaust Memorial Museum,Washington,DC
-USITC.GOV,Federal Agency,U. S. International Trade Commission,Washington,DC
-OSC.GOV,Federal Agency,U. S. Office of Special Counsel,Washington,DC
-OSCNET.GOV,Federal Agency,U. S. Office of Special Counsel,Washington,DC
-PEACECORPS.GOV,Federal Agency,U. S. Peace Corps,Washington,DC
-CHANGEOFADDRESS.GOV,Federal Agency,U. S. Postal Service,Washington,DC
-MAIL.GOV,Federal Agency,U. S. Postal Service,Raleigh,NC
-MYUSPS.GOV,Federal Agency,U. S. Postal Service,Raleigh,NC
-POSTOFFICE.GOV,Federal Agency,U. S. Postal Service,Raleigh,NC
-PURCHASING.GOV,Federal Agency,U. S. Postal Service,Raleigh,NC
-USPIS.GOV,Federal Agency,U. S. Postal Service,Arlington,VA
-USPS.GOV,Federal Agency,U. S. Postal Service,Raleigh,NC
-USPSINFORMEDDELIVERY.GOV,Federal Agency,U. S. Postal Service,Raleigh,NC
-USPSINNOVATES.GOV,Federal Agency,U. S. Postal Service,Washington,DC
-BANKRUPTCY.GOV,Federal Agency,U.S Courts,Washington,DC
-CAVC.GOV,Federal Agency,U.S Courts,Washington,DC
-FEDERALCOURTS.GOV,Federal Agency,U.S Courts,Washington,DC
-FEDERALPROBATION.GOV,Federal Agency,U.S Courts,Washington,DC
-FEDERALRULES.GOV,Federal Agency,U.S Courts,Washington,DC
-FJC.GOV,Federal Agency,U.S Courts,Washington,DC
-JUDICIALCONFERENCE.GOV,Federal Agency,U.S Courts,Washington,DC
-NMCOURT.FED.US,Federal Agency,U.S Courts,Albuquerque,NM
-PACER.GOV,Federal Agency,U.S Courts,Washington,DC
-USBANKRUPTCY.GOV,Federal Agency,U.S Courts,Washington,DC
-USC.GOV,Federal Agency,U.S Courts,Washington,DC
-USCAVC.GOV,Federal Agency,U.S Courts,Washington,DC
-USCOURTS.GOV,Federal Agency,U.S Courts,Washington,DC
-USPROBATION.GOV,Federal Agency,U.S Courts,Washington,DC
-USSC.GOV,Federal Agency,U.S Courts,Washington,DC
-USTAXCOURT.GOV,Federal Agency,U.S Courts,Washington,DC
 CHILDRENINADVERSITY.GOV,Federal Agency,U.S. Agency for International Development,Washington,DC
 DFAFACTS.GOV,Federal Agency,U.S. Agency for International Development,Washington,DC
 FEEDTHEFUTURE.GOV,Federal Agency,U.S. Agency for International Development,Washington,DC
@@ -1268,16 +1187,95 @@ PMI.GOV,Federal Agency,U.S. Agency for International Development,Washington,DC
 USAID.GOV,Federal Agency,U.S. Agency for International Development,Washington,DC
 USCAPITOLPOLICE.GOV,Federal Agency,U.S. Capitol Police,Washington,DC
 USCP.GOV,Federal Agency,U.S. Capitol Police,Washington,DC
+HERITAGEABROAD.GOV,Federal Agency,U.S. Commission for the Preservation of Americas Heritage Abroad,Washington,DC
 CFA.GOV,Federal Agency,U.S. Commission of Fine Arts,Washington,DC
 USCCR.GOV,Federal Agency,U.S. Commission on Civil Rights,Washington,DC
 USCIRF.GOV,Federal Agency,U.S. Commission on International Religious Freedom,Washington,DC
-PEACECORPSOIG.GOV,Federal Agency,"U.S. Postal Service, Office of Inspector General",Washington,DC
-USPSOIG.GOV,Federal Agency,"U.S. Postal Service, Office of Inspector General",Arlington,VA
-USTDA.GOV,Federal Agency,U.S. Trade and Development Agency,Arlington,VA
-GLOBALCHANGE.GOV,Federal Agency,United Stated Global Change Research Program,Washington,DC
-USGCRP.GOV,Federal Agency,United Stated Global Change Research Program,Washington,DC
+BANKRUPTCY.GOV,Federal Agency,U.S. Courts,Washington,DC
+CAVC.GOV,Federal Agency,U.S. Courts,Washington,DC
+FEDERALCOURTS.GOV,Federal Agency,U.S. Courts,Washington,DC
+FEDERALPROBATION.GOV,Federal Agency,U.S. Courts,Washington,DC
+FEDERALRULES.GOV,Federal Agency,U.S. Courts,Washington,DC
+FJC.GOV,Federal Agency,U.S. Courts,Washington,DC
+JUDICIALCONFERENCE.GOV,Federal Agency,U.S. Courts,Washington,DC
+NMCOURT.FED.US,Federal Agency,U.S. Courts,Albuquerque,NM
+PACER.GOV,Federal Agency,U.S. Courts,Washington,DC
+USBANKRUPTCY.GOV,Federal Agency,U.S. Courts,Washington,DC
+USC.GOV,Federal Agency,U.S. Courts,Washington,DC
+USCAVC.GOV,Federal Agency,U.S. Courts,Washington,DC
+USCOURTS.GOV,Federal Agency,U.S. Courts,Washington,DC
+USPROBATION.GOV,Federal Agency,U.S. Courts,Washington,DC
+USSC.GOV,Federal Agency,U.S. Courts,Washington,DC
+USTAXCOURT.GOV,Federal Agency,U.S. Courts,Washington,DC
+AFF.GOV,Federal Agency,U.S. Department of Agriculture,Boise,ID
+AG.GOV,Federal Agency,U.S. Department of Agriculture,Fort Collins,CO
+ARS-GRIN.GOV,Federal Agency,U.S. Department of Agriculture,Beltsville,MD
+ARSUSDA.GOV,Federal Agency,U.S. Department of Agriculture,Beltsville,MD
+ASKKAREN.GOV,Federal Agency,U.S. Department of Agriculture,Washington,DC
+BEFOODSAFE.GOV,Federal Agency,U.S. Department of Agriculture,Washington,DC
+BIOPREFERRED.GOV,Federal Agency,U.S. Department of Agriculture,Washington,DC
+BOSQUE.GOV,Federal Agency,U.S. Department of Agriculture,Albuquerque,NM
+CHOOSEMYPLATE.GOV,Federal Agency,U.S. Department of Agriculture,Alexandria,VA
+COASTALAMERICA.GOV,Federal Agency,U.S. Department of Agriculture,Washington,DC
+DIETARYGUIDELINES.GOV,Federal Agency,U.S. Department of Agriculture,Alexandria,VA
+EMPOWHR.GOV,Federal Agency,U.S. Department of Agriculture,New Orleans,LA
+EXECSEC.GOV,Federal Agency,U.S. Department of Agriculture,Washington,DC
+FARMERS.GOV,Federal Agency,U.S. Department of Agriculture,Washington,DC
+FOODSAFETYJOBS.GOV,Federal Agency,U.S. Department of Agriculture,Washington,DC
+FORESTSANDRANGELANDS.GOV,Federal Agency,U.S. Department of Agriculture,Washington,DC
+FS.FED.US,Federal Agency,U.S. Department of Agriculture,Washington,DC
+GREEN.GOV,Federal Agency,U.S. Department of Agriculture,Washington,DC
+ICBEMP.GOV,Federal Agency,U.S. Department of Agriculture,Portland,OR
+INVASIVESPECIESINFO.GOV,Federal Agency,U.S. Department of Agriculture,Beltsville,MD
+IPM.GOV,Federal Agency,U.S. Department of Agriculture,Washington,DC
+ISITDONEYET.GOV,Federal Agency,U.S. Department of Agriculture,Washington,DC
+ITAP.GOV,Federal Agency,U.S. Department of Agriculture,Beltsville,MD
+JUNIORFORESTRANGER.GOV,Federal Agency,U.S. Department of Agriculture,Washington,DC
+LCACOMMONS.GOV,Federal Agency,U.S. Department of Agriculture,Beltsville,MD
+MTBS.GOV,Federal Agency,U.S. Department of Agriculture,Salt Lake City,UT
+MYPLATE.GOV,Federal Agency,U.S. Department of Agriculture,Alexandria,VA
+NAFRI.GOV,Federal Agency,U.S. Department of Agriculture,Tucson,AZ
+NEL.GOV,Federal Agency,U.S. Department of Agriculture,Alexandria,VA
+NUTRITION.GOV,Federal Agency,U.S. Department of Agriculture,Washington,DC
+NUTRITIONEVIDENCELIBRARY.GOV,Federal Agency,U.S. Department of Agriculture,Alexandria,VA
+NWCG.GOV,Federal Agency,U.S. Department of Agriculture,Boise,ID
+PREGUNTELEAKAREN.GOV,Federal Agency,U.S. Department of Agriculture,Washington,DC
+RECREATION.GOV,Federal Agency,U.S. Department of Agriculture,Ogden,UT
+REO.GOV,Federal Agency,U.S. Department of Agriculture,Portland,OR
+SMOKEYBEAR.GOV,Federal Agency,U.S. Department of Agriculture,Washington,DC
+SYMBOLS.GOV,Federal Agency,U.S. Department of Agriculture,Washington,DC
+THEPEOPLESGARDEN.GOV,Federal Agency,U.S. Department of Agriculture,Washington,DC
+USDA.GOV,Federal Agency,U.S. Department of Agriculture,Ft. Collins,CO
+USDAPII.GOV,Federal Agency,U.S. Department of Agriculture,Washington,DC
+WILDFIRE.GOV,Federal Agency,U.S. Department of Agriculture,Boise,ID
+WOODSY.GOV,Federal Agency,U.S. Department of Agriculture,Washington,DC
+WOODSYOWL.GOV,Federal Agency,U.S. Department of Agriculture,Washington,DC
+OSC.GOV,Federal Agency,U.S. Office of Special Counsel,Washington,DC
+OSCNET.GOV,Federal Agency,U.S. Office of Special Counsel,Washington,DC
+PEACECORPS.GOV,Federal Agency,U.S. Peace Corps,Washington,DC
+ABILITYONE.GOV,Federal Agency,United States AbilityOne,Arlington,VA
+JWOD.GOV,Federal Agency,United States AbilityOne,Arlington,VA
+ACCESS-BOARD.GOV,Federal Agency,United States Access Board,Washington,DC
+ADF.GOV,Federal Agency,United States African Development Foundation,Washington,DC
+USADF.GOV,Federal Agency,United States African Development Foundation,Washington,DC
+GLOBALCHANGE.GOV,Federal Agency,United States Global Change Research Program,Washington,DC
+USGCRP.GOV,Federal Agency,United States Global Change Research Program,Washington,DC
+USHMM.GOV,Federal Agency,United States Holocaust Memorial Museum,Washington,DC
 USIP.GOV,Federal Agency,United States Institute of Peace,Washington,DC
-HERITAGEABROAD.GOV,Federal Agency,US Commission for the Preservation of Americas Heritage Abroad,Washington,DC
-ICH.GOV,Federal Agency,US Interagency Council on Homelessness,washington,DC
-USICH.GOV,Federal Agency,US Interagency Council on Homelessness,Washington,DC
+ICH.GOV,Federal Agency,United States Interagency Council on Homelessness,Washington,DC
+USICH.GOV,Federal Agency,United States Interagency Council on Homelessness,Washington,DC
+USITC.GOV,Federal Agency,United States International Trade Commission,Washington,DC
+USITCOIG.GOV,Federal Agency,"United States International Trade Commission, Office of Inspector General",Washington,DC
+CHANGEOFADDRESS.GOV,Federal Agency,United States Postal Service,Washington,DC
+MAIL.GOV,Federal Agency,United States Postal Service,Raleigh,NC
+MYUSPS.GOV,Federal Agency,United States Postal Service,Raleigh,NC
+POSTOFFICE.GOV,Federal Agency,United States Postal Service,Raleigh,NC
+PURCHASING.GOV,Federal Agency,United States Postal Service,Raleigh,NC
+USPIS.GOV,Federal Agency,United States Postal Service,Arlington,VA
+USPS.GOV,Federal Agency,United States Postal Service,Raleigh,NC
+USPSINFORMEDDELIVERY.GOV,Federal Agency,United States Postal Service,Raleigh,NC
+USPSINNOVATES.GOV,Federal Agency,United States Postal Service,Washington,DC
+PEACECORPSOIG.GOV,Federal Agency,"United States Postal Service, Office of Inspector General",Washington,DC
+USPSOIG.GOV,Federal Agency,"United States Postal Service, Office of Inspector General",Arlington,VA
+USTDA.GOV,Federal Agency,United States Trade and Development Agency,Arlington,VA
 VEF.GOV,Federal Agency,Vietnam Education Foundation,Arlington,VA

--- a/dotgov-domains/current-full.csv
+++ b/dotgov-domains/current-full.csv
@@ -1,4 +1,4 @@
-﻿Domain Name,Domain Type,Agency,City,State
+Domain Name,Domain Type,Agency,City,State
 ABERDEENMD.GOV,City,Non-Federal Agency,Aberdeen,MD
 ABERDEENWA.GOV,City,Non-Federal Agency,Aberdeen,WA
 ABILENETX.GOV,City,Non-Federal Agency,Abilene,TX
@@ -108,11 +108,13 @@ AVON-MA.GOV,City,Non-Federal Agency,Avon,MA
 AVONCT.GOV,City,Non-Federal Agency,Avon,CT
 AVONDALEAZ.GOV,City,Non-Federal Agency,Avondale,AZ
 AZTECNM.GOV,City,Non-Federal Agency,Aztec,NM
+BADENPA.GOV,City,Non-Federal Agency,Baden,PA
 BAINBRIDGEWA.GOV,City,Non-Federal Agency,Bainbridge Island,WA
 BAKERSFIELD-CA.GOV,City,Non-Federal Agency,Bakersfield,CA
 BALHARBOURFL.GOV,City,Non-Federal Agency,Bal Harbour,FL
 BALTIMORECITY.GOV,City,Non-Federal Agency,Baltimore,MD
 BANGORMAINE.GOV,City,Non-Federal Agency,Bangor,ME
+BARDSTOWNKY.GOV,City,Non-Federal Agency,Bardstown,KY
 BARHARBORMAINE.GOV,City,Non-Federal Agency,Bar Harbor,ME
 BARLINGAR.GOV,City,Non-Federal Agency,Barling,AR
 BARRINGTON-IL.GOV,City,Non-Federal Agency,Barrington,IL
@@ -254,6 +256,7 @@ BROKENARROWOK.GOV,City,Non-Federal Agency,Broken Arrow,OK
 BROOKFIELD-WI.GOV,City,Non-Federal Agency,Brookfield,WI
 BROOKFIELDCT.GOV,City,Non-Federal Agency,Brookfield,CT
 BROOKFIELDIL.GOV,City,Non-Federal Agency,Brookfield ,IL
+BROOKHAVEN-MS.GOV,City,Non-Federal Agency,Brookhaven,MS
 BROOKHAVENGA.GOV,City,Non-Federal Agency,Dunwoody,GA
 BROOKHAVENNY.GOV,City,Non-Federal Agency,Farmingville,NY
 BROOKLINEMA.GOV,City,Non-Federal Agency,Brookline,MA
@@ -462,6 +465,7 @@ CITYOFMARIONWI.GOV,City,Non-Federal Agency,MARION,WI
 CITYOFMATTAWA-WA.GOV,City,Non-Federal Agency,Mattawa,WA
 CITYOFMCCAYSVILLEGA.GOV,City,Non-Federal Agency,McCaysville,GA
 CITYOFMENASHA-WI.GOV,City,Non-Federal Agency,Menasha,WI
+CITYOFMETTERGA.GOV,City,Non-Federal Agency,Metter,GA
 CITYOFMIDLANDMI.GOV,City,Non-Federal Agency,Midland,MI
 CITYOFMILLBROOK-AL.GOV,City,Non-Federal Agency,Millbrook,AL
 CITYOFMILLENGA.GOV,City,Non-Federal Agency,Millen,GA
@@ -1420,7 +1424,6 @@ MIDDLEBURGVA.GOV,City,Non-Federal Agency,Middleburg,VA
 MIDDLESEXBORO-NJ.GOV,City,Non-Federal Agency,Middlesex,NJ
 MIDDLETONMA.GOV,City,Non-Federal Agency,Middleton,MA
 MIDDLETONNH.GOV,City,Non-Federal Agency,Middleton,NH
-MIDDLETOWN-CT.GOV,City,Non-Federal Agency,Middletown,CT
 MIDDLETOWNCT.GOV,City,Non-Federal Agency,Middletown,CT
 MIDDLETOWNVA.GOV,City,Non-Federal Agency,Middletown,VA
 MIDLANDTEXAS.GOV,City,Non-Federal Agency,Midland,TX
@@ -1744,7 +1747,6 @@ PLATTSBURG-MO.GOV,City,Non-Federal Agency,Plattsburg,MO
 PLEASANTHILLCA.GOV,City,Non-Federal Agency,Pleasant Hill,CA
 PLEASANTONCA.GOV,City,Non-Federal Agency,Pleasanton,CA
 PLEASANTONTX.GOV,City,Non-Federal Agency,Pleasanton,TX
-PLEASANTPRAIRIE-WI.GOV,City,Non-Federal Agency,Pleasant Prairie,WI
 PLEASANTPRAIRIEWI.GOV,City,Non-Federal Agency,Pleasant Prairie,WI
 PLEASANTVALLEY-NY.GOV,City,Non-Federal Agency,Pleasant Valley,NY
 PLEASANTVILLE-NY.GOV,City,Non-Federal Agency,Pleasantville,NY
@@ -2438,6 +2440,7 @@ WOODLANDHILLS-UT.GOV,City,Non-Federal Agency,Woodland Hills,UT
 WOODSTOCKCT.GOV,City,Non-Federal Agency,Woodstock,CT
 WOODSTOCKGA.GOV,City,Non-Federal Agency,Woodstock,GA
 WOODSTOCKIL.GOV,City,Non-Federal Agency,Woodstock,IL
+WOODVILLAGEOR.GOV,City,Non-Federal Agency,Wood Village,OR
 WOODVILLE-TX.GOV,City,Non-Federal Agency,Woodville,TX
 WORCESTERMA.GOV,City,Non-Federal Agency,Worcester,MA
 WRGA.GOV,City,Non-Federal Agency,Warner Robins,GA
@@ -2469,6 +2472,7 @@ ALLEGHANYCOUNTY-NC.GOV,County,Non-Federal Agency,Sparta,NC
 ALLEGHENYCOUNTYPA.GOV,County,Non-Federal Agency,Pittsburgh,PA
 ALPINECOUNTYCA.GOV,County,Non-Federal Agency,Markleeville,CA
 AMITECOUNTYMS.GOV,County,Non-Federal Agency,Liberty,MS
+ANDERSONCOUNTYSC.GOV,County,Non-Federal Agency,Anderson,SC
 ANDROSCOGGINCOUNTYMAINE.GOV,County,Non-Federal Agency,Auburn,ME
 ANOKACOUNTYMN.GOV,County,Non-Federal Agency,Anoka,MN
 APPOMATTOXCOUNTYVA.GOV,County,Non-Federal Agency,Appomattox,VA
@@ -2593,6 +2597,7 @@ COAHOMACOUNTYMS.GOV,County,Non-Federal Agency,Clarksdale,MS
 COBBCOUNTYGA.GOV,County,Non-Federal Agency,Marietta,GA
 COCKECOUNTYTN.GOV,County,Non-Federal Agency,Newport,TN
 COFFEECOUNTYTN.GOV,County,Non-Federal Agency,Manchester,TN
+COLLIERCOUNTYFL.GOV,County,Non-Federal Agency,Naples,FL
 COLLINCOUNTYTEXAS.GOV,County,Non-Federal Agency,Mckinney,TX
 COLLINCOUNTYTX.GOV,County,Non-Federal Agency,McKinney,TX
 COLUMBIACOUNTYGA.GOV,County,Non-Federal Agency,Evans,GA
@@ -2697,6 +2702,7 @@ GREENMCHENRYCOUNTYILLINOIS.GOV,County,Non-Federal Agency,Woodstock,IL
 GREENSVILLECOUNTYVA.GOV,County,Non-Federal Agency,Emporia,VA
 GREENUPCOUNTYKY.GOV,County,Non-Federal Agency,Greenup,KY
 GREENVILLECOUNTYSC.GOV,County,Non-Federal Agency,Greenville,SC
+GREENWOODCOUNTY-SC.GOV,County,Non-Federal Agency,Greenwood,SC
 GREENWOODSC.GOV,County,Non-Federal Agency,Greenwood,SC
 GRIGGSCOUNTYND.GOV,County,Non-Federal Agency,Bismarck,ND
 GUILFORDCOUNTYNC.GOV,County,Non-Federal Agency,Greensboro,NC
@@ -2749,6 +2755,7 @@ JACKSONCOUNTY-IL.GOV,County,Non-Federal Agency,Murphysboro,IL
 JACKSONCOUNTYAL.GOV,County,Non-Federal Agency,Scottsboro,AL
 JAMESCITYCOUNTYVA.GOV,County,Non-Federal Agency,Williamsburg,VA
 JASPERCOUNTYIN.GOV,County,Non-Federal Agency,Rensselaer,IN
+JASPERCOUNTYMO.GOV,County,Non-Federal Agency,Carthage,MO
 JASPERCOUNTYSC.GOV,County,Non-Federal Agency,Ridgeland,SC
 JEFFERSONCOUNTY-MT.GOV,County,Non-Federal Agency,Boulder,MT
 JEFFERSONCOUNTYAR.GOV,County,Non-Federal Agency,Pine Bluff,AR
@@ -3091,11 +3098,9 @@ YORKCOUNTYPA.GOV,County,Non-Federal Agency,York,PA
 YUMACOUNTYARIZONA.GOV,County,Non-Federal Agency,Yuma,AZ
 YUMACOUNTYAZ.GOV,County,Non-Federal Agency,Yuma,AZ
 ZAPATACOUNTYTX.GOV,County,Non-Federal Agency,Zapata,TX
-ACUS.GOV,Federal Agency,Administrative Conference of the United States,WASHINGTON,DC
+ACUS.GOV,Federal Agency,Administrative Conference of the United States,Washington,DC
 ACHP.GOV,Federal Agency,Advisory Council on Historic Preservation,Washington,DC
 PRESERVEAMERICA.GOV,Federal Agency,Advisory Council on Historic Preservation,Washington,DC
-ADF.GOV,Federal Agency,African Development Foundation,Washington,DC
-USADF.GOV,Federal Agency,African Development Foundation,Washington,DC
 ABMC.GOV,Federal Agency,American Battle Monuments Commission,Arlington,VA
 ABMCSCHOLAR.GOV,Federal Agency,American Battle Monuments Commission,Arlington,VA
 NATIONALMALL.GOV,Federal Agency,American Battle Monuments Commission,Arlington,VA
@@ -3112,24 +3117,24 @@ VISITTHECAPITAL.GOV,Federal Agency,Architect of the Capitol,Washington,DC
 VISITTHECAPITOL.GOV,Federal Agency,Architect of the Capitol,Washington,DC
 AFRH.GOV,Federal Agency,Armed Forces Retirement Home,Washington,DC
 GOLDWATERSCHOLARSHIP.GOV,Federal Agency,Barry Goldwater Scholarship and Excellence in Education Foundation,Springfield,VA
+BBG.GOV,Federal Agency,Broadcasting Board of Governors,Washington,DC
+IBB.GOV,Federal Agency,Broadcasting Board of Governors,Washington,DC
+VOA.GOV,Federal Agency,Broadcasting Board of Governors,Washington,DC
 CIA.GOV,Federal Agency,Central Intelligence Agency,Washington,DC
-DF.GOV,Federal Agency,Central Intelligence Agency,WASHINGTON,DC
+DF.GOV,Federal Agency,Central Intelligence Agency,Washington,DC
 IC.GOV,Federal Agency,Central Intelligence Agency,Washington,DC
 ISTAC.GOV,Federal Agency,Central Intelligence Agency,Washington,DC
 NCTC.GOV,Federal Agency,Central Intelligence Agency,Washington,DC
 ODCI.GOV,Federal Agency,Central Intelligence Agency,Washington,DC
 OPENSOURCE.GOV,Federal Agency,Central Intelligence Agency,Washington,DC
 OSDE.GOV,Federal Agency,Central Intelligence Agency,Reston,VA
-OSDLS.GOV,Federal Agency,Central Intelligence Agency,McLean,VA
 TTIC.GOV,Federal Agency,Central Intelligence Agency,Washington,DC
 UCIA.GOV,Federal Agency,Central Intelligence Agency,Washington,DC
 CHEMSAFETY.GOV,Federal Agency,Chemical Safety Board,Washington,DC
 CSB.GOV,Federal Agency,Chemical Safety Board,Washington,DC
 SAFETYVIDEOS.GOV,Federal Agency,Chemical Safety Board,Washington,DC
-CAP.GOV,Federal Agency,Civil Air Patrol,BIRMINGHAM,MI
-CAPNHQ.GOV,Federal Agency,Civil Air Patrol,MAXWELL AFB,AL
-ABILITYONE.GOV,Federal Agency,Comm for People Who Are Blind/Severly Disabled,Arlington,VA
-JWOD.GOV,Federal Agency,Comm for People Who Are Blind/Severly Disabled,Arlington,VA
+CAP.GOV,Federal Agency,Civil Air Patrol,Birmingham,MI
+CAPNHQ.GOV,Federal Agency,Civil Air Patrol,Maxwell AFB,AL
 CFTC.GOV,Federal Agency,Commodity Futures Trading Commission,Washington,DC
 SMARTCHECK.GOV,Federal Agency,Commodity Futures Trading Commission,Washington,DC
 WHISTLEBLOWER.GOV,Federal Agency,Commodity Futures Trading Commission,Washington,DC
@@ -3169,9 +3174,9 @@ SERVE.GOV,Federal Agency,Corporation for National & Community Service,Washington
 SERVICE.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC
 VISTACAMPUS.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC
 VOLUNTEERINGINAMERICA.GOV,Federal Agency,Corporation for National & Community Service,Washington,DC
-CIGIE.GOV,Federal Agency,Council of Inspector General on Integrity and Efficiency,WASHINGTON,DC
-IGNET.GOV,Federal Agency,Council of Inspector General on Integrity and Efficiency,Washington,DC
-OVERSIGHT.GOV,Federal Agency,Council of Inspector General on Integrity and Efficiency,Washington,DC
+CIGIE.GOV,Federal Agency,Council of Inspectors General on Integrity and Efficiency,Washington,DC
+IGNET.GOV,Federal Agency,Council of Inspectors General on Integrity and Efficiency,Washington,DC
+OVERSIGHT.GOV,Federal Agency,Council of Inspectors General on Integrity and Efficiency,Washington,DC
 CSOSA.FED.US,Federal Agency,Court Services and Offender Supervision,Washington,DC
 CSOSA.GOV,Federal Agency,Court Services and Offender Supervision,Washington,DC
 PRETRIALSERVICES.GOV,Federal Agency,Court Services and Offender Supervision,Washington,DC
@@ -3180,49 +3185,6 @@ DNFSB.GOV,Federal Agency,Defense Nuclear Facilities Safety Board,Washington,DC
 DRA.GOV,Federal Agency,Delta Regional Authority,Clarksdale,MS
 DENALI.GOV,Federal Agency,Denali Commission,Anchorage,AK
 FEA.GOV,Federal Agency,Denali Commission,Anchorage,AK
-AFF.GOV,Federal Agency,Department of Agriculture,Boise,ID
-AG.GOV,Federal Agency,Department of Agriculture,Fort Collins,CO
-ARS-GRIN.GOV,Federal Agency,Department of Agriculture,Beltsville,MD
-ARSUSDA.GOV,Federal Agency,Department of Agriculture,Beltsville,MD
-ASKKAREN.GOV,Federal Agency,Department of Agriculture,Washington,DC
-BEFOODSAFE.GOV,Federal Agency,Department of Agriculture,Washington,DC
-BIOPREFERRED.GOV,Federal Agency,Department of Agriculture,Washington,DC
-BOSQUE.GOV,Federal Agency,Department of Agriculture,Albuquerque,NM
-CHOOSEMYPLATE.GOV,Federal Agency,Department of Agriculture,Alexandria,VA
-COASTALAMERICA.GOV,Federal Agency,Department of Agriculture,Washington,DC
-DIETARYGUIDELINES.GOV,Federal Agency,Department of Agriculture,Alexandria,VA
-EMPOWHR.GOV,Federal Agency,Department of Agriculture,New Orleans,LA
-EXECSEC.GOV,Federal Agency,Department of Agriculture,Washington,DC
-FARMERS.GOV,Federal Agency,Department of Agriculture,Washington,DC
-FOODSAFETYJOBS.GOV,Federal Agency,Department of Agriculture,Washington,DC
-FORESTSANDRANGELANDS.GOV,Federal Agency,Department of Agriculture,Washington,DC
-FS.FED.US,Federal Agency,Department of Agriculture,Washington,DC
-GREEN.GOV,Federal Agency,Department of Agriculture,Washington,DC
-ICBEMP.GOV,Federal Agency,Department of Agriculture,Portland,OR
-INVASIVESPECIESINFO.GOV,Federal Agency,Department of Agriculture,Beltsville,MD
-IPM.GOV,Federal Agency,Department of Agriculture,Washington,DC
-ISITDONEYET.GOV,Federal Agency,Department of Agriculture,Washington,DC
-ITAP.GOV,Federal Agency,Department of Agriculture,Beltsville,MD
-JUNIORFORESTRANGER.GOV,Federal Agency,Department of Agriculture,Washington,DC
-LCACOMMONS.GOV,Federal Agency,Department of Agriculture,Beltsville,MD
-MTBS.GOV,Federal Agency,Department of Agriculture,Salt Lake City,UT
-MYPLATE.GOV,Federal Agency,Department of Agriculture,Alexandria,VA
-NAFRI.GOV,Federal Agency,Department of Agriculture,Tucson,AZ
-NEL.GOV,Federal Agency,Department of Agriculture,Alexandria,VA
-NUTRITION.GOV,Federal Agency,Department of Agriculture,Washington,DC
-NUTRITIONEVIDENCELIBRARY.GOV,Federal Agency,Department of Agriculture,Alexandria,VA
-NWCG.GOV,Federal Agency,Department of Agriculture,Boise,ID
-PREGUNTELEAKAREN.GOV,Federal Agency,Department of Agriculture,Washington,DC
-RECREATION.GOV,Federal Agency,Department of Agriculture,Ogden,UT
-REO.GOV,Federal Agency,Department of Agriculture,Portland,OR
-SMOKEYBEAR.GOV,Federal Agency,Department of Agriculture,Washington,DC
-SYMBOLS.GOV,Federal Agency,Department of Agriculture,Washington,DC
-THEPEOPLESGARDEN.GOV,Federal Agency,Department of Agriculture,Wahington,DC
-USDA.GOV,Federal Agency,Department of Agriculture,Ft. Collins,CO
-USDAPII.GOV,Federal Agency,Department of Agriculture,Washington,DC
-WILDFIRE.GOV,Federal Agency,Department of Agriculture,Boise,ID
-WOODSY.GOV,Federal Agency,Department of Agriculture,Washington,DC
-WOODSYOWL.GOV,Federal Agency,Department of Agriculture,Washington,DC
 2020CENSUS.GOV,Federal Agency,Department of Commerce,Suitland,MD
 AP.GOV,Federal Agency,Department of Commerce,Washington,DC
 AVIATIONWEATHER.GOV,Federal Agency,Department of Commerce,Silver Spring,MD
@@ -3277,11 +3239,11 @@ WEATHER.GOV,Federal Agency,Department of Commerce,Silver Spring,MD
 XD.GOV,Federal Agency,Department of Commerce,Suitland,MD
 ADLNET.GOV,Federal Agency,Department of Defense,Washington,DC
 AFTAC.GOV,Federal Agency,Department of Defense,Patrick AFB,FL
-ALTUSANDC.GOV,Federal Agency,Department of Defense,"patrick, afb",FL
+ALTUSANDC.GOV,Federal Agency,Department of Defense,Patrick AFB,FL
 BRAC.GOV,Federal Agency,Department of Defense,Alexandria,VA
 BUSINESSDEFENSE.GOV,Federal Agency,Department of Defense,Washington,DC
 CMTS.GOV,Federal Agency,Department of Defense,Mobile,AL
-CNSS.GOV,Federal Agency,Department of Defense,Ft George G. Meade,MD
+CNSS.GOV,Federal Agency,Department of Defense,Fort Meade,MD
 CTOC.GOV,Federal Agency,Department of Defense,Starke,FL
 CTTSO.GOV,Federal Agency,Department of Defense,Arlington,VA
 DC3ON.GOV,Federal Agency,Department of Defense,Linthicum,MD
@@ -3290,19 +3252,20 @@ DOD.GOV,Federal Agency,Department of Defense,Fort Meade,MD
 EACLEARINGHOUSE.GOV,Federal Agency,Department of Defense,Arlington,VA
 ERDC.GOV,Federal Agency,Department of Defense,Vicksburg,MS
 FVAP.GOV,Federal Agency,Department of Defense,Alexandria,VA
-IAD.GOV,Federal Agency,Department of Defense,Ft Meade,MD
+IAD.GOV,Federal Agency,Department of Defense,Fort Meade,MD
 IOSS.GOV,Federal Agency,Department of Defense,Greenbelt,MD
-ITC.GOV,Federal Agency,Department of Defense,Ft. Washington,MD
+ITC.GOV,Federal Agency,Department of Defense,Fort Washington,MD
 JCCS.GOV,Federal Agency,Department of Defense,Alexandria,VA
 MOJAVEDATA.GOV,Federal Agency,Department of Defense,Barstow,CA
 MTMC.GOV,Federal Agency,Department of Defense,Alexandria,VA
 MYPAY.GOV,Federal Agency,Department of Defense,Pensacola,FL
-NATIONALRESOURCEDIRECTORY.GOV,Federal Agency,Department of Defense,ARLINGTON,VA
+NATIONALRESOURCEDIRECTORY.GOV,Federal Agency,Department of Defense,Arlington,VA
+NBIS.GOV,Federal Agency,Department of Defense,Fort Meade,MD
 NCR.GOV,Federal Agency,Department of Defense,Washington,DC
-NRD.GOV,Federal Agency,Department of Defense,ARLINGTON,VA
+NRD.GOV,Federal Agency,Department of Defense,Arlington,VA
 NRO.GOV,Federal Agency,Department of Defense,Chantilly,VA
 NROJR.GOV,Federal Agency,Department of Defense,Chantilly,VA
-NSA.GOV,Federal Agency,Department of Defense,Ft. Meade,MD
+NSA.GOV,Federal Agency,Department of Defense,Fort Meade,MD
 NSEP.GOV,Federal Agency,Department of Defense,Alexandria,VA
 OEA.GOV,Federal Agency,Department of Defense,Arlington,VA
 PENTAGON.GOV,Federal Agency,Department of Defense,Fort Meade,MD
@@ -3329,7 +3292,6 @@ ARM.GOV,Federal Agency,Department of Energy,Richland,WA
 BIOMASSBOARD.GOV,Federal Agency,Department of Energy,Washington,DC
 BNL.GOV,Federal Agency,Department of Energy,Upton,NY
 BPA.GOV,Federal Agency,Department of Energy,Portland,OR
-BRC.GOV,Federal Agency,Department of Energy,Washington,DC
 BUILDINGAMERICA.GOV,Federal Agency,Department of Energy,Golden,CO
 CASL.GOV,Federal Agency,Department of Energy,Oak Ridge,TN
 CEBAF.GOV,Federal Agency,Department of Energy,Newport News,VA
@@ -3386,123 +3348,124 @@ UNNPP.GOV,Federal Agency,Department of Energy,West Mifflin,PA
 UNRPNET.GOV,Federal Agency,Department of Energy,Washington,DC
 WAPA.GOV,Federal Agency,Department of Energy,Lakewood,CO
 YMP.GOV,Federal Agency,Department of Energy,Las Vegas,NV
-ACF.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-ACL.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-AFTERSCHOOL.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-AGING.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-AGINGSTATS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-AHCPR.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
-AHRQ.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
-AIDS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-ALZHEIMERS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-AOA.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-BAM.GOV,Federal Agency,Department of Health And Human Services,Atlanta,GA
-BETOBACCOFREE.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-BIOETHICS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-BRAINHEALTH.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-CANCER.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
-CANCERNET.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
-CDC.GOV,Federal Agency,Department of Health And Human Services,Atlanta,GA
-CDCPARTNERS.GOV,Federal Agency,Department of Health And Human Services,Atlanta,GA
-CEREBROSANO.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
-CHILDCARE.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-CHILDWELFARE.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-CLINICALTRIAL.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
-CLINICALTRIALS.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
-CMS.GOV,Federal Agency,Department of Health And Human Services,Baltimore,MD
-COLLEGEDRINKINGPREVENTION.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
-CUIDADODESALUD.GOV,Federal Agency,Department of Health And Human Services,Baltimore,MD
-DHHS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-DIABETESCOMMITTEE.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-DOCLINE.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
-DONACIONDEORGANOS.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
-DRUGABUSE.GOV,Federal Agency,Department of Health And Human Services,Baltimore,MD
-DRUGFREEWORKPLACE.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
-EDISON.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
-ELDERCARE.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-ENDINGTHEDOCUMENTGAME.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-EVERYTRYCOUNTS.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
-FATHERHOOD.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-FDA.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
-FITNESS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-FLU.GOV,Federal Agency,Department of Health And Human Services,Atlanta,GA
-FOODSAFETY.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-FRESHEMPIRE.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-FRUITSANDVEGGIESMATTER.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-GENBANK.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
-GENOME.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
-GIRLSHEALTH.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-GLOBALHEALTH.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
-GRANTS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-GRANTSOLUTIONS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-GUIDELINE.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
-GUIDELINES.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
-HC.GOV,Federal Agency,Department of Health And Human Services,Baltimore,MD
-HCQUALITYCOMMISSION.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
-HEALTH.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-HEALTHCARE.GOV,Federal Agency,Department of Health And Human Services,Baltimore,MD
-HEALTHDATA.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-HEALTHFINDER.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-HEALTHINDICATORS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-HEALTHIT.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-HEALTHYPEOPLE.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-HEARTTRUTH.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
-HHS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-HHSOIG.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-HHSOPS.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
-HIV.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-HRSA.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
-IDEALAB.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-IEDISON.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
-IHS.GOV,Federal Agency,Department of Health And Human Services,Albuquerque,NM
-INSUREKIDSNOW.GOV,Federal Agency,Department of Health And Human Services,Baltimore,MD
-LOCATORPLUS.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
-LONGTERMCARE.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-MEDICAID.GOV,Federal Agency,Department of Health And Human Services,Baltimore,MD
-MEDICALCOUNTERMEASURES.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-MEDICARE.GOV,Federal Agency,Department of Health And Human Services,Baltimore,MD
-MEDLINE.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
-MEDLINEPLUS.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
-MENTALHEALTH.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
-MESH.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
-MYMEDICARE.GOV,Federal Agency,Department of Health And Human Services,Baltimore,MD
-NATIONALCHILDRENSSTUDY.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
-NCIFCRF.GOV,Federal Agency,Department of Health And Human Services,Frederick,MD
-NGC.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
-NIH.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
-NIHSENIORHEALTH.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
-NIOSH.GOV,Federal Agency,Department of Health And Human Services,Atlanta,GA
-NLM.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
-NNLM.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
-OPIOIDS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-ORGANDONOR.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
-PANDEMICFLU.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-PHE.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-PSC.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
-PUBMED.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
-PUBMEDCENTRAL.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
-QUIC.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
-RECOVERYMONTH.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
-SAFEYOUTH.GOV,Federal Agency,Department of Health And Human Services,Atlanta,GA
-SAMHSA.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
-SELECTAGENTS.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-SMOKEFREE.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
-STOPALCOHOLABUSE.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-STOPBULLYING.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-SURGEONGENERAL.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-THECOOLSPOT.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
-THEREALCOST.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-THISFREELIFE.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-TISSUEENGINEERING.GOV,Federal Agency,Department of Health And Human Services,Bethesda,MD
-TOBACCO.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-USABILITY.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-USBM.GOV,Federal Agency,Department of Health And Human Services,Atlanta,GA
-USPHS.GOV,Federal Agency,Department of Health And Human Services,Rockville,MD
-VACCINES.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-WHAGING.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-WHITEHOUSECONFERENCEONAGING.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-WOMENSHEALTH.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
-YOUTH.GOV,Federal Agency,Department of Health And Human Services,Washington,DC
+ACF.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+ACL.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+AFTERSCHOOL.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+AGING.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+AGINGSTATS.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+AHCPR.GOV,Federal Agency,Department of Health and Human Services,Rockville,MD
+AHRQ.GOV,Federal Agency,Department of Health and Human Services,Rockville,MD
+AIDS.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+ALZHEIMERS.GOV,Federal Agency,Department of Health and Human Services,Bethesda,MD
+AOA.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+BAM.GOV,Federal Agency,Department of Health and Human Services,Atlanta,GA
+BETOBACCOFREE.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+BIOETHICS.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+BRAINHEALTH.GOV,Federal Agency,Department of Health and Human Services,Bethesda,MD
+CANCER.GOV,Federal Agency,Department of Health and Human Services,Rockville,MD
+CANCERNET.GOV,Federal Agency,Department of Health and Human Services,Rockville,MD
+CDC.GOV,Federal Agency,Department of Health and Human Services,Atlanta,GA
+CDCPARTNERS.GOV,Federal Agency,Department of Health and Human Services,Atlanta,GA
+CEREBROSANO.GOV,Federal Agency,Department of Health and Human Services,Bethesda,MD
+CHILDCARE.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+CHILDWELFARE.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+CLINICALTRIAL.GOV,Federal Agency,Department of Health and Human Services,Bethesda,MD
+CLINICALTRIALS.GOV,Federal Agency,Department of Health and Human Services,Bethesda,MD
+CMS.GOV,Federal Agency,Department of Health and Human Services,Baltimore,MD
+COLLEGEDRINKINGPREVENTION.GOV,Federal Agency,Department of Health and Human Services,Bethesda,MD
+CUIDADODESALUD.GOV,Federal Agency,Department of Health and Human Services,Baltimore,MD
+DHHS.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+DIABETESCOMMITTEE.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+DOCLINE.GOV,Federal Agency,Department of Health and Human Services,Bethesda,MD
+DONACIONDEORGANOS.GOV,Federal Agency,Department of Health and Human Services,Rockville,MD
+DRUGABUSE.GOV,Federal Agency,Department of Health and Human Services,Baltimore,MD
+DRUGFREEWORKPLACE.GOV,Federal Agency,Department of Health and Human Services,Rockville,MD
+EDISON.GOV,Federal Agency,Department of Health and Human Services,Bethesda,MD
+ELDERCARE.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+ENDINGTHEDOCUMENTGAME.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+EVERYTRYCOUNTS.GOV,Federal Agency,Department of Health and Human Services,Bethesda,MD
+FATHERHOOD.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+FDA.GOV,Federal Agency,Department of Health and Human Services,Rockville,MD
+FITNESS.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+FLU.GOV,Federal Agency,Department of Health and Human Services,Atlanta,GA
+FOODSAFETY.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+FRESHEMPIRE.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+FRUITSANDVEGGIESMATTER.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+GENBANK.GOV,Federal Agency,Department of Health and Human Services,Bethesda,MD
+GENOME.GOV,Federal Agency,Department of Health and Human Services,Bethesda,MD
+GIRLSHEALTH.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+GLOBALHEALTH.GOV,Federal Agency,Department of Health and Human Services,Rockville,MD
+GRANTS.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+GRANTSOLUTIONS.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+GUIDELINE.GOV,Federal Agency,Department of Health and Human Services,Rockville,MD
+GUIDELINES.GOV,Federal Agency,Department of Health and Human Services,Rockville,MD
+HC.GOV,Federal Agency,Department of Health and Human Services,Baltimore,MD
+HCQUALITYCOMMISSION.GOV,Federal Agency,Department of Health and Human Services,Rockville,MD
+HEALTH.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+HEALTHCARE.GOV,Federal Agency,Department of Health and Human Services,Baltimore,MD
+HEALTHDATA.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+HEALTHFINDER.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+HEALTHINDICATORS.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+HEALTHIT.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+HEALTHYPEOPLE.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+HEARTTRUTH.GOV,Federal Agency,Department of Health and Human Services,Bethesda,MD
+HHS.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+HHSOIG.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+HHSOPS.GOV,Federal Agency,Department of Health and Human Services,Rockville,MD
+HIV.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+HRSA.GOV,Federal Agency,Department of Health and Human Services,Rockville,MD
+IDEALAB.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+IEDISON.GOV,Federal Agency,Department of Health and Human Services,Bethesda,MD
+IHS.GOV,Federal Agency,Department of Health and Human Services,Albuquerque,NM
+INSUREKIDSNOW.GOV,Federal Agency,Department of Health and Human Services,Baltimore,MD
+LOCATORPLUS.GOV,Federal Agency,Department of Health and Human Services,Bethesda,MD
+LONGTERMCARE.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+MEDICAID.GOV,Federal Agency,Department of Health and Human Services,Baltimore,MD
+MEDICALCOUNTERMEASURES.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+MEDICARE.GOV,Federal Agency,Department of Health and Human Services,Baltimore,MD
+MEDLINE.GOV,Federal Agency,Department of Health and Human Services,Bethesda,MD
+MEDLINEPLUS.GOV,Federal Agency,Department of Health and Human Services,Bethesda,MD
+MENTALHEALTH.GOV,Federal Agency,Department of Health and Human Services,Rockville,MD
+MESH.GOV,Federal Agency,Department of Health and Human Services,Bethesda,MD
+MYMEDICARE.GOV,Federal Agency,Department of Health and Human Services,Baltimore,MD
+NATIONALCHILDRENSSTUDY.GOV,Federal Agency,Department of Health and Human Services,Bethesda,MD
+NCIFCRF.GOV,Federal Agency,Department of Health and Human Services,Frederick,MD
+NGC.GOV,Federal Agency,Department of Health and Human Services,Rockville,MD
+NIH.GOV,Federal Agency,Department of Health and Human Services,Bethesda,MD
+NIHSENIORHEALTH.GOV,Federal Agency,Department of Health and Human Services,Bethesda,MD
+NIOSH.GOV,Federal Agency,Department of Health and Human Services,Atlanta,GA
+NLM.GOV,Federal Agency,Department of Health and Human Services,Bethesda,MD
+NNLM.GOV,Federal Agency,Department of Health and Human Services,Bethesda,MD
+OPIOIDS.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+ORGANDONOR.GOV,Federal Agency,Department of Health and Human Services,Rockville,MD
+PANDEMICFLU.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+PHE.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+PSC.GOV,Federal Agency,Department of Health and Human Services,Rockville,MD
+PUBMED.GOV,Federal Agency,Department of Health and Human Services,Bethesda,MD
+PUBMEDCENTRAL.GOV,Federal Agency,Department of Health and Human Services,Bethesda,MD
+QUIC.GOV,Federal Agency,Department of Health and Human Services,Rockville,MD
+RECOVERYMONTH.GOV,Federal Agency,Department of Health and Human Services,Rockville,MD
+SAFEYOUTH.GOV,Federal Agency,Department of Health and Human Services,Atlanta,GA
+SAMHSA.GOV,Federal Agency,Department of Health and Human Services,Rockville,MD
+SELECTAGENTS.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+SMOKEFREE.GOV,Federal Agency,Department of Health and Human Services,Rockville,MD
+STOPALCOHOLABUSE.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+STOPBULLYING.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+SURGEONGENERAL.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+THECOOLSPOT.GOV,Federal Agency,Department of Health and Human Services,Rockville,MD
+THEREALCOST.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+THISFREELIFE.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+TISSUEENGINEERING.GOV,Federal Agency,Department of Health and Human Services,Bethesda,MD
+TOBACCO.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+TOX21.GOV,Federal Agency,Department of Health and Human Services,Rockville,MD
+USABILITY.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+USBM.GOV,Federal Agency,Department of Health and Human Services,Atlanta,GA
+USPHS.GOV,Federal Agency,Department of Health and Human Services,Rockville,MD
+VACCINES.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+WHAGING.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+WHITEHOUSECONFERENCEONAGING.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+WOMENSHEALTH.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
+YOUTH.GOV,Federal Agency,Department of Health and Human Services,Washington,DC
 BIOMETRICS.GOV,Federal Agency,Department of Homeland Security,Arlington,VA
 CBP.GOV,Federal Agency,Department of Homeland Security,Washington,DC
 CPNIREPORTING.GOV,Federal Agency,Department of Homeland Security,Washington,DC
@@ -3528,23 +3491,23 @@ READY.GOV,Federal Agency,Department of Homeland Security,Washington,DC
 READYBUSINESS.GOV,Federal Agency,Department of Homeland Security,Washington,DC
 SAFECOMPROGRAM.GOV,Federal Agency,Department of Homeland Security,Washington,DC
 SAFETYACT.GOV,Federal Agency,Department of Homeland Security,Washington,DC
-SECRETSERVICE.GOV,Federal Agency,Department of Homeland Security,Washington D.C.,DC
+SECRETSERVICE.GOV,Federal Agency,Department of Homeland Security,Washington,DC
 TSA.GOV,Federal Agency,Department of Homeland Security,Arlington,VA
 US-CERT.GOV,Federal Agency,Department of Homeland Security,Washington,DC
 USCG.GOV,Federal Agency,Department of Homeland Security,Alexandria,VA
 USCIS.GOV,Federal Agency,Department of Homeland Security,Washington,DC
 USSS.GOV,Federal Agency,Department of Homeland Security,Washington,DC
-DISASTERHOUSING.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC
-FHA.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC
-GINNIEMAE.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC
-HOMESALES.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC
-HUD.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC
-HUDOIG.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC
-HUDUSER.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC
-NATIONALHOUSING.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC
-NATIONALHOUSINGLOCATOR.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC
-NHL.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC
-NLS.GOV,Federal Agency,Department of Housing And Urban Development,Washington,DC
+DISASTERHOUSING.GOV,Federal Agency,Department of Housing and Urban Development,Washington,DC
+FHA.GOV,Federal Agency,Department of Housing and Urban Development,Washington,DC
+GINNIEMAE.GOV,Federal Agency,Department of Housing and Urban Development,Washington,DC
+HOMESALES.GOV,Federal Agency,Department of Housing and Urban Development,Washington,DC
+HUD.GOV,Federal Agency,Department of Housing and Urban Development,Washington,DC
+HUDOIG.GOV,Federal Agency,Department of Housing and Urban Development,Washington,DC
+HUDUSER.GOV,Federal Agency,Department of Housing and Urban Development,Washington,DC
+NATIONALHOUSING.GOV,Federal Agency,Department of Housing and Urban Development,Washington,DC
+NATIONALHOUSINGLOCATOR.GOV,Federal Agency,Department of Housing and Urban Development,Washington,DC
+NHL.GOV,Federal Agency,Department of Housing and Urban Development,Washington,DC
+NLS.GOV,Federal Agency,Department of Housing and Urban Development,Washington,DC
 ADA.GOV,Federal Agency,Department of Justice,Rockville,MD
 ADR.GOV,Federal Agency,Department of Justice,Rockville,MD
 AMBERALERT.GOV,Federal Agency,Department of Justice,Potomac,MD
@@ -3567,7 +3530,7 @@ DSAC.GOV,Federal Agency,Department of Justice,Potomac,MD
 EGUARDIAN.GOV,Federal Agency,Department of Justice,Washington,DC
 ELDERJUSTICE.GOV,Federal Agency,Department of Justice,Washington,DC
 EPIC.GOV,Federal Agency,Department of Justice,Rockville,MD
-FARA.GOV,Federal Agency,Department of Justice,potomac,MD
+FARA.GOV,Federal Agency,Department of Justice,Potomac,MD
 FBI.GOV,Federal Agency,Department of Justice,Washington,DC
 FBIJOBS.GOV,Federal Agency,Department of Justice,Washington,DC
 FIRSTFREEDOM.GOV,Federal Agency,Department of Justice,Potomac,MD
@@ -3627,7 +3590,6 @@ DOL-ESA.GOV,Federal Agency,Department of Labor,Washington,DC
 DOL.GOV,Federal Agency,Department of Labor,Washington,DC
 DOLETA.GOV,Federal Agency,Department of Labor,Washington,DC
 EMPLOYER.GOV,Federal Agency,Department of Labor,Washington,DC
-GOVBENEFITS.GOV,Federal Agency,Department of Labor,Washington,DC
 GOVLOANS.GOV,Federal Agency,Department of Labor,Washington,DC
 HIREVETS.GOV,Federal Agency,Department of Labor,Washington,DC
 JOBCORPS.GOV,Federal Agency,Department of Labor,Austin,TX
@@ -3661,7 +3623,7 @@ USASEANCONNECT.GOV,Federal Agency,Department of State,Jakarta,Jakarta
 USCONSULATE.GOV,Federal Agency,Department of State,Washington,DC
 USEMBASSY.GOV,Federal Agency,Department of State,Washington,DC
 USMISSION.GOV,Federal Agency,Department of State,Washington,DC
-STATEOIG.GOV,Federal Agency,Department of State OIG,Arlington,VA
+STATEOIG.GOV,Federal Agency,"Department of State, Office of Inspector General",Arlington,VA
 ABANDONEDMINES.GOV,Federal Agency,Department of the Interior,Washington,DC
 ACWI.GOV,Federal Agency,Department of the Interior,Reston,VA
 ALASKACENTERS.GOV,Federal Agency,Department of the Interior,Washington,DC
@@ -3675,7 +3637,7 @@ BSEE.GOV,Federal Agency,Department of the Interior,Herndon,VA
 CORALREEF.GOV,Federal Agency,Department of the Interior,Denver,CO
 CUPCAO.GOV,Federal Agency,Department of the Interior,Denver,CO
 DOI.GOV,Federal Agency,Department of the Interior,Washington,DC
-DOIOIG.GOV,Federal Agency,Department of the Interior,RESTON,VA
+DOIOIG.GOV,Federal Agency,Department of the Interior,Reston,VA
 EARTHQUAKE.GOV,Federal Agency,Department of the Interior,Menlo Park,CA
 EVERGLADESRESTORATION.GOV,Federal Agency,Department of the Interior,Davie,FL
 FCG.GOV,Federal Agency,Department of the Interior,Denver,CO
@@ -3712,7 +3674,7 @@ NBC.GOV,Federal Agency,Department of the Interior,Denver,CO
 NEMI.GOV,Federal Agency,Department of the Interior,Middleton,WI
 NFPORS.GOV,Federal Agency,Department of the Interior,Washington,DC
 NIFC.GOV,Federal Agency,Department of the Interior,Boise,ID
-NPS.GOV,Federal Agency,Department of the Interior,WASHINGTON DC,DC
+NPS.GOV,Federal Agency,Department of the Interior,Washington,DC
 ONHIR.GOV,Federal Agency,Department of the Interior,Flagstaff,AZ
 ONRR.GOV,Federal Agency,Department of the Interior,Herndon,VA
 OSM.GOV,Federal Agency,Department of the Interior,Washington,DC
@@ -3751,7 +3713,7 @@ COMPTROLLEROFTHECURRENCY.GOV,Federal Agency,Department of the Treasury,Washingto
 DIRECTOASUCUENTA.GOV,Federal Agency,Department of the Treasury,Washington,DC
 EAGLECASH.GOV,Federal Agency,Department of the Treasury,Washington,DC
 EFTPS.GOV,Federal Agency,Department of the Treasury,Washington,DC
-ETA-FIND.GOV,Federal Agency,Department of the Treasury,DALLAS,TX
+ETA-FIND.GOV,Federal Agency,Department of the Treasury,Dallas,TX
 ETHICSBURG.GOV,Federal Agency,Department of the Treasury,Parkersburg,WV
 EYENOTE.GOV,Federal Agency,Department of the Treasury,Washington,DC
 FEDERALINVESTMENTS.GOV,Federal Agency,Department of the Treasury,Pakersburg,WV
@@ -3836,7 +3798,7 @@ DISTRACTEDDRIVING.GOV,Federal Agency,Department of Transportation,Washington,DC
 DISTRACTION.GOV,Federal Agency,Department of Transportation,Washington,DC
 DOT.GOV,Federal Agency,Department of Transportation,Washington,DC
 DOTIDEAHUB.GOV,Federal Agency,Department of Transportation,Washington,DC
-DOTTRAFFICRECORDS.GOV,Federal Agency,Department of Transportation,Room 2202,DC
+DOTTRAFFICRECORDS.GOV,Federal Agency,Department of Transportation,Washington,DC
 EMS.GOV,Federal Agency,Department of Transportation,Washington,DC
 ESC.GOV,Federal Agency,Department of Transportation,Oklahoma City,OK
 FAA.GOV,Federal Agency,Department of Transportation,Washington,DC
@@ -3866,16 +3828,16 @@ IARPA-IDEAS.GOV,Federal Agency,Director of National Intelligence,Washington,DC
 IARPA.GOV,Federal Agency,Director of National Intelligence,College Park,MD
 ICJOINTDUTY.GOV,Federal Agency,Director of National Intelligence,Washington,DC
 INTEL.GOV,Federal Agency,Director of National Intelligence,McLean,VA
-INTELINK.GOV,Federal Agency,Director of National Intelligence,Ft. George G. Meade,MD
+INTELINK.GOV,Federal Agency,Director of National Intelligence,Fort Meade,MD
 INTELLIGENCE.GOV,Federal Agency,Director of National Intelligence,Washington,DC
 ISE.GOV,Federal Agency,Director of National Intelligence,Washington ,DC
 NCIX.GOV,Federal Agency,Director of National Intelligence,Washington,DC
 NCSC.GOV,Federal Agency,Director of National Intelligence,Bethesda,MD
 ODNI.GOV,Federal Agency,Director of National Intelligence,Washington,DC
-OSIS.GOV,Federal Agency,Director of National Intelligence,Fort George G. Meade,MD
+OSIS.GOV,Federal Agency,Director of National Intelligence,Fort Meade,MD
 PIX.GOV,Federal Agency,Director of National Intelligence,Washington,DC
 QART.GOV,Federal Agency,Director of National Intelligence,Washington,DC
-UGOV.GOV,Federal Agency,Director of National Intelligence,Fort George G Meade,MD
+UGOV.GOV,Federal Agency,Director of National Intelligence,Fort Meade,MD
 AIRNOW.GOV,Federal Agency,Environmental Protection Agency,Durham,NC
 CBI-EPA.GOV,Federal Agency,Environmental Protection Agency,Durham,NC
 E-ENTERPRISE.GOV,Federal Agency,Environmental Protection Agency,Washington,DC
@@ -3890,9 +3852,9 @@ GREENGOV.GOV,Federal Agency,Environmental Protection Agency,Washington,DC
 REGULATIONS.GOV,Federal Agency,Environmental Protection Agency,Washington,DC
 RELOCATEFEDS.GOV,Federal Agency,Environmental Protection Agency,Cincinnati,OH
 SUSTAINABILITY.GOV,Federal Agency,Environmental Protection Agency,Washington,DC
-TOX21.GOV,Federal Agency,Environmental Protection Agency,Rockville,MD
 URBANWATERS.GOV,Federal Agency,Environmental Protection Agency,Washington,DC
 EEOC.GOV,Federal Agency,Equal Employment Opportunity Commission,Washington,DC
+BEBEST.GOV,Federal Agency,Executive Office of the President,Washington,DC
 BUDGET.GOV,Federal Agency,Executive Office of the President,Washington,DC
 CODE.GOV,Federal Agency,Executive Office of the President,Washington,DC
 CRISISNEXTDOOR.GOV,Federal Agency,Executive Office of the President,Washington,DC
@@ -3902,7 +3864,7 @@ EARMARKS.GOV,Federal Agency,Executive Office of the President,Washington,DC
 EOP.GOV,Federal Agency,Executive Office of the President,Washington,DC
 GREATAGAIN.GOV,Federal Agency,Executive Office of the President,Washington,DC
 ITDASHBOARD.GOV,Federal Agency,Executive Office of the President,Washington,DC
-MAX.GOV,Federal Agency,Executive Office of the President,NW,WA
+MAX.GOV,Federal Agency,Executive Office of the President,Washington,DC
 NEPA.GOV,Federal Agency,Executive Office of the President,Washington,DC
 NOTALONE.GOV,Federal Agency,Executive Office of the President,Washington,DC
 OMB.GOV,Federal Agency,Executive Office of the President,Washington,DC
@@ -3937,28 +3899,28 @@ FDICIG.GOV,Federal Agency,Federal Deposit Insurance Corporation,Arlington,VA
 FDICOIG.GOV,Federal Agency,Federal Deposit Insurance Corporation,Washington,DC
 FDICSEGURO.GOV,Federal Agency,Federal Deposit Insurance Corporation,Arlington,VA
 MYFDIC.GOV,Federal Agency,Federal Deposit Insurance Corporation,Arlington,VA
-FEC.GOV,Federal Agency,Federal Elections Commission,Washington,DC
+FEC.GOV,Federal Agency,Federal Election Commission,Washington,DC
 FERC.GOV,Federal Agency,Federal Energy Regulatory Commission,Washington,DC
 FERCALT.GOV,Federal Agency,Federal Energy Regulatory Commission,Washington,DC
 FHFA.GOV,Federal Agency,Federal Housing Finance Agency,Washington,DC
 HARP.GOV,Federal Agency,Federal Housing Finance Agency,Washington,DC
-FHFAOIG.GOV,Federal Agency,Federal Housing Finance Agency Office of Inspector General,Washington,DC
+FHFAOIG.GOV,Federal Agency,"Federal Housing Finance Agency, Office of Inspector General",Washington,DC
 FLRA.GOV,Federal Agency,Federal Labor Relations Authority,Washington,DC
 FMC.GOV,Federal Agency,Federal Maritime Commission,Washington,DC
 FMCS.GOV,Federal Agency,Federal Mediation and Conciliation Service,Washington,DC
-FMSHRC.GOV,Federal Agency,Federal Mine Safety and Health Review Company,Washington,DC
-FBIIC.GOV,Federal Agency,Federal Reserve System,Washington,DC
-FEDERALRESERVE.GOV,Federal Agency,Federal Reserve System,Washington,DC
-FEDERALRESERVE100.GOV,Federal Agency,Federal Reserve System,Washington ,DC
-FEDERALRESERVE2013.GOV,Federal Agency,Federal Reserve System,Washington,DC
-FEDERALRESERVECONSUMERHELP.GOV,Federal Agency,Federal Reserve System,Washington,DC
-FEDPARTNERSHIP.GOV,Federal Agency,Federal Reserve System,Washington,DC
-FFIEC.GOV,Federal Agency,Federal Reserve System,Washington,DC
-FRB.FED.US,Federal Agency,Federal Reserve System,Washington,DC
-FRB.GOV,Federal Agency,Federal Reserve System,Washington,DC
-FRS.GOV,Federal Agency,Federal Reserve System,Washington,DC
-NEWMONEY.GOV,Federal Agency,Federal Reserve System,Washington,DC
-USCURRENCY.GOV,Federal Agency,Federal Reserve System,Washington,DC
+FMSHRC.GOV,Federal Agency,Federal Mine Safety and Health Review Commission,Washington,DC
+FBIIC.GOV,Federal Agency,Federal Reserve Board of Governors,Washington,DC
+FEDERALRESERVE.GOV,Federal Agency,Federal Reserve Board of Governors,Washington,DC
+FEDERALRESERVE100.GOV,Federal Agency,Federal Reserve Board of Governors,Washington ,DC
+FEDERALRESERVE2013.GOV,Federal Agency,Federal Reserve Board of Governors,Washington,DC
+FEDERALRESERVECONSUMERHELP.GOV,Federal Agency,Federal Reserve Board of Governors,Washington,DC
+FEDPARTNERSHIP.GOV,Federal Agency,Federal Reserve Board of Governors,Washington,DC
+FFIEC.GOV,Federal Agency,Federal Reserve Board of Governors,Washington,DC
+FRB.FED.US,Federal Agency,Federal Reserve Board of Governors,Washington,DC
+FRB.GOV,Federal Agency,Federal Reserve Board of Governors,Washington,DC
+FRS.GOV,Federal Agency,Federal Reserve Board of Governors,Washington,DC
+NEWMONEY.GOV,Federal Agency,Federal Reserve Board of Governors,Washington,DC
+USCURRENCY.GOV,Federal Agency,Federal Reserve Board of Governors,Washington,DC
 EXPLORETSP.GOV,Federal Agency,Federal Retirement Thrift Investment Board,Washington,DC
 FRTIB.GOV,Federal Agency,Federal Retirement Thrift Investment Board,Washington,DC
 FRTIBTEST.GOV,Federal Agency,Federal Retirement Thrift Investment Board,Washigton,DC
@@ -3988,6 +3950,7 @@ ROBODEIDENTIDAD.GOV,Federal Agency,Federal Trade Commission,Washington,DC
 SENTINEL.GOV,Federal Agency,Federal Trade Commission,Washington,DC
 UCE.GOV,Federal Agency,Federal Trade Commission,Washington,DC
 18F.GOV,Federal Agency,General Services Administration,Washington,DC
+ACCESSIBILITY.GOV,Federal Agency,General Services Administration,Washington,DC
 ACQUISITION.GOV,Federal Agency,General Services Administration,Arlington,VA
 AFADVANTAGE.GOV,Federal Agency,General Services Administration,Washington,DC
 APP.GOV,Federal Agency,General Services Administration,Washington,DC
@@ -4002,7 +3965,7 @@ CFOC.GOV,Federal Agency,General Services Administration,Washington,DC
 CHALLENGE.GOV,Federal Agency,General Services Administration,Washington,DC
 CHALLENGES.GOV,Federal Agency,General Services Administration,Washington,DC
 CIO.GOV,Federal Agency,General Services Administration,Washington,DC
-CITIZENSCIENCE.GOV,Federal Agency,General Services Administration,NW,DC
+CITIZENSCIENCE.GOV,Federal Agency,General Services Administration,Washington,DC
 CLOUD.GOV,Federal Agency,General Services Administration,Washington,DC
 COMPUTERSFORLEARNING.GOV,Federal Agency,General Services Administration,Arlington,VA
 CONNECT.GOV,Federal Agency,General Services Administration,Washington,DC
@@ -4010,15 +3973,15 @@ CONSUMERACTION.GOV,Federal Agency,General Services Administration,Washington,DC
 CONTRACTDIRECTORY.GOV,Federal Agency,General Services Administration,Arlington,VA
 CPARS.GOV,Federal Agency,General Services Administration,Washington,DC
 DATA.GOV,Federal Agency,General Services Administration,Washington,DC
-DIGITAL.GOV,Federal Agency,General Services Administration,Washington D.C.,DC
+DIGITAL.GOV,Federal Agency,General Services Administration,Washington,DC
 DIGITALDASHBOARD.GOV,Federal Agency,General Services Administration,Washington,DC
 DIGITALGOV.GOV,Federal Agency,General Services Administration,Washington,DC
 DOTGOV.GOV,Federal Agency,General Services Administration,Fairfax,VA
 EAC.GOV,Federal Agency,General Services Administration,Washington,DC
 ECPIC.GOV,Federal Agency,General Services Administration,Washington,DC
 EISENHOWERMEMORIAL.GOV,Federal Agency,General Services Administration,Washington,DC
-ESRS.GOV,Federal Agency,General Services Administration,arlington,VA
-EVERYKIDINAPARK.GOV,Federal Agency,General Services Administration,Washington DC,DC
+ESRS.GOV,Federal Agency,General Services Administration,Arlington,VA
+EVERYKIDINAPARK.GOV,Federal Agency,General Services Administration,Washington,DC
 FACA.GOV,Federal Agency,General Services Administration,Washington,DC
 FACADATABASE.GOV,Federal Agency,General Services Administration,Washington,DC
 FAI.GOV,Federal Agency,General Services Administration,Washington,DC
@@ -4040,7 +4003,7 @@ FPISC.GOV,Federal Agency,General Services Administration,Washington,DC
 FPKI-LAB.GOV,Federal Agency,General Services Administration,Washington,DC
 FPKI.GOV,Federal Agency,General Services Administration,Washington,DC
 FRPG.GOV,Federal Agency,General Services Administration,Washington,DC
-FRPP-PA.GOV,Federal Agency,General Services Administration,WASHINGTON,DC
+FRPP-PA.GOV,Federal Agency,General Services Administration,Washington,DC
 FSD.GOV,Federal Agency,General Services Administration,Arlington,VA
 FSRS.GOV,Federal Agency,General Services Administration,Crystal City,VA
 GOBIERNO.GOV,Federal Agency,General Services Administration,Washington,DC
@@ -4061,7 +4024,7 @@ HOWTO.GOV,Federal Agency,General Services Administration,Washington,DC
 IDENTITYSANDBOX.GOV,Federal Agency,General Services Administration,Washington,DC
 IDMANAGEMENT.GOV,Federal Agency,General Services Administration,Washington,DC
 INFO.GOV,Federal Agency,General Services Administration,Washington,DC
-INNOVATION.GOV,Federal Agency,General Services Administration,NW,DC
+INNOVATION.GOV,Federal Agency,General Services Administration,Washington,DC
 KIDS.GOV,Federal Agency,General Services Administration,Washington,DC
 LOGIN.GOV,Federal Agency,General Services Administration,Washington,DC
 NBRC.GOV,Federal Agency,General Services Administration,Concord,NH
@@ -4074,12 +4037,12 @@ PERFORMANCE.GOV,Federal Agency,General Services Administration,Washington,DC
 PIC.GOV,Federal Agency,General Services Administration,Washington,DC
 PIF.GOV,Federal Agency,General Services Administration,Washington,DC
 PKI-LAB.GOV,Federal Agency,General Services Administration,Washington,DC
-PKI.GOV,Federal Agency,General Services Administration,Wahington,DC
+PKI.GOV,Federal Agency,General Services Administration,Washington,DC
 PLAINLANGUAGE.GOV,Federal Agency,General Services Administration,Washington,DC
 PPIRS.GOV,Federal Agency,General Services Administration,Washington,DC
 PRESIDENTIALINNOVATIONFELLOWS.GOV,Federal Agency,General Services Administration,Washington,DC
-PROMESA.GOV,Federal Agency,General Services Administration,WASHINGTON,DC
-PTT.GOV,Federal Agency,General Services Administration,Washington D.C.,DC
+PROMESA.GOV,Federal Agency,General Services Administration,Washington,DC
+PTT.GOV,Federal Agency,General Services Administration,Washington,DC
 REALESTATESALES.GOV,Federal Agency,General Services Administration,Washington,DC
 REALPROPERTYPROFILE.GOV,Federal Agency,General Services Administration,Washington,DC
 REGINFO.GOV,Federal Agency,General Services Administration,Washington,DC
@@ -4099,7 +4062,7 @@ USAGOV.GOV,Federal Agency,General Services Administration,Washington,DC
 USGOVERNMENT.GOV,Federal Agency,General Services Administration,Washington,DC
 USSM.GOV,Federal Agency,General Services Administration,Washington,DC
 VOTE.GOV,Federal Agency,General Services Administration,Washington,DC
-VOTEBYMAIL.GOV,Federal Agency,General Services Administration,SILVER SPRING,MD
+VOTEBYMAIL.GOV,Federal Agency,General Services Administration,Silver Spring,MD
 CONGRESSIONALDIRECTORY.GOV,Federal Agency,Government Publishing Office,Washington,DC
 CONGRESSIONALRECORD.GOV,Federal Agency,Government Publishing Office,Washington,DC
 ECFR.GOV,Federal Agency,Government Publishing Office,Washington,DC
@@ -4117,13 +4080,10 @@ SENATECALENDAR.GOV,Federal Agency,Government Publishing Office,Washington,DC
 USCC.GOV,Federal Agency,Government Publishing Office,Washington,DC
 USCODE.GOV,Federal Agency,Government Publishing Office,Washington,DC
 USGOVERNMENTMANUAL.GOV,Federal Agency,Government Publishing Office,College Park,MD
-RESTORETHEGULF.GOV,Federal Agency,Gulf Coast Ecosystem Restoration Council (GCERC),Silver Spring,MD
+RESTORETHEGULF.GOV,Federal Agency,Gulf Coast Ecosystem Restoration Council,Silver Spring,MD
 TRUMAN.GOV,Federal Agency,Harry S. Truman Scholarship Foundation,Washington,DC
 IMLS.GOV,Federal Agency,Institute of Museum and Library Services,Washington,DC
 IAF.GOV,Federal Agency,Inter-American Foundation,Washington,DC
-BBG.GOV,Federal Agency,International Broadcasting Bureau,Washington,DC
-IBB.GOV,Federal Agency,International Broadcasting Bureau,Washington,DC
-VOA.GOV,Federal Agency,International Broadcasting Bureau,Washington,DC
 JAMESMADISON.GOV,Federal Agency,James Madison Memorial Fellowship Foundation,Alexandria,VA
 JUSFC.GOV,Federal Agency,Japan-US Friendship Commision,Washington,DC
 KENNEDY-CENTER.GOV,Federal Agency,John F. Kennedy Center for Performing Arts,Washington,DC
@@ -4164,12 +4124,12 @@ MEDPAC.GOV,Federal Agency,Medical Payment Advisory Commission,Washington,DC
 MSPB.GOV,Federal Agency,Merit Systems Protection Board,Washington,DC
 MCC.GOV,Federal Agency,Millennium Challenge Corporation,Washington,DC
 MCCTEST.GOV,Federal Agency,Millennium Challenge Corporation,Washington,DC
-ECR.GOV,Federal Agency,Morris K. Udall Foundation,Tucson,AZ
-UDALL.GOV,Federal Agency,Morris K. Udall Foundation,Tucson,AZ
+ECR.GOV,Federal Agency,Morris K. Udall and Stewart L. Udall Foundation,Tucson,AZ
+UDALL.GOV,Federal Agency,Morris K. Udall and Stewart L. Udall Foundation,Tucson,AZ
 GLOBE.GOV,Federal Agency,National Aeronautics and Space Administration,Greenbelt,MD
-NASA.GOV,Federal Agency,National Aeronautics and Space Administration,MSFC,AL
-SCIJINKS.GOV,Federal Agency,National Aeronautics and Space Administration,MSFC,AL
-USGEO.GOV,Federal Agency,National Aeronautics and Space Administration,MSFC,AL
+NASA.GOV,Federal Agency,National Aeronautics and Space Administration,Huntsville,AL
+SCIJINKS.GOV,Federal Agency,National Aeronautics and Space Administration,Huntsville,AL
+USGEO.GOV,Federal Agency,National Aeronautics and Space Administration,Huntsville,AL
 9-11COMMISSION.GOV,Federal Agency,National Archives and Records Administration,College Park,MD
 911COMMISSION.GOV,Federal Agency,National Archives and Records Administration,College Park,MD
 ARCHIVES.GOV,Federal Agency,National Archives and Records Administration,College Park,MD
@@ -4180,7 +4140,7 @@ FORDLIBRARYMUSEUM.GOV,Federal Agency,National Archives and Records Administratio
 FRC.GOV,Federal Agency,National Archives and Records Administration,College Park,MD
 GEORGEWBUSHLIBRARY.GOV,Federal Agency,National Archives and Records Administration,College Park,MD
 HISTORY.GOV,Federal Agency,National Archives and Records Administration,College Park,MD
-JIMMYCARTERLIBRARY.GOV,Federal Agency,National Archives and Records Administration,College,MD
+JIMMYCARTERLIBRARY.GOV,Federal Agency,National Archives and Records Administration,College Park,MD
 NARA-AT-WORK.GOV,Federal Agency,National Archives and Records Administration,College Park,MD
 NARA.GOV,Federal Agency,National Archives and Records Administration,College Park,MD
 NIXONLIBRARY.GOV,Federal Agency,National Archives and Records Administration,College Park,MD
@@ -4213,17 +4173,16 @@ RESEARCH.GOV,Federal Agency,National Science Foundation,Alexandria,VA
 SAC.GOV,Federal Agency,National Science Foundation,Alexandria,VA
 SCIENCE360.GOV,Federal Agency,National Science Foundation,Alexandria,VA
 USAP.GOV,Federal Agency,National Science Foundation,Arlington,VA
-INTELLIGENCECAREERS.GOV,Federal Agency,National Security Agency,Ft. Meade,MD
+INTELLIGENCECAREERS.GOV,Federal Agency,National Security Agency,Fort Meade,MD
 LPS.GOV,Federal Agency,National Security Agency,College Park,MD
 NTSB.GOV,Federal Agency,National Transportation Safety Board,Washington,DC
-ITRD.GOV,Federal Agency,Networking Information Technology Research and Development (NITRD),Arlington,VA
-NITRD.GOV,Federal Agency,Networking Information Technology Research and Development (NITRD),Arlington,VA
+ITRD.GOV,Federal Agency,Networking Information Technology Research and Development,Arlington,VA
+NITRD.GOV,Federal Agency,Networking Information Technology Research and Development,Arlington,VA
 NRC-GATEWAY.GOV,Federal Agency,Nuclear Regulatory Commission,Rockville,MD
 NRC.GOV,Federal Agency,Nuclear Regulatory Commission,Rockville,MD
 OSHRC.GOV,Federal Agency,Occupational Safety & Health Review Commission,Washington,DC
 INTEGRITY.GOV,Federal Agency,Office of Government Ethics,Washington,DC
 OGE.GOV,Federal Agency,Office of Government Ethics,Washington,DC
-USITCOIG.GOV,Federal Agency,Office of Inspector General for the U.S. International Trade Commission,Washington,DC
 APPLICATIONMANAGER.GOV,Federal Agency,Office of Personnel Management,Macon,GA
 CHCOC.GOV,Federal Agency,Office of Personnel Management,Washington,DC
 CYBERCAREERS.GOV,Federal Agency,Office of Personnel Management,Washington,DC
@@ -4238,7 +4197,6 @@ FSAFEDS.GOV,Federal Agency,Office of Personnel Management,Washington,DC
 GOLEARN.GOV,Federal Agency,Office of Personnel Management,Washington,DC
 GOVERNMENTJOBS.GOV,Federal Agency,Office of Personnel Management,Macon,GA
 HRU.GOV,Federal Agency,Office of Personnel Management,Washington,DC
-LMRCOUNCIL.GOV,Federal Agency,Office of Personnel Management,Washington,DC
 NBIB.GOV,Federal Agency,Office of Personnel Management,Washington,DC
 OPM.GOV,Federal Agency,Office of Personnel Management,Macon,GA
 PAC.GOV,Federal Agency,Office of Personnel Management,Washington,DC
@@ -4250,7 +4208,7 @@ USALEARNING.GOV,Federal Agency,Office of Personnel Management,Washington,DC
 USASTAFFING.GOV,Federal Agency,Office of Personnel Management,Macon,GA
 OPIC.GOV,Federal Agency,Overseas Private Investment Corporation,Washington,DC
 PBGC.GOV,Federal Agency,Pension Benefit Guaranty Corporation,Washington,DC
-PRC.GOV,Federal Agency,Postal Rate Commission,Washington,DC
+PRC.GOV,Federal Agency,Postal Regulatory Commission,Washington,DC
 RRB.GOV,Federal Agency,Railroad Retirement Board,Chicago,IL
 INVESTOR.GOV,Federal Agency,Securities and Exchange Commission,Washington,DC
 SEC.GOV,Federal Agency,Securities and Exchange Commission,Washington,DC
@@ -4263,93 +4221,62 @@ ITIS.GOV,Federal Agency,Smithsonian Institution,Washington,DC
 SEGUROSOCIAL.GOV,Federal Agency,Social Security Administration,Baltimore,MD
 SOCIALSECURITY.GOV,Federal Agency,Social Security Administration,Baltimore,MD
 SSA.GOV,Federal Agency,Social Security Administration,Baltimore,MD
-SSAB.GOV,Federal Agency,Social Security Advisory Board,WASHINGTON,DC
-SJI.GOV,Federal Agency,State Justice Institute (SJI),Reston,VA
+SSAB.GOV,Federal Agency,Social Security Advisory Board,Washington,DC
+SJI.GOV,Federal Agency,State Justice Institute,Reston,VA
 STENNIS.GOV,Federal Agency,Stennis Center for Public Service,Starkville,MS
-STB.GOV,Federal Agency,Surface Transportation Board (STB),Washington,DC
+STB.GOV,Federal Agency,Surface Transportation Board,Washington,DC
 TVA.GOV,Federal Agency,Tennessee Valley Authority,Knoxville,TN
 TVAOIG.GOV,Federal Agency,Tennessee Valley Authority,Knoxville,TN
 TSC.GOV,Federal Agency,Terrorist Screening Center,Washington,DC
 PTF.GOV,Federal Agency,The Intelligence Community,Washington,DC
-CBO.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
-CBONEWS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
-CECC.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
-CHINA-COMMISSION.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
-CHINACOMMISSION.GOV,Federal Agency,The Legislative Branch (Congress),Washington,MD
-CITIZENCOSPONSORS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
-CITIZENS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
-COSPONSOR.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
-CSCE.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
-DEMOCRATICLEADER.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
-DEMOCRATICWHIP.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
-DEMOCRATS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
-DEMS.GOV,Federal Agency,The Legislative Branch (Congress),Washington DC,DC
-ESECLAB.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
-FASAB.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
-GAO.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
-GAONET.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
-GOP.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
-GOPLEADER.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
-HOUSE.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
-HOUSECOMMUNICATIONS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
-HOUSED.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
-HOUSEDEMOCRATS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
-HOUSEDEMS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
-HOUSELIVE.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
-HOUSENEWSLETTERS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
-JCT.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
-LISTENSTOYOU.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
-MAJORITYLEADER.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
-MAJORITYWHIP.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
-PDBCECC.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
-PPDCECC.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
-REPUBLICANS.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
-SEN.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
-SENATE.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
-SPEAKER.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
-TAXREFORM.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
-TMDBHOUSE.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
-USHOUSE.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
-USHR.GOV,Federal Agency,The Legislative Branch (Congress),Washington,DC
+CBO.GOV,Federal Agency,The Legislative Branch,Washington,DC
+CBONEWS.GOV,Federal Agency,The Legislative Branch,Washington,DC
+CECC.GOV,Federal Agency,The Legislative Branch,Washington,DC
+CHINA-COMMISSION.GOV,Federal Agency,The Legislative Branch,Washington,DC
+CHINACOMMISSION.GOV,Federal Agency,The Legislative Branch,Washington,MD
+CITIZENCOSPONSORS.GOV,Federal Agency,The Legislative Branch,Washington,DC
+CITIZENS.GOV,Federal Agency,The Legislative Branch,Washington,DC
+COSPONSOR.GOV,Federal Agency,The Legislative Branch,Washington,DC
+CSCE.GOV,Federal Agency,The Legislative Branch,Washington,DC
+DEMOCRATICLEADER.GOV,Federal Agency,The Legislative Branch,Washington,DC
+DEMOCRATICWHIP.GOV,Federal Agency,The Legislative Branch,Washington,DC
+DEMOCRATS.GOV,Federal Agency,The Legislative Branch,Washington,DC
+DEMS.GOV,Federal Agency,The Legislative Branch,Washington,DC
+ESECLAB.GOV,Federal Agency,The Legislative Branch,Washington,DC
+FASAB.GOV,Federal Agency,The Legislative Branch,Washington,DC
+GAO.GOV,Federal Agency,The Legislative Branch,Washington,DC
+GAONET.GOV,Federal Agency,The Legislative Branch,Washington,DC
+GOP.GOV,Federal Agency,The Legislative Branch,Washington,DC
+GOPLEADER.GOV,Federal Agency,The Legislative Branch,Washington,DC
+HOUSE.GOV,Federal Agency,The Legislative Branch,Washington,DC
+HOUSECOMMUNICATIONS.GOV,Federal Agency,The Legislative Branch,Washington,DC
+HOUSED.GOV,Federal Agency,The Legislative Branch,Washington,DC
+HOUSEDEMOCRATS.GOV,Federal Agency,The Legislative Branch,Washington,DC
+HOUSEDEMS.GOV,Federal Agency,The Legislative Branch,Washington,DC
+HOUSELIVE.GOV,Federal Agency,The Legislative Branch,Washington,DC
+HOUSENEWSLETTERS.GOV,Federal Agency,The Legislative Branch,Washington,DC
+JCT.GOV,Federal Agency,The Legislative Branch,Washington,DC
+LISTENSTOYOU.GOV,Federal Agency,The Legislative Branch,Washington,DC
+MAJORITYLEADER.GOV,Federal Agency,The Legislative Branch,Washington,DC
+MAJORITYWHIP.GOV,Federal Agency,The Legislative Branch,Washington,DC
+PDBCECC.GOV,Federal Agency,The Legislative Branch,Washington,DC
+PPDCECC.GOV,Federal Agency,The Legislative Branch,Washington,DC
+REPUBLICANS.GOV,Federal Agency,The Legislative Branch,Washington,DC
+SEN.GOV,Federal Agency,The Legislative Branch,Washington,DC
+SENATE.GOV,Federal Agency,The Legislative Branch,Washington,DC
+SPEAKER.GOV,Federal Agency,The Legislative Branch,Washington,DC
+TAXREFORM.GOV,Federal Agency,The Legislative Branch,Washington,DC
+TMDBHOUSE.GOV,Federal Agency,The Legislative Branch,Washington,DC
+USHOUSE.GOV,Federal Agency,The Legislative Branch,Washington,DC
+USHR.GOV,Federal Agency,The Legislative Branch,Washington,DC
 SC-US.GOV,Federal Agency,The Supreme Court,Washington,DC
 SCINET-TEST.GOV,Federal Agency,The Supreme Court,Washington,DC
 SCINET.GOV,Federal Agency,The Supreme Court,Washington,DC
-SCUS.GOV,Federal Agency,The Supreme Court,WASHINGTON,DC
+SCUS.GOV,Federal Agency,The Supreme Court,Washington,DC
 SUPREME-COURT.GOV,Federal Agency,The Supreme Court,Washington,DC
 SUPREMECOURT.GOV,Federal Agency,The Supreme Court,Washington,DC
 SUPREMECOURTUS.GOV,Federal Agency,The Supreme Court,Washington,DC
 WORLDWAR1CENTENNIAL.GOV,Federal Agency,The United States World War One Centennial Commission,Washington,DC
-ACCESS-BOARD.GOV,Federal Agency,U. S. Access Board,Washington,DC
-USHMM.GOV,Federal Agency,U. S. Holocaust Memorial Museum,Washington,DC
-USITC.GOV,Federal Agency,U. S. International Trade Commission,Washington,DC
-OSC.GOV,Federal Agency,U. S. Office of Special Counsel,Washington,DC
-OSCNET.GOV,Federal Agency,U. S. Office of Special Counsel,Washington,DC
-PEACECORPS.GOV,Federal Agency,U. S. Peace Corps,Washington,DC
-CHANGEOFADDRESS.GOV,Federal Agency,U. S. Postal Service,Washington,DC
-MAIL.GOV,Federal Agency,U. S. Postal Service,Raleigh,NC
-MYUSPS.GOV,Federal Agency,U. S. Postal Service,Raleigh,NC
-POSTOFFICE.GOV,Federal Agency,U. S. Postal Service,Raleigh,NC
-PURCHASING.GOV,Federal Agency,U. S. Postal Service,Raleigh,NC
-USPIS.GOV,Federal Agency,U. S. Postal Service,Arlington,VA
-USPS.GOV,Federal Agency,U. S. Postal Service,Raleigh,NC
-USPSINFORMEDDELIVERY.GOV,Federal Agency,U. S. Postal Service,Raleigh,NC
-USPSINNOVATES.GOV,Federal Agency,U. S. Postal Service,Washington,DC
-BANKRUPTCY.GOV,Federal Agency,U.S Courts,Washington,DC
-CAVC.GOV,Federal Agency,U.S Courts,Washington,DC
-FEDERALCOURTS.GOV,Federal Agency,U.S Courts,Washington,DC
-FEDERALPROBATION.GOV,Federal Agency,U.S Courts,Washington,DC
-FEDERALRULES.GOV,Federal Agency,U.S Courts,Washington,DC
-FJC.GOV,Federal Agency,U.S Courts,Washington,DC
-JUDICIALCONFERENCE.GOV,Federal Agency,U.S Courts,Washington,DC
-NMCOURT.FED.US,Federal Agency,U.S Courts,Albuquerque,NM
-PACER.GOV,Federal Agency,U.S Courts,Washington,DC
-USBANKRUPTCY.GOV,Federal Agency,U.S Courts,Washington,DC
-USC.GOV,Federal Agency,U.S Courts,Washington,DC
-USCAVC.GOV,Federal Agency,U.S Courts,Washington,DC
-USCOURTS.GOV,Federal Agency,U.S Courts,Washington,DC
-USPROBATION.GOV,Federal Agency,U.S Courts,Washington,DC
-USSC.GOV,Federal Agency,U.S Courts,Washington,DC
-USTAXCOURT.GOV,Federal Agency,U.S Courts,Washington,DC
 CHILDRENINADVERSITY.GOV,Federal Agency,U.S. Agency for International Development,Washington,DC
 DFAFACTS.GOV,Federal Agency,U.S. Agency for International Development,Washington,DC
 FEEDTHEFUTURE.GOV,Federal Agency,U.S. Agency for International Development,Washington,DC
@@ -4360,18 +4287,97 @@ PMI.GOV,Federal Agency,U.S. Agency for International Development,Washington,DC
 USAID.GOV,Federal Agency,U.S. Agency for International Development,Washington,DC
 USCAPITOLPOLICE.GOV,Federal Agency,U.S. Capitol Police,Washington,DC
 USCP.GOV,Federal Agency,U.S. Capitol Police,Washington,DC
+HERITAGEABROAD.GOV,Federal Agency,U.S. Commission for the Preservation of Americas Heritage Abroad,Washington,DC
 CFA.GOV,Federal Agency,U.S. Commission of Fine Arts,Washington,DC
 USCCR.GOV,Federal Agency,U.S. Commission on Civil Rights,Washington,DC
 USCIRF.GOV,Federal Agency,U.S. Commission on International Religious Freedom,Washington,DC
-PEACECORPSOIG.GOV,Federal Agency,"U.S. Postal Service, Office of Inspector General",Washington,DC
-USPSOIG.GOV,Federal Agency,"U.S. Postal Service, Office of Inspector General",Arlington,VA
-USTDA.GOV,Federal Agency,U.S. Trade and Development Agency,Arlington,VA
-GLOBALCHANGE.GOV,Federal Agency,United Stated Global Change Research Program,Washington,DC
-USGCRP.GOV,Federal Agency,United Stated Global Change Research Program,Washington,DC
+BANKRUPTCY.GOV,Federal Agency,U.S. Courts,Washington,DC
+CAVC.GOV,Federal Agency,U.S. Courts,Washington,DC
+FEDERALCOURTS.GOV,Federal Agency,U.S. Courts,Washington,DC
+FEDERALPROBATION.GOV,Federal Agency,U.S. Courts,Washington,DC
+FEDERALRULES.GOV,Federal Agency,U.S. Courts,Washington,DC
+FJC.GOV,Federal Agency,U.S. Courts,Washington,DC
+JUDICIALCONFERENCE.GOV,Federal Agency,U.S. Courts,Washington,DC
+NMCOURT.FED.US,Federal Agency,U.S. Courts,Albuquerque,NM
+PACER.GOV,Federal Agency,U.S. Courts,Washington,DC
+USBANKRUPTCY.GOV,Federal Agency,U.S. Courts,Washington,DC
+USC.GOV,Federal Agency,U.S. Courts,Washington,DC
+USCAVC.GOV,Federal Agency,U.S. Courts,Washington,DC
+USCOURTS.GOV,Federal Agency,U.S. Courts,Washington,DC
+USPROBATION.GOV,Federal Agency,U.S. Courts,Washington,DC
+USSC.GOV,Federal Agency,U.S. Courts,Washington,DC
+USTAXCOURT.GOV,Federal Agency,U.S. Courts,Washington,DC
+AFF.GOV,Federal Agency,U.S. Department of Agriculture,Boise,ID
+AG.GOV,Federal Agency,U.S. Department of Agriculture,Fort Collins,CO
+ARS-GRIN.GOV,Federal Agency,U.S. Department of Agriculture,Beltsville,MD
+ARSUSDA.GOV,Federal Agency,U.S. Department of Agriculture,Beltsville,MD
+ASKKAREN.GOV,Federal Agency,U.S. Department of Agriculture,Washington,DC
+BEFOODSAFE.GOV,Federal Agency,U.S. Department of Agriculture,Washington,DC
+BIOPREFERRED.GOV,Federal Agency,U.S. Department of Agriculture,Washington,DC
+BOSQUE.GOV,Federal Agency,U.S. Department of Agriculture,Albuquerque,NM
+CHOOSEMYPLATE.GOV,Federal Agency,U.S. Department of Agriculture,Alexandria,VA
+COASTALAMERICA.GOV,Federal Agency,U.S. Department of Agriculture,Washington,DC
+DIETARYGUIDELINES.GOV,Federal Agency,U.S. Department of Agriculture,Alexandria,VA
+EMPOWHR.GOV,Federal Agency,U.S. Department of Agriculture,New Orleans,LA
+EXECSEC.GOV,Federal Agency,U.S. Department of Agriculture,Washington,DC
+FARMERS.GOV,Federal Agency,U.S. Department of Agriculture,Washington,DC
+FOODSAFETYJOBS.GOV,Federal Agency,U.S. Department of Agriculture,Washington,DC
+FORESTSANDRANGELANDS.GOV,Federal Agency,U.S. Department of Agriculture,Washington,DC
+FS.FED.US,Federal Agency,U.S. Department of Agriculture,Washington,DC
+GREEN.GOV,Federal Agency,U.S. Department of Agriculture,Washington,DC
+ICBEMP.GOV,Federal Agency,U.S. Department of Agriculture,Portland,OR
+INVASIVESPECIESINFO.GOV,Federal Agency,U.S. Department of Agriculture,Beltsville,MD
+IPM.GOV,Federal Agency,U.S. Department of Agriculture,Washington,DC
+ISITDONEYET.GOV,Federal Agency,U.S. Department of Agriculture,Washington,DC
+ITAP.GOV,Federal Agency,U.S. Department of Agriculture,Beltsville,MD
+JUNIORFORESTRANGER.GOV,Federal Agency,U.S. Department of Agriculture,Washington,DC
+LCACOMMONS.GOV,Federal Agency,U.S. Department of Agriculture,Beltsville,MD
+MTBS.GOV,Federal Agency,U.S. Department of Agriculture,Salt Lake City,UT
+MYPLATE.GOV,Federal Agency,U.S. Department of Agriculture,Alexandria,VA
+NAFRI.GOV,Federal Agency,U.S. Department of Agriculture,Tucson,AZ
+NEL.GOV,Federal Agency,U.S. Department of Agriculture,Alexandria,VA
+NUTRITION.GOV,Federal Agency,U.S. Department of Agriculture,Washington,DC
+NUTRITIONEVIDENCELIBRARY.GOV,Federal Agency,U.S. Department of Agriculture,Alexandria,VA
+NWCG.GOV,Federal Agency,U.S. Department of Agriculture,Boise,ID
+PREGUNTELEAKAREN.GOV,Federal Agency,U.S. Department of Agriculture,Washington,DC
+RECREATION.GOV,Federal Agency,U.S. Department of Agriculture,Ogden,UT
+REO.GOV,Federal Agency,U.S. Department of Agriculture,Portland,OR
+SMOKEYBEAR.GOV,Federal Agency,U.S. Department of Agriculture,Washington,DC
+SYMBOLS.GOV,Federal Agency,U.S. Department of Agriculture,Washington,DC
+THEPEOPLESGARDEN.GOV,Federal Agency,U.S. Department of Agriculture,Washington,DC
+USDA.GOV,Federal Agency,U.S. Department of Agriculture,Ft. Collins,CO
+USDAPII.GOV,Federal Agency,U.S. Department of Agriculture,Washington,DC
+WILDFIRE.GOV,Federal Agency,U.S. Department of Agriculture,Boise,ID
+WOODSY.GOV,Federal Agency,U.S. Department of Agriculture,Washington,DC
+WOODSYOWL.GOV,Federal Agency,U.S. Department of Agriculture,Washington,DC
+OSC.GOV,Federal Agency,U.S. Office of Special Counsel,Washington,DC
+OSCNET.GOV,Federal Agency,U.S. Office of Special Counsel,Washington,DC
+PEACECORPS.GOV,Federal Agency,U.S. Peace Corps,Washington,DC
+ABILITYONE.GOV,Federal Agency,United States AbilityOne,Arlington,VA
+JWOD.GOV,Federal Agency,United States AbilityOne,Arlington,VA
+ACCESS-BOARD.GOV,Federal Agency,United States Access Board,Washington,DC
+ADF.GOV,Federal Agency,United States African Development Foundation,Washington,DC
+USADF.GOV,Federal Agency,United States African Development Foundation,Washington,DC
+GLOBALCHANGE.GOV,Federal Agency,United States Global Change Research Program,Washington,DC
+USGCRP.GOV,Federal Agency,United States Global Change Research Program,Washington,DC
+USHMM.GOV,Federal Agency,United States Holocaust Memorial Museum,Washington,DC
 USIP.GOV,Federal Agency,United States Institute of Peace,Washington,DC
-HERITAGEABROAD.GOV,Federal Agency,US Commission for the Preservation of Americas Heritage Abroad,Washington,DC
-ICH.GOV,Federal Agency,US Interagency Council on Homelessness,washington,DC
-USICH.GOV,Federal Agency,US Interagency Council on Homelessness,Washington,DC
+ICH.GOV,Federal Agency,United States Interagency Council on Homelessness,Washington,DC
+USICH.GOV,Federal Agency,United States Interagency Council on Homelessness,Washington,DC
+USITC.GOV,Federal Agency,United States International Trade Commission,Washington,DC
+USITCOIG.GOV,Federal Agency,"United States International Trade Commission, Office of Inspector General",Washington,DC
+CHANGEOFADDRESS.GOV,Federal Agency,United States Postal Service,Washington,DC
+MAIL.GOV,Federal Agency,United States Postal Service,Raleigh,NC
+MYUSPS.GOV,Federal Agency,United States Postal Service,Raleigh,NC
+POSTOFFICE.GOV,Federal Agency,United States Postal Service,Raleigh,NC
+PURCHASING.GOV,Federal Agency,United States Postal Service,Raleigh,NC
+USPIS.GOV,Federal Agency,United States Postal Service,Arlington,VA
+USPS.GOV,Federal Agency,United States Postal Service,Raleigh,NC
+USPSINFORMEDDELIVERY.GOV,Federal Agency,United States Postal Service,Raleigh,NC
+USPSINNOVATES.GOV,Federal Agency,United States Postal Service,Washington,DC
+PEACECORPSOIG.GOV,Federal Agency,"United States Postal Service, Office of Inspector General",Washington,DC
+USPSOIG.GOV,Federal Agency,"United States Postal Service, Office of Inspector General",Arlington,VA
+USTDA.GOV,Federal Agency,United States Trade and Development Agency,Arlington,VA
 VEF.GOV,Federal Agency,Vietnam Education Foundation,Arlington,VA
 29PALMSBOMI-NSN.GOV,Native Sovereign Nation,Indian Affairs,Coachella,CA
 29PALMSGAMING-NSN.GOV,Native Sovereign Nation,Indian Affairs,Coachella,CA
@@ -4497,6 +4503,7 @@ REDCLIFF-NSN.GOV,Native Sovereign Nation,Indian Affairs,Bayfield,WI
 ROSEBUDSIOUXTRIBE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Rosebud,SD
 RST-NSN.GOV,Native Sovereign Nation,Indian Affairs,Rosebud,SD
 SACANDFOXNATION-NSN.GOV,Native Sovereign Nation,Indian Affairs,Stroud,OK
+SANJUANPAIUTE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Tuba City,AZ
 SANMANUEL-NSN.GOV,Native Sovereign Nation,Indian Affairs,Highland,CA
 SANTAANA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Santa Ana,NM
 SANTAROSACAHUILLA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Anza,CA
@@ -4773,7 +4780,6 @@ COAG.GOV,State/Local Govt,Non-Federal Agency,Denver,CO
 COBERTURAMEDICAILLINOIS.GOV,State/Local Govt,Non-Federal Agency,Chicago,IL
 COCICJIS.GOV,State/Local Govt,Non-Federal Agency,Golden,CO
 CODOT.GOV,State/Local Govt,Non-Federal Agency,Denver,CO
-COLLIERCOUNTYFL.GOV,State/Local Govt,Non-Federal Agency,Naples,FL
 COLORADO.GOV,State/Local Govt,Non-Federal Agency,Denver,CO
 COLORADOATTORNEYGENERAL.GOV,State/Local Govt,Non-Federal Agency,Denver,CO
 COLORADOJUDICIAL.GOV,State/Local Govt,Non-Federal Agency,Denver,CO
@@ -4821,8 +4827,6 @@ DEVAZ.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
 DEVAZDHS.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
 DEVAZDOT.GOV,State/Local Govt,Non-Federal Agency,Phoenix,AZ
 DMG.GOV,State/Local Govt,Non-Federal Agency,Barstow,CA
-DNSSECOHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
-DNSTESTOHIO.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
 DOJMT.GOV,State/Local Govt,Non-Federal Agency,Helena,MT
 DOSEOFREALITYWI.GOV,State/Local Govt,Non-Federal Agency,Madison,WI
 DRIVEBAKEDGETBUSTEDFL.GOV,State/Local Govt,Non-Federal Agency,Tallahassee,FL
@@ -5101,7 +5105,6 @@ MDCOURTS.GOV,State/Local Govt,Non-Federal Agency,Annapolis,MD
 ME.GOV,State/Local Govt,Non-Federal Agency,Augusta,ME
 MEASURETN.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN
 MEDCMI.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI
-MENTORMICHIGAN.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI
 MGCBMI.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI
 MHB.GOV,State/Local Govt,Non-Federal Agency,Mobile,AL
 MI.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI
@@ -5129,7 +5132,6 @@ MONCKSCORNERSC.GOV,State/Local Govt,Non-Federal Agency,MONCKS CORNER,SC
 MONSON-MA.GOV,State/Local Govt,Non-Federal Agency,Monson,MA
 MONTANA.GOV,State/Local Govt,Non-Federal Agency,Helena,MT
 MONTANAWORKS.GOV,State/Local Govt,Non-Federal Agency,Helena,MT
-MOPROSECUTORS.GOV,State/Local Govt,Non-Federal Agency,Jefferson City,MO
 MRCOG-NM.GOV,State/Local Govt,Non-Federal Agency,Albuquerque,NM
 MS.GOV,State/Local Govt,Non-Federal Agency,Jackson,MS
 MSLMI.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI
@@ -5137,6 +5139,7 @@ MSPADMI.GOV,State/Local Govt,Non-Federal Agency,Lansing,MI
 MT.GOV,State/Local Govt,Non-Federal Agency,Helena,MT
 MTCOUNTYRESULTS.GOV,State/Local Govt,Non-Federal Agency,Helena,MT
 MTELECTIONRESULTS.GOV,State/Local Govt,Non-Federal Agency,Helena,MT
+MTREALID.GOV,State/Local Govt,Non-Federal Agency,Helena,MT
 MTREVENUE.GOV,State/Local Govt,Non-Federal Agency,Helena,MT
 MTSOSFILINGS.GOV,State/Local Govt,Non-Federal Agency,Helena,MT
 MYALABAMA.GOV,State/Local Govt,Non-Federal Agency,Montgomery,AL
@@ -5178,7 +5181,6 @@ NCDOJ.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
 NCDOR.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
 NCDOT.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
 NCDPS.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
-NCFAST.GOV,State/Local Govt,Non-Federal Agency,RTP,NC
 NCFORECLOSUREPREVENTION.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
 NCFORESTPRODUCTS.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
 NCFORESTSERVICE.GOV,State/Local Govt,Non-Federal Agency,Raleigh,NC
@@ -5238,6 +5240,7 @@ NEXTCHAPTERTN.GOV,State/Local Govt,Non-Federal Agency,Smyrna,TN
 NEXTTENNESSEE.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN
 NH.GOV,State/Local Govt,Non-Federal Agency,Concord,NH
 NJ.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ
+NJCARES.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ
 NJCCC.GOV,State/Local Govt,Non-Federal Agency,Atlantic City,NJ
 NJCHILDSUPPORT.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ
 NJCIVILRIGHTS.GOV,State/Local Govt,Non-Federal Agency,Trenton,NJ
@@ -5342,7 +5345,6 @@ OHIOTREASURER.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
 OHIOVET.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
 OHIOVETERANSHOME.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
 OHIOVETS.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
-OHIOWOMENVETS.GOV,State/Local Govt,Non-Federal Agency,Columbus,OH
 OHVIDAHO.GOV,State/Local Govt,Non-Federal Agency,Boise,ID
 OK.GOV,State/Local Govt,Non-Federal Agency,Oklahoma City,OK
 OKBENEFITS.GOV,State/Local Govt,Non-Federal Agency,Oklahoma City,OK
@@ -5542,6 +5544,7 @@ TNFOSTERS.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN
 TNHIGHWAYPATROL.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN
 TNIIS.GOV,State/Local Govt,Non-Federal Agency,Smyrna,TN
 TNK12.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN
+TNLPR.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN
 TNPROMISE.GOV,State/Local Govt,Non-Federal Agency,Smyrna,TN
 TNQUITLINE.GOV,State/Local Govt,Non-Federal Agency,Smyrna,TN
 TNREADY.GOV,State/Local Govt,Non-Federal Agency,Nashville,TN
@@ -5571,7 +5574,6 @@ TXDOT.GOV,State/Local Govt,Non-Federal Agency,Austin,TX
 TXOAG.GOV,State/Local Govt,Non-Federal Agency,Austin,TX
 US41WISCONSIN.GOV,State/Local Govt,Non-Federal Agency,Madison,WI
 UTAH.GOV,State/Local Govt,Non-Federal Agency,Salt Lake City,UT
-UTAHLAKE.GOV,State/Local Govt,Non-Federal Agency,Salt Lake City,UT
 UTAHTRUST.GOV,State/Local Govt,Non-Federal Agency,North Salt Lake,UT
 UTCOURTS.GOV,State/Local Govt,Non-Federal Agency,Salt Lake City,UT
 VACOURTS.GOV,State/Local Govt,Non-Federal Agency,Richmond,VA


### PR DESCRIPTION
This update include a number of changes to current-federal :us::
* more accurately captures the names of federal agencies as they call themselves (e.g., "U.S. Department of Agriculture" rather than "Department of Agriculture")
* fixes a few errors (e.g., "United Stated")
* cleans up place names (e.g., "Washington" is the city, "DC" is the "state", instead of `Washington D.C., DC`, `Washington DC, DC`; `WASHINGTON, DC`)