### PR TITLE
Adding some extra hosts

### DIFF
--- a/dotgov-websites/other-websites.csv
+++ b/dotgov-websites/other-websites.csv
@@ -12587,3 +12587,7 @@ youthhomelessness.acf.hhs.gov
 go.opic.gov
 irwin-console.doi.gov
 irwinoat-console.doi.gov
+uat.nfpors.gov
+uag-uat.nfpors.gov
+uag-qa.nfpors.gov
+qa.nfpors.gov


### PR DESCRIPTION
DOI asked NCATS to add to the HTTPS and Trustworthy Email report scanning.  I verified that these hosts were not being picked up through other means.