### PR TITLE
Removing domains.dotgov.gov from other-websites.csv

### DIFF
--- a/dotgov-websites/other-websites.csv
+++ b/dotgov-websites/other-websites.csv
@@ -1,5 +1,4 @@
 Domain
-domains.dotgov.gov
 kms.dsac.gov
 iapps-ctep.ha.nih.gov
 www-03.eftps.gov


### PR DESCRIPTION
This was being excluded through a fault of the code (anything prefixed with `domain`).