### PR TITLE
Adding a few more hosts from USDA per request

### DIFF
--- a/dotgov-websites/other-websites.csv
+++ b/dotgov-websites/other-websites.csv
@@ -1,4 +1,12 @@
 Domain
+icbsnew-trng.nwcg.gov
+ois-qt.nwcg.gov
+reports-qt.nwcg.gov
+rosshelp-qctest.nwcg.gov
+rossreports-qctest.nwcg.gov
+rossweb-qctest.nwcg.gov
+rossweb-tr.nwcg.gov
+wfdsswx.nwcg.gov
 pearlharbor.recreation.gov
 webmaster.nwcg.gov
 egpnew.nwcg.gov


### PR DESCRIPTION
USDA has sent along a few more hosts to add to the report:

```
icbsnew-trng.nwcg.gov
ois-qt.nwcg.gov
reports-qt.nwcg.gov
rosshelp-qctest.nwcg.gov
rossreports-qctest.nwcg.gov
rossweb-qctest.nwcg.gov
rossweb-tr.nwcg.gov
wfdsswx.nwcg.gov
```

All of them are publicly accessible over HTTP(S), and none of them currently appear in our discovery data.