### PR TITLE
Updating .gov list from May 21, 2018; add Interstate domains

### DIFF
--- a/dotgov-domains/current-federal.csv
+++ b/dotgov-domains/current-federal.csv
@@ -23,7 +23,6 @@ OPENSOURCE.GOV,Federal Agency - Executive,Central Intelligence Agency,DNI Open S
 OSDE.GOV,Federal Agency - Executive,Central Intelligence Agency,CIA\GCS OSEG,Reston,VA
 TTIC.GOV,Federal Agency - Executive,Central Intelligence Agency,National Counterterrorism Center,Washington,DC
 UCIA.GOV,Federal Agency - Executive,Central Intelligence Agency,Central Intelligence Agency,Washington,DC
-CHEMSAFETY.GOV,Federal Agency - Executive,Chemical Safety Board,U.S. Chemical Safety and Hazard Investigation Board,Washington,DC
 CSB.GOV,Federal Agency - Executive,Chemical Safety Board,U.S. Chemical Safety and Hazard Investigation Board,Washington,DC
 SAFETYVIDEOS.GOV,Federal Agency - Executive,Chemical Safety Board,U.S. Chemical Safety and Hazard Investigation Board,Washington,DC
 CAP.GOV,Federal Agency - Executive,Civil Air Patrol,"CIVIL AIR PATROL, USAF AUX.",Birmingham,MI
@@ -63,7 +62,6 @@ NATIONALSERVICERESOURCES.GOV,Federal Agency - Executive,Corporation for National
 PRESIDENTIALSERVICEAWARDS.GOV,Federal Agency - Executive,Corporation for National & Community Service,Corporation for National & Community Service,Washington,DC
 SENIORCORPS.GOV,Federal Agency - Executive,Corporation for National & Community Service,Corporation for National and Community Service,Washington,DC
 SERVE.GOV,Federal Agency - Executive,Corporation for National & Community Service,Corporation for National and Community Service,Washington,DC
-SERVICE.GOV,Federal Agency - Executive,Corporation for National & Community Service,Corporation for National and Community Service,Washington,DC
 VISTACAMPUS.GOV,Federal Agency - Executive,Corporation for National & Community Service,Corporation for National & Community Service,Washington,DC
 VOLUNTEERINGINAMERICA.GOV,Federal Agency - Executive,Corporation for National & Community Service,Corporation for National and Community Service,Washington,DC
 CIGIE.GOV,Federal Agency - Executive,Council of Inspectors General on Integrity and Efficiency,COUNCIL OF INSPECTOR GENERAL ON INTEGRITY AND EFFICIENCY,Washington,DC
@@ -584,7 +582,7 @@ UTAHFIREINFO.GOV,Federal Agency - Executive,Department of the Interior,Bureau of
 VOLCANO.GOV,Federal Agency - Executive,Department of the Interior,US Geological Survey/Volcano Science Center,Vancouver,WA
 VOLUNTEER.GOV,Federal Agency - Executive,Department of the Interior,Department of the Interior,Reston,VA
 WATERMONITOR.GOV,Federal Agency - Executive,Department of the Interior,U.S. Geological Survey,Reston,VA
-WILDLIFEADAPTATIONSTRATEGY.GOV,Federal Agency - Executive,Department of the Interior,U.S. Fish and Wildlife Service,Arlington,VA
+WILDLIFEADAPTATIONSTRATEGY.GOV,Federal Agency - Executive,Department of the Interior,U.S. Fish and Wildlife Service,Falls Church,VA
 WLCI.GOV,Federal Agency - Executive,Department of the Interior,US Geological Survey,Denver,CO
 AMA.GOV,Federal Agency - Executive,Department of the Treasury,Department of the Treasury - FMS,Washington,DC
 AMERICATHEBEAUTIFULQUARTERS.GOV,Federal Agency - Executive,Department of the Treasury,Department of the Treasury - Mint,Washington,DC
@@ -706,7 +704,6 @@ SAFERTRUCK.GOV,Federal Agency - Executive,Department of Transportation,DOT NHTSA
 SHARETHEROADSAFELY.GOV,Federal Agency - Executive,Department of Transportation,Federal Motor Carrier Safety Administration,Washington,DC
 SMARTERSKIES.GOV,Federal Agency - Executive,Department of Transportation,US Dept of Transportation,Washington,DC
 STRONGPORTS.GOV,Federal Agency - Executive,Department of Transportation,Department of Transportation - MAritime Administration,Washington,DC
-SUSTAINABLECOMMUNITIES.GOV,Federal Agency - Executive,Department of Transportation,U.S. Department of Transportation Office of the Chief Information Officer ,Washington,DC
 TFHRC.GOV,Federal Agency - Executive,Department of Transportation,Turner Fairbank Highway Research Center,Mclean,VA
 TRAFFICSAFETYMARKETING.GOV,Federal Agency - Executive,Department of Transportation,NHTSA,Washington,DC
 TRANSPORTATION.GOV,Federal Agency - Executive,Department of Transportation,U.S. Department of Transportation,Washington,DC
@@ -893,7 +890,6 @@ FPISC.GOV,Federal Agency - Executive,General Services Administration,FEDERAL PER
 FPKI-LAB.GOV,Federal Agency - Executive,General Services Administration,"GSA, Office of Governmentwide Policy",Washington,DC
 FPKI.GOV,Federal Agency - Executive,General Services Administration,"GSA, Office of Governmentwide Policy",Washington,DC
 FRPG.GOV,Federal Agency - Executive,General Services Administration,US General Services Administration,Washington,DC
-FRPP-PA.GOV,Federal Agency - Executive,General Services Administration,Office of the CHief Information Officer,Washington,DC
 FSD.GOV,Federal Agency - Executive,General Services Administration,"Office of the Chief Acquisition Officer, Office of Acquisition Systems",Arlington,VA
 FSRS.GOV,Federal Agency - Executive,General Services Administration,GSA Acquisition Systems Division,Crystal City,VA
 GOBIERNO.GOV,Federal Agency - Executive,General Services Administration,FirstGov.gov,Washington,DC
@@ -1194,7 +1190,6 @@ GOVINFO.GOV,Federal Agency - Legislative,Government Publishing Office,US Governm
 GPO.GOV,Federal Agency - Legislative,Government Publishing Office,US Govt Publishing Office,Washington,DC
 HOUSECALENDAR.GOV,Federal Agency - Legislative,Government Publishing Office,United States Government Publishing Office,Washington,DC
 OFR.GOV,Federal Agency - Legislative,Government Publishing Office,US Government Publishing Office,Washington,DC
-OPENWORLD.GOV,Federal Agency - Legislative,Government Publishing Office,The Open World Leadership Center,Washington,DC
 PRESIDENTIALDOCUMENTS.GOV,Federal Agency - Legislative,Government Publishing Office,U.S. Government Publishing Office,Washington,DC
 SENATECALENDAR.GOV,Federal Agency - Legislative,Government Publishing Office,Government Publishing Office,Washington,DC
 USCC.GOV,Federal Agency - Legislative,Government Publishing Office,U.S. - China Economic and Security Review Commission,Washington,DC
@@ -1233,6 +1228,7 @@ WOMENSHISTORYMONTH.GOV,Federal Agency - Legislative,Library of Congress,Library 
 MACPAC.GOV,Federal Agency - Legislative,Medicaid and CHIP Payment and Access Commission,Medicaid and CHIP Payment and Access Commission,Washington,DC
 MEDPAC.GOV,Federal Agency - Legislative,Medical Payment Advisory Commission,Medicare Payment Advisory Commission,Washington,DC
 INSPIRE2SERVE.GOV,Federal Agency - Legislative,"National Commission on Military, National, and Public Service","National Commission on Military, National, and Public Service",Arlington,VA
+OPENWORLD.GOV,Federal Agency - Legislative,Open World Leadership Center,The Open World Leadership Center,Washington,DC
 STENNIS.GOV,Federal Agency - Legislative,Stennis Center for Public Service,John C. Stennis Center for Public Service,Starkville,MS
 CBO.GOV,Federal Agency - Legislative,The Legislative Branch,Congressional Budget Office,Washington,DC
 CBONEWS.GOV,Federal Agency - Legislative,The Legislative Branch,Congressional Budget Office,Washington,DC

--- a/dotgov-domains/current-full.csv
+++ b/dotgov-domains/current-full.csv
@@ -71,6 +71,7 @@ ARCADIA-FL.GOV,City,Non-Federal Agency,City of Arcadia,Arcadia,FL
 ARCADIACA.GOV,City,Non-Federal Agency,City of Arcadia,Arcadia,CA
 ARCHBALDBOROUGHPA.GOV,City,Non-Federal Agency,Archbald Borough,Archbald,PA
 ARCHDALE-NC.GOV,City,Non-Federal Agency,City of Archdale,ARCHDALE,NC
+ARCHERLODGENC.GOV,City,Non-Federal Agency,Town of Archer Lodge,Clayton,NC
 ARKANSASCITYKS.GOV,City,Non-Federal Agency,City of Arkansas City,Arkansas City,KS
 ARLINGTON-TX.GOV,City,Non-Federal Agency,"City of Arlington, Texas",Arlington,TX
 ARLINGTONMA.GOV,City,Non-Federal Agency,Town of Arlington,Arlington,MA
@@ -132,6 +133,7 @@ BAYSTLOUIS-MS.GOV,City,Non-Federal Agency,City of Bay St. Louis,Bay St. Louis,MS
 BAYVILLENY.GOV,City,Non-Federal Agency,Incorporated Village of Bayville,Bayville,NY
 BEACHHAVEN-NJ.GOV,City,Non-Federal Agency,Borough of Beach Haven,Beach Haven,NJ
 BEAUMONT-CA.GOV,City,Non-Federal Agency,"City of Beaumont, California",Beaumont,CA
+BEAUMONTCA.GOV,City,Non-Federal Agency,City of Beaumont,Beaumont,CA
 BEAUMONTTEXAS.GOV,City,Non-Federal Agency,City of Beaumont,Beaumont,TX
 BEAUXARTS-WA.GOV,City,Non-Federal Agency,Town of Beaux Arts Village,Beaux Arts,WA
 BEAVERCREEKOHIO.GOV,City,Non-Federal Agency,City of Beavercreek,Beavercreek,OH
@@ -308,6 +310,7 @@ CAMPBELLCA.GOV,City,Non-Federal Agency,City of Campbell,Campbell,CA
 CAMPBELLOHIO.GOV,City,Non-Federal Agency,City of Campbell Ohio,Campbell,OH
 CANALWINCHESTEROHIO.GOV,City,Non-Federal Agency,City of Canal Winchester,Canal Winchester,OH
 CANANDAIGUANEWYORK.GOV,City,Non-Federal Agency,City of Canandaigua,Canandaigua,NY
+CANBYOREGON.GOV,City,Non-Federal Agency,City of Canby,Canby,OR
 CANNONFALLSMN.GOV,City,Non-Federal Agency,City of Cannon Falls,Cannon Falls,MN
 CANTONGA.GOV,City,Non-Federal Agency,City of Canton,Canton,GA
 CANTONOHIO.GOV,City,Non-Federal Agency,"City of Canton, Ohio",Canton,OH
@@ -466,6 +469,7 @@ CITYOFMACON-MO.GOV,City,Non-Federal Agency,City Of Macon,Macon,MO
 CITYOFMADISONWI.GOV,City,Non-Federal Agency,City of Madison,Madison,WI
 CITYOFMARIONIL.GOV,City,Non-Federal Agency,City of Marion,Marion,IL
 CITYOFMARIONWI.GOV,City,Non-Federal Agency,CITY OF MARION,MARION,WI
+CITYOFMARSHALLVILLEGA.GOV,City,Non-Federal Agency,City of Marshallville,Marshallville,GA
 CITYOFMATTAWA-WA.GOV,City,Non-Federal Agency,City of Mattawa,Mattawa,WA
 CITYOFMCCAYSVILLEGA.GOV,City,Non-Federal Agency,City of McCaysville,McCaysville,GA
 CITYOFMENASHA-WI.GOV,City,Non-Federal Agency,City of Menasha,Menasha,WI
@@ -546,6 +550,7 @@ CLINTONNJ.GOV,City,Non-Federal Agency,Clinton Town,New Jersey,NJ
 CLINTONOK.GOV,City,Non-Federal Agency,"City of Clinton, OK",Clinton,OK
 CLINTONTOWNSHIP-MI.GOV,City,Non-Federal Agency,Charter Township of Clinton,Clinton Township,MI
 CLOQUETMN.GOV,City,Non-Federal Agency,City of Cloquet,Cloquet,MN
+CLUTETEXAS.GOV,City,Non-Federal Agency,"City of Clute, Texas",Clute,TX
 CLYDEPARKMT.GOV,City,Non-Federal Agency,Town of Clyde Park,Clyde Park,MT
 CMSDCA.GOV,City,Non-Federal Agency,Costa Mesa Sanitary District,Costa Mesa,CA
 COALCITY-IL.GOV,City,Non-Federal Agency,Village of Coal City,Coal City,IL
@@ -957,6 +962,7 @@ GREENCASTLEPA.GOV,City,Non-Federal Agency,Borough of Greencastle,Greencastle,PA
 GREENEVILLETN.GOV,City,Non-Federal Agency,Town of Greeneville,Greeneville,TN
 GREENFIELD-MA.GOV,City,Non-Federal Agency,City of Greenfield,Greenfield,MA
 GREENFIELD-NH.GOV,City,Non-Federal Agency,Town of Greenfield,Greenfield,NH
+GREENFIELDTOWNSHIPPA.GOV,City,Non-Federal Agency,Greenfield Township,Claysburg,PA
 GREENHOUSTONTX.GOV,City,Non-Federal Agency,City of Houston,Houston,TX
 GREENISLANDNY.GOV,City,Non-Federal Agency,Village of Green Island ,Green Island,NY
 GREENSBORO-GA.GOV,City,Non-Federal Agency,City of Greensboro,Greensboro,GA
@@ -985,6 +991,7 @@ HADDONFIELD-NJ.GOV,City,Non-Federal Agency,Haddonfield,Haddonfield,NJ
 HADLEYMA.GOV,City,Non-Federal Agency,Town of Hadley,Hadley,MA
 HAHIRAGA.GOV,City,Non-Federal Agency,"Hahira, Georgia",Hahira,GA
 HALLANDALEBEACHFL.GOV,City,Non-Federal Agency,"Hallandale Beach, City of",hallandale beach,FL
+HALTOMCITYTX.GOV,City,Non-Federal Agency,city of Haltom City,Haltom City,TX
 HAMILTON-NY.GOV,City,Non-Federal Agency,VILLAGE OF HAMILTON,HAMILTON,NY
 HAMILTON-OH.GOV,City,Non-Federal Agency,"City of Hamilton, Ohio",Hamilton,OH
 HAMILTONMA.GOV,City,Non-Federal Agency,Town of Hamilton,So. Hamilton,MA
@@ -1020,12 +1027,14 @@ HASTINGSMN.GOV,City,Non-Federal Agency,City of Hastings,Hastings,MN
 HAVANAIL.GOV,City,Non-Federal Agency,City of Havana,Havana,IL
 HAVERHILLMA.GOV,City,Non-Federal Agency,City of Haverhill,Haverhill,MA
 HAVREDEGRACEMD.GOV,City,Non-Federal Agency,The City of Havre de Grace,Havre de Grace,MD
+HAWKINSVILLEGA.GOV,City,Non-Federal Agency,City of Hawkinsville,Hawkinsville,GA
 HAWTHORNECA.GOV,City,Non-Federal Agency,City of Hawthorne,Hawthorne,CA
 HAYESTOWNSHIPMI.GOV,City,Non-Federal Agency,hayes Township,Charlevoix,MI
 HAYSIVIRGINIA.GOV,City,Non-Federal Agency,Town of Haysi,Haysi,VA
 HAYWARD-CA.GOV,City,Non-Federal Agency,CITY OF HAYWARD,Hayward,CA
 HAZARDKY.GOV,City,Non-Federal Agency,City of Hazard,Hazard,KY
 HAZLEHURSTGA.GOV,City,Non-Federal Agency,City of Hazlehurst,Hazlehurst,GA
+HCTX.GOV,City,Non-Federal Agency,city of Haltom City,Haltom City,TX
 HEADOFTHEHARBORNY.GOV,City,Non-Federal Agency,Village of Head of the Harbor,Saint James,NY
 HEATHOHIO.GOV,City,Non-Federal Agency,"City of Heath, Ohio",Heath,OH
 HEDWIGTX.GOV,City,Non-Federal Agency,Hedwig Village,Houston,TX
@@ -1166,6 +1175,7 @@ KINGSLANDGA.GOV,City,Non-Federal Agency,City of Kingsland,Kingsland,GA
 KINGSPORTTN.GOV,City,Non-Federal Agency,City of Kingsport,Kingsport,TN
 KINGSTON-NY.GOV,City,Non-Federal Agency,City of Kingston,Kingston,NY
 KINGSTONSPRINGS-TN.GOV,City,Non-Federal Agency,The City of Kingston Springs,Kingston Springs,TN
+KINGSTONTN.GOV,City,Non-Federal Agency,City of Kingston,Kingston,TN
 KINROSSTOWNSHIP-MI.GOV,City,Non-Federal Agency,Kinross Charter Township,Kincheloe,MI
 KINSTONNC.GOV,City,Non-Federal Agency,City of Kinston,Kinston,NC
 KIRKLANDWA.GOV,City,Non-Federal Agency,City of Kirkland,Kirkland,WA
@@ -1185,6 +1195,7 @@ LAGRANGEGA.GOV,City,Non-Federal Agency,City of LaGrange,LaGrange,GA
 LAGRANGENY.GOV,City,Non-Federal Agency,Town of LaGrange,Lagrangeville,NY
 LAGUNAHILLSCA.GOV,City,Non-Federal Agency,City of Laguna Hills,Laguna Hills,CA
 LAHABRACA.GOV,City,Non-Federal Agency,CITY OF LA HABRA,LA HABRA,CA
+LAKECITYSC.GOV,City,Non-Federal Agency,City of Lake City,Lake City,SC
 LAKEFORESTCA.GOV,City,Non-Federal Agency,City of Lake Forest,Lake Forest,CA
 LAKEGROVENY.GOV,City,Non-Federal Agency,Village of Lake Grove,Lake Grove,NY
 LAKEHURST-NJ.GOV,City,Non-Federal Agency,City Connections,Hazlet,NJ
@@ -1645,6 +1656,7 @@ OAKLAND-ME.GOV,City,Non-Federal Agency,Town of Oakland,Oakland,ME
 OAKLANDCA.GOV,City,Non-Federal Agency,City of Oakland,Oakland,CA
 OAKLANDFL.GOV,City,Non-Federal Agency,Town of Oakland,Oakland,FL
 OAKLANDPARKFL.GOV,City,Non-Federal Agency,City of Oakland Park,Oakland Park,FL
+OAKLANDTN.GOV,City,Non-Federal Agency,Town of Oakland,Oakland,TN
 OAKLAWN-IL.GOV,City,Non-Federal Agency,VILLAGE OF OAK LAWN,OAK LAWN,IL
 OAKPARKMI.GOV,City,Non-Federal Agency,City of Oak Park,Oak Park,MI
 OAKRIDGETN.GOV,City,Non-Federal Agency,"City of Oak Ridge, TN","Oak Ridge, TN 37830 United States",TN
@@ -2043,6 +2055,7 @@ SOUTHPASADENACA.GOV,City,Non-Federal Agency,City of South Pasadena,South Pasaden
 SOUTHPITTSBURG-TN.GOV,City,Non-Federal Agency,City of South Pittsburg,South Pittsburg,TN
 SOUTHSANFRANCISCOCA.GOV,City,Non-Federal Agency,City of South San Francisco,South San Francisco,CA
 SOUTHTUCSONAZ.GOV,City,Non-Federal Agency,City of South Tucson,South Tucson,AZ
+SPARTANJ.GOV,City,Non-Federal Agency,Township of Sparta,Sparta,NJ
 SPARTATN.GOV,City,Non-Federal Agency,City of Sparta,Sparta,TN
 SPEEDWAYIN.GOV,City,Non-Federal Agency,Town of Speedway,Speedway,IN
 SPENCERMA.GOV,City,Non-Federal Agency,Town of Spencer,Spencer,MA
@@ -2584,6 +2597,7 @@ CHEROKEECOUNTY-NC.GOV,County,Non-Federal Agency,Cherokee County Government,Murph
 CHEROKEECOUNTYKS.GOV,County,Non-Federal Agency,Cherokee County,Columbus,KS
 CHEROKEECOUNTYSC.GOV,County,Non-Federal Agency,Cherokee County,Gaffney,SC
 CHESTERFIELDCOUNTY.GOV,County,Non-Federal Agency,"Chesterfield County, VA",Chesterfield,VA
+CHICOTCOUNTYAR.GOV,County,Non-Federal Agency,Chicot County Arkansas,Lake Village,AR
 CHIPPEWACOUNTYMI.GOV,County,Non-Federal Agency,Chippewa County,Sault Ste Marie,MI
 CHOWANCOUNTY-NC.GOV,County,Non-Federal Agency,Chowan County,Edenton,NC
 CHRISTIANCOUNTYKY.GOV,County,Non-Federal Agency,Christian County Government,Hopkinsville,KY
@@ -2889,7 +2903,6 @@ NOBLECOUNTYOHIO.GOV,County,Non-Federal Agency,Noble County,Caldwell,OH
 NORTONCOUNTYKS.GOV,County,Non-Federal Agency,Norton County,Norton,KS
 NWCLEANAIRWA.GOV,County,Non-Federal Agency,Northwest Clean Air Agency,Mount Vernon,WA
 OAKLANDCOUNTYMI.GOV,County,Non-Federal Agency,Oakland County Michigan,Pontiac,MI
-OGEMAWCOUNTYMI.GOV,County,Non-Federal Agency,Ogemaw County,West Branch,MI
 OGLETHORPECOUNTYGA.GOV,County,Non-Federal Agency,Oglethorpe County Board of Commissioners,Lexington,GA
 OHIOCOUNTYIN.GOV,County,Non-Federal Agency,Ohio County Courthouse,Rising Sun,IN
 OHIOCOUNTYKY.GOV,County,Non-Federal Agency,"Ohio County, KY Government",Hartford,KY
@@ -2904,6 +2917,7 @@ ORLEANSCOUNTYNY.GOV,County,Non-Federal Agency,Orleans County,Albion,NY
 OSWEGOCOUNTYNY.GOV,County,Non-Federal Agency,Oswego County Central Services,Oswego,NY
 OTSEGOCOUNTYMI.GOV,County,Non-Federal Agency,County of Otsego,Gaylord,MI
 OURAYCOUNTYCO.GOV,County,Non-Federal Agency,Ouray County,Ouray,CO
+PALMBEACHCOUNTYTAXCOLLECTOR-FL.GOV,County,Non-Federal Agency,"Tax Collector, West Palm Beach",West Palm Beach,FL
 PARKECOUNTY-IN.GOV,County,Non-Federal Agency,Parke County Units of Government,Rockville,IN
 PAYNECOUNTYOK.GOV,County,Non-Federal Agency,"Payne County, Oklahoma",Stillwater,OK
 PEMBINACOUNTYND.GOV,County,Non-Federal Agency,Pembina County,Cavalier,ND
@@ -2964,6 +2978,7 @@ ROWANCOUNTYNC.GOV,County,Non-Federal Agency,County of Rowan,Salisbury,NC
 RUSSELLCOUNTYVA.GOV,County,Non-Federal Agency,Russell County Board of Supervisors,Lebanon,VA
 RUTHERFORDCOUNTYNC.GOV,County,Non-Federal Agency,Rutherford County Government,Rutherfordton,NC
 RUTHERFORDCOUNTYTN.GOV,County,Non-Federal Agency,Rutherford County Govt,Murfreesboro,TN
+SAGADAHOCCOUNTYME.GOV,County,Non-Federal Agency,Sagadahoc County,Bath,ME
 SAGUACHECOUNTY-CO.GOV,County,Non-Federal Agency,Saguache County,Saguache,CO
 SALEMCOUNTYNJ.GOV,County,Non-Federal Agency,County Of Salem,Salem,NJ
 SANDIEGOCOUNTY.GOV,County,Non-Federal Agency,County of San Diego,San Diego,CA
@@ -2971,7 +2986,6 @@ SANDOVALCOUNTYNM.GOV,County,Non-Federal Agency,Sandoval County,Bernalillo,NM
 SANMIGUELCOUNTYCO.GOV,County,Non-Federal Agency,SAN MIGUEL COUNTY,TELLURIDE,CO
 SANPETECOUNTY-UT.GOV,County,Non-Federal Agency,Sanpete County,Manti,UT
 SANPETECOUNTYUTAH.GOV,County,Non-Federal Agency,Sanpete County Utah,Manti,UT
-SANTACLARACOUNTYCA.GOV,County,Non-Federal Agency,Santa Clara County,San Jose,CA
 SANTACRUZCOUNTYAZ.GOV,County,Non-Federal Agency,Santa Cruz County,Nogales,AZ
 SANTAFECOUNTYNM.GOV,County,Non-Federal Agency,Santa Fe County,Santa Fe,NM
 SARATOGACOUNTYNY.GOV,County,Non-Federal Agency,County of Saratoga,Ballston Spa,NY
@@ -3130,7 +3144,6 @@ OPENSOURCE.GOV,Federal Agency - Executive,Central Intelligence Agency,DNI Open S
 OSDE.GOV,Federal Agency - Executive,Central Intelligence Agency,CIA\GCS OSEG,Reston,VA
 TTIC.GOV,Federal Agency - Executive,Central Intelligence Agency,National Counterterrorism Center,Washington,DC
 UCIA.GOV,Federal Agency - Executive,Central Intelligence Agency,Central Intelligence Agency,Washington,DC
-CHEMSAFETY.GOV,Federal Agency - Executive,Chemical Safety Board,U.S. Chemical Safety and Hazard Investigation Board,Washington,DC
 CSB.GOV,Federal Agency - Executive,Chemical Safety Board,U.S. Chemical Safety and Hazard Investigation Board,Washington,DC
 SAFETYVIDEOS.GOV,Federal Agency - Executive,Chemical Safety Board,U.S. Chemical Safety and Hazard Investigation Board,Washington,DC
 CAP.GOV,Federal Agency - Executive,Civil Air Patrol,"CIVIL AIR PATROL, USAF AUX.",Birmingham,MI
@@ -3170,7 +3183,6 @@ NATIONALSERVICERESOURCES.GOV,Federal Agency - Executive,Corporation for National
 PRESIDENTIALSERVICEAWARDS.GOV,Federal Agency - Executive,Corporation for National & Community Service,Corporation for National & Community Service,Washington,DC
 SENIORCORPS.GOV,Federal Agency - Executive,Corporation for National & Community Service,Corporation for National and Community Service,Washington,DC
 SERVE.GOV,Federal Agency - Executive,Corporation for National & Community Service,Corporation for National and Community Service,Washington,DC
-SERVICE.GOV,Federal Agency - Executive,Corporation for National & Community Service,Corporation for National and Community Service,Washington,DC
 VISTACAMPUS.GOV,Federal Agency - Executive,Corporation for National & Community Service,Corporation for National & Community Service,Washington,DC
 VOLUNTEERINGINAMERICA.GOV,Federal Agency - Executive,Corporation for National & Community Service,Corporation for National and Community Service,Washington,DC
 CIGIE.GOV,Federal Agency - Executive,Council of Inspectors General on Integrity and Efficiency,COUNCIL OF INSPECTOR GENERAL ON INTEGRITY AND EFFICIENCY,Washington,DC
@@ -3691,7 +3703,7 @@ UTAHFIREINFO.GOV,Federal Agency - Executive,Department of the Interior,Bureau of
 VOLCANO.GOV,Federal Agency - Executive,Department of the Interior,US Geological Survey/Volcano Science Center,Vancouver,WA
 VOLUNTEER.GOV,Federal Agency - Executive,Department of the Interior,Department of the Interior,Reston,VA
 WATERMONITOR.GOV,Federal Agency - Executive,Department of the Interior,U.S. Geological Survey,Reston,VA
-WILDLIFEADAPTATIONSTRATEGY.GOV,Federal Agency - Executive,Department of the Interior,U.S. Fish and Wildlife Service,Arlington,VA
+WILDLIFEADAPTATIONSTRATEGY.GOV,Federal Agency - Executive,Department of the Interior,U.S. Fish and Wildlife Service,Falls Church,VA
 WLCI.GOV,Federal Agency - Executive,Department of the Interior,US Geological Survey,Denver,CO
 AMA.GOV,Federal Agency - Executive,Department of the Treasury,Department of the Treasury - FMS,Washington,DC
 AMERICATHEBEAUTIFULQUARTERS.GOV,Federal Agency - Executive,Department of the Treasury,Department of the Treasury - Mint,Washington,DC
@@ -3813,7 +3825,6 @@ SAFERTRUCK.GOV,Federal Agency - Executive,Department of Transportation,DOT NHTSA
 SHARETHEROADSAFELY.GOV,Federal Agency - Executive,Department of Transportation,Federal Motor Carrier Safety Administration,Washington,DC
 SMARTERSKIES.GOV,Federal Agency - Executive,Department of Transportation,US Dept of Transportation,Washington,DC
 STRONGPORTS.GOV,Federal Agency - Executive,Department of Transportation,Department of Transportation - MAritime Administration,Washington,DC
-SUSTAINABLECOMMUNITIES.GOV,Federal Agency - Executive,Department of Transportation,U.S. Department of Transportation Office of the Chief Information Officer ,Washington,DC
 TFHRC.GOV,Federal Agency - Executive,Department of Transportation,Turner Fairbank Highway Research Center,Mclean,VA
 TRAFFICSAFETYMARKETING.GOV,Federal Agency - Executive,Department of Transportation,NHTSA,Washington,DC
 TRANSPORTATION.GOV,Federal Agency - Executive,Department of Transportation,U.S. Department of Transportation,Washington,DC
@@ -4000,7 +4011,6 @@ FPISC.GOV,Federal Agency - Executive,General Services Administration,FEDERAL PER
 FPKI-LAB.GOV,Federal Agency - Executive,General Services Administration,"GSA, Office of Governmentwide Policy",Washington,DC
 FPKI.GOV,Federal Agency - Executive,General Services Administration,"GSA, Office of Governmentwide Policy",Washington,DC
 FRPG.GOV,Federal Agency - Executive,General Services Administration,US General Services Administration,Washington,DC
-FRPP-PA.GOV,Federal Agency - Executive,General Services Administration,Office of the CHief Information Officer,Washington,DC
 FSD.GOV,Federal Agency - Executive,General Services Administration,"Office of the Chief Acquisition Officer, Office of Acquisition Systems",Arlington,VA
 FSRS.GOV,Federal Agency - Executive,General Services Administration,GSA Acquisition Systems Division,Crystal City,VA
 GOBIERNO.GOV,Federal Agency - Executive,General Services Administration,FirstGov.gov,Washington,DC
@@ -4301,7 +4311,6 @@ GOVINFO.GOV,Federal Agency - Legislative,Government Publishing Office,US Governm
 GPO.GOV,Federal Agency - Legislative,Government Publishing Office,US Govt Publishing Office,Washington,DC
 HOUSECALENDAR.GOV,Federal Agency - Legislative,Government Publishing Office,United States Government Publishing Office,Washington,DC
 OFR.GOV,Federal Agency - Legislative,Government Publishing Office,US Government Publishing Office,Washington,DC
-OPENWORLD.GOV,Federal Agency - Legislative,Government Publishing Office,The Open World Leadership Center,Washington,DC
 PRESIDENTIALDOCUMENTS.GOV,Federal Agency - Legislative,Government Publishing Office,U.S. Government Publishing Office,Washington,DC
 SENATECALENDAR.GOV,Federal Agency - Legislative,Government Publishing Office,Government Publishing Office,Washington,DC
 USCC.GOV,Federal Agency - Legislative,Government Publishing Office,U.S. - China Economic and Security Review Commission,Washington,DC
@@ -4340,6 +4349,7 @@ WOMENSHISTORYMONTH.GOV,Federal Agency - Legislative,Library of Congress,Library 
 MACPAC.GOV,Federal Agency - Legislative,Medicaid and CHIP Payment and Access Commission,Medicaid and CHIP Payment and Access Commission,Washington,DC
 MEDPAC.GOV,Federal Agency - Legislative,Medical Payment Advisory Commission,Medicare Payment Advisory Commission,Washington,DC
 INSPIRE2SERVE.GOV,Federal Agency - Legislative,"National Commission on Military, National, and Public Service","National Commission on Military, National, and Public Service",Arlington,VA
+OPENWORLD.GOV,Federal Agency - Legislative,Open World Leadership Center,The Open World Leadership Center,Washington,DC
 STENNIS.GOV,Federal Agency - Legislative,Stennis Center for Public Service,John C. Stennis Center for Public Service,Starkville,MS
 CBO.GOV,Federal Agency - Legislative,The Legislative Branch,Congressional Budget Office,Washington,DC
 CBONEWS.GOV,Federal Agency - Legislative,The Legislative Branch,Congressional Budget Office,Washington,DC
@@ -4383,6 +4393,10 @@ USHOUSE.GOV,Federal Agency - Legislative,The Legislative Branch,US House of Repr
 USHR.GOV,Federal Agency - Legislative,The Legislative Branch,US House of Representatives,Washington,DC
 USCAPITOLPOLICE.GOV,Federal Agency - Legislative,U.S. Capitol Police,U.S. Capitol Police,Washington,DC
 USCP.GOV,Federal Agency - Legislative,U.S. Capitol Police,United States Capitol Police,Washington,DC
+WMSC.GOV,Interstate Agency,Metrorail Safety Commission,Metrorail Safety Commission,Washington,DC
+MTC.GOV,Interstate Agency,Multistate Tax Commission,Multistate Tax Commission,Washington,DC
+PACIFICFLYWAY.GOV,Interstate Agency,Pacific Flyway Council,Pacific Flyway Council,Vancouver,WA
+PANYNJ.GOV,Interstate Agency,The Port Authority of New York and New Jersey,The Port Authority of New York and New Jersey,New York,NY
 29PALMSBOMI-NSN.GOV,Native Sovereign Nation,Indian Affairs,Twenty-Nine Palms Band of Mission Indians,Coachella,CA
 29PALMSGAMING-NSN.GOV,Native Sovereign Nation,Indian Affairs,Twenty-Nine Palms Band of Mission Indians,Coachella,CA
 ABSENTEESHAWNEETRIBE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Absentee Shawnee Tribe of Indians of Oklahoma,Shawnee,OK
@@ -4449,6 +4463,7 @@ JACKSONRANCHERIA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Jackson Rancheri
 JIV-NSN.GOV,Native Sovereign Nation,Indian Affairs,Jamul Indian Village,Jamul,CA
 KAIBABPAIUTE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Kaibab Band of Paiute Indians,Fredonia,AZ
 KAKE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Organized Village of Kake,Kake,AK
+KALISPELTRIBE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Kalispel Tribe of Indians,Usk,WA
 KAWAIKA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Pueblo of Laguna,Laguna,NM
 KAYENTATOWNSHIP-NSN.GOV,Native Sovereign Nation,Indian Affairs,Kayenta Township,Kayenta,AZ
 KBIC-NSN.GOV,Native Sovereign Nation,Indian Affairs,Keweenaw Bay Indian Community,Baraga,MI
@@ -4496,6 +4511,7 @@ PCI-NSN.GOV,Native Sovereign Nation,Indian Affairs,Poarch Band of Creek Indians,
 PECHANGA-NSN.GOV,Native Sovereign Nation,Indian Affairs,Pechanga Tribal Government,Temecula,CA
 PEQUOT-NSN.GOV,Native Sovereign Nation,Indian Affairs,The Mashantucket Pequot Tribal Nation,Mashantucket,CT
 PHC-NSN.GOV,Native Sovereign Nation,Indian Affairs,Passamaquoddy Health Center,Princeton,ME
+PINOLEVILLE-NSN.GOV,Native Sovereign Nation,Indian Affairs,Pinoleville Pomo Nation,Ukiah,CA
 POARCHCREEKINDIANS-NSN.GOV,Native Sovereign Nation,Indian Affairs,Poarch Band of Creek Indians,ATMORE,AL
 POKAGONBAND-NSN.GOV,Native Sovereign Nation,Indian Affairs,Pokagon Band of Potawatomi Indians,DOWAGIAC,MI
 POL-NSN.GOV,Native Sovereign Nation,Indian Affairs,Pueblo of Laguna,Laguna,NM
@@ -4557,13 +4573,13 @@ DINEH-NSN.GOV,Native Sovereign Nation,Non-Federal Agency,Navajo Nation,Window Ro
 LRBOI-NSN.GOV,Native Sovereign Nation,Non-Federal Agency,Little River Band of Ottawa Indians Tribal Government ,Manistee,MI
 NAVAJO-NSN.GOV,Native Sovereign Nation,Non-Federal Agency,Navajo Nation,Window Rock,AZ
 YDSP-NSN.GOV,Native Sovereign Nation,Non-Federal Agency,Ysleta Del Sur Pueblo,El Pas,TX
-MTC.GOV,State/Local Govt,Multistate Tax Commission,Multistate Tax Commission,Washington,DC
 511TX.GOV,State/Local Govt,Non-Federal Agency,Tx. Dept. of Transportation,Austin,TX
 511WI.GOV,State/Local Govt,Non-Federal Agency,Wisconsin Department of Transportation,Madison,WI
 ABLETN.GOV,State/Local Govt,Non-Federal Agency,Office for Information Resources,Nashville,TN
 ADRCNJ.GOV,State/Local Govt,Non-Federal Agency," NJ Department of Human Services, DoAS",Mercerville,NJ
 AGAZ.GOV,State/Local Govt,Non-Federal Agency,Arizona Attorney General,Phoenix,AZ
 AGUTAH.GOV,State/Local Govt,Non-Federal Agency,Utah Attorney General's Office,Salt Lake City,UT
+AIDMONTANA.GOV,State/Local Govt,Non-Federal Agency,Montana Department of Justice,Helena,MT
 AK.GOV,State/Local Govt,Non-Federal Agency,State of Alaska,Juneau,AK
 AKAEROSPACE.GOV,State/Local Govt,Non-Federal Agency,Alaska Aerospace Development Corporation,Anchorage,AK
 AKLEG.GOV,State/Local Govt,Non-Federal Agency,Alaska Legislature,Juneau,AK
@@ -4766,7 +4782,6 @@ CAHWNET.GOV,State/Local Govt,Non-Federal Agency,HHSDC,Sacramento,CA
 CALEDONIA-WI.GOV,State/Local Govt,Non-Federal Agency,Village of Caledonia,Racine,WI
 CALIFORNIA.GOV,State/Local Govt,Non-Federal Agency,State of California,Rancho Cordova,CA
 CAMBRIDGERETIREMENTMA.GOV,State/Local Govt,Non-Federal Agency,City of Cambridge Contributory Retirement System,Cambridge,MA
-CANBYOREGON.GOV,State/Local Govt,Non-Federal Agency,City of Canby,Canby,OR
 CANTONNY.GOV,State/Local Govt,Non-Federal Agency,Village of Canton,Canton,NY
 CAREERSINCOLORADO.GOV,State/Local Govt,Non-Federal Agency,Colorado Department of Labor and Employment,Denver,CO
 CASAAZ.GOV,State/Local Govt,Non-Federal Agency,Arizona Supreme Court,Phoenix,AZ
@@ -4936,7 +4951,6 @@ GOLFMANOROH.GOV,State/Local Govt,Non-Federal Agency,The Village of Golf Manor,Go
 GOVOTEVERMONT.GOV,State/Local Govt,Non-Federal Agency,  Vermont Department of Information and Innovation on behalf of Vermont Secretary of State,Montpelier,VT
 GREATIOWATREASUREHUNT.GOV,State/Local Govt,Non-Federal Agency,Office of the Chief Information Officer,Des Moines,IA
 GREATNECKESTATES-NY.GOV,State/Local Govt,Non-Federal Agency,Village of Great Neck Estates,Great Neck Estates,NY
-GREENFIELDTOWNSHIPPA.GOV,State/Local Govt,Non-Federal Agency,Greenfield Township,Claysburg,PA
 GRFDAZ.GOV,State/Local Govt,Non-Federal Agency,Golder Ranch Fire District ,Tucson,AZ
 GROWNJKIDS.GOV,State/Local Govt,Non-Federal Agency,Department of Human Services Division of Family Development,Trenton,NJ
 GUAM.GOV,State/Local Govt,Non-Federal Agency,Dept of Admin Data Processing,Agana,GU
@@ -5048,7 +5062,6 @@ KDHEKS.GOV,State/Local Govt,Non-Federal Agency,Kansas Department of Health and E
 KENTUCKY.GOV,State/Local Govt,Non-Federal Agency,Commonwealth of Kentucky,Frankfort,KY
 KIDCENTRALTENNESSEE.GOV,State/Local Govt,Non-Federal Agency,State of Tennessee,Nashville,TN
 KIDCENTRALTN.GOV,State/Local Govt,Non-Federal Agency,State of Tennessee,Nashville,TN
-KINGSTONTN.GOV,State/Local Govt,Non-Federal Agency,City of Kingston,Kingston,TN
 KPL.GOV,State/Local Govt,Non-Federal Agency,Kalamazoo Public Library,KALAMAZOO,MI
 KS.GOV,State/Local Govt,Non-Federal Agency,"State of Kansas, DISC",Topeka,KS
 KSCAREERNAV.GOV,State/Local Govt,Non-Federal Agency,Kansas Department of Commerce,Topeka,KS
@@ -5185,7 +5198,6 @@ NCDPS.GOV,State/Local Govt,Non-Federal Agency,N.C. Department of Public Safety,R
 NCFORECLOSUREPREVENTION.GOV,State/Local Govt,Non-Federal Agency,NC Housing Finance Agency,Raleigh,NC
 NCFORESTPRODUCTS.GOV,State/Local Govt,Non-Federal Agency,North Carolina Forest Service,Raleigh,NC
 NCFORESTSERVICE.GOV,State/Local Govt,Non-Federal Agency,North Carolina Forest Service,Raleigh,NC
-NCGRANTS.GOV,State/Local Govt,Non-Federal Agency,NC Office of State Budget and Management,Raleigh,NC
 NCHEALTHCONNEX.GOV,State/Local Govt,Non-Federal Agency,"DIT, State of North Carolina",Raleigh,NC
 NCISAAC.GOV,State/Local Govt,Non-Federal Agency,North Carolina Department of Justice,Raleigh,NC
 NCLAMP.GOV,State/Local Govt,Non-Federal Agency,North Carolina State Bar,Raleigh,NC
@@ -5194,7 +5206,6 @@ NCLAWSPECIALISTS.GOV,State/Local Govt,Non-Federal Agency,North Carolina State Ba
 NCMORTGAGEHELP.GOV,State/Local Govt,Non-Federal Agency,NC Housing Finance Agency,27609,NC
 NCMST.GOV,State/Local Govt,Non-Federal Agency,NC Division of Parks and Recreation,Raleigh,NC
 NCONEMAP.GOV,State/Local Govt,Non-Federal Agency,DENR - CGIA,Raleigh,NC
-NCOPENBOOK.GOV,State/Local Govt,Non-Federal Agency,NC Office of State Budget and Management,Raleigh,NC
 NCPARKS.GOV,State/Local Govt,Non-Federal Agency,North Carolina Division of Parks and Recreation,Raleigh,NC
 NCPUBLICSCHOOLS.GOV,State/Local Govt,Non-Federal Agency,North Carolina Department of Public Instruction,Raleigh,NC
 NCREALID.GOV,State/Local Govt,Non-Federal Agency,North Carolina Department Of Transportation,Raleigh,NC
@@ -5248,6 +5259,7 @@ NJCIVILRIGHTS.GOV,State/Local Govt,Non-Federal Agency,"State of NJ, Dept. of Law
 NJCONSUMERAFFAIRS.GOV,State/Local Govt,Non-Federal Agency,"State of New Jersey, Dept. of Law & Pub. Safety, Office of the Attorney General",Trenton,NJ
 NJCOURTS.GOV,State/Local Govt,Non-Federal Agency,NJ Judiciary,Trenton,NJ
 NJDOC.GOV,State/Local Govt,Non-Federal Agency,New Jersey Department of Corrections,Trenton,NJ
+NJGUNSTAT.GOV,State/Local Govt,Non-Federal Agency,"NJ Law and Public Safety, Office of the Attorney General",Trenton,NJ
 NJHAS.GOV,State/Local Govt,Non-Federal Agency,NJHMFA,Trenton,NJ
 NJHELPS.GOV,State/Local Govt,Non-Federal Agency,Department of Human Services Division of Family Development,Trenton,NJ
 NJHMFA.GOV,State/Local Govt,Non-Federal Agency,New Jersey Housing and Mortgage Finance Agency (NJHMFA),Trenton,NJ
@@ -5392,13 +5404,10 @@ PA529.GOV,State/Local Govt,Non-Federal Agency,PA Treasury,Harrisburg,PA
 PA529ABLE.GOV,State/Local Govt,Non-Federal Agency,PA Treasury,Harrisburg,PA
 PAABLE.GOV,State/Local Govt,Non-Federal Agency,PA Treasury,Harrisburg,PA
 PAAUDITOR.GOV,State/Local Govt,Non-Federal Agency,Pennsylvania Department of the Auditor General,Harrisburg,PA
-PACIFICFLYWAY.GOV,State/Local Govt,Non-Federal Agency,Pacific Flyway Council,Vancouver,WA
 PADILLABAY.GOV,State/Local Govt,Non-Federal Agency,Padilla Bay National Estuarine Research Reserve,MOUNT VERNON,WA
 PAHOUSE.GOV,State/Local Govt,Non-Federal Agency,Pennsylvania Legislative Data Processing Center,Harrisburg,PA
 PAINVEST.GOV,State/Local Govt,Non-Federal Agency,Pennsylvania Treasury,Harrisburg,PA
 PALATINETOWNSHIP-IL.GOV,State/Local Govt,Non-Federal Agency,Palatine Township,Palatine,IL
-PALMBEACHCOUNTYTAXCOLLECTOR-FL.GOV,State/Local Govt,Non-Federal Agency,"Tax Collector, West Palm Beach",West Palm Beach,FL
-PANYNJ.GOV,State/Local Govt,Non-Federal Agency,The Port Authority of New York and New Jersey,New York,NY
 PAOPENFORBUSINESS.GOV,State/Local Govt,Non-Federal Agency,Commonwealth of Pennsylvania,Harrisburg,PA
 PARTNERSFORHEALTHTN.GOV,State/Local Govt,Non-Federal Agency,State of Tennessee,Nashville,TN
 PASEN.GOV,State/Local Govt,Non-Federal Agency,Senate of Pennsylvania,Harrisburg,PA
@@ -5638,7 +5647,6 @@ WISCONSINRAILPLAN.GOV,State/Local Govt,Non-Federal Agency,Wisconsin Department o
 WISCONSINROUNDABOUTS.GOV,State/Local Govt,Non-Federal Agency,Wisconsin Department of Transportation,Madison,WI
 WMATA.GOV,State/Local Govt,Non-Federal Agency,Washignton Metropoltan Area Transit Authority,Washington,DC
 WMATC.GOV,State/Local Govt,Non-Federal Agency,Washington Metropolitan Area Transit Commission,Silver Spring,MD
-WMSC.GOV,State/Local Govt,Non-Federal Agency,Metrorail Safety Commission,Washington,DC
 WSDOT.GOV,State/Local Govt,Non-Federal Agency,Washington State Department of Transportation,Olympia,WA
 WV.GOV,State/Local Govt,Non-Federal Agency,State of West Virginia,Charleston,WV
 WV457.GOV,State/Local Govt,Non-Federal Agency,Office of the State Treasurer,Charleston,WV


### PR DESCRIPTION
In addition to the new/retired domains, this change adds an `Interstate` domain type and recategorizes several domains. From our [domain requirements write-up](https://home.dotgov.gov/registration/requirements/#interstate-domains): 

>Interstate governmental organizations are most frequently formed via legislation from Congress or from a legal accord between the state governments of two or more states.
