### PR TITLE
Updating .gov list from May 25, 2018

### DIFF
--- a/dotgov-domains/current-federal.csv
+++ b/dotgov-domains/current-federal.csv
@@ -1,4 +1,4 @@
-Domain Name,Domain Type,Agency,Organization,City,State
+﻿Domain Name,Domain Type,Agency,Organization,City,State
 ACUS.GOV,Federal Agency - Executive,Administrative Conference of the United States,ADMINISTRATIVE CONFERENCE OF THE UNITED STATES,Washington,DC
 ACHP.GOV,Federal Agency - Executive,Advisory Council on Historic Preservation,ACHP,Washington,DC
 PRESERVEAMERICA.GOV,Federal Agency - Executive,Advisory Council on Historic Preservation,ACHP,Washington,DC
@@ -901,10 +901,6 @@ GSAAUCTIONS.GOV,Federal Agency - Executive,General Services Administration,Gener
 GSAIG.GOV,Federal Agency - Executive,General Services Administration,GSA Office of Inspector General,Washington,DC
 GSATEST1.GOV,Federal Agency - Executive,General Services Administration,GSA,Washington,DC
 GSATEST2.GOV,Federal Agency - Executive,General Services Administration,GSA,Washington,DC
-GSATEST3.GOV,Federal Agency - Executive,General Services Administration,GSA,Washington,DC
-GSATEST4.GOV,Federal Agency - Executive,General Services Administration,GSA,Washington,DC
-GSATEST5.GOV,Federal Agency - Executive,General Services Administration,GSA,Washington,DC
-GSATESTNSN.GOV,Federal Agency - Executive,General Services Administration,GSA,Washington,DC
 GSAXCESS.GOV,Federal Agency - Executive,General Services Administration,General Services Administration,Arlington,VA
 HOWTO.GOV,Federal Agency - Executive,General Services Administration,OCSIT,Washington,DC
 IDENTITYSANDBOX.GOV,Federal Agency - Executive,General Services Administration,18F,Washington,DC

--- a/dotgov-domains/current-full.csv
+++ b/dotgov-domains/current-full.csv
@@ -1,4 +1,4 @@
-Domain Name,Domain Type,Agency,Organization,City,State
+﻿Domain Name,Domain Type,Agency,Organization,City,State
 ABERDEENMD.GOV,City,Non-Federal Agency,City of Aberdeen,Aberdeen,MD
 ABERDEENWA.GOV,City,Non-Federal Agency,City of Aberdeen,Aberdeen,WA
 ABILENETX.GOV,City,Non-Federal Agency,City of Abilene,Abilene,TX
@@ -518,6 +518,7 @@ CITYOFSTOCKBRIDGE-GA.GOV,City,Non-Federal Agency,City of Stockbridge,Stockbridge
 CITYOFSUNRISEFL.GOV,City,Non-Federal Agency,City of Sunrise,Sunrise,FL
 CITYOFSUNRISEFLORIDA.GOV,City,Non-Federal Agency,City of Sunrise,Sunrise,FL
 CITYOFTITUSVILLEPA.GOV,City,Non-Federal Agency,City of Titusville Pennsylvania,Titusville,PA
+CITYOFTOMBSTONEAZ.GOV,City,Non-Federal Agency,City of Tombstone,Tombstone,AZ
 CITYOFTORRANCECA.GOV,City,Non-Federal Agency,City Of Torrance,Torrance,CA
 CITYOFTYLERTX.GOV,City,Non-Federal Agency,City of Tyler,Tyler,TX
 CITYOFWARRENPA.GOV,City,Non-Federal Agency,City of Warren,Warren,PA
@@ -1917,6 +1918,7 @@ RRNM.GOV,City,Non-Federal Agency,City of Rio Rancho,Rio Rancho,NM
 RUIDOSO-NM.GOV,City,Non-Federal Agency,Village of Ruidoso,Ruidoso,NM
 RUMSONNJ.GOV,City,Non-Federal Agency,The Borough of Rumson,Rumson,NJ
 RUSSELLSPOINT-OH.GOV,City,Non-Federal Agency,Village of Russells Point,Russells Point,OH
+RVCNY.GOV,City,Non-Federal Agency,Village of Rockville Centre,Rockville Centre,NY
 RYENY.GOV,City,Non-Federal Agency,City of Rye,Rye,NY
 SACKETSHARBOR-NY.GOV,City,Non-Federal Agency,Village of Sackets Harbor,Sackets Harbor,NY
 SADDLEBROOKNJ.GOV,City,Non-Federal Agency,Saddle Brook Towbship,Saddlebrook,NJ
@@ -2186,6 +2188,7 @@ TOWNOFCATSKILLNY.GOV,City,Non-Federal Agency,"Town of Catskill, NY",Catskill,NY
 TOWNOFCHAPELHILLTN.GOV,City,Non-Federal Agency,Town of Chapel Hill,Chapel Hill,TN
 TOWNOFCROWNPOINTNY.GOV,City,Non-Federal Agency,Town of Crown Point,Crown Point,NY
 TOWNOFDUNNWI.GOV,City,Non-Federal Agency,Town of Dunn,McFarland,WI
+TOWNOFGRANVILLEWV.GOV,City,Non-Federal Agency,Town of Granville,Granville,WV
 TOWNOFHALFMOON-NY.GOV,City,Non-Federal Agency,Town of Halfmoon,Halfmoon,NY
 TOWNOFHAVERHILL-FL.GOV,City,Non-Federal Agency,Town of Haverhill,Haverhill,FL
 TOWNOFHAYDENAZ.GOV,City,Non-Federal Agency,Town of Hayden,Hayden,AZ
@@ -2444,7 +2447,7 @@ WINDCREST-TX.GOV,City,Non-Federal Agency,City of Windcrest,Windcrest,TX
 WINDGAP-PA.GOV,City,Non-Federal Agency,Wind Gap Borough,Wind Gap,PA
 WINDHAMNH.GOV,City,Non-Federal Agency,Town of Windham,Windham,NH
 WINDSOR-VA.GOV,City,Non-Federal Agency,"Town of Windsor, Virginia",Windsor,VA
-WINDSORWI.GOV,City,Non-Federal Agency,Town of Windsor,DeForest,WI
+WINDSORWI.GOV,City,Non-Federal Agency,Village of Windsor,DeForest,WI
 WINNECONNEWI.GOV,City,Non-Federal Agency,Village of Winneconne,Winneconne,WI
 WINSLOW-ME.GOV,City,Non-Federal Agency,Town of Winslow,Winslow,ME
 WINSLOWAZ.GOV,City,Non-Federal Agency,City Of Winslow,Winslow,AZ
@@ -4022,10 +4025,6 @@ GSAAUCTIONS.GOV,Federal Agency - Executive,General Services Administration,Gener
 GSAIG.GOV,Federal Agency - Executive,General Services Administration,GSA Office of Inspector General,Washington,DC
 GSATEST1.GOV,Federal Agency - Executive,General Services Administration,GSA,Washington,DC
 GSATEST2.GOV,Federal Agency - Executive,General Services Administration,GSA,Washington,DC
-GSATEST3.GOV,Federal Agency - Executive,General Services Administration,GSA,Washington,DC
-GSATEST4.GOV,Federal Agency - Executive,General Services Administration,GSA,Washington,DC
-GSATEST5.GOV,Federal Agency - Executive,General Services Administration,GSA,Washington,DC
-GSATESTNSN.GOV,Federal Agency - Executive,General Services Administration,GSA,Washington,DC
 GSAXCESS.GOV,Federal Agency - Executive,General Services Administration,General Services Administration,Arlington,VA
 HOWTO.GOV,Federal Agency - Executive,General Services Administration,OCSIT,Washington,DC
 IDENTITYSANDBOX.GOV,Federal Agency - Executive,General Services Administration,18F,Washington,DC
@@ -4718,7 +4717,6 @@ AZLOTTERY.GOV,State/Local Govt,Non-Federal Agency,Arizona Lottery,Phoenix,AZ
 AZMAG.GOV,State/Local Govt,Non-Federal Agency,Maricopa Association of Governments,Phoenix,AZ
 AZMD.GOV,State/Local Govt,Non-Federal Agency,Arizona Medical Board,Scottsdale,AZ
 AZMINORITYHEALTH.GOV,State/Local Govt,Non-Federal Agency,Arizona Department of Health Services,Phoenix,AZ
-AZMORTGAGERESOURCE.GOV,State/Local Govt,Non-Federal Agency,Arizona Attorney General's Office,Phoenix,AZ
 AZMYFAMILYBENEFITS.GOV,State/Local Govt,Non-Federal Agency,Arizona Department of Economic Security,Phoenix,AZ
 AZND.GOV,State/Local Govt,Non-Federal Agency,State of Arizona,Phoenix,AZ
 AZNET.GOV,State/Local Govt,Non-Federal Agency,State of Arizona,Phoenix,AZ
@@ -5195,6 +5193,7 @@ NCDOJ.GOV,State/Local Govt,Non-Federal Agency,North Carolina Department of Justi
 NCDOR.GOV,State/Local Govt,Non-Federal Agency,Department of Information Technology,Raleigh,NC
 NCDOT.GOV,State/Local Govt,Non-Federal Agency,North Carolina Department of Transportation,Raleigh,NC
 NCDPS.GOV,State/Local Govt,Non-Federal Agency,N.C. Department of Public Safety,Raleigh,NC
+NCDRC.GOV,State/Local Govt,Non-Federal Agency,Administrative Office of the Courts,Raleigh,NC
 NCFORECLOSUREPREVENTION.GOV,State/Local Govt,Non-Federal Agency,NC Housing Finance Agency,Raleigh,NC
 NCFORESTPRODUCTS.GOV,State/Local Govt,Non-Federal Agency,North Carolina Forest Service,Raleigh,NC
 NCFORESTSERVICE.GOV,State/Local Govt,Non-Federal Agency,North Carolina Forest Service,Raleigh,NC


### PR DESCRIPTION
Quick release, mostly to account for the deletion of several GSA test domains.