### PR TITLE
Fix Unicode character issue in CSV header rows

### DIFF
--- a/dotgov-domains/current-federal.csv
+++ b/dotgov-domains/current-federal.csv
@@ -1,4 +1,4 @@
-﻿Domain Name,Domain Type,Agency,Organization,City,State
+Domain Name,Domain Type,Agency,Organization,City,State
 ACUS.GOV,Federal Agency - Executive,Administrative Conference of the United States,ADMINISTRATIVE CONFERENCE OF THE UNITED STATES,Washington,DC
 ACHP.GOV,Federal Agency - Executive,Advisory Council on Historic Preservation,ACHP,Washington,DC
 PRESERVEAMERICA.GOV,Federal Agency - Executive,Advisory Council on Historic Preservation,ACHP,Washington,DC

--- a/dotgov-domains/current-full.csv
+++ b/dotgov-domains/current-full.csv
@@ -1,4 +1,4 @@
-﻿Domain Name,Domain Type,Agency,Organization,City,State
+Domain Name,Domain Type,Agency,Organization,City,State
 ABERDEENMD.GOV,City,Non-Federal Agency,City of Aberdeen,Aberdeen,MD
 ABERDEENWA.GOV,City,Non-Federal Agency,City of Aberdeen,Aberdeen,WA
 ABILENETX.GOV,City,Non-Federal Agency,City of Abilene,Abilene,TX


### PR DESCRIPTION
This fixes a subtle regression in https://github.com/GSA/data/pull/147#pullrequestreview-124477848 where a Unicode character was introduced as the first character in the two domain CSV files, which can cause issues in CSV parsers.

I used `nano` to make the edits, which also added a blank newline at the end of the file, which is pretty standard (and generally recommended) anyway.

I verified that the fixed files parse properly in at least one parser that was failing previously (Pulse).