### PR TITLE
Adding a couple of email/calendar G Suite aliases

### DIFF
--- a/dotgov-websites/other-websites.csv
+++ b/dotgov-websites/other-websites.csv
@@ -1,4 +1,8 @@
 Domain
+email.nara.gov
+calendar.gsa.gov
+email.gsa.gov
+calendar.nara.gov
 icbsnew-trng.nwcg.gov
 ois-qt.nwcg.gov
 reports-qt.nwcg.gov


### PR DESCRIPTION
This adds `email` and `calendar` aliases for GSA and NARA G Suite instances.