### PR TITLE
Adding the domain openforest.fs.usda.gov for USDA

### DIFF
--- a/dotgov-websites/other-websites.csv
+++ b/dotgov-websites/other-websites.csv
@@ -12956,3 +12956,4 @@ pdgta.org
 subscribers.usda.gov
 ead.federation.usda.net
 mobile.cfpb.gov
+openforest.fs.usda.gov


### PR DESCRIPTION
See NCATS JIRA ticket OPS-2709 for details.