### PR TITLE
Adding a hostname as requested by NOAA

### DIFF
--- a/dotgov-websites/other-websites.csv
+++ b/dotgov-websites/other-websites.csv
@@ -1,4 +1,5 @@
 Domain
+ug.roc.noaa.gov
 vpn.nogales.ibwc.gov
 vpn.sandiego.ibwc.gov
 email.nara.gov


### PR DESCRIPTION
Adds ug.roc.noaa.gov to the manual list.