### PR TITLE
Adding second-level non-.gov domains for DOE

### DIFF
--- a/dotgov-domains/current-federal.csv
+++ b/dotgov-domains/current-federal.csv
@@ -203,6 +203,7 @@ INL.GOV,Federal Agency - Executive,Department of Energy,Idaho National Laborator
 ISOTOPE.GOV,Federal Agency - Executive,Department of Energy,The National Isotope Development Center ,Oak Ridge,TN
 ISOTOPES.GOV,Federal Agency - Executive,Department of Energy,The National Isotope Development Center ,Oak Ridge,TN
 KAPL.GOV,Federal Agency - Executive,Department of Energy,Knolls Atomic Power Laboratory,Schenectady,NY
+kcp.com,Federal Agency - Executive,Department of Energy,National Nuclear Security Administration,Kansas City,MO
 LANL.GOV,Federal Agency - Executive,Department of Energy,Los Alamos National Laboratory,Los Alamos,NM
 LBL.GOV,Federal Agency - Executive,Department of Energy,Lawrence Berkeley National Laboratory,Berkeley,CA
 LLNL.GOV,Federal Agency - Executive,Department of Energy,Lawrence Livermore National Laboratory,Livermore,CA
@@ -218,6 +219,7 @@ NWTRB.GOV,Federal Agency - Executive,Department of Energy,Nuclear Waste Technica
 ORAU.GOV,Federal Agency - Executive,Department of Energy,ORAU,Oak Ridge,TN
 ORNL.GOV,Federal Agency - Executive,Department of Energy,Oak Ridge National Laboratory,Oak Ridge,TN
 OSTI.GOV,Federal Agency - Executive,Department of Energy,OSTI,Oak Ridge,TN
+pantex.com,Federal Agency - Executive,Department of Energy,National Nuclear Security Administration,Amarillo,TX
 PNL.GOV,Federal Agency - Executive,Department of Energy,Pacific Northwest National Laboratory,Richland,WA
 PNNL.GOV,Federal Agency - Executive,Department of Energy,Pacific Northwest National Laboratory,Richland,WA
 PPPL.GOV,Federal Agency - Executive,Department of Energy,Princeton Plasma Physics Lab,Princeton,NJ
@@ -235,6 +237,7 @@ SWPA.GOV,Federal Agency - Executive,Department of Energy,Southwestern Power Admi
 UNNPP.GOV,Federal Agency - Executive,Department of Energy,"Bechtel Bettis, Inc.",West Mifflin,PA
 UNRPNET.GOV,Federal Agency - Executive,Department of Energy,Department of Energy,Washington,DC
 WAPA.GOV,Federal Agency - Executive,Department of Energy,Western Area Power Administration,Lakewood,CO
+wipp.ws,Federal Agency - Executive,Department of Energy,TRANSCOM,Carlsbad,NM
 YMP.GOV,Federal Agency - Executive,Department of Energy,Office of Civilian Radioactive Waste Management (OCRWM),Las Vegas,NV
 ACF.GOV,Federal Agency - Executive,Department of Health and Human Services,Health and Human Services,Washington,DC
 ACL.GOV,Federal Agency - Executive,Department of Health and Human Services,Administration for Community Living,Washington,DC


### PR DESCRIPTION
kcp.com(206): http://kcp.com redirects to https://kcnsc.doe.gov, and the certificate at https://kcp.com is issued to www.kcnsc.doe.gov

pantex.com(222): http://pantex.com redirects to https://pantex.energy.gov, and the certificate at https://pantex.com is issued to pantex.energy.gov

wipp.ws(240): certificate at https://wipp.ws issued to WIPP (organization) Transcom (organizational unit), and google of WIPP Transcom resulted in energy.gov sites that are for Transportation Tracking and Communication System (TRANSCOM) and Waste Isolation Pilot Plant (WIPP) for disposal which are monitored by that system