### PR TITLE
Create a CSV file tracking OCSP/CRL sites

### DIFF
--- a/dotgov-websites/ocsp-crl.csv
+++ b/dotgov-websites/ocsp-crl.csv
@@ -1,0 +1,3 @@
+ocsp-1.llnl.gov
+ocsp-2.llnl.gov
+ocsp.llnl.gov


### PR DESCRIPTION
This starts a CSV file with manually marked OCSP-only or CRL-only hostnames, for those services that meet the [OCSP/CRL exclusion](https://https.cio.gov/guide/#are-federally-operated-certificate-revocation-services-crl-ocsp-also-required-to-move-to-https) in M-15-13 and BOD 18-01.

To start, it's a few self-reported hosts within llnl.gov.

I think it will be important to be strict about only adding services which are reserved principally for production OCSP/CRL services. Dev/staging sites that may also dual-host content, for example, would not be appropriate to add here, nor would any other service that an agency might believe merits exemption on the grounds of being unimportant or not "public-facing".