### PR TITLE
Add two Department of State OCSP/CRL sites

### DIFF
--- a/dotgov-websites/ocsp-crl.csv
+++ b/dotgov-websites/ocsp-crl.csv
@@ -1,3 +1,5 @@
 ocsp-1.llnl.gov
 ocsp-2.llnl.gov
 ocsp.llnl.gov
+ocsp.pki.state.gov
+crls.pki.state.gov


### PR DESCRIPTION
These two sites should be added to the OCSP/CRL list so that Department of State does not get pinged for them not being compliant with BOD 18-01.