### PR TITLE
Add 7 domains for DOC

### DIFF
--- a/dotgov-websites/ocsp-crl.csv
+++ b/dotgov-websites/ocsp-crl.csv
@@ -6,3 +6,10 @@ crls.pki.state.gov
 hc.nasa.gov
 ocsp.nasa.gov
 ocsp-rra.ndc.nasa.gov
+ocsp-byr.uspto.gov
+ocsp.uspto.gov
+ipki-alx.uspto.gov
+ipki-byr.uspto.gov
+ipki.uspto.gov
+ocsp-alx.uspto.gov
+secure-auth.uspto.gov


### PR DESCRIPTION
DOC has reported that the added 7 USPTO IPKI URLs have been configured per RFC standards (RFC 5280 & RFC6960)and should be out of scope for HTTPS/HSTS checks according to https://https.cio.gov/guide/#are-federally-operated-certificate-revocation-services-crl-ocsp-also-required-to-move-to-https.