### PR TITLE
Update agency name for OPIC.gov

### DIFF
--- a/dotgov-domains/current-federal.csv
+++ b/dotgov-domains/current-federal.csv
@@ -1010,7 +1010,6 @@ UNLOCKTALENT.GOV,Federal Agency - Executive,Office of Personnel Management,U.S. 
 USAJOBS.GOV,Federal Agency - Executive,Office of Personnel Management,U. S. Office of Personnel Management,Washington,DC,(blank)
 USALEARNING.GOV,Federal Agency - Executive,Office of Personnel Management,Office of e-Government Initiatives,Washington,DC,(blank)
 USASTAFFING.GOV,Federal Agency - Executive,Office of Personnel Management,Network Management Group,Macon,GA,(blank)
-OPIC.GOV,Federal Agency - Executive,Overseas Private Investment Corporation,Overseas Private Investment Corporation,Washington,DC,(blank)
 PBGC.GOV,Federal Agency - Executive,Pension Benefit Guaranty Corporation,Pension Benefit Guaranty Corporation,Washington,DC,INFO-USCERT@pbgc.gov
 PRC.GOV,Federal Agency - Executive,Postal Regulatory Commission,Postal Regulatory Commission,Washington,DC,lee.martin@prc.gov
 PRESIDIO.GOV,Federal Agency - Executive,Presidio Trust,Presidio Trust,San Francisco,CA,(blank)
@@ -1104,6 +1103,7 @@ ICH.GOV,Federal Agency - Executive,United States Interagency Council on Homeless
 USICH.GOV,Federal Agency - Executive,United States Interagency Council on Homelessness,United States Interagency Council on Homelessness,Washington,DC,(blank)
 DFC.GOV,Federal Agency - Executive,United States International Development Finance Corporation,US International Development Finance Corporation,Washington,DC,ciso@opic.gov
 IDFC.GOV,Federal Agency - Executive,United States International Development Finance Corporation,US International Development Finance Corporation,Washington,DC,CISO@opic.gov
+OPIC.GOV,Federal Agency - Executive,United States International Development Finance Corporation,US International Development Finance Corporation,Washington,DC,(blank)
 USDFC.GOV,Federal Agency - Executive,United States International Development Finance Corporation,US International Development Finance Corporation,washington,DC,ciso@opic.gov
 USIDFC.GOV,Federal Agency - Executive,United States International Development Finance Corporation,US International Development Finance Corporation,Washington,DC,CISO@opic.gov
 USITC.GOV,Federal Agency - Executive,United States International Trade Commission,United States International Trade Commission,Washington,DC,(blank)


### PR DESCRIPTION
According to OPIC/DFC contacts, as of January 2, 2020, OPIC is now the US International Development Finance Corporation (DFC).  Their old opic.gov domain continues to be active and redirects users to their new site - www.dfc.gov - when they click the link.  If you search “OPIC” in Google, you can even see that the agency was renamed, as the first link that pops up shows “OPIC is now DFC… The Overseas Private Investment Corporation transformed into the U.S. International Development Finance Corporation.”

On February 21, 2020, the .GOV Helpdesk has stated that they updated the agency name on their end.  Any further changes will need to come from one of the authorized contacts on the domain(s).