### PR TITLE
Add 7 subdomains for HHS/CDC

### DIFF
--- a/dotgov-websites/other-websites.csv
+++ b/dotgov-websites/other-websites.csv
@@ -14340,3 +14340,10 @@ vetpro.org
 fcp.vetpro.org
 preprod.vetpro.org
 warm.vetpro.org
+communitycountsdataviz.cdc.gov
+easauth-piv.cdc.gov
+fl-mmria.services.cdc.gov
+flulimslb.cdc.gov
+icd10cmtool.cdc.gov
+nodewebservicedev.cdc.gov
+vaccinecodeset.cdc.gov


### PR DESCRIPTION
HHS noticed that some domains are missing from their HTTPS/Tmail reports, and would like to request that the 7 added to this list be included in their weekly reports.