### PR TITLE
Add a new website for VA

### DIFF
--- a/dotgov-websites/other-websites.csv
+++ b/dotgov-websites/other-websites.csv
@@ -14348,3 +14348,4 @@ icd10cmtool.cdc.gov
 nodewebservicedev.cdc.gov
 vaccinecodeset.cdc.gov
 pandemic.oversight.gov
+care2.va.gov


### PR DESCRIPTION
VA has reached out to ask if we can scan care2.va.gov, which isn't currently included in the reports we send them.