### PR TITLE
Adding VA OCSP/PKI Domain

### DIFF
--- a/dotgov-websites/ocsp-crl.csv
+++ b/dotgov-websites/ocsp-crl.csv
@@ -13,3 +13,4 @@ ipki-byr.uspto.gov
 ipki.uspto.gov
 ocsp-alx.uspto.gov
 secure-auth.uspto.gov
+ocsp.pki.va.gov


### PR DESCRIPTION
VA has requested this domain be marked out of scope for their HTTPS compliance report.