### PR TITLE
Adding USAID Domain

### DIFF
--- a/dotgov-websites/other-websites.csv
+++ b/dotgov-websites/other-websites.csv
@@ -14349,3 +14349,4 @@ nodewebservicedev.cdc.gov
 vaccinecodeset.cdc.gov
 pandemic.oversight.gov
 care2.va.gov
+usaidlibraryguides.usaid.gov


### PR DESCRIPTION
Per USAID's request, they request to add this domain to their scope for HTTPS and Trustworthy Email compliance reports.