### PR TITLE
Correct Typo in Agency Name (JUSFC)

### DIFF
--- a/dotgov-domains/current-federal.csv
+++ b/dotgov-domains/current-federal.csv
@@ -919,7 +919,7 @@ TRUMAN.GOV,Federal Agency - Executive,Harry S. Truman Scholarship Foundation,Har
 IMLS.GOV,Federal Agency - Executive,Institute of Museum and Library Services,IMLS,Washington,DC,(blank)
 IAF.GOV,Federal Agency - Executive,Inter-American Foundation,Inter-American Foundation,Washington,DC,iafhelpdesk@iaf.gov
 JAMESMADISON.GOV,Federal Agency - Executive,James Madison Memorial Fellowship Foundation,James Madison Memorial Fellowship Foundation,Alexandria,VA,(blank)
-JUSFC.GOV,Federal Agency - Executive,Japan-US Friendship Commision,Japan-US Friendship Commission,Washington,DC,(blank)
+JUSFC.GOV,Federal Agency - Executive,Japan-US Friendship Commission,Japan-US Friendship Commission,Washington,DC,(blank)
 KENNEDY-CENTER.GOV,Federal Agency - Executive,John F. Kennedy Center for Performing Arts,John F Kennedy Center for Performing Arts,Washington,DC,(blank)
 LSC.GOV,Federal Agency - Executive,Legal Services Corporation,Legal Services Corporation,Washington,DC,(blank)
 MMC.GOV,Federal Agency - Executive,Marine Mammal Commission,Marine Mammal Commission,Bethesda,MD,(blank)


### PR DESCRIPTION
JUSFC's full name is spelled incorrectly, this makes it difficult for CISA's domain gathering tools to reference the list for the agency's base domain(s).