### PR TITLE
Adding the new FOIA website for DHS

### DIFF
--- a/dotgov-websites/other-websites.csv
+++ b/dotgov-websites/other-websites.csv
@@ -14384,3 +14384,4 @@ rpg-eds.acf.hhs.gov
 shepherd.otip.acf.hhs.gov
 shspfm.gss.acf.hhs.gov
 wethinktwice.acf.hhs.gov
+foiarequest.dhs.gov


### PR DESCRIPTION
Please add this subdomain so that it shows up in the DHS HTTPS/Tmail reports. Thanks!