### PR TITLE
Adding 3 OCSP/CRL Domains for DOC

### DIFF
--- a/dotgov-websites/ocsp-crl.csv
+++ b/dotgov-websites/ocsp-crl.csv
@@ -36,3 +36,6 @@ gpo-crl.ois.gpo.gov
 gpo-fbca-crls.ois.gpo.gov
 ocsp.gpo.gov
 ocsp.dhhs.gov
+betty.nist.gov
+seclab7.ncsl.nist.gov
+smime2.nist.gov


### PR DESCRIPTION
DOC has reported 3 PKI test domains for inclusion in the OCSP/CRL list.  Please note that seclab7 is not currently live, but I figured it probably didn't hurt to add it to this list anyway.