### PR TITLE
Add non-.gov and 3 subs for VA

### DIFF
--- a/dotgov-websites/other-websites.csv
+++ b/dotgov-websites/other-websites.csv
@@ -14397,3 +14397,7 @@ cncs.oversight.gov
 crossfeed.cyber.dhs.gov
 wl.worklife4you.com
 adminefiling.ftc.gov
+vaitcampus.com
+test.vaitcampus.com
+specialevent.vaitcampus.com
+ui.vaitcampus.com


### PR DESCRIPTION
VA has requested that we add vaitcampus.com to their HTTPS and Tmail reports.  I double checked it is a VA owned site, and a Google search of site:vaitcampus.com shows 3 subs (other than www, which will automatically be scanned): test.vaitcampus.com, specialevent.vaitcampus.com, and ui.vaitcampus.com.  Please add these to the federal "other websites" list so they show up in the VA reports.  Thank you!  :)