### PR TITLE
Add 3 DOT Domains for HTTPS Exception

### DIFF
--- a/dotgov-websites/ocsp-crl.csv
+++ b/dotgov-websites/ocsp-crl.csv
@@ -43,3 +43,6 @@ smime2.nist.gov
 pki.fhfa.gov
 dc081.fhfa.gov
 va081.fhfa.gov
+keys1.dot.gov
+keys2.dot.gov
+crl.oig.dot.gov


### PR DESCRIPTION
DOT has requested these domain be marked as an exception for their HTTPS compliance report due to being CRL centric only.